### PR TITLE
chore: bump cluster-image kantoku to 0.18.3

### DIFF
--- a/cluster-image-builder/requirements.txt
+++ b/cluster-image-builder/requirements.txt
@@ -11,5 +11,5 @@ ray[serve]
 bentoml==1.4.6
 PyYAML==6.0.1
 vllm==0.7.2
-kantoku==0.18.1
+kantoku==0.18.3
 openai==1.65.2


### PR DESCRIPTION
## Issues


## Changes


## Test
