### PR TITLE
fix: postgresql data always re-init when pod recreate

### DIFF
--- a/deploy/chart/neutree/templates/migration-job.yaml
+++ b/deploy/chart/neutree/templates/migration-job.yaml
@@ -19,6 +19,12 @@ spec:
       {{- end }}    
       serviceAccountName: {{ include "neutree.fullname" . }}-sa
       initContainers:
+        - name: wait-postgresql
+          image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag}}"
+          imagePullPolicy: {{ .Values.k8sWaitFor.image.pullPolicy }}
+          args:
+            - pod
+            - -lapp.kubernetes.io/component=neutree-postgresql
         - name: wait-auth-service
           image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag}}"
           imagePullPolicy: {{ .Values.k8sWaitFor.image.pullPolicy }}

--- a/deploy/chart/neutree/templates/post-migration-hook-job.yaml
+++ b/deploy/chart/neutree/templates/post-migration-hook-job.yaml
@@ -19,6 +19,12 @@ spec:
       {{- end }}    
       serviceAccountName: {{ include "neutree.fullname" . }}-sa
       initContainers:
+        - name: wait-postgresql
+          image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag}}"
+          imagePullPolicy: {{ .Values.k8sWaitFor.image.pullPolicy }}
+          args:
+            - pod
+            - -lapp.kubernetes.io/component=neutree-postgresql
         - name: wait-migration-job
           image: "{{ .Values.k8sWaitFor.image.repository }}:{{ .Values.k8sWaitFor.image.tag}}"
           imagePullPolicy: {{ .Values.k8sWaitFor.image.pullPolicy }}

--- a/deploy/chart/neutree/templates/postgresql-deployment.yaml
+++ b/deploy/chart/neutree/templates/postgresql-deployment.yaml
@@ -59,7 +59,8 @@ spec:
             {{- toYaml .Values.db.resources | nindent 12 }}
           volumeMounts:
             - name: postgresql-data
-              mountPath: /var/lib/postgresql
+              mountPath: /var/lib/postgresql/data
+              subPath: postgres-data
             - name: postgresql-initdb
               mountPath: /docker-entrypoint-initdb.d
       volumes:


### PR DESCRIPTION
## Issues

postgresql data always re-init when pod recreate due to the image mount /var/lib/postgresql/data

## Changes

use volume subpath mount /var/lib/postgresql/data

other changes
1. migration/post-migration-hook job adds postgresql health wait


## Test

recreate pod, the log show `Skipping initialization`

<img width="719" alt="image" src="https://github.com/user-attachments/assets/2dc9fbe5-b580-411c-90bf-ff3e51a4348b" />


