### PR TITLE
chore: bump default cluster image version to v19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 VERSION ?= $(shell git describe --tags --always --dirty)
 UI_VERSION ?= main
-CLUSTER_VERSION ?= v18
+CLUSTER_VERSION ?= v19
 LATEST ?= false
 
 IMAGE_REPO ?= docker.io


### PR DESCRIPTION
## Issues


## Changes


## Test
