### PR TITLE
return grafana URL in system API

### DIFF
--- a/cmd/neutree-api/neutree-api.go
+++ b/cmd/neutree-api/neutree-api.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/neutree-ai/neutree/internal/routes/models"
 	"github.com/neutree-ai/neutree/internal/routes/proxies"
+	"github.com/neutree-ai/neutree/internal/routes/system"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
@@ -23,6 +24,7 @@ var (
 	ginMode          = flag.String("gin-mode", "release", "gin mode: debug, release, test")
 	staticDir        = flag.String("static-dir", "./public", "directory for static files")
 	authEndpoint     = flag.String("auth-endpoint", "http://auth:9999", "auth service endpoint")
+	grafanaURL       = flag.String("grafana-url", "", "grafana url for system info API")
 )
 
 func main() {
@@ -66,6 +68,10 @@ func main() {
 		StorageAccessURL: *storageAccessURL,
 		ServiceToken:     *serviceToken,
 		AuthEndpoint:     *authEndpoint,
+	})
+
+	system.RegisterRoutes(r, &system.Dependencies{
+		GrafanaURL: *grafanaURL,
 	})
 
 	serverAddr := fmt.Sprintf("%s:%d", *host, *port)

--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -21,6 +21,7 @@ type neutreeCoreInstallOptions struct {
 
 	jwtSecret             string
 	metricsRemoteWriteURL string
+	grafanaURL            string
 	version               string
 }
 
@@ -42,6 +43,7 @@ Components Included:
 Configuration Options:
   --jwt-secret             JWT secret for authentication
   --metrics-remote-write-url Remote metrics storage URL
+  --grafana-url            Grafana dashboard URL for system info API
   --version                Component version (default: v0.0.1)
 
 Examples:
@@ -51,8 +53,8 @@ Examples:
   # Custom version installation
   neutree-cli launch neutree-core --version v1.2.0
   
-  # With remote metrics storage
-  neutree-cli launch neutree-core --metrics-remote-write-url http://metrics.example.com`,
+  # With remote metrics storage and Grafana
+  neutree-cli launch neutree-core --metrics-remote-write-url http://metrics.example.com --grafana-url http://grafana.example.com:3030`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// set default node ip
 			if options.nodeIP == "" {
@@ -68,6 +70,7 @@ Examples:
 
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.jwtSecret, "jwt-secret", "mDCvM4zSk0ghmpyKhgqWb0g4igcOP0Lp", "neutree core jwt secret")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.metricsRemoteWriteURL, "metrics-remote-write-url", "", "metrics remote write url")
+	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.grafanaURL, "grafana-url", "", "grafana dashboard url for system info API")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.version, "version", "v0.0.1", "neutree core version")
 
 	return neutreeCoreInstallCmd
