### PR TITLE
feat: auto create workspace engines

### DIFF
--- a/api/v1/basic_types.go
+++ b/api/v1/basic_types.go
@@ -3,8 +3,8 @@ package v1
 type Metadata struct {
 	Workspace         string            `json:"workspace,omitempty"`
 	DeletionTimestamp string            `json:"deletion_timestamp,omitempty"`
-	CreationTimestamp string            `json:"creation_timestamp"`
-	UpdateTimestamp   string            `json:"update_timestamp"`
+	CreationTimestamp string            `json:"creation_timestamp,omitempty"`
+	UpdateTimestamp   string            `json:"update_timestamp,omitempty"`
 	Labels            map[string]string `json:"labels,omitempty"`
 	Name              string            `json:"name"`
 }

--- a/cluster-image-builder/Dockerfile
+++ b/cluster-image-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM rayproject/ray:2.43.0-py312-cu124
+FROM rayproject/ray:2.43.0-py312-cu121
 
 # Copy requirements file
 COPY requirements.txt .

--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -85,6 +86,19 @@ func installNeutreeCoreSingleNodeByDocker(exector command.Executor, options neut
 	err := prepareNeutreeCoreDeployConfig(options)
 	if err != nil {
 		return errors.Wrap(err, "prepare neutree core launch config failed")
+	}
+
+	if options.dryRun {
+		fmt.Println("dry run, skip install neutree core")
+
+		composeContent, err := os.ReadFile(filepath.Join(options.workDir, "neutree-core", "docker-compose.yml"))
+		if err != nil {
+			return errors.Wrap(err, "read docker compose file failed")
+		}
+
+		fmt.Println(string(composeContent))
+
+		return nil
 	}
 
 	output, err := exector.Execute(context.Background(), "docker",

--- a/cmd/neutree-cli/app/cmd/launch/launch.go
+++ b/cmd/neutree-cli/app/cmd/launch/launch.go
@@ -22,6 +22,8 @@ type commonOptions struct {
 	nodeIP     string
 
 	mirrorRegistry string
+
+	dryRun bool
 }
 
 func NewLaunchCmd() *cobra.Command {
@@ -64,6 +66,7 @@ Examples:
 	launchCmd.PersistentFlags().StringVar(&commonOptions.nodeIP, "node-ip", "", "current deploy node ip")
 
 	launchCmd.PersistentFlags().StringVar(&commonOptions.mirrorRegistry, "mirror-registry", "", "mirror registry")
+	launchCmd.PersistentFlags().BoolVar(&commonOptions.dryRun, "dry-run", false, "dry run")
 
 	exector := &command.OSExecutor{}
 	launchCmd.AddCommand(NewObsStackInstallCmd(exector, commonOptions))

--- a/cmd/neutree-cli/app/cmd/launch/obs_stack.go
+++ b/cmd/neutree-cli/app/cmd/launch/obs_stack.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -80,6 +81,17 @@ func installObsStackSingleNodeByDocker(exector command.Executor, options obsStac
 	err := prepareObsStackDeployConfig(&options)
 	if err != nil {
 		return errors.Wrap(err, "prepare obs stack deploy config failed")
+	}
+
+	if options.dryRun {
+		fmt.Println("dry run, skip install obs stack")
+
+		composeContent, err := os.ReadFile(filepath.Join(options.workDir, "obs-stack", "docker-compose.yml"))
+		if err != nil {
+			return errors.Wrap(err, "read docker compose file failed")
+		}
+
+		fmt.Println(string(composeContent))
 	}
 
 	output, err := exector.Execute(context.Background(), "docker",

--- a/controllers/image_registry_controller.go
+++ b/controllers/image_registry_controller.go
@@ -127,8 +127,6 @@ func (c *ImageRegistryController) sync(obj *v1.ImageRegistry) error {
 		}
 	}()
 
-	klog.Info("Connect to image registry " + obj.Metadata.Name)
-
 	err = c.connectImageRegistry(obj)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect image registry "+obj.Metadata.Name)

--- a/controllers/model_registry_controller.go
+++ b/controllers/model_registry_controller.go
@@ -128,8 +128,6 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 	}()
 
 	if obj.Status == nil || obj.Status.Phase == "" || obj.Status.Phase == v1.ModelRegistryPhasePENDING {
-		klog.Info("Connect model registry " + obj.Metadata.Name)
-
 		err = modelRegistry.Connect()
 		if err != nil {
 			return errors.Wrap(err, "failed to connect model registry "+obj.Metadata.Name)
@@ -139,8 +137,6 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 	}
 
 	if obj.Status != nil && obj.Status.Phase == v1.ModelRegistryPhaseFAILED {
-		klog.Info("Reconnect model registry " + obj.Metadata.Name)
-
 		if err = modelRegistry.Disconnect(); err != nil {
 			return errors.Wrap(err, "failed to disconnect model registry "+obj.Metadata.Name)
 		}
@@ -153,8 +149,6 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 	}
 
 	if obj.Status != nil && obj.Status.Phase == v1.ModelRegistryPhaseCONNECTED {
-		klog.Info("Health check model registry " + obj.Metadata.Name)
-
 		healthy := modelRegistry.HealthyCheck()
 		if !healthy {
 			return errors.New("health check model registry " + obj.Metadata.Name + " failed")

--- a/controllers/workspace_controller_test.go
+++ b/controllers/workspace_controller_test.go
@@ -88,6 +88,7 @@ func TestWorkspaceController_Sync_Deletion(t *testing.T) {
 			name:  "Deleting (Phase=CREATED) -> Set Phase=DELETED (Update success)",
 			input: testWorkspaceWithDeletionTimestamp(workspaceID, v1.WorkspacePhaseCREATED),
 			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListEngine", mock.Anything).Return(nil, nil)
 				s.On("UpdateWorkspace", workspaceIDStr, mock.MatchedBy(func(r *v1.Workspace) bool {
 					return r.Status != nil && r.Status.Phase == v1.WorkspacePhaseDELETED && r.Status.ErrorMessage == ""
 				})).Return(nil).Once()
@@ -98,6 +99,7 @@ func TestWorkspaceController_Sync_Deletion(t *testing.T) {
 			name:  "Deleting (Phase=PENDING) -> Set Phase=DELETED (Update failed)",
 			input: testWorkspaceWithDeletionTimestamp(workspaceID, v1.WorkspacePhasePENDING),
 			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListEngine", mock.Anything).Return(nil, nil)
 				s.On("UpdateWorkspace", workspaceIDStr, mock.MatchedBy(func(r *v1.Workspace) bool {
 					return r.Status != nil && r.Status.Phase == v1.WorkspacePhaseDELETED
 				})).Return(assert.AnError).Once()
@@ -108,6 +110,7 @@ func TestWorkspaceController_Sync_Deletion(t *testing.T) {
 			name:  "Deleting (No Status) -> Set Phase=DELETED (Update success)",
 			input: testWorkspaceWithDeletionTimestamp(workspaceID, ""), // No initial status
 			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListEngine", mock.Anything).Return(nil, nil)
 				s.On("UpdateWorkspace", workspaceIDStr, mock.MatchedBy(func(r *v1.Workspace) bool {
 					return r.Status != nil && r.Status.Phase == v1.WorkspacePhaseDELETED && r.Status.ErrorMessage == ""
 				})).Return(nil).Once()
@@ -178,7 +181,8 @@ func TestWorkspaceController_Sync_CreateOrUpdate(t *testing.T) {
 			name:  "Phase=CREATED -> No Change",
 			input: testWorkspace(workspaceID, v1.WorkspacePhaseCREATED),
 			mockSetup: func(s *storagemocks.MockStorage) {
-				// Expect no calls to UpdateWorkspace or DeleteWorkspace.
+				s.On("ListEngine", mock.Anything).Return(nil, nil)
+				s.On("CreateEngine", mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -295,6 +299,8 @@ func TestWorkspaceController_Reconcile(t *testing.T) {
 			name:     "Reconcile success (real sync, no status change)", // Test scenario using default sync handler.
 			inputKey: workspaceID,
 			mockSetup: func(s *storagemocks.MockStorage) {
+				s.On("ListEngine", mock.Anything).Return(nil, nil)
+				s.On("CreateEngine", mock.Anything).Return(nil)
 				// GetWorkspace succeeds, workspace is already in the desired state.
 				s.On("GetWorkspace", workspaceIDStr).Return(testWorkspace(workspaceID, v1.WorkspacePhaseCREATED), nil).Once()
 				// The real 'sync' method expects no further storage calls here.

--- a/internal/orchestrator/ray/cluster/ssh.go
+++ b/internal/orchestrator/ray/cluster/ssh.go
@@ -334,8 +334,8 @@ func generateRayClusterConfig(cluster *v1.Cluster, imageRegistry *v1.ImageRegist
 	}
 
 	initializationCommands := []string{}
-	// set registry CA.
-	if imageRegistry.Spec.Ca != "" {
+	// only set registry CA if user is root.
+	if rayClusterConfig.Auth.SSHUser == "root" && imageRegistry.Spec.Ca != "" {
 		certPath := filepath.Join("/etc/docker/certs.d", registryURL.Host)
 		initializationCommands = append(initializationCommands, "mkdir -p "+certPath)
 		initializationCommands = append(initializationCommands, fmt.Sprintf(`echo "%s" | base64 -d > %s/ca.crt`, imageRegistry.Spec.Ca, certPath))

--- a/internal/orchestrator/ray/cluster/ssh_test.go
+++ b/internal/orchestrator/ray/cluster/ssh_test.go
@@ -580,7 +580,11 @@ func TestGenerateRayClusterConfig(t *testing.T) {
 				Metadata: &v1.Metadata{Name: "test-cluster"},
 				Spec: &v1.ClusterSpec{
 					Version: "v1.0.0",
-					Config:  map[string]interface{}{},
+					Config: map[string]interface{}{
+						"auth": map[string]interface{}{
+							"ssh_user": "root",
+						},
+					},
 				},
 			},
 			imageRegistry: &v1.ImageRegistry{
@@ -633,7 +637,11 @@ func TestGenerateRayClusterConfig(t *testing.T) {
 				Metadata: &v1.Metadata{Name: "test-cluster"},
 				Spec: &v1.ClusterSpec{
 					Version: "v1.0.0",
-					Config:  map[string]interface{}{},
+					Config: map[string]interface{}{
+						"auth": map[string]interface{}{
+							"ssh_user": "root",
+						},
+					},
 				},
 			},
 			imageRegistry: &v1.ImageRegistry{
@@ -686,7 +694,11 @@ func TestGenerateRayClusterConfig(t *testing.T) {
 				Metadata: &v1.Metadata{Name: "test-cluster"},
 				Spec: &v1.ClusterSpec{
 					Version: "v1.0.0",
-					Config:  map[string]interface{}{},
+					Config: map[string]interface{}{
+						"auth": map[string]interface{}{
+							"ssh_user": "root",
+						},
+					},
 				},
 			},
 			imageRegistry: &v1.ImageRegistry{
@@ -739,7 +751,11 @@ func TestGenerateRayClusterConfig(t *testing.T) {
 				Metadata: &v1.Metadata{Name: "test-cluster"},
 				Spec: &v1.ClusterSpec{
 					Version: "v1.0.0",
-					Config:  map[string]interface{}{},
+					Config: map[string]interface{}{
+						"auth": map[string]interface{}{
+							"ssh_user": "root",
+						},
+					},
 				},
 			},
 			imageRegistry: &v1.ImageRegistry{
@@ -789,7 +805,11 @@ func TestGenerateRayClusterConfig(t *testing.T) {
 				Metadata: &v1.Metadata{Name: "test-cluster"},
 				Spec: &v1.ClusterSpec{
 					Version: "v1.0.0",
-					Config:  map[string]interface{}{},
+					Config: map[string]interface{}{
+						"auth": map[string]interface{}{
+							"ssh_user": "root",
+						},
+					},
 				},
 			},
 			imageRegistry: &v1.ImageRegistry{

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -316,7 +316,7 @@ func (o *RayOrchestrator) CreateEndpoint(endpoint *v1.Endpoint) (*v1.EndpointSta
 		return nil, errors.New("model registry " + endpoint.Spec.Model.Registry + " not found")
 	}
 
-	if modelRegistry[0].Status.Phase != v1.ModelRegistryPhaseCONNECTED {
+	if modelRegistry[0].Status == nil || modelRegistry[0].Status.Phase != v1.ModelRegistryPhaseCONNECTED {
 		return nil, errors.New("model registry " + endpoint.Spec.Model.Registry + " not ready")
 	}
 


### PR DESCRIPTION
## Issues

feat: auto create workspace engines

## Changes

feat: auto init workspace engines

others changes
1.  fix cluster delete hang due to unexpected cluster config
2. add neutree-cli launch --dry-run options
3. fix list model failed
4. fix cpu pod detected gpu devices
5. only set registry CA when cluster ssh_user is root
6. add `--num-cpus=0` params when start head node on kubernetes
7. Downgrade cluster image cuda version


## Test

auto create workspace engines
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/33e6cc87-228e-407e-9adf-14fa8b39a46b" />


common k8s cluster test
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/b064bc67-008f-45a2-8fe9-97228f450631" />




