### PR TITLE
Support custom NodePort for NeuTree API Service.

### DIFF
--- a/deploy/chart/neutree/templates/neutree-api-service.yaml
+++ b/deploy/chart/neutree/templates/neutree-api-service.yaml
@@ -5,11 +5,14 @@ metadata:
   labels:
     {{- include "neutree.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.api.service.type }}
+  type: {{ .Values.api.service.type | default "ClusterIP" }}
   ports:
     - port: 3000
       targetPort: http
       protocol: TCP
       name: http
+      {{- if eq .Values.api.service.type "NodePort" }}
+      nodePort: {{ .Values.api.service.nodePort }}
+      {{- end }}
   selector:
     app.kubernetes.io/component: neutree-api

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -21,7 +21,6 @@ dbScripts:
     tag: ""
     pullPolicy: IfNotPresent
 
-
 db:
   image:
     repository: postgres
@@ -40,7 +39,7 @@ db:
   persistence:
     enabled: true
     size: 40Gi
-    accessModes: 
+    accessModes:
       - ReadWriteOnce
   service:
     type: ClusterIP
@@ -61,7 +60,7 @@ auth:
   tolerations: []
   affinity: {}
   service:
-    type: ClusterIP      
+    type: ClusterIP
 
 migration:
   image:
@@ -90,7 +89,7 @@ postgrest:
   affinity: {}
   service:
     type: ClusterIP
-  
+
 postgresmeta:
   image:
     repository: supabase/postgres-meta
@@ -124,7 +123,7 @@ api:
     repository: neutree-ai/neutree-api
     tag: ""
     pullPolicy: IfNotPresent
-  resources: 
+  resources:
     requests:
       cpu: 100m
       memory: 128Mi
@@ -150,7 +149,7 @@ vmagent:
   persistence:
     enabled: true
     size: 1Gi
-    accessModes: 
+    accessModes:
       - ReadWriteOnce
 
 kong:


### PR DESCRIPTION
## Issues
Unable to specify a custom NodePort port

## Changes

1. Support custom NodePort for NeuTree API Service.
2. Improved the values.yaml file by removing unnecessary whitespace.