@@ -161,6 +164,7 @@ func prepareNeutreeCoreDeployConfig(options neutreeCoreInstallOptions) error {
 		"NeutreeCoreWorkDir":     coreWorkDir,
 		"JwtSecret":              options.jwtSecret,
 		"MetricsRemoteWriteURL":  options.metricsRemoteWriteURL,
+		"GrafanaURL":             options.grafanaURL,
 		"VictoriaMetricsVersion": constants.VictoriaMetricsVersion,
 		"NeutreeCoreVersion":     options.version,
 		"NeutreeAPIVersion":      options.version,

--- a/deploy/chart/neutree/templates/neutree-api-deployment.yaml
+++ b/deploy/chart/neutree/templates/neutree-api-deployment.yaml
@@ -28,6 +28,9 @@ spec:
             - --static-dir=./public
             - --gin-mode=release
             - --auth-endpoint=http://{{ include "neutree.fullname" . }}-auth-service:9999
+            {{- if .Values.system.grafana.url }}
+            - --grafana-url={{ .Values.system.grafana.url }}
+            {{- end }}
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -5,6 +5,10 @@
 jwtSecret: "mDCvM4zSk0ghmpyKhgqWb0g4igcOP0Lp"
 imagePullSecrets: []
 
+system:
+  grafana:
+    url: ""
+
 metrics:
   enabled: false
   remoteWriteUrl: ""

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -175,6 +175,7 @@ services:
       - --static-dir=./public
       - --gin-mode=release
       - --auth-endpoint=http://auth:9999
+      - --grafana-url={{.GrafanaURL}}
     ports:
       - 3000:3000
     networks:

--- a/internal/routes/system/system.go
+++ b/internal/routes/system/system.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -50,15 +51,15 @@ func handleSystemInfo(deps *Dependencies) gin.HandlerFunc {
 
 // validateAndCleanURL validates and cleans a URL string
 func validateAndCleanURL(rawURL string) (string, error) {
+	// Ensure the URL starts with http:// or https://
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		return "", fmt.Errorf("URL must start with http:// or https://: %s", rawURL)
+	}
+
 	// Parse the URL to validate it
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return "", err
-	}
-
-	// Ensure the URL has a scheme
-	if parsedURL.Scheme == "" {
-		parsedURL.Scheme = "http"
 	}
 
 	// Clean up the URL (remove trailing slashes, etc.)

--- a/internal/routes/system/system.go
+++ b/internal/routes/system/system.go
@@ -1,0 +1,69 @@
+package system
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+)
+
+// Dependencies defines the dependencies for system handlers
+type Dependencies struct {
+	// GrafanaURL is the URL to the Grafana instance for monitoring
+	GrafanaURL string
+}
+
+// SystemInfo represents the system information response
+type SystemInfo struct {
+	// GrafanaURL is the URL to access Grafana dashboard
+	GrafanaURL string `json:"grafana_url,omitempty"`
+}
+
+// RegisterRoutes registers system-related routes
+func RegisterRoutes(r *gin.Engine, deps *Dependencies) {
+	apiV1 := r.Group("/api/v1")
+
+	// System information endpoint
+	apiV1.GET("/system/info", handleSystemInfo(deps))
+}
+
+// handleSystemInfo returns system information including URLs to monitoring services
+func handleSystemInfo(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		info := &SystemInfo{}
+
+		// Add Grafana URL if configured
+		if deps.GrafanaURL != "" {
+			// Validate and clean the URL
+			if grafanaURL, err := validateAndCleanURL(deps.GrafanaURL); err == nil {
+				info.GrafanaURL = grafanaURL
+			} else {
+				klog.Warningf("Invalid Grafana URL configured: %v", err)
+			}
+		}
+
+		c.JSON(http.StatusOK, info)
+	}
+}
+
+// validateAndCleanURL validates and cleans a URL string
+func validateAndCleanURL(rawURL string) (string, error) {
+	// Parse the URL to validate it
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Ensure the URL has a scheme
+	if parsedURL.Scheme == "" {
+		parsedURL.Scheme = "http"
+	}
+
+	// Clean up the URL (remove trailing slashes, etc.)
+	cleanURL := parsedURL.String()
+	cleanURL = strings.TrimSuffix(cleanURL, "/")
+
+	return cleanURL, nil
+}

