### PR TITLE
fix: checkClusterImage panic due to imageService is nil

### DIFF
--- a/controllers/endpoint_controller.go
+++ b/controllers/endpoint_controller.go
@@ -37,7 +37,8 @@ func NewEndpointController(option *EndpointControllerOption) (*EndpointControlle
 			workers:      option.Workers,
 			syncInterval: time.Second * 10,
 		},
-		storage: option.Storage,
+		storage:      option.Storage,
+		imageService: option.ImageService,
 	}
 
 	c.syncHandler = c.sync


### PR DESCRIPTION
## Issues

<img width="984" alt="image" src="https://github.com/user-attachments/assets/d0774cfa-1c99-42f0-9fb6-647da54d45b1" />


`checkClusterImage` panic due to `imageService` is nil

## Changes

1. config endpointController imageService param

## Test

endpoints create
<img width="1686" alt="image" src="https://github.com/user-attachments/assets/e4bb0fa6-5b87-4bc6-861c-e20eee99ed3c" />

neutree core container normal
<img width="736" alt="image" src="https://github.com/user-attachments/assets/cca7a8a6-3cbb-428d-aadf-2c82f93dcb5d" />
