### PR TITLE
impl the endpoint controller

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,7 +77,7 @@ linters-settings:
     check-type-assertions: true
   funlen:
     # max function body len
-    lines: 100
+    lines: 150
     # max function body statements
     statements: 100
   goconst:

--- a/api/v1/api_gen.go
+++ b/api/v1/api_gen.go
@@ -1021,6 +1021,10 @@ type ApiResourceSpec struct {
 	Memory      interface{} `json:"memory"`
 }
 
+type ApiReplicaSpec struct {
+	Num interface{} `json:"num"`
+}
+
 type ApiEndpointSpec struct {
 	Cluster           string      `json:"cluster"`
 	Model             interface{} `json:"model"`

--- a/api/v1/api_key_types.go
+++ b/api/v1/api_key_types.go
@@ -1,7 +1,5 @@
 package v1
 
-import "time"
-
 type ApiKeySpec struct {
 	Quota int64 `json:"quota,omitempty"`
 }
@@ -16,12 +14,12 @@ const (
 
 type ApiKeyStatus struct {
 	ErrorMessage       string      `json:"error_message,omitempty"`
-	LastTransitionTime time.Time   `json:"last_transition_time,omitempty"`
+	LastTransitionTime string      `json:"last_transition_time,omitempty"`
 	Phase              ApiKeyPhase `json:"phase,omitempty"`
 	SkValue            string      `json:"sk_value,omitempty"`
 	Usage              int64       `json:"usage,omitempty"`
-	LastUsedAt         time.Time   `json:"last_used_at,omitempty"`
-	LastSyncAt         time.Time   `json:"last_sync_at,omitempty"`
+	LastUsedAt         string      `json:"last_used_at,omitempty"`
+	LastSyncAt         string      `json:"last_sync_at,omitempty"`
 }
 
 type ApiKey struct {

--- a/api/v1/endpoint_types.go
+++ b/api/v1/endpoint_types.go
@@ -20,10 +20,16 @@ type ResourceSpec struct {
 	Memory      *float64           `json:"memory,omitempty"`
 }
 
+type ReplicaSepc struct {
+	Num *int `json:"num,omitempty"`
+}
+
 type EndpointSpec struct {
 	Cluster           string                 `json:"cluster,omitempty"`
 	Model             *ModelSpec             `json:"model,omitempty"`
 	Engine            *EndpointEngineSpec    `json:"engine,omitempty"`
+	Resources         *ResourceSpec          `json:"resources,omitempty"`
+	Replicas          ReplicaSepc            `json:"replicas,omitempty"`
 	DeploymentOptions map[string]interface{} `json:"deployment_options,omitempty"`
 	Variables         map[string]interface{} `json:"variables,omitempty"`
 }

--- a/api/v1/endpoint_types.go
+++ b/api/v1/endpoint_types.go
@@ -1,0 +1,56 @@
+package v1
+
+type ModelSpec struct {
+	Registry string `json:"registry,omitempty"`
+	Name     string `json:"name,omitempty"`
+	File     string `json:"file,omitempty"`
+	Version  string `json:"version,omitempty"`
+	Task     string `json:"task,omitempty"`
+}
+
+type EndpointEngineSpec struct {
+	Engine  string `json:"engine,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type ResourceSpec struct {
+	CPU         float64                `json:"cpu,omitempty"`
+	GPU         float64                `json:"gpu,omitempty"`
+	Accelerator map[string]interface{} `json:"accelerator,omitempty"`
+	Memory      float64                `json:"memory,omitempty"`
+}
+
+type EndpointSpec struct {
+	Cluster           string                 `json:"cluster,omitempty"`
+	Model             *ModelSpec             `json:"model,omitempty"`
+	Engine            *EndpointEngineSpec    `json:"engine,omitempty"`
+	Resources         *ResourceSpec          `json:"resources,omitempty"`
+	Replicas          int                    `json:"replicas,omitempty"`
+	DeploymentOptions map[string]interface{} `json:"deployment_options,omitempty"`
+	Variables         map[string]interface{} `json:"variables,omitempty"`
+}
+
+type EndpointPhase string
+
+const (
+	EndpointPhasePENDING EndpointPhase = "Pending"
+	EndpointPhaseRUNNING EndpointPhase = "Running"
+	EndpointPhaseFAILED  EndpointPhase = "Failed"
+	EndpointPhaseDELETED EndpointPhase = "Deleted"
+)
+
+type EndpointStatus struct {
+	Phase              EndpointPhase `json:"phase,omitempty"`
+	ServiceURL         string        `json:"service_url,omitempty"`
+	LastTransitionTime string        `json:"last_transition_time,omitempty"`
+	ErrorMessage       string        `json:"error_message,omitempty"`
+}
+
+type Endpoint struct {
+	ID         int             `json:"id,omitempty"`
+	APIVersion string          `json:"api_version,omitempty"`
+	Kind       string          `json:"kind,omitempty"`
+	Metadata   *Metadata       `json:"metadata,omitempty"`
+	Spec       *EndpointSpec   `json:"spec,omitempty"`
+	Status     *EndpointStatus `json:"status,omitempty"`
+}

--- a/api/v1/endpoint_types.go
+++ b/api/v1/endpoint_types.go
@@ -14,18 +14,16 @@ type EndpointEngineSpec struct {
 }
 
 type ResourceSpec struct {
-	CPU         float64                `json:"cpu,omitempty"`
-	GPU         float64                `json:"gpu,omitempty"`
-	Accelerator map[string]interface{} `json:"accelerator,omitempty"`
-	Memory      float64                `json:"memory,omitempty"`
+	CPU         *float64           `json:"cpu,omitempty"`
+	GPU         *float64           `json:"gpu,omitempty"`
+	Accelerator map[string]float64 `json:"accelerator,omitempty"`
+	Memory      *float64           `json:"memory,omitempty"`
 }
 
 type EndpointSpec struct {
 	Cluster           string                 `json:"cluster,omitempty"`
 	Model             *ModelSpec             `json:"model,omitempty"`
 	Engine            *EndpointEngineSpec    `json:"engine,omitempty"`
-	Resources         *ResourceSpec          `json:"resources,omitempty"`
-	Replicas          int                    `json:"replicas,omitempty"`
 	DeploymentOptions map[string]interface{} `json:"deployment_options,omitempty"`
 	Variables         map[string]interface{} `json:"variables,omitempty"`
 }

--- a/api/v1/engine_types.go
+++ b/api/v1/engine_types.go
@@ -1,7 +1,5 @@
 package v1
 
-import "time"
-
 type EngineVersion struct {
 	Version      string                 `json:"version,omitempty"`
 	ValuesSchema map[string]interface{} `json:"values_schema,omitempty"`
@@ -23,7 +21,7 @@ const (
 
 type EngineStatus struct {
 	Phase              EnginePhase `json:"phase,omitempty"`
-	LastTransitionTime *time.Time  `json:"last_transition_time,omitempty"`
+	LastTransitionTime string      `json:"last_transition_time,omitempty"`
 	ErrorMessage       string      `json:"error_message,omitempty"`
 }
 

--- a/cluster-image-builder/requirements.txt
+++ b/cluster-image-builder/requirements.txt
@@ -1,0 +1,15 @@
+llama_cpp_python==0.3.7
+fastapi==0.109.2
+typing_extensions==4.12.2
+sse-starlette==2.1.3
+starlette-context==0.3.6
+pydantic==2.9.2
+pydantic_core==2.23.4
+pydantic-settings==2.8.1
+huggingface-hub==0.29.1
+ray[serve]
+bentoml==1.4.2
+PyYAML==6.0.1
+vllm==0.7.2
+kantoku==0.18.1
+openai==1.65.2

--- a/cluster-image-builder/serve/llama_cpp/v1/app.py
+++ b/cluster-image-builder/serve/llama_cpp/v1/app.py
@@ -210,15 +210,11 @@ class Controller:
 def app_builder(args: Dict[str, Any]) -> Application:
     """
     Application builder function that configures and returns the Backend and Controller deployments.
-    
-    Args:
-        args: A dictionary containing all the configuration parameters, expected to have
-              'model', 'deployment_options', and 'model_settings' keys.
     """
     # Extract configuration sections
     model = args.get('model', {})
     deployment_options = args.get('deployment_options', {})
-    model_settings = args.get('model_settings', {})
+    model_settings = args.get('engine_args', {})
     
     # Extract backend deployment options
     backend_options = deployment_options.get('backend', {})

--- a/cmd/neutree-core/neutree-core.go
+++ b/cmd/neutree-core/neutree-core.go
@@ -79,6 +79,23 @@ func main() {
 		klog.Fatalf("failed to init cluster controller: %s", err.Error())
 	}
 
+	engineController, err := controllers.NewEngineController(&controllers.EngineControllerOption{
+		Storage: s,
+		Workers: *controllerWorkers,
+	})
+	if err != nil {
+		klog.Fatalf("failed to init engine controller: %s", err.Error())
+	}
+
+	endpointController, err := controllers.NewEndpointController(&controllers.EndpointControllerOption{
+		Storage:      s,
+		Workers:      *controllerWorkers,
+		ImageService: imageService,
+	})
+	if err != nil {
+		klog.Fatalf("failed to init endpoint controller: %s", err.Error())
+	}
+
 	roleController, err := controllers.NewRoleController(&controllers.RoleControllerOption{
 		Storage: s,
 		Workers: *controllerWorkers,
@@ -109,6 +126,8 @@ func main() {
 	go imageRegistryController.Start(ctx)
 	go modelRegistryController.Start(ctx)
 	go clusterController.Start(ctx)
+	go engineController.Start(ctx)
+	go endpointController.Start(ctx)
 	go roleController.Start(ctx)
 	go roleAssignmentController.Start(ctx)
 	go workspaceController.Start(ctx)

--- a/controllers/api_key_controller.go
+++ b/controllers/api_key_controller.go
@@ -118,7 +118,7 @@ func (c *ApiKeyController) sync(obj *v1.ApiKey) error {
 
 func (c *ApiKeyController) updateStatus(obj *v1.ApiKey, phase v1.ApiKeyPhase, err error) error {
 	newStatus := &v1.ApiKeyStatus{
-		LastTransitionTime: time.Now(),
+		LastTransitionTime: time.Now().Format(time.RFC3339Nano),
 		Phase:              phase,
 	}
 	if err != nil {

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -117,6 +117,7 @@ func (c *ClusterController) sync(obj *v1.Cluster) error {
 		Cluster:       obj,
 		ImageRegistry: imageRegistry,
 		ImageService:  c.imageService,
+		Storage:       c.storage,
 	})
 	if err != nil {
 		return err

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -108,16 +108,10 @@ func (c *ClusterController) sync(obj *v1.Cluster) error {
 		obj.Spec.Version = c.defaultClusterVersion
 	}
 
-	imageRegistry, err := c.getRelateImageRegistry(obj)
-	if err != nil {
-		return errors.Wrap(err, "failed to get relate image registry")
-	}
-
 	clusterOrchestrator, err := orchestrator.NewOrchestrator(orchestrator.Options{
-		Cluster:       obj,
-		ImageRegistry: imageRegistry,
-		ImageService:  c.imageService,
-		Storage:       c.storage,
+		Cluster:      obj,
+		ImageService: c.imageService,
+		Storage:      c.storage,
 	})
 	if err != nil {
 		return err
@@ -344,35 +338,6 @@ func (c *ClusterController) reconcileDelete(cluster *v1.Cluster, clusterOrchestr
 	}
 
 	return nil
-}
-
-func (c *ClusterController) getRelateImageRegistry(cluster *v1.Cluster) (*v1.ImageRegistry, error) {
-	imageRegistryFilter := []storage.Filter{
-		{
-			Column:   "metadata->name",
-			Operator: "eq",
-			Value:    fmt.Sprintf(`"%s"`, cluster.Spec.ImageRegistry),
-		},
-	}
-
-	if cluster.Metadata.Workspace != "" {
-		imageRegistryFilter = append(imageRegistryFilter, storage.Filter{
-			Column:   "metadata->workspace",
-			Operator: "eq",
-			Value:    fmt.Sprintf(`"%s"`, cluster.Metadata.Workspace),
-		})
-	}
-
-	imageRegistryList, err := c.storage.ListImageRegistry(storage.ListOption{Filters: imageRegistryFilter})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list image registry")
-	}
-
-	if len(imageRegistryList) == 0 {
-		return nil, errors.New("relate image registry not found")
-	}
-
-	return &imageRegistryList[0], nil
 }
 
 func (c *ClusterController) updateStatus(obj *v1.Cluster, clusterOrchestrator orchestrator.Orchestrator, phase v1.ClusterPhase, err error) error {

--- a/controllers/endpoint_controller.go
+++ b/controllers/endpoint_controller.go
@@ -10,19 +10,23 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/orchestrator"
+	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 type EndpointController struct {
 	baseController *BaseController
 
-	storage     storage.Storage
-	syncHandler func(endpoint *v1.Endpoint) error // Added syncHandler field
+	storage      storage.Storage
+	imageService registry.ImageService
+	syncHandler  func(endpoint *v1.Endpoint) error // Added syncHandler field
 }
 
 type EndpointControllerOption struct {
-	Storage storage.Storage
-	Workers int
+	ImageService registry.ImageService
+	Storage      storage.Storage
+	Workers      int
 }
 
 func NewEndpointController(option *EndpointControllerOption) (*EndpointController, error) {
@@ -94,8 +98,13 @@ func (c *EndpointController) sync(obj *v1.Endpoint) error {
 		}
 
 		klog.Info("Deleting endpoint " + obj.Metadata.Name)
+		err = c.cleanupEndpoint(obj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to cleanup endpoint %s", obj.Metadata.Name)
+		}
+
 		// Update status to DELETED
-		err = c.updateStatus(obj, v1.EndpointPhaseDELETED, nil)
+		err = c.updateStatus(obj, c.formatStatus(v1.EndpointPhaseDELETED, nil))
 		if err != nil {
 			return errors.Wrapf(err, "failed to update endpoint %s status to DELETED", obj.Metadata.Name)
 		}
@@ -106,11 +115,56 @@ func (c *EndpointController) sync(obj *v1.Endpoint) error {
 	// Handle creation/update (when not deleting)
 	// If status is missing or PENDING, update it to RUNNING.
 	if obj.Status == nil || obj.Status.Phase == "" || obj.Status.Phase == v1.EndpointPhasePENDING {
-		klog.Infof("Endpoint %s is PENDING or has no status, updating to RUNNING", obj.Metadata.Name)
-		err = c.updateStatus(obj, v1.EndpointPhaseRUNNING, nil)
-
+		klog.Infof("Endpoint %s is PENDING or has no status, creating", obj.Metadata.Name)
+		status, err := c.createEndpoint(obj)
 		if err != nil {
-			return errors.Wrapf(err, "failed to update endpoint %s status to RUNNING", obj.Metadata.Name)
+			return errors.Wrapf(err, "failed to create endpoint %s", obj.Metadata.Name)
+		}
+
+		err = c.updateStatus(obj, status)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update endpoint %s status", obj.Metadata.Name)
+		}
+
+		return nil
+	}
+
+	if obj.Status.Phase == v1.EndpointPhaseFAILED {
+		// TODO: check this strategy
+		klog.Infof("Endpoint %s is FAILED, re-creating", obj.Metadata.Name)
+
+		err = c.cleanupEndpoint(obj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to cleanup endpoint %s", obj.Metadata.Name)
+		}
+
+		status, err := c.createEndpoint(obj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create endpoint %s", obj.Metadata.Name)
+		}
+
+		err = c.updateStatus(obj, status)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update endpoint %s status", obj.Metadata.Name)
+		}
+
+		return nil
+	}
+
+	if obj.Status.Phase == v1.EndpointPhaseRUNNING {
+		klog.Infof("Endpoint %s is RUNNING, checking health", obj.Metadata.Name)
+		status, err := c.checkEndpointHealth(obj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to check endpoint %s health", obj.Metadata.Name)
+		}
+
+		if status.Phase != v1.EndpointPhaseRUNNING {
+			klog.Infof("Endpoint %s is not RUNNING, updating status", obj.Metadata.Name)
+
+			err = c.updateStatus(obj, status)
+			if err != nil {
+				return errors.Wrapf(err, "failed to update endpoint %s status", obj.Metadata.Name)
+			}
 		}
 
 		return nil
@@ -119,7 +173,45 @@ func (c *EndpointController) sync(obj *v1.Endpoint) error {
 	return nil
 }
 
-func (c *EndpointController) updateStatus(obj *v1.Endpoint, phase v1.EndpointPhase, err error) error {
+func (c *EndpointController) createEndpoint(obj *v1.Endpoint) (*v1.EndpointStatus, error) {
+	o, err := c.getOrchestrator(obj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get orchestrator for endpoint %s", obj.Metadata.Name)
+	}
+
+	status, err := o.CreateEndpoint(obj)
+	if err != nil {
+		return status, errors.Wrapf(err, "failed to create endpoint %s", obj.Metadata.Name)
+	}
+
+	return status, nil
+}
+
+func (c *EndpointController) cleanupEndpoint(obj *v1.Endpoint) error {
+	return nil
+}
+
+func (c *EndpointController) checkEndpointHealth(obj *v1.Endpoint) (*v1.EndpointStatus, error) {
+	o, err := c.getOrchestrator(obj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get orchestrator for endpoint %s", obj.Metadata.Name)
+	}
+
+	status, err := o.GetEndpointStatus(obj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get endpoint %s status", obj.Metadata.Name)
+	}
+
+	return status, err
+}
+
+func (c *EndpointController) updateStatus(obj *v1.Endpoint, status *v1.EndpointStatus) error {
+	status.LastTransitionTime = time.Now().Format(time.RFC3339Nano)
+
+	return c.storage.UpdateEndpoint(strconv.Itoa(obj.ID), &v1.Endpoint{Status: status})
+}
+
+func (c *EndpointController) formatStatus(phase v1.EndpointPhase, err error) *v1.EndpointStatus {
 	newStatus := &v1.EndpointStatus{
 		LastTransitionTime: time.Now().Format(time.RFC3339Nano),
 		Phase:              phase,
@@ -130,5 +222,38 @@ func (c *EndpointController) updateStatus(obj *v1.Endpoint, phase v1.EndpointPha
 		newStatus.ErrorMessage = ""
 	}
 
-	return c.storage.UpdateEndpoint(strconv.Itoa(obj.ID), &v1.Endpoint{Status: newStatus})
+	return newStatus
+}
+
+func (c *EndpointController) getOrchestrator(obj *v1.Endpoint) (orchestrator.Orchestrator, error) {
+	cluster, err := c.storage.ListCluster(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->name",
+				Operator: "eq",
+				Value:    obj.Spec.Cluster,
+			},
+			{
+				Column:   "metadata->workspace",
+				Operator: "eq",
+				Value:    obj.Metadata.Workspace,
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get cluster %s", obj.Spec.Cluster)
+	}
+	if len(cluster) == 0 {
+		return nil, errors.New("cluster not found")
+	}
+
+	orchestrator, err := orchestrator.NewOrchestrator(orchestrator.Options{
+		Cluster:      &cluster[0],
+		Storage:      c.storage,
+		ImageService: c.imageService,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create orchestrator for cluster %s", cluster[0].Metadata.Name)
+	}
+	return orchestrator, nil
 }

--- a/controllers/endpoint_controller.go
+++ b/controllers/endpoint_controller.go
@@ -1,0 +1,134 @@
+package controllers
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+type EndpointController struct {
+	baseController *BaseController
+
+	storage     storage.Storage
+	syncHandler func(endpoint *v1.Endpoint) error // Added syncHandler field
+}
+
+type EndpointControllerOption struct {
+	Storage storage.Storage
+	Workers int
+}
+
+func NewEndpointController(option *EndpointControllerOption) (*EndpointController, error) {
+	c := &EndpointController{
+		baseController: &BaseController{
+			queue:        workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{Name: "endpoint"}),
+			workers:      option.Workers,
+			syncInterval: time.Second * 10,
+		},
+		storage: option.Storage,
+	}
+
+	c.syncHandler = c.sync
+
+	return c, nil
+}
+
+func (c *EndpointController) Start(ctx context.Context) {
+	klog.Infof("Starting endpoint controller")
+
+	c.baseController.Start(ctx, c, c)
+}
+
+func (c *EndpointController) Reconcile(key interface{}) error {
+	_endpointID, ok := key.(int)
+	if !ok {
+		return errors.New("failed to assert key to endpointID")
+	}
+
+	endpointID := strconv.Itoa(_endpointID)
+
+	obj, err := c.storage.GetEndpoint(endpointID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get endpoint %s", endpointID)
+	}
+
+	klog.V(4).Info("Reconcile endpoint " + obj.Metadata.Name)
+
+	return c.syncHandler(obj)
+}
+
+func (c *EndpointController) ListKeys() ([]interface{}, error) {
+	endpoints, err := c.storage.ListEndpoint(storage.ListOption{})
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]interface{}, len(endpoints))
+	for i := range endpoints {
+		keys[i] = endpoints[i].ID
+	}
+
+	return keys, nil
+}
+
+func (c *EndpointController) sync(obj *v1.Endpoint) error {
+	var err error
+
+	if obj.Metadata != nil && obj.Metadata.DeletionTimestamp != "" {
+		if obj.Status != nil && obj.Status.Phase == v1.EndpointPhaseDELETED {
+			klog.Infof("Endpoint %s already marked as deleted, removing from DB", obj.Metadata.Name)
+
+			err = c.storage.DeleteEndpoint(strconv.Itoa(obj.ID))
+			if err != nil {
+				return errors.Wrapf(err, "failed to delete endpoint in DB %s", obj.Metadata.Name)
+			}
+
+			return nil
+		}
+
+		klog.Info("Deleting endpoint " + obj.Metadata.Name)
+		// Update status to DELETED
+		err = c.updateStatus(obj, v1.EndpointPhaseDELETED, nil)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update endpoint %s status to DELETED", obj.Metadata.Name)
+		}
+
+		return nil
+	}
+
+	// Handle creation/update (when not deleting)
+	// If status is missing or PENDING, update it to RUNNING.
+	if obj.Status == nil || obj.Status.Phase == "" || obj.Status.Phase == v1.EndpointPhasePENDING {
+		klog.Infof("Endpoint %s is PENDING or has no status, updating to RUNNING", obj.Metadata.Name)
+		err = c.updateStatus(obj, v1.EndpointPhaseRUNNING, nil)
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to update endpoint %s status to RUNNING", obj.Metadata.Name)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func (c *EndpointController) updateStatus(obj *v1.Endpoint, phase v1.EndpointPhase, err error) error {
+	newStatus := &v1.EndpointStatus{
+		LastTransitionTime: time.Now().Format(time.RFC3339Nano),
+		Phase:              phase,
+	}
+	if err != nil {
+		newStatus.ErrorMessage = err.Error()
+	} else {
+		newStatus.ErrorMessage = ""
+	}
+
+	return c.storage.UpdateEndpoint(strconv.Itoa(obj.ID), &v1.Endpoint{Status: newStatus})
+}

--- a/controllers/endpoint_controller.go
+++ b/controllers/endpoint_controller.go
@@ -191,6 +191,16 @@ func (c *EndpointController) createEndpoint(obj *v1.Endpoint) (*v1.EndpointStatu
 }
 
 func (c *EndpointController) cleanupEndpoint(obj *v1.Endpoint) error {
+	o, err := c.getOrchestrator(obj)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get orchestrator for endpoint %s", obj.Metadata.Name)
+	}
+
+	err = o.DeleteEndpoint(obj)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete endpoint %s", obj.Metadata.Name)
+	}
+
 	return nil
 }
 
@@ -234,12 +244,12 @@ func (c *EndpointController) getOrchestrator(obj *v1.Endpoint) (orchestrator.Orc
 			{
 				Column:   "metadata->name",
 				Operator: "eq",
-				Value:    obj.Spec.Cluster,
+				Value:    strconv.Quote(obj.Spec.Cluster),
 			},
 			{
 				Column:   "metadata->workspace",
 				Operator: "eq",
-				Value:    obj.Metadata.Workspace,
+				Value:    strconv.Quote(obj.Metadata.Workspace),
 			},
 		},
 	})

--- a/controllers/endpoint_controller.go
+++ b/controllers/endpoint_controller.go
@@ -98,6 +98,7 @@ func (c *EndpointController) sync(obj *v1.Endpoint) error {
 		}
 
 		klog.Info("Deleting endpoint " + obj.Metadata.Name)
+
 		err = c.cleanupEndpoint(obj)
 		if err != nil {
 			return errors.Wrapf(err, "failed to cleanup endpoint %s", obj.Metadata.Name)
@@ -116,6 +117,7 @@ func (c *EndpointController) sync(obj *v1.Endpoint) error {
 	// If status is missing or PENDING, update it to RUNNING.
 	if obj.Status == nil || obj.Status.Phase == "" || obj.Status.Phase == v1.EndpointPhasePENDING {
 		klog.Infof("Endpoint %s is PENDING or has no status, creating", obj.Metadata.Name)
+
 		status, err := c.createEndpoint(obj)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create endpoint %s", obj.Metadata.Name)
@@ -153,6 +155,7 @@ func (c *EndpointController) sync(obj *v1.Endpoint) error {
 
 	if obj.Status.Phase == v1.EndpointPhaseRUNNING {
 		klog.Infof("Endpoint %s is RUNNING, checking health", obj.Metadata.Name)
+
 		status, err := c.checkEndpointHealth(obj)
 		if err != nil {
 			return errors.Wrapf(err, "failed to check endpoint %s health", obj.Metadata.Name)
@@ -243,6 +246,7 @@ func (c *EndpointController) getOrchestrator(obj *v1.Endpoint) (orchestrator.Orc
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get cluster %s", obj.Spec.Cluster)
 	}
+
 	if len(cluster) == 0 {
 		return nil, errors.New("cluster not found")
 	}
@@ -255,5 +259,6 @@ func (c *EndpointController) getOrchestrator(obj *v1.Endpoint) (orchestrator.Orc
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create orchestrator for cluster %s", cluster[0].Metadata.Name)
 	}
+
 	return orchestrator, nil
 }

--- a/controllers/endpoint_controller_test.go
+++ b/controllers/endpoint_controller_test.go
@@ -1,0 +1,378 @@
+package controllers
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/client-go/util/workqueue"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+// newTestEndpointController is a helper to create a EndpointController with mocked storage for testing.
+func newTestEndpointController(storage *storagemocks.MockStorage) *EndpointController {
+	c, _ := NewEndpointController(&EndpointControllerOption{
+		Storage: storage,
+		Workers: 1,
+	})
+	// Use a predictable queue for testing.
+	c.baseController.queue = workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{Name: "endpoint-test"})
+	return c
+}
+
+// testEndpoint is a helper to create a basic Endpoint object for tests.
+func testEndpoint(id int, phase v1.EndpointPhase) *v1.Endpoint {
+	endpoint := &v1.Endpoint{
+		ID: id,
+		Metadata: &v1.Metadata{
+			Name: "test-endpoint-" + strconv.Itoa(id),
+		},
+		Spec: &v1.EndpointSpec{},
+	}
+	if phase != "" { // Only set status if phase is provided.
+		endpoint.Status = &v1.EndpointStatus{Phase: phase}
+	}
+	return endpoint
+}
+
+// testEndpointWithDeletionTimestamp is a helper to create a Endpoint object marked for deletion.
+func testEndpointWithDeletionTimestamp(id int, phase v1.EndpointPhase) *v1.Endpoint {
+	endpoint := testEndpoint(id, phase)
+	endpoint.Metadata.DeletionTimestamp = time.Now().Format(time.RFC3339Nano)
+	return endpoint
+}
+
+// --- Tests for the 'sync' method ---
+
+func TestEndpointController_Sync_Deletion(t *testing.T) {
+	endpointID := 1
+	endpointIDStr := strconv.Itoa(endpointID)
+
+	tests := []struct {
+		name      string
+		input     *v1.Endpoint
+		mockSetup func(*storagemocks.MockStorage)
+		wantErr   bool
+	}{
+		{
+			name:  "Deleting (Phase=DELETED) -> Deleted (DB delete success)",
+			input: testEndpointWithDeletionTimestamp(endpointID, v1.EndpointPhaseDELETED),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("DeleteEndpoint", endpointIDStr).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:  "Deleting (Phase=DELETED) -> Error (DB delete failed)",
+			input: testEndpointWithDeletionTimestamp(endpointID, v1.EndpointPhaseDELETED),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("DeleteEndpoint", endpointIDStr).Return(assert.AnError).Once()
+			},
+			wantErr: true,
+		},
+		{
+			name:  "Deleting (Phase=RUNNING) -> Set Phase=DELETED (Update success)",
+			input: testEndpointWithDeletionTimestamp(endpointID, v1.EndpointPhaseRUNNING),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("UpdateEndpoint", endpointIDStr, mock.MatchedBy(func(r *v1.Endpoint) bool {
+					return r.Status != nil && r.Status.Phase == v1.EndpointPhaseDELETED && r.Status.ErrorMessage == ""
+				})).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:  "Deleting (Phase=PENDING) -> Set Phase=DELETED (Update failed)",
+			input: testEndpointWithDeletionTimestamp(endpointID, v1.EndpointPhasePENDING),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("UpdateEndpoint", endpointIDStr, mock.MatchedBy(func(r *v1.Endpoint) bool {
+					return r.Status != nil && r.Status.Phase == v1.EndpointPhaseDELETED
+				})).Return(assert.AnError).Once()
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := &storagemocks.MockStorage{}
+			tt.mockSetup(mockStorage)
+			c := newTestEndpointController(mockStorage)
+
+			err := c.sync(tt.input) // Test sync directly.
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			mockStorage.AssertExpectations(t)
+		})
+	}
+}
+
+func TestEndpointController_Sync_CreateOrUpdate(t *testing.T) {
+	endpointID := 1
+	endpointIDStr := strconv.Itoa(endpointID)
+
+	tests := []struct {
+		name      string
+		input     *v1.Endpoint
+		mockSetup func(*storagemocks.MockStorage)
+		wantErr   bool
+	}{
+		{
+			name:  "No Status -> Set Phase=RUNNING (Update success)",
+			input: testEndpoint(endpointID, ""),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("UpdateEndpoint", endpointIDStr, mock.MatchedBy(func(r *v1.Endpoint) bool {
+					return r.Status != nil && r.Status.Phase == v1.EndpointPhaseRUNNING && r.Status.ErrorMessage == ""
+				})).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:  "Phase=PENDING -> Set Phase=RUNNING (Update success)",
+			input: testEndpoint(endpointID, v1.EndpointPhasePENDING),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("UpdateEndpoint", endpointIDStr, mock.MatchedBy(func(r *v1.Endpoint) bool {
+					return r.Status != nil && r.Status.Phase == v1.EndpointPhaseRUNNING && r.Status.ErrorMessage == ""
+				})).Return(nil).Once()
+			},
+			wantErr: false,
+		},
+		{
+			name:  "Phase=PENDING -> Set Phase=RUNNING (Update failed)",
+			input: testEndpoint(endpointID, v1.EndpointPhasePENDING),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("UpdateEndpoint", endpointIDStr, mock.MatchedBy(func(r *v1.Endpoint) bool {
+					return r.Status != nil && r.Status.Phase == v1.EndpointPhaseRUNNING
+				})).Return(assert.AnError).Once()
+			},
+			wantErr: true,
+		},
+		{
+			name:  "Phase=RUNNING -> No Change",
+			input: testEndpoint(endpointID, v1.EndpointPhaseRUNNING),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				// Expect no calls to UpdateEndpoint or DeleteEndpoint.
+			},
+			wantErr: false,
+		},
+		{
+			name:  "Phase=DELETED (no deletionTimestamp) -> No Change",
+			input: testEndpoint(endpointID, v1.EndpointPhaseDELETED),
+			mockSetup: func(s *storagemocks.MockStorage) {
+				// Expect no calls to UpdateEndpoint or DeleteEndpoint.
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := &storagemocks.MockStorage{}
+			tt.mockSetup(mockStorage)
+			c := newTestEndpointController(mockStorage)
+
+			err := c.sync(tt.input) // Test sync directly.
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			mockStorage.AssertExpectations(t)
+		})
+	}
+}
+
+// --- Test for ListKeys ---
+
+func TestEndpointController_ListKeys(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockSetup func(*storagemocks.MockStorage)
+		wantKeys  []interface{}
+		wantErr   bool
+	}{
+		{
+			name: "List success",
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListEndpoint", storage.ListOption{}).Return([]v1.Endpoint{
+					{ID: 1}, {ID: 5}, {ID: 10},
+				}, nil).Once()
+			},
+			wantKeys: []interface{}{1, 5, 10},
+			wantErr:  false,
+		},
+		{
+			name: "List returns empty",
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListEndpoint", storage.ListOption{}).Return([]v1.Endpoint{}, nil).Once()
+			},
+			wantKeys: []interface{}{},
+			wantErr:  false,
+		},
+		{
+			name: "List returns error",
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListEndpoint", storage.ListOption{}).Return(nil, assert.AnError).Once()
+			},
+			wantKeys: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := &storagemocks.MockStorage{}
+			tt.mockSetup(mockStorage)
+			c := newTestEndpointController(mockStorage)
+
+			keys, err := c.ListKeys()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, keys)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantKeys, keys)
+			}
+			mockStorage.AssertExpectations(t)
+		})
+	}
+}
+
+// --- Test for Reconcile ---
+
+func TestEndpointController_Reconcile(t *testing.T) {
+	endpointID := 1
+	endpointIDStr := strconv.Itoa(endpointID)
+
+	// mockSyncHandler provides a controllable sync function for Reconcile tests.
+	mockSyncHandler := func(obj *v1.Endpoint) error {
+		// Check for a condition to simulate failure.
+		if obj != nil && obj.Metadata != nil && obj.Metadata.Name == "sync-should-fail" {
+			return errors.New("mock sync failed")
+		}
+		// Simulate successful sync.
+		return nil
+	}
+
+	tests := []struct {
+		name          string
+		inputKey      interface{}
+		mockSetup     func(*storagemocks.MockStorage)
+		useMockSync   bool  // Flag to indicate if the mock syncHandler should be used.
+		expectedError error // Expected contained error string for specific checks.
+		wantErr       bool
+	}{
+		{
+			name:     "Reconcile success (real sync, no status change)", // Test scenario using default sync handler.
+			inputKey: endpointID,
+			mockSetup: func(s *storagemocks.MockStorage) {
+				// GetEndpoint succeeds, endpoint is already in the desired state.
+				s.On("GetEndpoint", endpointIDStr).Return(testEndpoint(endpointID, v1.EndpointPhaseRUNNING), nil).Once()
+				// The real 'sync' method expects no further storage calls here.
+			},
+			useMockSync: false, // Use the default c.sync via syncHandler.
+			wantErr:     false,
+		},
+		{
+			name:     "Reconcile success (real sync, status updated)", // Test scenario using default sync handler.
+			inputKey: endpointID,
+			mockSetup: func(s *storagemocks.MockStorage) {
+				// GetEndpoint succeeds, endpoint needs status update.
+				s.On("GetEndpoint", endpointIDStr).Return(testEndpoint(endpointID, v1.EndpointPhasePENDING), nil).Once()
+				// The real 'sync' method expects UpdateEndpoint to be called.
+				s.On("UpdateEndpoint", endpointIDStr, mock.MatchedBy(func(r *v1.Endpoint) bool {
+					return r.Status != nil && r.Status.Phase == v1.EndpointPhaseRUNNING
+				})).Return(nil).Once()
+			},
+			useMockSync: false, // Use the default c.sync via syncHandler.
+			wantErr:     false,
+		},
+		{
+			name:     "Reconcile success (mock sync)", // Test Reconcile isolation using mock handler.
+			inputKey: endpointID,
+			mockSetup: func(s *storagemocks.MockStorage) {
+				// GetEndpoint succeeds.
+				s.On("GetEndpoint", endpointIDStr).Return(testEndpoint(endpointID, v1.EndpointPhaseRUNNING), nil).Once()
+				// No further storage calls expected by Reconcile before calling syncHandler.
+			},
+			useMockSync: true, // Override with mockSyncHandler.
+			wantErr:     false,
+		},
+		{
+			name:     "Invalid key type",
+			inputKey: "not-an-int",
+			mockSetup: func(s *storagemocks.MockStorage) {
+				// No storage calls expected.
+			},
+			useMockSync:   false, // Fails before sync handler.
+			wantErr:       true,
+			expectedError: errors.New("failed to assert key to endpointID"),
+		},
+		{
+			name:     "GetEndpoint returns error",
+			inputKey: endpointID,
+			mockSetup: func(s *storagemocks.MockStorage) {
+				// Mock GetEndpoint to return an error.
+				s.On("GetEndpoint", endpointIDStr).Return(nil, assert.AnError).Once()
+			},
+			useMockSync: false, // Fails before sync handler.
+			wantErr:     true,  // Expect error from GetEndpoint to be propagated.
+		},
+		{
+			name:     "Sync handler returns error (mock sync)",
+			inputKey: endpointID,
+			mockSetup: func(s *storagemocks.MockStorage) {
+				// GetEndpoint succeeds, providing the endpoint that triggers mock failure.
+				endpoint := testEndpoint(endpointID, v1.EndpointPhaseRUNNING)
+				endpoint.Metadata.Name = "sync-should-fail" // Condition for mockSyncHandler failure.
+				s.On("GetEndpoint", endpointIDStr).Return(endpoint, nil).Once()
+			},
+			useMockSync: true, // Use the mock handler.
+			wantErr:     true, // Expect error from mock sync handler to be propagated.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := &storagemocks.MockStorage{}
+			if tt.mockSetup != nil {
+				tt.mockSetup(mockStorage)
+			}
+
+			// Create controller using the helper.
+			c := newTestEndpointController(mockStorage)
+
+			// Override syncHandler if the test case requires the mock.
+			if tt.useMockSync {
+				c.syncHandler = mockSyncHandler
+			}
+
+			// Directly call the Reconcile method.
+			err := c.Reconcile(tt.inputKey)
+
+			// Assertions.
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedError != nil {
+					// Use Contains for checking wrapped errors.
+					assert.Contains(t, err.Error(), tt.expectedError.Error())
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			// Verify mock expectations.
+			mockStorage.AssertExpectations(t)
+		})
+	}
+}

--- a/controllers/engine_controller.go
+++ b/controllers/engine_controller.go
@@ -121,11 +121,8 @@ func (c *EngineController) sync(obj *v1.Engine) error {
 
 func (c *EngineController) updateStatus(obj *v1.Engine, phase v1.EnginePhase, err error) error {
 	newStatus := &v1.EngineStatus{
-		LastTransitionTime: func() *time.Time {
-			now := time.Now()
-			return &now
-		}(),
-		Phase: phase,
+		LastTransitionTime: time.Now().Format(time.RFC3339Nano),
+		Phase:              phase,
 	}
 	if err != nil {
 		newStatus.ErrorMessage = err.Error()

--- a/db/migrations/003_resources.up.sql
+++ b/db/migrations/003_resources.up.sql
@@ -21,10 +21,16 @@ CREATE TYPE api.resource_spec AS (
     memory FLOAT
 );
 
+CREATE TYPE api.replica_spec AS (
+    num INTEGER
+);
+
 CREATE TYPE api.endpoint_spec AS (
     cluster TEXT,
     model api.model_spec,
     engine api.endpoint_engine_spec,
+    resources api.resource_spec,
+    replicas api.replica_spec,
     deployment_options json,
     variables json
 );

--- a/db/migrations/003_resources.up.sql
+++ b/db/migrations/003_resources.up.sql
@@ -25,8 +25,6 @@ CREATE TYPE api.endpoint_spec AS (
     cluster TEXT,
     model api.model_spec,
     engine api.endpoint_engine_spec,
-    resources api.resource_spec,
-    replicas INTEGER,
     deployment_options json,
     variables json
 );

--- a/internal/orchestrator/mocks/mock_orchestrator.go
+++ b/internal/orchestrator/mocks/mock_orchestrator.go
@@ -133,6 +133,64 @@ func (_c *MockOrchestrator_CreateCluster_Call) RunAndReturn(run func() (string, 
 	return _c
 }
 
+// CreateEndpoint provides a mock function with given fields: endpoint
+func (_m *MockOrchestrator) CreateEndpoint(endpoint *v1.Endpoint) (*v1.EndpointStatus, error) {
+	ret := _m.Called(endpoint)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateEndpoint")
+	}
+
+	var r0 *v1.EndpointStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*v1.Endpoint) (*v1.EndpointStatus, error)); ok {
+		return rf(endpoint)
+	}
+	if rf, ok := ret.Get(0).(func(*v1.Endpoint) *v1.EndpointStatus); ok {
+		r0 = rf(endpoint)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.EndpointStatus)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*v1.Endpoint) error); ok {
+		r1 = rf(endpoint)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockOrchestrator_CreateEndpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateEndpoint'
+type MockOrchestrator_CreateEndpoint_Call struct {
+	*mock.Call
+}
+
+// CreateEndpoint is a helper method to define mock.On call
+//   - endpoint *v1.Endpoint
+func (_e *MockOrchestrator_Expecter) CreateEndpoint(endpoint interface{}) *MockOrchestrator_CreateEndpoint_Call {
+	return &MockOrchestrator_CreateEndpoint_Call{Call: _e.mock.On("CreateEndpoint", endpoint)}
+}
+
+func (_c *MockOrchestrator_CreateEndpoint_Call) Run(run func(endpoint *v1.Endpoint)) *MockOrchestrator_CreateEndpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*v1.Endpoint))
+	})
+	return _c
+}
+
+func (_c *MockOrchestrator_CreateEndpoint_Call) Return(_a0 *v1.EndpointStatus, _a1 error) *MockOrchestrator_CreateEndpoint_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockOrchestrator_CreateEndpoint_Call) RunAndReturn(run func(*v1.Endpoint) (*v1.EndpointStatus, error)) *MockOrchestrator_CreateEndpoint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteCluster provides a mock function with no fields
 func (_m *MockOrchestrator) DeleteCluster() error {
 	ret := _m.Called()
@@ -174,6 +232,52 @@ func (_c *MockOrchestrator_DeleteCluster_Call) Return(_a0 error) *MockOrchestrat
 }
 
 func (_c *MockOrchestrator_DeleteCluster_Call) RunAndReturn(run func() error) *MockOrchestrator_DeleteCluster_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteEndpoint provides a mock function with given fields: endpoint
+func (_m *MockOrchestrator) DeleteEndpoint(endpoint *v1.Endpoint) error {
+	ret := _m.Called(endpoint)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteEndpoint")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.Endpoint) error); ok {
+		r0 = rf(endpoint)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockOrchestrator_DeleteEndpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteEndpoint'
+type MockOrchestrator_DeleteEndpoint_Call struct {
+	*mock.Call
+}
+
+// DeleteEndpoint is a helper method to define mock.On call
+//   - endpoint *v1.Endpoint
+func (_e *MockOrchestrator_Expecter) DeleteEndpoint(endpoint interface{}) *MockOrchestrator_DeleteEndpoint_Call {
+	return &MockOrchestrator_DeleteEndpoint_Call{Call: _e.mock.On("DeleteEndpoint", endpoint)}
+}
+
+func (_c *MockOrchestrator_DeleteEndpoint_Call) Run(run func(endpoint *v1.Endpoint)) *MockOrchestrator_DeleteEndpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*v1.Endpoint))
+	})
+	return _c
+}
+
+func (_c *MockOrchestrator_DeleteEndpoint_Call) Return(_a0 error) *MockOrchestrator_DeleteEndpoint_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockOrchestrator_DeleteEndpoint_Call) RunAndReturn(run func(*v1.Endpoint) error) *MockOrchestrator_DeleteEndpoint_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -221,6 +325,64 @@ func (_c *MockOrchestrator_GetDesireStaticWorkersIP_Call) Return(_a0 []string) *
 }
 
 func (_c *MockOrchestrator_GetDesireStaticWorkersIP_Call) RunAndReturn(run func() []string) *MockOrchestrator_GetDesireStaticWorkersIP_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetEndpointStatus provides a mock function with given fields: endpoint
+func (_m *MockOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.EndpointStatus, error) {
+	ret := _m.Called(endpoint)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEndpointStatus")
+	}
+
+	var r0 *v1.EndpointStatus
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*v1.Endpoint) (*v1.EndpointStatus, error)); ok {
+		return rf(endpoint)
+	}
+	if rf, ok := ret.Get(0).(func(*v1.Endpoint) *v1.EndpointStatus); ok {
+		r0 = rf(endpoint)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.EndpointStatus)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*v1.Endpoint) error); ok {
+		r1 = rf(endpoint)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockOrchestrator_GetEndpointStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEndpointStatus'
+type MockOrchestrator_GetEndpointStatus_Call struct {
+	*mock.Call
+}
+
+// GetEndpointStatus is a helper method to define mock.On call
+//   - endpoint *v1.Endpoint
+func (_e *MockOrchestrator_Expecter) GetEndpointStatus(endpoint interface{}) *MockOrchestrator_GetEndpointStatus_Call {
+	return &MockOrchestrator_GetEndpointStatus_Call{Call: _e.mock.On("GetEndpointStatus", endpoint)}
+}
+
+func (_c *MockOrchestrator_GetEndpointStatus_Call) Run(run func(endpoint *v1.Endpoint)) *MockOrchestrator_GetEndpointStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*v1.Endpoint))
+	})
+	return _c
+}
+
+func (_c *MockOrchestrator_GetEndpointStatus_Call) Return(_a0 *v1.EndpointStatus, _a1 error) *MockOrchestrator_GetEndpointStatus_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockOrchestrator_GetEndpointStatus_Call) RunAndReturn(run func(*v1.Endpoint) (*v1.EndpointStatus, error)) *MockOrchestrator_GetEndpointStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3,10 +3,11 @@ package orchestrator
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/pkg/storage"
-	"github.com/pkg/errors"
 )
 
 // Orchestrator defines the core interface for cluster orchestration

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5,6 +5,7 @@ import (
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/registry"
+	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 // Orchestrator defines the core interface for cluster orchestration
@@ -17,12 +18,17 @@ type Orchestrator interface {
 	HealthCheck() error
 	ClusterStatus() (*v1.RayClusterStatus, error)
 	ListNodes() ([]v1.NodeSummary, error)
+
+	CreateEndpoint(endpoint *v1.Endpoint) (*v1.EndpointStatus, error)
+	DeleteEndpoint(endpoint *v1.Endpoint) error
+	GetEndpointStatus(endpoint *v1.Endpoint) (*v1.EndpointStatus, error)
 }
 
 type Options struct {
 	Cluster       *v1.Cluster
 	ImageRegistry *v1.ImageRegistry
 	ImageService  registry.ImageService
+	Storage       storage.Storage
 }
 
 type NewOrchestratorFunc func(opts Options) (Orchestrator, error)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,0 +1,86 @@
+package orchestrator
+
+import (
+	"testing"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestOrchestrator_getRelateImageRegistry(t *testing.T) {
+	testImageRegistry := v1.ImageRegistry{
+		ID: 1,
+		Metadata: &v1.Metadata{
+			Name: "test",
+		},
+		Spec: &v1.ImageRegistrySpec{
+			AuthConfig: v1.ImageRegistryAuthConfig{
+				Username: "test",
+				Password: "test",
+			},
+			URL:        "test",
+			Repository: "neutree",
+		},
+	}
+
+	testCluster := &v1.Cluster{
+		ID: 1,
+		Metadata: &v1.Metadata{
+			Name: "test",
+		},
+		Spec: &v1.ClusterSpec{
+			ImageRegistry: "test",
+			Version:       "test",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		input     *v1.Cluster
+		mockSetup func(*storagemocks.MockStorage)
+		wantErr   bool
+	}{
+		{
+			name:  "get relate image registry error",
+			input: testCluster,
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListImageRegistry", mock.Anything).Return(nil, assert.AnError)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "get relate image registry not found",
+			input: testCluster,
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListImageRegistry", mock.Anything).Return(nil, nil)
+			},
+			wantErr: true,
+		},
+		{
+			name:  "get relate image registry success",
+			input: testCluster,
+			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{testImageRegistry}, nil)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := new(storagemocks.MockStorage)
+			tt.mockSetup(storage)
+			v, err := getRelateImageRegistry(storage, tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, testImageRegistry.ID, v.ID)
+			}
+
+			storage.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/orchestrator/ray/command_runner/docker_command_runner.go
+++ b/internal/orchestrator/ray/command_runner/docker_command_runner.go
@@ -265,7 +265,7 @@ func (d *DockerCommandRunner) configureRuntime(ctx context.Context, runOptions [
 	if strings.Contains(runtimeOutput, "nvidia-container-runtime") {
 		_, err := d.sshCommandRunner.Run(ctx, "nvidia-smi", false, nil, false, nil, "host", "", false)
 		if err == nil {
-			return append(runOptions, "--runtime=nvidia"), nil
+			return append(runOptions, " --runtime=nvidia --gpus all "), nil
 		}
 
 		klog.Info("Nvidia Container Runtime is present, but no GPUs found.")

--- a/internal/orchestrator/ray/dashboard/client.go
+++ b/internal/orchestrator/ray/dashboard/client.go
@@ -43,11 +43,13 @@ func new(dashboardURL string) DashboardService {
 
 func (c *Client) doRequest(method, path string, body, result interface{}) error {
 	var reqBody io.Reader
+
 	if body != nil {
 		jsonData, err := json.Marshal(body)
 		if err != nil {
 			return err
 		}
+
 		reqBody = bytes.NewBuffer(jsonData)
 	}
 

--- a/internal/orchestrator/ray/dashboard/client.go
+++ b/internal/orchestrator/ray/dashboard/client.go
@@ -1,8 +1,10 @@
 package dashboard
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -13,6 +15,10 @@ type DashboardService interface {
 	GetClusterMetadata() (*ClusterMetadataResponse, error)
 	ListNodes() ([]v1.NodeSummary, error)
 	GetClusterAutoScaleStatus() (v1.AutoscalerReport, error)
+
+	// Serve related methods
+	GetServeApplications() (*RayServeApplicationsResponse, error)
+	UpdateServeApplications(appsReq RayServeApplicationsRequest) error
 }
 
 type Client struct {
@@ -35,10 +41,23 @@ func new(dashboardURL string) DashboardService {
 	}
 }
 
-func (c *Client) doRequest(method, path string, result interface{}) error {
-	req, err := http.NewRequest(method, c.dashboardURL+path, nil)
+func (c *Client) doRequest(method, path string, body, result interface{}) error {
+	var reqBody io.Reader
+	if body != nil {
+		jsonData, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reqBody = bytes.NewBuffer(jsonData)
+	}
+
+	req, err := http.NewRequest(method, c.dashboardURL+path, reqBody)
 	if err != nil {
 		return err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	resp, err := c.client.Do(req)
@@ -51,7 +70,11 @@ func (c *Client) doRequest(method, path string, result interface{}) error {
 		return fmt.Errorf("API request failed: %s", resp.Status)
 	}
 
-	return json.NewDecoder(resp.Body).Decode(result)
+	if result != nil {
+		return json.NewDecoder(resp.Body).Decode(result)
+	}
+
+	return nil
 }
 
 type ClusterMetadataResponse struct {
@@ -62,7 +85,7 @@ type ClusterMetadataResponse struct {
 
 func (c *Client) GetClusterMetadata() (*ClusterMetadataResponse, error) {
 	var result ClusterMetadataResponse
-	err := c.doRequest("GET", "/api/v0/cluster_metadata", &result)
+	err := c.doRequest("GET", "/api/v0/cluster_metadata", nil, &result)
 
 	return &result, err
 }
@@ -77,7 +100,7 @@ type NodeListData struct {
 
 func (c *Client) ListNodes() ([]v1.NodeSummary, error) {
 	var result NodeListResponse
-	err := c.doRequest("GET", "/nodes?view=summary", &result)
+	err := c.doRequest("GET", "/nodes?view=summary", nil, &result)
 
 	return result.Data.Summary, err
 }
@@ -95,7 +118,7 @@ type ClusterStatusData struct {
 
 func (c *Client) GetClusterAutoScaleStatus() (v1.AutoscalerReport, error) {
 	var result ClusterStatusResponse
-	err := c.doRequest("GET", "/api/cluster_status?format=0", &result)
+	err := c.doRequest("GET", "/api/cluster_status?format=0", nil, &result)
 
 	return result.Data.ClusterStatus.AutoscalerReport, err
 }

--- a/internal/orchestrator/ray/dashboard/mocks/mock_dashboard_service.go
+++ b/internal/orchestrator/ray/dashboard/mocks/mock_dashboard_service.go
@@ -134,6 +134,63 @@ func (_c *MockDashboardService_GetClusterMetadata_Call) RunAndReturn(run func() 
 	return _c
 }
 
+// GetServeApplications provides a mock function with no fields
+func (_m *MockDashboardService) GetServeApplications() (*dashboard.RayServeApplicationsResponse, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetServeApplications")
+	}
+
+	var r0 *dashboard.RayServeApplicationsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (*dashboard.RayServeApplicationsResponse, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() *dashboard.RayServeApplicationsResponse); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dashboard.RayServeApplicationsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDashboardService_GetServeApplications_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetServeApplications'
+type MockDashboardService_GetServeApplications_Call struct {
+	*mock.Call
+}
+
+// GetServeApplications is a helper method to define mock.On call
+func (_e *MockDashboardService_Expecter) GetServeApplications() *MockDashboardService_GetServeApplications_Call {
+	return &MockDashboardService_GetServeApplications_Call{Call: _e.mock.On("GetServeApplications")}
+}
+
+func (_c *MockDashboardService_GetServeApplications_Call) Run(run func()) *MockDashboardService_GetServeApplications_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockDashboardService_GetServeApplications_Call) Return(_a0 *dashboard.RayServeApplicationsResponse, _a1 error) *MockDashboardService_GetServeApplications_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDashboardService_GetServeApplications_Call) RunAndReturn(run func() (*dashboard.RayServeApplicationsResponse, error)) *MockDashboardService_GetServeApplications_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListNodes provides a mock function with no fields
 func (_m *MockDashboardService) ListNodes() ([]v1.NodeSummary, error) {
 	ret := _m.Called()
@@ -187,6 +244,52 @@ func (_c *MockDashboardService_ListNodes_Call) Return(_a0 []v1.NodeSummary, _a1 
 }
 
 func (_c *MockDashboardService_ListNodes_Call) RunAndReturn(run func() ([]v1.NodeSummary, error)) *MockDashboardService_ListNodes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateServeApplications provides a mock function with given fields: appsReq
+func (_m *MockDashboardService) UpdateServeApplications(appsReq dashboard.RayServeApplicationsRequest) error {
+	ret := _m.Called(appsReq)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateServeApplications")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(dashboard.RayServeApplicationsRequest) error); ok {
+		r0 = rf(appsReq)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockDashboardService_UpdateServeApplications_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateServeApplications'
+type MockDashboardService_UpdateServeApplications_Call struct {
+	*mock.Call
+}
+
+// UpdateServeApplications is a helper method to define mock.On call
+//   - appsReq dashboard.RayServeApplicationsRequest
+func (_e *MockDashboardService_Expecter) UpdateServeApplications(appsReq interface{}) *MockDashboardService_UpdateServeApplications_Call {
+	return &MockDashboardService_UpdateServeApplications_Call{Call: _e.mock.On("UpdateServeApplications", appsReq)}
+}
+
+func (_c *MockDashboardService_UpdateServeApplications_Call) Run(run func(appsReq dashboard.RayServeApplicationsRequest)) *MockDashboardService_UpdateServeApplications_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(dashboard.RayServeApplicationsRequest))
+	})
+	return _c
+}
+
+func (_c *MockDashboardService_UpdateServeApplications_Call) Return(_a0 error) *MockDashboardService_UpdateServeApplications_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockDashboardService_UpdateServeApplications_Call) RunAndReturn(run func(dashboard.RayServeApplicationsRequest) error) *MockDashboardService_UpdateServeApplications_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/orchestrator/ray/dashboard/serve.go
+++ b/internal/orchestrator/ray/dashboard/serve.go
@@ -48,18 +48,17 @@ func EndpointToApplication(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistr
 	}
 
 	endpoint.Spec.DeploymentOptions["backend"] = map[string]interface{}{
-		"backend": map[string]interface{}{
-			"num_replicas": endpoint.Spec.Replicas.Num,
-			"num_cpus":     endpoint.Spec.Resources.CPU,
-			"num_gpus":     endpoint.Spec.Resources.GPU,
-			"memory":       endpoint.Spec.Resources.Memory,
-			"resources":    accelerator,
-		},
-		"controller": map[string]interface{}{
-			"num_replicas": 1,
-			"num_cpus":     0.1,
-			"num_gpus":     0,
-		},
+		"num_replicas": endpoint.Spec.Replicas.Num,
+		"num_cpus":     endpoint.Spec.Resources.CPU,
+		"num_gpus":     endpoint.Spec.Resources.GPU,
+		"memory":       endpoint.Spec.Resources.Memory,
+		"resources":    accelerator,
+	}
+
+	endpoint.Spec.DeploymentOptions["controller"] = map[string]interface{}{
+		"num_replicas": 1,
+		"num_cpus":     0.1,
+		"num_gpus":     0,
 	}
 
 	args := map[string]interface{}{

--- a/internal/orchestrator/ray/dashboard/serve.go
+++ b/internal/orchestrator/ray/dashboard/serve.go
@@ -38,6 +38,27 @@ type RayServeApplicationsResponse struct {
 
 // endpointToApplication converts Neutree Endpoint and ModelRegistry to a RayServeApplication.
 func EndpointToApplication(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistry) RayServeApplication {
+	accelerator := map[string]float64{}
+	for key, value := range endpoint.Spec.Resources.Accelerator {
+		if key != "-" && value > 0 {
+			accelerator[key] = value
+		}
+	}
+
+	endpoint.Spec.DeploymentOptions["backend"] = map[string]interface{}{
+		"backend": map[string]interface{}{
+			"num_replicas": endpoint.Spec.Replicas.Num,
+			"num_cpus":     endpoint.Spec.Resources.CPU,
+			"num_gpus":     endpoint.Spec.Resources.GPU,
+			"memory":       endpoint.Spec.Resources.Memory,
+			"resources":    accelerator,
+		},
+		"controller": map[string]interface{}{
+			"num_replicas": 1,
+			"num_cpus":     0.1,
+			"num_gpus":     0,
+		},
+	}
 
 	args := map[string]interface{}{
 		"model": map[string]interface{}{

--- a/internal/orchestrator/ray/dashboard/serve.go
+++ b/internal/orchestrator/ray/dashboard/serve.go
@@ -1,0 +1,97 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"maps"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/pkg/errors"
+)
+
+// RayServeApplication represents the structure expected by the Ray Serve API.
+type RayServeApplication struct {
+	Name        string                 `json:"name"`
+	RoutePrefix string                 `json:"route_prefix"`
+	ImportPath  string                 `json:"import_path"`
+	Args        map[string]interface{} `json:"args"`
+}
+
+// RayServeApplicationsRequest represents the payload for updating applications.
+type RayServeApplicationsRequest struct {
+	Applications []RayServeApplication `json:"applications"`
+}
+
+// RayServeApplicationStatus represents the status part of the response from Ray Serve API.
+type RayServeApplicationStatus struct {
+	Status            string               `json:"status"`
+	Message           string               `json:"message"`
+	DeployedAppConfig *RayServeApplication `json:"deployed_app_config"` // Used when getting current apps
+}
+
+// RayServeApplicationsResponse represents the full response when getting applications.
+type RayServeApplicationsResponse struct {
+	Applications map[string]RayServeApplicationStatus `json:"applications"`
+}
+
+// endpointToApplication converts Neutree Endpoint and ModelRegistry to a RayServeApplication.
+func EndpointToApplication(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistry) RayServeApplication {
+
+	args := map[string]interface{}{
+		"model": map[string]interface{}{
+			"registry_type": modelRegistry.Spec.Type,
+			"name":          endpoint.Spec.Model.Name,
+			"file":          endpoint.Spec.Model.File,
+			"version":       endpoint.Spec.Model.Version,
+			"task":          endpoint.Spec.Model.Task,
+		},
+		"deployment_options": endpoint.Spec.DeploymentOptions,
+	}
+
+	maps.Copy(args, endpoint.Spec.Variables)
+
+	return RayServeApplication{
+		Name:        endpoint.Metadata.Name,
+		RoutePrefix: fmt.Sprintf("/%s", endpoint.Metadata.Name),
+		ImportPath:  fmt.Sprintf("serve.%s.%s.app:app_builder", endpoint.Spec.Engine.Engine, endpoint.Spec.Engine.Version),
+		Args:        args,
+	}
+}
+
+// GetServeApplications retrieves the current Ray Serve applications.
+func (c *Client) GetServeApplications() (*RayServeApplicationsResponse, error) {
+	var appsResp RayServeApplicationsResponse
+	err := c.doRequest(http.MethodGet, "/api/serve/applications/", nil, &appsResp)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to execute request to get serve applications")
+	}
+
+	return &appsResp, nil
+}
+
+// UpdateServeApplications updates the Ray Serve applications configuration.
+func (c *Client) UpdateServeApplications(appsReq RayServeApplicationsRequest) error {
+	err := c.doRequest(http.MethodPut, "/api/serve/applications/", &appsReq, nil)
+
+	if err != nil {
+		// Consider reading body for more error details
+		return errors.Wrapf(err, "failed to update serve applications")
+	}
+
+	return nil
+}
+
+// formatServiceURL constructs the service URL for an endpoint.
+func FormatServiceURL(cluster *v1.Cluster, endpoint *v1.Endpoint) (string, error) {
+	if cluster.Status == nil || cluster.Status.DashboardURL == "" {
+		return "", errors.New("cluster dashboard URL is not available")
+	}
+	dashboardURL, err := url.Parse(cluster.Status.DashboardURL)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse cluster dashboard URL")
+	}
+	// Ray serve applications are typically exposed on port 8000 by default
+	return fmt.Sprintf("%s://%s:8000/%s", dashboardURL.Scheme, dashboardURL.Hostname(), endpoint.Metadata.Name), nil
+}

--- a/internal/orchestrator/ray/dashboard/serve.go
+++ b/internal/orchestrator/ray/dashboard/serve.go
@@ -7,8 +7,9 @@ import (
 
 	"maps"
 
-	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/pkg/errors"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
 // RayServeApplication represents the structure expected by the Ray Serve API.
@@ -39,6 +40,7 @@ type RayServeApplicationsResponse struct {
 // endpointToApplication converts Neutree Endpoint and ModelRegistry to a RayServeApplication.
 func EndpointToApplication(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistry) RayServeApplication {
 	accelerator := map[string]float64{}
+
 	for key, value := range endpoint.Spec.Resources.Accelerator {
 		if key != "-" && value > 0 {
 			accelerator[key] = value
@@ -84,6 +86,7 @@ func EndpointToApplication(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistr
 // GetServeApplications retrieves the current Ray Serve applications.
 func (c *Client) GetServeApplications() (*RayServeApplicationsResponse, error) {
 	var appsResp RayServeApplicationsResponse
+
 	err := c.doRequest(http.MethodGet, "/api/serve/applications/", nil, &appsResp)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to execute request to get serve applications")
@@ -109,6 +112,7 @@ func FormatServiceURL(cluster *v1.Cluster, endpoint *v1.Endpoint) (string, error
 	if cluster.Status == nil || cluster.Status.DashboardURL == "" {
 		return "", errors.New("cluster dashboard URL is not available")
 	}
+
 	dashboardURL, err := url.Parse(cluster.Status.DashboardURL)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse cluster dashboard URL")

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -51,6 +51,11 @@ type RayOrchestrator struct {
 	opTimeout     OperationConfig
 }
 
+type RayOptions struct {
+	Options
+	ImageRegistry *v1.ImageRegistry
+}
+
 func (o *RayOrchestrator) CreateCluster() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), o.opTimeout.UpTimeout)
 	defer cancel()
@@ -266,7 +271,7 @@ func (o *RayOrchestrator) ClusterStatus() (*v1.RayClusterStatus, error) {
 	return clusterStatus, nil
 }
 
-func NewRayOrchestrator(opts Options) (*RayOrchestrator, error) {
+func NewRayOrchestrator(opts RayOptions) (*RayOrchestrator, error) {
 	rayClusterConfig := &v1.RayClusterConfig{}
 
 	rayConfig, err := json.Marshal(opts.Cluster.Spec.Config)

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -479,6 +479,7 @@ func (o *RayOrchestrator) CreateEndpoint(endpoint *v1.Endpoint) (*v1.EndpointSta
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list cluster")
 	}
+
 	if len(cluster) == 0 {
 		return nil, errors.New("cluster " + endpoint.Spec.Cluster + " not found")
 	}
@@ -495,20 +496,24 @@ func (o *RayOrchestrator) CreateEndpoint(endpoint *v1.Endpoint) (*v1.EndpointSta
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list engine")
 	}
+
 	if len(engine) == 0 {
 		return nil, errors.New("engine " + endpoint.Spec.Engine.Engine + " not found")
 	}
+
 	if engine[0].Status.Phase != v1.EnginePhaseCreated {
 		return nil, errors.New("engine " + endpoint.Spec.Engine.Engine + " not ready")
 	}
 
 	versionMatched := false
+
 	for _, v := range engine[0].Spec.Versions {
 		if v.Version == endpoint.Spec.Engine.Version {
 			versionMatched = true
 			break
 		}
 	}
+
 	if !versionMatched {
 		return nil, errors.New("engine " + endpoint.Spec.Engine.Engine + " version " + endpoint.Spec.Engine.Version + " not found")
 	}
@@ -525,9 +530,11 @@ func (o *RayOrchestrator) CreateEndpoint(endpoint *v1.Endpoint) (*v1.EndpointSta
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list model registry")
 	}
+
 	if len(modelRegistry) == 0 {
 		return nil, errors.New("model registry " + endpoint.Spec.Model.Registry + " not found")
 	}
+
 	if modelRegistry[0].Status.Phase != v1.ModelRegistryPhaseCONNECTED {
 		return nil, errors.New("model registry " + endpoint.Spec.Model.Registry + " not ready")
 	}
@@ -551,6 +558,7 @@ func (o *RayOrchestrator) CreateEndpoint(endpoint *v1.Endpoint) (*v1.EndpointSta
 	for _, appStatus := range currentAppsResp.Applications {
 		updatedAppsList = append(updatedAppsList, *appStatus.DeployedAppConfig)
 	}
+
 	updatedAppsList = append(updatedAppsList, newApp)
 
 	updateReq := dashboard.RayServeApplicationsRequest{
@@ -596,6 +604,7 @@ func (o *RayOrchestrator) DeleteEndpoint(endpoint *v1.Endpoint) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to list cluster")
 	}
+
 	if len(cluster) == 0 {
 		// it's safe to ignore this, because the cluster has been removed
 		return nil
@@ -614,11 +623,13 @@ func (o *RayOrchestrator) DeleteEndpoint(endpoint *v1.Endpoint) error {
 	// Build the list of applications excluding the one to delete
 	updatedAppsList := make([]dashboard.RayServeApplication, 0, len(currentAppsResp.Applications))
 	found := false
+
 	for name, appStatus := range currentAppsResp.Applications {
 		if name == endpoint.Metadata.Name {
 			found = true
 			continue // Skip the endpoint to be deleted
 		}
+
 		updatedAppsList = append(updatedAppsList, *appStatus.DeployedAppConfig)
 	}
 
@@ -672,6 +683,7 @@ func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.Endpoint
 	// Basic status mapping
 	// https://docs.ray.io/en/latest/serve/api/doc/ray.serve.schema.ApplicationStatus.html#ray.serve.schema.ApplicationStatus
 	var phase v1.EndpointPhase
+
 	switch status.Status {
 	case "RUNNING":
 	case "DELETING":

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/klog/v2"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/orchestrator/ray"
@@ -19,6 +20,7 @@ import (
 	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/internal/semver"
 	"github.com/neutree-ai/neutree/pkg/command"
+	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 var _ Orchestrator = &RayOrchestrator{}
@@ -45,6 +47,7 @@ type RayOrchestrator struct {
 	imageService  registry.ImageService
 
 	clusterHelper ray.ClusterManager
+	storage       storage.Storage
 	opTimeout     OperationConfig
 }
 
@@ -280,6 +283,7 @@ func NewRayOrchestrator(opts Options) (*RayOrchestrator, error) {
 		cluster:       opts.Cluster,
 		imageRegistry: opts.ImageRegistry,
 		imageService:  opts.ImageService,
+		storage:       opts.Storage,
 		config:        rayClusterConfig,
 		opTimeout: OperationConfig{
 			UpTimeout:        time.Minute * 30,
@@ -450,6 +454,243 @@ func (o *RayOrchestrator) getDashboardService(ctx context.Context) (dashboard.Da
 	}
 
 	return dashboardService, nil
+}
+
+// CreateEndpoint deploys a new endpoint using Ray Serve.
+func (o *RayOrchestrator) CreateEndpoint(endpoint *v1.Endpoint) (*v1.EndpointStatus, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), o.opTimeout.CommonTimeout)
+	defer cancel()
+
+	// pre-check related resources
+	cluster, err := o.storage.ListCluster(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->name",
+				Operator: "eq",
+				Value:    endpoint.Spec.Cluster,
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list cluster")
+	}
+	if len(cluster) == 0 {
+		return nil, errors.New("cluster " + endpoint.Spec.Cluster + " not found")
+	}
+
+	engine, err := o.storage.ListEngine(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->name",
+				Operator: "eq",
+				Value:    endpoint.Spec.Engine.Engine,
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list engine")
+	}
+	if len(engine) == 0 {
+		return nil, errors.New("engine " + endpoint.Spec.Engine.Engine + " not found")
+	}
+	if engine[0].Status.Phase != v1.EnginePhaseCreated {
+		return nil, errors.New("engine " + endpoint.Spec.Engine.Engine + " not ready")
+	}
+
+	versionMatched := false
+	for _, v := range engine[0].Spec.Versions {
+		if v.Version == endpoint.Spec.Engine.Version {
+			versionMatched = true
+			break
+		}
+	}
+	if !versionMatched {
+		return nil, errors.New("engine " + endpoint.Spec.Engine.Engine + " version " + endpoint.Spec.Engine.Version + " not found")
+	}
+
+	modelRegistry, err := o.storage.ListModelRegistry(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->name",
+				Operator: "eq",
+				Value:    endpoint.Spec.Model.Registry,
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list model registry")
+	}
+	if len(modelRegistry) == 0 {
+		return nil, errors.New("model registry " + endpoint.Spec.Model.Registry + " not found")
+	}
+	if modelRegistry[0].Status.Phase != v1.ModelRegistryPhaseCONNECTED {
+		return nil, errors.New("model registry " + endpoint.Spec.Model.Registry + " not ready")
+	}
+
+	// call ray dashboard API
+
+	dashboardService, err := o.getDashboardService(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get dashboard service for creating endpoint")
+	}
+
+	currentAppsResp, err := dashboardService.GetServeApplications()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get current serve applications")
+	}
+
+	newApp := dashboard.EndpointToApplication(endpoint, &modelRegistry[0])
+
+	// Build the list of applications for the PUT request
+	updatedAppsList := make([]dashboard.RayServeApplication, 0, len(currentAppsResp.Applications)+1)
+	for _, appStatus := range currentAppsResp.Applications {
+		updatedAppsList = append(updatedAppsList, *appStatus.DeployedAppConfig)
+	}
+	updatedAppsList = append(updatedAppsList, newApp)
+
+	updateReq := dashboard.RayServeApplicationsRequest{
+		Applications: updatedAppsList,
+	}
+
+	err = dashboardService.UpdateServeApplications(updateReq)
+	if err != nil {
+		return &v1.EndpointStatus{
+			Phase:        v1.EndpointPhaseFAILED,
+			ErrorMessage: errors.Wrap(err, "failed to update serve applications").Error(),
+		}, nil // Return nil error as the operation failed but we captured status
+	}
+
+	serviceURL, err := dashboard.FormatServiceURL(o.cluster, endpoint)
+	if err != nil {
+		// Log the error, but the endpoint might still be running
+		klog.Warningf("Warning: failed to format service URL: %v", err)
+	}
+
+	return &v1.EndpointStatus{
+		Phase:        v1.EndpointPhaseRUNNING,
+		ServiceURL:   serviceURL,
+		ErrorMessage: "",
+	}, nil
+}
+
+// DeleteEndpoint removes an endpoint from Ray Serve.
+func (o *RayOrchestrator) DeleteEndpoint(endpoint *v1.Endpoint) error {
+	ctx, cancel := context.WithTimeout(context.Background(), o.opTimeout.CommonTimeout)
+	defer cancel()
+
+	// pre-check cluster
+	cluster, err := o.storage.ListCluster(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->name",
+				Operator: "eq",
+				Value:    endpoint.Spec.Cluster,
+			},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to list cluster")
+	}
+	if len(cluster) == 0 {
+		// it's safe to ignore this, because the cluster has been removed
+		return nil
+	}
+
+	dashboardService, err := o.getDashboardService(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get dashboard service for deleting endpoint")
+	}
+
+	currentAppsResp, err := dashboardService.GetServeApplications()
+	if err != nil {
+		return errors.Wrap(err, "failed to get current serve applications before deletion")
+	}
+
+	// Build the list of applications excluding the one to delete
+	updatedAppsList := make([]dashboard.RayServeApplication, 0, len(currentAppsResp.Applications))
+	found := false
+	for name, appStatus := range currentAppsResp.Applications {
+		if name == endpoint.Metadata.Name {
+			found = true
+			continue // Skip the endpoint to be deleted
+		}
+		updatedAppsList = append(updatedAppsList, *appStatus.DeployedAppConfig)
+	}
+
+	if !found {
+		// Endpoint not found, consider it successfully deleted (idempotency)
+		klog.Infof("Endpoint %s not found during deletion, assuming already deleted.\n", endpoint.Metadata.Name)
+		return nil
+	}
+
+	updateReq := dashboard.RayServeApplicationsRequest{
+		Applications: updatedAppsList,
+	}
+
+	err = dashboardService.UpdateServeApplications(updateReq)
+	if err != nil {
+		return errors.Wrap(err, "failed to update serve applications for deletion")
+	}
+
+	return nil
+}
+
+// GetEndpointStatus retrieves the status of a specific endpoint from Ray Serve.
+func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.EndpointStatus, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), o.opTimeout.CommonTimeout)
+	defer cancel()
+
+	// Placeholder implementation: Get all apps and check if ours exists.
+	// A more robust implementation would query the specific app status if the API supports it,
+	// or parse the status field from the GetServeApplications response.
+	dashboardService, err := o.getDashboardService(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get dashboard service for getting endpoint status")
+	}
+
+	currentAppsResp, err := dashboardService.GetServeApplications()
+	if err != nil {
+		return &v1.EndpointStatus{
+			Phase:        v1.EndpointPhaseFAILED,
+			ErrorMessage: errors.Wrap(err, "failed to get serve applications to check status").Error(),
+		}, nil
+	}
+
+	status, exists := currentAppsResp.Applications[endpoint.Metadata.Name]
+	if !exists {
+		return &v1.EndpointStatus{
+			Phase:        v1.EndpointPhasePENDING,
+			ErrorMessage: "Endpoint not found in Ray Serve applications",
+		}, nil
+	}
+
+	// Basic status mapping
+	// https://docs.ray.io/en/latest/serve/api/doc/ray.serve.schema.ApplicationStatus.html#ray.serve.schema.ApplicationStatus
+	var phase v1.EndpointPhase
+	switch status.Status {
+	case "RUNNING":
+	case "DELETING":
+		phase = v1.EndpointPhaseRUNNING
+	case "NOT_STARTED":
+	case "DEPLOYING":
+		phase = v1.EndpointPhasePENDING
+	case "DEPLOY_FAILED":
+	case "UNHEALTHY":
+		phase = v1.EndpointPhaseFAILED
+	default:
+		phase = v1.EndpointPhaseFAILED
+	}
+
+	serviceURL, err := dashboard.FormatServiceURL(o.cluster, endpoint)
+	if err != nil {
+		fmt.Printf("Warning: failed to format service URL while getting status: %v\n", err)
+	}
+
+	return &v1.EndpointStatus{
+		Phase:        phase,
+		ServiceURL:   serviceURL,
+		ErrorMessage: status.Message, // Use message from Ray if available
+	}, nil
 }
 
 func getRayTmpDir() string {

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -173,14 +173,16 @@ func TestNewRayOrchestrator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := Options{
-				Cluster:       tt.cluster,
-				ImageRegistry: tt.imageRegistry,
+				Cluster: tt.cluster,
 			}
 
 			setUp()
 			defer tearDown()
 
-			o, err := NewRayOrchestrator(opts)
+			o, err := NewRayOrchestrator(RayOptions{
+				Options:       opts,
+				ImageRegistry: tt.imageRegistry,
+			})
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/pkg/storage/mocks/mock_storage.go
+++ b/pkg/storage/mocks/mock_storage.go
@@ -114,6 +114,52 @@ func (_c *MockStorage_CreateCluster_Call) RunAndReturn(run func(*v1.Cluster) err
 	return _c
 }
 
+// CreateEndpoint provides a mock function with given fields: data
+func (_m *MockStorage) CreateEndpoint(data *v1.Endpoint) error {
+	ret := _m.Called(data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateEndpoint")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.Endpoint) error); ok {
+		r0 = rf(data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorage_CreateEndpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateEndpoint'
+type MockStorage_CreateEndpoint_Call struct {
+	*mock.Call
+}
+
+// CreateEndpoint is a helper method to define mock.On call
+//   - data *v1.Endpoint
+func (_e *MockStorage_Expecter) CreateEndpoint(data interface{}) *MockStorage_CreateEndpoint_Call {
+	return &MockStorage_CreateEndpoint_Call{Call: _e.mock.On("CreateEndpoint", data)}
+}
+
+func (_c *MockStorage_CreateEndpoint_Call) Run(run func(data *v1.Endpoint)) *MockStorage_CreateEndpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*v1.Endpoint))
+	})
+	return _c
+}
+
+func (_c *MockStorage_CreateEndpoint_Call) Return(_a0 error) *MockStorage_CreateEndpoint_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorage_CreateEndpoint_Call) RunAndReturn(run func(*v1.Endpoint) error) *MockStorage_CreateEndpoint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateEngine provides a mock function with given fields: data
 func (_m *MockStorage) CreateEngine(data *v1.Engine) error {
 	ret := _m.Called(data)
@@ -478,6 +524,52 @@ func (_c *MockStorage_DeleteCluster_Call) Return(_a0 error) *MockStorage_DeleteC
 }
 
 func (_c *MockStorage_DeleteCluster_Call) RunAndReturn(run func(string) error) *MockStorage_DeleteCluster_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteEndpoint provides a mock function with given fields: id
+func (_m *MockStorage) DeleteEndpoint(id string) error {
+	ret := _m.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteEndpoint")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorage_DeleteEndpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteEndpoint'
+type MockStorage_DeleteEndpoint_Call struct {
+	*mock.Call
+}
+
+// DeleteEndpoint is a helper method to define mock.On call
+//   - id string
+func (_e *MockStorage_Expecter) DeleteEndpoint(id interface{}) *MockStorage_DeleteEndpoint_Call {
+	return &MockStorage_DeleteEndpoint_Call{Call: _e.mock.On("DeleteEndpoint", id)}
+}
+
+func (_c *MockStorage_DeleteEndpoint_Call) Run(run func(id string)) *MockStorage_DeleteEndpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockStorage_DeleteEndpoint_Call) Return(_a0 error) *MockStorage_DeleteEndpoint_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorage_DeleteEndpoint_Call) RunAndReturn(run func(string) error) *MockStorage_DeleteEndpoint_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -870,6 +962,64 @@ func (_c *MockStorage_GetCluster_Call) Return(_a0 *v1.Cluster, _a1 error) *MockS
 }
 
 func (_c *MockStorage_GetCluster_Call) RunAndReturn(run func(string) (*v1.Cluster, error)) *MockStorage_GetCluster_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetEndpoint provides a mock function with given fields: id
+func (_m *MockStorage) GetEndpoint(id string) (*v1.Endpoint, error) {
+	ret := _m.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEndpoint")
+	}
+
+	var r0 *v1.Endpoint
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*v1.Endpoint, error)); ok {
+		return rf(id)
+	}
+	if rf, ok := ret.Get(0).(func(string) *v1.Endpoint); ok {
+		r0 = rf(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.Endpoint)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockStorage_GetEndpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEndpoint'
+type MockStorage_GetEndpoint_Call struct {
+	*mock.Call
+}
+
+// GetEndpoint is a helper method to define mock.On call
+//   - id string
+func (_e *MockStorage_Expecter) GetEndpoint(id interface{}) *MockStorage_GetEndpoint_Call {
+	return &MockStorage_GetEndpoint_Call{Call: _e.mock.On("GetEndpoint", id)}
+}
+
+func (_c *MockStorage_GetEndpoint_Call) Run(run func(id string)) *MockStorage_GetEndpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockStorage_GetEndpoint_Call) Return(_a0 *v1.Endpoint, _a1 error) *MockStorage_GetEndpoint_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockStorage_GetEndpoint_Call) RunAndReturn(run func(string) (*v1.Endpoint, error)) *MockStorage_GetEndpoint_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1338,6 +1488,64 @@ func (_c *MockStorage_ListCluster_Call) RunAndReturn(run func(storage.ListOption
 	return _c
 }
 
+// ListEndpoint provides a mock function with given fields: option
+func (_m *MockStorage) ListEndpoint(option storage.ListOption) ([]v1.Endpoint, error) {
+	ret := _m.Called(option)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListEndpoint")
+	}
+
+	var r0 []v1.Endpoint
+	var r1 error
+	if rf, ok := ret.Get(0).(func(storage.ListOption) ([]v1.Endpoint, error)); ok {
+		return rf(option)
+	}
+	if rf, ok := ret.Get(0).(func(storage.ListOption) []v1.Endpoint); ok {
+		r0 = rf(option)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]v1.Endpoint)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(storage.ListOption) error); ok {
+		r1 = rf(option)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockStorage_ListEndpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListEndpoint'
+type MockStorage_ListEndpoint_Call struct {
+	*mock.Call
+}
+
+// ListEndpoint is a helper method to define mock.On call
+//   - option storage.ListOption
+func (_e *MockStorage_Expecter) ListEndpoint(option interface{}) *MockStorage_ListEndpoint_Call {
+	return &MockStorage_ListEndpoint_Call{Call: _e.mock.On("ListEndpoint", option)}
+}
+
+func (_c *MockStorage_ListEndpoint_Call) Run(run func(option storage.ListOption)) *MockStorage_ListEndpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(storage.ListOption))
+	})
+	return _c
+}
+
+func (_c *MockStorage_ListEndpoint_Call) Return(_a0 []v1.Endpoint, _a1 error) *MockStorage_ListEndpoint_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockStorage_ListEndpoint_Call) RunAndReturn(run func(storage.ListOption) ([]v1.Endpoint, error)) *MockStorage_ListEndpoint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListEngine provides a mock function with given fields: option
 func (_m *MockStorage) ListEngine(option storage.ListOption) ([]v1.Engine, error) {
 	ret := _m.Called(option)
@@ -1776,6 +1984,53 @@ func (_c *MockStorage_UpdateCluster_Call) Return(_a0 error) *MockStorage_UpdateC
 }
 
 func (_c *MockStorage_UpdateCluster_Call) RunAndReturn(run func(string, *v1.Cluster) error) *MockStorage_UpdateCluster_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateEndpoint provides a mock function with given fields: id, data
+func (_m *MockStorage) UpdateEndpoint(id string, data *v1.Endpoint) error {
+	ret := _m.Called(id, data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateEndpoint")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *v1.Endpoint) error); ok {
+		r0 = rf(id, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorage_UpdateEndpoint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateEndpoint'
+type MockStorage_UpdateEndpoint_Call struct {
+	*mock.Call
+}
+
+// UpdateEndpoint is a helper method to define mock.On call
+//   - id string
+//   - data *v1.Endpoint
+func (_e *MockStorage_Expecter) UpdateEndpoint(id interface{}, data interface{}) *MockStorage_UpdateEndpoint_Call {
+	return &MockStorage_UpdateEndpoint_Call{Call: _e.mock.On("UpdateEndpoint", id, data)}
+}
+
+func (_c *MockStorage_UpdateEndpoint_Call) Run(run func(id string, data *v1.Endpoint)) *MockStorage_UpdateEndpoint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(*v1.Endpoint))
+	})
+	return _c
+}
+
+func (_c *MockStorage_UpdateEndpoint_Call) Return(_a0 error) *MockStorage_UpdateEndpoint_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorage_UpdateEndpoint_Call) RunAndReturn(run func(string, *v1.Endpoint) error) *MockStorage_UpdateEndpoint_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/storage/postgrest.go
+++ b/pkg/storage/postgrest.go
@@ -560,3 +560,68 @@ func (s *postgrestStorage) ListEngine(option ListOption) ([]v1.Engine, error) {
 
 	return response, err
 }
+
+func (s *postgrestStorage) CreateEndpoint(data *v1.Endpoint) error {
+	var (
+		err error
+	)
+
+	if _, _, err = s.postgrestClient.From(ENDPOINT_TABLE).Insert(data, true, "", "", "").Execute(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *postgrestStorage) DeleteEndpoint(id string) error {
+	var (
+		err error
+	)
+
+	if _, _, err = s.postgrestClient.From(ENDPOINT_TABLE).Delete("", "").Filter("id", "eq", id).Execute(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *postgrestStorage) UpdateEndpoint(id string, data *v1.Endpoint) error {
+	var (
+		err error
+	)
+
+	if _, _, err = s.postgrestClient.From(ENDPOINT_TABLE).Update(data, "", "").Filter("id", "eq", id).Execute(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *postgrestStorage) GetEndpoint(id string) (*v1.Endpoint, error) {
+	var (
+		response []v1.Endpoint
+		err      error
+	)
+
+	responseContent, _, err := s.postgrestClient.From(ENDPOINT_TABLE).Select("*", "", false).Filter("id", "eq", id).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = parseResponse(&response, responseContent); err != nil {
+		return nil, err
+	}
+
+	if len(response) == 0 {
+		return nil, ErrResourceNotFound
+	}
+
+	return &response[0], nil
+}
+
+func (s *postgrestStorage) ListEndpoint(option ListOption) ([]v1.Endpoint, error) {
+	var response []v1.Endpoint
+	err := s.genericList(ENDPOINT_TABLE, &response, option)
+
+	return response, err
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -128,6 +128,19 @@ type EngineStorage interface {
 	ListEngine(option ListOption) ([]v1.Engine, error)
 }
 
+type EndpointStorage interface {
+	// CreateEndpoint creates a new endpoint in the database.
+	CreateEndpoint(data *v1.Endpoint) error
+	// DeleteEndpoint deletes a endpoint by its ID.
+	DeleteEndpoint(id string) error
+	// UpdateEndpoint updates an existing endpoint in the database.
+	UpdateEndpoint(id string, data *v1.Endpoint) error
+	// GetEndpoint retrieves a endpoint by its ID.
+	GetEndpoint(id string) (*v1.Endpoint, error)
+	// ListEndpoint retrieves a list of endpoint with optional filters.
+	ListEndpoint(option ListOption) ([]v1.Endpoint, error)
+}
+
 type Storage interface {
 	ClusterStorage
 	ImageRegistryStorage
@@ -137,6 +150,7 @@ type Storage interface {
 	WorkspaceStorage
 	ApiKeyStorage
 	EngineStorage
+	EndpointStorage
 }
 
 type Options struct {


### PR DESCRIPTION
## Issues


## Changes

There are several architectural changes in this patch. @Levi080513, please check whether these are the decent ways.

1. The `getRelateImageRegistry` function has been moved into the orchestrator constructor, so the controllers can share this function.
2. The `RayOrchestrator` now has a `RayOptions` param,  which equals to`Options` + `ImageRegistry`.
3. Now the orchestrator can access storage/api.
4. Since we need to call the Ray dashboard's serve APIs, I've extended the Ray dashboard client. Instead of adding new functions into `client.go`, I've created a separate `serve.go` file to include the serve API clients.

WIP: still need E2E tests to check this patch.

## Test
