### PR TITLE
fix: improve memory usage during model pushing and remove timeout

### DIFF
--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -72,7 +72,7 @@ func NewPushCmd() *cobra.Command {
 			}
 
 			// Create client
-			c := client.NewClient(serverURL, client.WithAPIKey(apiKey))
+			c := client.NewClient(serverURL, client.WithAPIKey(apiKey), client.WithTimeout(0))
 
 			fmt.Printf("Pushing model %s:%s to registry...\n", modelName, version)
 


### PR DESCRIPTION
## Issues

Previously, we were copyingthe  whole archive file into memory, which cause OOM when the archive file is large.

## Changes

Now, we do an IO pipe to copy archive file into multipart reader, and send to the backend API in a chunking style.

## Test

After pushing a larger model, the memory usage does not increase a lot during the push stage.