--- a/internal/routes/system/system_test.go
+++ b/internal/routes/system/system_test.go
@@ -1,0 +1,157 @@
+package system
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// createTestContext creates a test context for testing
+func createTestContext(method, path string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	req := httptest.NewRequest(method, path, nil)
+	c.Request = req
+
+	return c, w
+}
+
+// TestHandleSystemInfo_WithGrafanaURL tests system info with Grafana URL configured
+func TestHandleSystemInfo_WithGrafanaURL(t *testing.T) {
+	deps := &Dependencies{
+		GrafanaURL: "http://example.com:3030",
+	}
+
+	c, w := createTestContext("GET", "/api/v1/system/info")
+
+	handler := handleSystemInfo(deps)
+	handler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response SystemInfo
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "http://example.com:3030", response.GrafanaURL)
+}
+
+// TestHandleSystemInfo_WithoutGrafanaURL tests system info without Grafana URL configured
+func TestHandleSystemInfo_WithoutGrafanaURL(t *testing.T) {
+	deps := &Dependencies{
+		GrafanaURL: "",
+	}
+
+	c, w := createTestContext("GET", "/api/v1/system/info")
+
+	handler := handleSystemInfo(deps)
+	handler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response SystemInfo
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Empty(t, response.GrafanaURL)
+}
+
+// TestHandleSystemInfo_WithTrailingSlash tests URL cleaning
+func TestHandleSystemInfo_WithTrailingSlash(t *testing.T) {
+	deps := &Dependencies{
+		GrafanaURL: "http://example.com:3030/",
+	}
+
+	c, w := createTestContext("GET", "/api/v1/system/info")
+
+	handler := handleSystemInfo(deps)
+	handler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response SystemInfo
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	// Should remove trailing slash
+	assert.Equal(t, "http://example.com:3030", response.GrafanaURL)
+}
+
+// TestHandleSystemInfo_WithInvalidURL tests handling of invalid URLs
+func TestHandleSystemInfo_WithInvalidURL(t *testing.T) {
+	deps := &Dependencies{
+		GrafanaURL: "://invalid-url",
+	}
+
+	c, w := createTestContext("GET", "/api/v1/system/info")
+
+	handler := handleSystemInfo(deps)
+	handler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response SystemInfo
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	// Invalid URL should be omitted
+	assert.Empty(t, response.GrafanaURL)
+}
+
+// TestValidateAndCleanURL tests the URL validation and cleaning function
+func TestValidateAndCleanURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		hasError bool
+	}{
+		{
+			name:     "Valid HTTP URL",
+			input:    "http://example.com:3030",
+			expected: "http://example.com:3030",
+			hasError: false,
+		},
+		{
+			name:     "Valid HTTPS URL",
+			input:    "https://example.com:3030",
+			expected: "https://example.com:3030",
+			hasError: false,
+		},
+		{
+			name:     "URL with trailing slash",
+			input:    "http://example.com:3030/",
+			expected: "http://example.com:3030",
+			hasError: false,
+		},
+		{
+			name:     "URL without scheme",
+			input:    "example.com:3030",
+			expected: "http://example.com:3030",
+			hasError: false,
+		},
+		{
+			name:     "Invalid URL",
+			input:    "://invalid",
+			expected: "",
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := validateAndCleanURL(tt.input)
+
+			if tt.hasError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/internal/routes/system/system_test.go
+++ b/internal/routes/system/system_test.go
@@ -101,6 +101,26 @@ func TestHandleSystemInfo_WithInvalidURL(t *testing.T) {
 	assert.Empty(t, response.GrafanaURL)
 }
 
+// TestHandleSystemInfo_WithURLWithoutScheme tests handling of URLs without scheme
+func TestHandleSystemInfo_WithURLWithoutScheme(t *testing.T) {
+	deps := &Dependencies{
+		GrafanaURL: "example.com:3030",
+	}
+
+	c, w := createTestContext("GET", "/api/v1/system/info")
+
+	handler := handleSystemInfo(deps)
+	handler(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response SystemInfo
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	// URL without scheme should be omitted
+	assert.Empty(t, response.GrafanaURL)
+}
+
 // TestValidateAndCleanURL tests the URL validation and cleaning function
 func TestValidateAndCleanURL(t *testing.T) {
 	tests := []struct {
@@ -124,12 +144,6 @@ func TestValidateAndCleanURL(t *testing.T) {
 		{
 			name:     "URL with trailing slash",
 			input:    "http://example.com:3030/",
-			expected: "http://example.com:3030",
-			hasError: false,
-		},
-		{
-			name:     "URL without scheme",
-			input:    "example.com:3030",
 			expected: "http://example.com:3030",
 			hasError: false,
 		},


### PR DESCRIPTION
## Issues

The UI needs to load Grafana panels, which requires either proxying requests through the server or accessing Grafana directly via its URL.

## Changes

After exploring several approaches outlined in [Grafana’s reverse proxy guide](https://grafana.com/tutorials/run-grafana-behind-a-proxy/), we were unable to find a reliable way to proxy all Grafana panel requests under a subpath of our server.

As a workaround, we now expose a system API that returns the Grafana URL configured by the user during deployment. The UI can then use this URL to communicate with Grafana directly.

## Test

Manually tested in the UI.

<img width="1675" alt="image" src="https://github.com/user-attachments/assets/69addd70-d2eb-4b92-99a9-cc6b93e7d264" />

