### PR TITLE
feat: support model cache

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -1,6 +1,10 @@
 package v1
 
-import "strconv"
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 // Neutree node provision status.
 const (
@@ -30,7 +34,8 @@ type RaySSHProvisionClusterConfig struct {
 	Provider Provider `json:"provider,omitempty" yaml:"provider,omitempty"`
 	Auth     Auth     `json:"auth,omitempty" yaml:"auth,omitempty"`
 	// todo: after heterogeneous accelerator hybrid clusters are supported, this field will be deprecated.
-	AcceleratorType *string `json:"accelerator_type,omitempty" yaml:"accelerator_type,omitempty"`
+	AcceleratorType *string     `json:"accelerator_type,omitempty" yaml:"accelerator_type,omitempty"`
+	ModelCache      *ModelCache `json:"model_cache,omitempty" yaml:"model_cache,omitempty"`
 }
 
 type RayKubernetesProvisionClusterConfig struct {
@@ -38,7 +43,8 @@ type RayKubernetesProvisionClusterConfig struct {
 	HeadNodeSpec     HeadNodeSpec      `json:"head_node_spec,omitempty" yaml:"head_node_spec,omitempty"`
 	WorkerGroupSpecs []WorkerGroupSpec `json:"worker_group_specs,omitempty" yaml:"worker_group_specs,omitempty"`
 	// todo: after heterogeneous accelerator hybrid clusters are supported, this field will be deprecated.
-	AcceleratorType *string `json:"accelerator_type,omitempty" yaml:"accelerator_type,omitempty"`
+	AcceleratorType *string     `json:"accelerator_type,omitempty" yaml:"accelerator_type,omitempty"`
+	ModelCache      *ModelCache `json:"model_cache,omitempty" yaml:"model_cache,omitempty"`
 }
 
 type KubernetesAccessMode string
@@ -59,6 +65,13 @@ type WorkerGroupSpec struct {
 	MinReplicas int32             `json:"min_replicas,omitempty" yaml:"min_replicas,omitempty"`
 	MaxReplicas int32             `json:"max_replicas,omitempty" yaml:"max_replicas,omitempty"`
 	Resources   map[string]string `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+type ModelCache struct {
+	HostPath *corev1.HostPathVolumeSource `json:"host_path,omitempty" yaml:"host_path,omitempty"`
+	// current only kubernetes type cluster is supported.
+	NFS *corev1.NFSVolumeSource
+	// todo: support other model cache type, e.g. pvc etc.
 }
 
 type ClusterStatus struct {

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -79,7 +79,7 @@ type ModelCache struct {
 	ModelRegistryType ModelRegistryType            `json:"model_registry_type,omitempty" yaml:"model_registry_type,omitempty"`
 	HostPath          *corev1.HostPathVolumeSource `json:"host_path,omitempty" yaml:"host_path,omitempty"`
 	// Only Kubernetes type cluster support NFS.
-	NFS *corev1.NFSVolumeSource
+	NFS *corev1.NFSVolumeSource `json:"nfs,omitempty" yaml:"nfs,omitempty"`
 	// todo: support other model cache type, e.g. pvc etc.
 }
 

--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -33,18 +33,26 @@ type ClusterSpec struct {
 type RaySSHProvisionClusterConfig struct {
 	Provider Provider `json:"provider,omitempty" yaml:"provider,omitempty"`
 	Auth     Auth     `json:"auth,omitempty" yaml:"auth,omitempty"`
-	// todo: after heterogeneous accelerator hybrid clusters are supported, this field will be deprecated.
-	AcceleratorType *string     `json:"accelerator_type,omitempty" yaml:"accelerator_type,omitempty"`
-	ModelCache      *ModelCache `json:"model_cache,omitempty" yaml:"model_cache,omitempty"`
+
+	CommonClusterConfig `json:",inline" yaml:",inline"`
 }
 
 type RayKubernetesProvisionClusterConfig struct {
 	Kubeconfig       string            `json:"kubeconfig,omitempty" yaml:"kubeconfig,omitempty"`
 	HeadNodeSpec     HeadNodeSpec      `json:"head_node_spec,omitempty" yaml:"head_node_spec,omitempty"`
 	WorkerGroupSpecs []WorkerGroupSpec `json:"worker_group_specs,omitempty" yaml:"worker_group_specs,omitempty"`
+
+	CommonClusterConfig `json:",inline" yaml:",inline"`
+}
+
+type CommonClusterConfig struct {
 	// todo: after heterogeneous accelerator hybrid clusters are supported, this field will be deprecated.
-	AcceleratorType *string     `json:"accelerator_type,omitempty" yaml:"accelerator_type,omitempty"`
-	ModelCache      *ModelCache `json:"model_cache,omitempty" yaml:"model_cache,omitempty"`
+	AcceleratorType *string `json:"accelerator_type,omitempty" yaml:"accelerator_type,omitempty"`
+	// ModelCache is used to cache models downloaded from remote model registries, such as huggingface hub, bentoml cloud, etc.
+	// It does not apply to local model registries, such as bentoml nfs/local dir type.
+	// In addition, other data may be cached, which depends on the corresponding model registry download implementation,
+	// so it is not recommended to share a storage with the local model registry.
+	ModelCaches []ModelCache `json:"model_caches,omitempty" yaml:"model_caches,omitempty"`
 }
 
 type KubernetesAccessMode string
@@ -68,8 +76,9 @@ type WorkerGroupSpec struct {
 }
 
 type ModelCache struct {
-	HostPath *corev1.HostPathVolumeSource `json:"host_path,omitempty" yaml:"host_path,omitempty"`
-	// current only kubernetes type cluster is supported.
+	ModelRegistryType ModelRegistryType            `json:"model_registry_type,omitempty" yaml:"model_registry_type,omitempty"`
+	HostPath          *corev1.HostPathVolumeSource `json:"host_path,omitempty" yaml:"host_path,omitempty"`
+	// Only Kubernetes type cluster support NFS.
 	NFS *corev1.NFSVolumeSource
 	// todo: support other model cache type, e.g. pvc etc.
 }

--- a/api/v1/model_registry_types.go
+++ b/api/v1/model_registry_types.go
@@ -25,6 +25,11 @@ const (
 	BentoMLModelRegistryConnectTypeFile = "file"
 )
 
+const (
+	HFHomeEnv      = "HF_HOME"
+	BentoMLHomeEnv = "BENTOML_HOME"
+)
+
 type ModelRegistrySpec struct {
 	Type        ModelRegistryType `json:"type"` // only support 'bentoml' | 'hugging-face'
 	Url         string            `json:"url"`  // only support 'file://path/to/model' | 'https://huggingface.co' | 'nfs://path/to/model';

--- a/internal/orchestrator/ray/cluster/kubernetes.go
+++ b/internal/orchestrator/ray/cluster/kubernetes.go
@@ -793,7 +793,7 @@ func (c *kubeRayClusterManager) mutateModelCaches(podTemplate *corev1.PodTemplat
 		return
 	}
 
-	var modifyPermissionComands []string
+	var modifyPermissionCommands []string
 	modifyPermissionContainer := corev1.Container{
 		Name:  "update-model-cache-permission",
 		Image: podTemplate.Spec.Containers[0].Image,
@@ -863,10 +863,10 @@ func (c *kubeRayClusterManager) mutateModelCaches(podTemplate *corev1.PodTemplat
 
 		podTemplate.Spec.Volumes = append(podTemplate.Spec.Volumes, volume)
 		modifyPermissionContainer.VolumeMounts = append(modifyPermissionContainer.VolumeMounts, volumeMount)
-		modifyPermissionComands = append(modifyPermissionComands, "sudo chown -R $(id -u):$(id -g) "+mountPath)
+		modifyPermissionCommands = append(modifyPermissionCommands, "sudo chown -R $(id -u):$(id -g) "+mountPath)
 	}
 
-	modifyPermissionContainer.Command = append(modifyPermissionContainer.Command, strings.Join(modifyPermissionComands, "&&"))
+	modifyPermissionContainer.Command = append(modifyPermissionContainer.Command, strings.Join(modifyPermissionCommands, "&&"))
 	// add init container to update model cache permission to the same user as the ray worker process.
 	podTemplate.Spec.InitContainers = append(podTemplate.Spec.InitContainers, modifyPermissionContainer)
 }

--- a/internal/orchestrator/ray/cluster/manager.go
+++ b/internal/orchestrator/ray/cluster/manager.go
@@ -14,6 +14,11 @@ import (
 	"github.com/neutree-ai/neutree/internal/registry"
 )
 
+const (
+	defaultWorkdir             = "/home/ray"
+	defaultModelCacheMountPath = defaultWorkdir + "/.neutree/model-cache"
+)
+
 var (
 	ErrImageNotFound     = errors.New("image not found")
 	ErrorRayNodeNotFound = errors.New("ray node not found")

--- a/internal/orchestrator/ray/cluster/ssh.go
+++ b/internal/orchestrator/ray/cluster/ssh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 
@@ -643,29 +644,43 @@ func (c *sshClusterManager) generateRayClusterConfig() (*v1.RayClusterConfig, er
 
 	rayClusterConfig.InitializationCommands = initializationCommands
 
-	c.mutateModelCache(rayClusterConfig)
+	c.mutateModelCaches(rayClusterConfig)
 
 	return rayClusterConfig, nil
 }
 
-func (c *sshClusterManager) mutateModelCache(config *v1.RayClusterConfig) {
-	modelCache := c.sshClusterConfig.ModelCache
-	if modelCache == nil {
+func (c *sshClusterManager) mutateModelCaches(config *v1.RayClusterConfig) {
+	modelCaches := c.sshClusterConfig.ModelCaches
+	if modelCaches == nil {
 		return
 	}
 
-	if modelCache.HostPath != nil {
-		hostPath := modelCache.HostPath.Path
-		config.Docker.RunOptions = append(config.Docker.RunOptions,
-			"--volume "+hostPath+":"+defaultModelCacheMountPath)
-		config.Docker.RunOptions = append(config.Docker.RunOptions,
-			"-e HF_HOME="+defaultModelCacheMountPath)
-		config.InitializationCommands = append(config.InitializationCommands,
-			fmt.Sprintf("mkdir -p %s && chmod 755 %s", hostPath, hostPath))
-		modifyPermissionCommand := fmt.Sprintf("sudo chown -R $(id -u):$(id -g) %s", defaultModelCacheMountPath)
-		config.HeadStartRayCommands = append([]string{modifyPermissionCommand}, config.HeadStartRayCommands...)
-		config.WorkerStartRayCommands = append([]string{modifyPermissionCommand}, config.WorkerStartRayCommands...)
-		config.StaticWorkerStartRayCommands = append([]string{modifyPermissionCommand}, config.StaticWorkerStartRayCommands...)
+	for _, modelCache := range modelCaches {
+		mountPath := path.Join(defaultModelCacheMountPath, string(modelCache.ModelRegistryType))
+
+		switch modelCache.ModelRegistryType {
+		case v1.HuggingFaceModelRegistryType:
+			config.Docker.RunOptions = append(config.Docker.RunOptions,
+				fmt.Sprintf("-e %s=%s", v1.HFHomeEnv, mountPath))
+		case v1.BentoMLModelRegistryType:
+			config.Docker.RunOptions = append(config.Docker.RunOptions,
+				fmt.Sprintf("-e %s=%s", v1.BentoMLHomeEnv, mountPath))
+		default:
+			klog.Warningf("Model registry type %s is not supported, skip", modelCache.ModelRegistryType)
+			continue
+		}
+
+		if modelCache.HostPath != nil {
+			hostPath := modelCache.HostPath.Path
+			config.Docker.RunOptions = append(config.Docker.RunOptions,
+				"--volume "+hostPath+":"+mountPath)
+			config.InitializationCommands = append(config.InitializationCommands,
+				fmt.Sprintf("mkdir -p %s && chmod 755 %s", hostPath, hostPath))
+			modifyPermissionCommand := fmt.Sprintf("sudo chown -R $(id -u):$(id -g) %s", mountPath)
+			config.HeadStartRayCommands = append([]string{modifyPermissionCommand}, config.HeadStartRayCommands...)
+			config.WorkerStartRayCommands = append([]string{modifyPermissionCommand}, config.WorkerStartRayCommands...)
+			config.StaticWorkerStartRayCommands = append([]string{modifyPermissionCommand}, config.StaticWorkerStartRayCommands...)
+		}
 	}
 }
 

--- a/internal/orchestrator/ray/cluster/ssh_test.go
+++ b/internal/orchestrator/ray/cluster/ssh_test.go
@@ -178,7 +178,9 @@ func TestSSHClusterManager_UpCluster(t *testing.T) {
 				},
 				imageService: mockImageRegistryService,
 				sshClusterConfig: &v1.RaySSHProvisionClusterConfig{
-					AcceleratorType: pointy.String(""),
+					CommonClusterConfig: v1.CommonClusterConfig{
+						AcceleratorType: pointy.String(""),
+					},
 				},
 				acceleratorManager: mockAcceleratorManager,
 			}
@@ -290,7 +292,9 @@ func TestStartNode_Success(t *testing.T) {
 		},
 		imageService: mockImageRegistryService,
 		sshClusterConfig: &v1.RaySSHProvisionClusterConfig{
-			AcceleratorType: pointy.String(""),
+			CommonClusterConfig: v1.CommonClusterConfig{
+				AcceleratorType: pointy.String(""),
+			},
 		},
 		acceleratorManager: mockAcceleratorManager,
 	}

--- a/internal/orchestrator/ray/dashboard/serve.go
+++ b/internal/orchestrator/ray/dashboard/serve.go
@@ -90,7 +90,7 @@ func EndpointToApplication(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistr
 		if url != nil && url.Scheme == v1.BentoMLModelRegistryConnectTypeNFS {
 			app.RuntimeEnv = map[string]interface{}{
 				"env_vars": map[string]string{
-					"BENTOML_HOME": filepath.Join("/mnt", endpoint.Key(), modelRegistry.Key(), endpoint.Spec.Model.Name),
+					v1.BentoMLHomeEnv: filepath.Join("/mnt", endpoint.Key(), modelRegistry.Key(), endpoint.Spec.Model.Name),
 				},
 			}
 		}

--- a/pkg/model_registry/bentoml/bentoml.go
+++ b/pkg/model_registry/bentoml/bentoml.go
@@ -18,6 +18,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
 type Model struct {
@@ -39,7 +41,7 @@ func GetModelDetail(homePath, modelName, version string) (*Model, error) {
 	}
 
 	cmd := exec.Command("bentoml", "models", "get", tag, "-o", "json")
-	cmd.Env = append(cmd.Env, "BENTOML_HOME="+homePath)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", v1.BentoMLHomeEnv, homePath))
 
 	content, err := cmd.CombinedOutput()
 	if err != nil {
@@ -64,7 +66,7 @@ func DeleteModel(homePath, modelName, version string) error {
 	}
 
 	cmd := exec.Command("bentoml", "models", "delete", tag, "-y")
-	cmd.Env = append(cmd.Env, "BENTOML_HOME="+homePath)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", v1.BentoMLHomeEnv, homePath))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -77,7 +79,7 @@ func DeleteModel(homePath, modelName, version string) error {
 // ImportModel imports a model file to BentoML store
 func ImportModel(homePath, modelPath string) error {
 	cmd := exec.Command("bentoml", "models", "import", modelPath)
-	cmd.Env = append(cmd.Env, "BENTOML_HOME="+homePath)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", v1.BentoMLHomeEnv, homePath))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -95,7 +97,7 @@ func ExportModel(homePath, modelName, version, outputPath string) error {
 	}
 
 	cmd := exec.Command("bentoml", "models", "export", tag, outputPath)
-	cmd.Env = append(cmd.Env, "BENTOML_HOME="+homePath)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", v1.BentoMLHomeEnv, homePath))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -138,7 +140,7 @@ func ListModels(homePath string) ([]Model, error) {
 	)
 
 	cmd := exec.Command("bentoml", "models", "list", "-o", "json")
-	cmd.Env = append(cmd.Env, "BENTOML_HOME="+homePath)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", v1.BentoMLHomeEnv, homePath))
 
 	content, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Issues


## Changes

Supports configuring multiple different types of model registry cache configurations, e.g. hugging-face, bentoml etc.

- For SSH cluster type, we can configure model cache, and the models downloaded from HF hub or BentoML cloud will be downloaded to hostPath.
- For Kubernetes cluster type, we can configure model cache, and the models downloaded from HF hub or BentoML cloud will be downloaded to hostPath or NFS.

## Test

create ssh cluster which use hostPath `/home/hf` cache HF model
```
{ "api_version": "v1", "kind": "Cluster", "metadata": { "name": "gpu", "workspace": "default" }, "spec": { "type": "ssh", "config": { "provider": { "head_ip": "10.255.1.84" }, "auth": { "ssh_user": "root", "ssh_private_key": "" }, "model_caches": [{"host_path": {"path":"/home/hf"},"model_registry_type":"hugging-face"}]}, "image_registry": "internal-registry", "version": "v21" } }
```
then create inference endpoints which use HF model registry
<img width="1124" alt="image" src="https://github.com/user-attachments/assets/5ad892b3-5c03-40a4-b6b3-58c9cdb0f111" />

the model is saved in the hostPath.
<img width="904" alt="image" src="https://github.com/user-attachments/assets/9dca371e-d0f0-4108-8e05-a6ec8422c93c" />


create kubernetes cluster which use nfs cache HF model
```
{  "api_version": "v1", "kind": "Cluster", "metadata": { "name": "gpu-k8s","workspace": "default"}, "spec": { "type": "kubernetes", "config": { "kubeconfig": "", "head_node_spec": { "access_mode": "LoadBalancer", "resources": { "cpu": "1", "memory": "4Gi" } }, "worker_group_specs": [ { "group_name": "default", "min_replicas": 1, "max_replicas": 1, "resources": { "cpu": "4", "memory": "22Gi" } } ],"model_caches": [{"nfs": {"server": "10.255.1.54", "path":"/bentoml/hf"},"model_registry_type":"hugging-face"}] }, "image_registry": "internal-registry", "version": "v21" }}
```

then create inference endpoints which use HF model registry
<img width="1078" alt="image" src="https://github.com/user-attachments/assets/14f42a8a-b8af-44ae-8bb4-ff68d985d3d7" />
the model is saved in the NFS.
<img width="866" alt="image" src="https://github.com/user-attachments/assets/a53e5afa-74ac-4d0e-a386-4862afe214bb" />




