### PR TITLE
feat: OEM config

### DIFF
--- a/api/v1/api_gen.go
+++ b/api/v1/api_gen.go
@@ -2,595 +2,55 @@ package v1
 
 import "database/sql"
 
-type AuthSchemaMigrationsSelect struct {
-	Version string `json:"version"`
+type ApiModelCatalogsSelect struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         int32                  `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
 }
 
-type AuthSchemaMigrationsInsert struct {
-	Version string `json:"version"`
+type ApiModelCatalogsInsert struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         sql.NullInt32          `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
 }
 
-type AuthSchemaMigrationsUpdate struct {
-	Version sql.NullString `json:"version"`
+type ApiModelCatalogsUpdate struct {
+	ApiVersion sql.NullString         `json:"api_version"`
+	Id         sql.NullInt32          `json:"id"`
+	Kind       sql.NullString         `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
 }
 
-type AuthUsersSelect struct {
-	Aud                      sql.NullString `json:"aud"`
-	BannedUntil              sql.NullString `json:"banned_until"`
-	ConfirmationSentAt       sql.NullString `json:"confirmation_sent_at"`
-	ConfirmationToken        sql.NullString `json:"confirmation_token"`
-	ConfirmedAt              sql.NullString `json:"confirmed_at"`
-	CreatedAt                sql.NullString `json:"created_at"`
-	DeletedAt                sql.NullString `json:"deleted_at"`
-	Email                    sql.NullString `json:"email"`
-	EmailChange              sql.NullString `json:"email_change"`
-	EmailChangeConfirmStatus sql.NullInt32  `json:"email_change_confirm_status"`
-	EmailChangeSentAt        sql.NullString `json:"email_change_sent_at"`
-	EmailChangeTokenCurrent  sql.NullString `json:"email_change_token_current"`
-	EmailChangeTokenNew      sql.NullString `json:"email_change_token_new"`
-	EmailConfirmedAt         sql.NullString `json:"email_confirmed_at"`
-	EncryptedPassword        sql.NullString `json:"encrypted_password"`
-	Id                       string         `json:"id"`
-	InstanceId               sql.NullString `json:"instance_id"`
-	InvitedAt                sql.NullString `json:"invited_at"`
-	IsAnonymous              bool           `json:"is_anonymous"`
-	IsSsoUser                bool           `json:"is_sso_user"`
-	IsSuperAdmin             sql.NullBool   `json:"is_super_admin"`
-	LastSignInAt             sql.NullString `json:"last_sign_in_at"`
-	Phone                    sql.NullString `json:"phone"`
-	PhoneChange              sql.NullString `json:"phone_change"`
-	PhoneChangeSentAt        sql.NullString `json:"phone_change_sent_at"`
-	PhoneChangeToken         sql.NullString `json:"phone_change_token"`
-	PhoneConfirmedAt         sql.NullString `json:"phone_confirmed_at"`
-	RawAppMetaData           interface{}    `json:"raw_app_meta_data"`
-	RawUserMetaData          interface{}    `json:"raw_user_meta_data"`
-	ReauthenticationSentAt   sql.NullString `json:"reauthentication_sent_at"`
-	ReauthenticationToken    sql.NullString `json:"reauthentication_token"`
-	RecoverySentAt           sql.NullString `json:"recovery_sent_at"`
-	RecoveryToken            sql.NullString `json:"recovery_token"`
-	Role                     sql.NullString `json:"role"`
-	UpdatedAt                sql.NullString `json:"updated_at"`
+type ApiOemConfigsSelect struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         int32                  `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
 }
 
-type AuthUsersInsert struct {
-	Aud                      sql.NullString `json:"aud"`
-	BannedUntil              sql.NullString `json:"banned_until"`
-	ConfirmationSentAt       sql.NullString `json:"confirmation_sent_at"`
-	ConfirmationToken        sql.NullString `json:"confirmation_token"`
-	ConfirmedAt              sql.NullString `json:"confirmed_at"`
-	CreatedAt                sql.NullString `json:"created_at"`
-	DeletedAt                sql.NullString `json:"deleted_at"`
-	Email                    sql.NullString `json:"email"`
-	EmailChange              sql.NullString `json:"email_change"`
-	EmailChangeConfirmStatus sql.NullInt32  `json:"email_change_confirm_status"`
-	EmailChangeSentAt        sql.NullString `json:"email_change_sent_at"`
-	EmailChangeTokenCurrent  sql.NullString `json:"email_change_token_current"`
-	EmailChangeTokenNew      sql.NullString `json:"email_change_token_new"`
-	EmailConfirmedAt         sql.NullString `json:"email_confirmed_at"`
-	EncryptedPassword        sql.NullString `json:"encrypted_password"`
-	Id                       string         `json:"id"`
-	InstanceId               sql.NullString `json:"instance_id"`
-	InvitedAt                sql.NullString `json:"invited_at"`
-	IsAnonymous              sql.NullBool   `json:"is_anonymous"`
-	IsSsoUser                sql.NullBool   `json:"is_sso_user"`
-	IsSuperAdmin             sql.NullBool   `json:"is_super_admin"`
-	LastSignInAt             sql.NullString `json:"last_sign_in_at"`
-	Phone                    sql.NullString `json:"phone"`
-	PhoneChange              sql.NullString `json:"phone_change"`
-	PhoneChangeSentAt        sql.NullString `json:"phone_change_sent_at"`
-	PhoneChangeToken         sql.NullString `json:"phone_change_token"`
-	PhoneConfirmedAt         sql.NullString `json:"phone_confirmed_at"`
-	RawAppMetaData           interface{}    `json:"raw_app_meta_data"`
-	RawUserMetaData          interface{}    `json:"raw_user_meta_data"`
-	ReauthenticationSentAt   sql.NullString `json:"reauthentication_sent_at"`
-	ReauthenticationToken    sql.NullString `json:"reauthentication_token"`
-	RecoverySentAt           sql.NullString `json:"recovery_sent_at"`
-	RecoveryToken            sql.NullString `json:"recovery_token"`
-	Role                     sql.NullString `json:"role"`
-	UpdatedAt                sql.NullString `json:"updated_at"`
+type ApiOemConfigsInsert struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         sql.NullInt32          `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
 }
 
-type AuthUsersUpdate struct {
-	Aud                      sql.NullString `json:"aud"`
-	BannedUntil              sql.NullString `json:"banned_until"`
-	ConfirmationSentAt       sql.NullString `json:"confirmation_sent_at"`
-	ConfirmationToken        sql.NullString `json:"confirmation_token"`
-	ConfirmedAt              sql.NullString `json:"confirmed_at"`
-	CreatedAt                sql.NullString `json:"created_at"`
-	DeletedAt                sql.NullString `json:"deleted_at"`
-	Email                    sql.NullString `json:"email"`
-	EmailChange              sql.NullString `json:"email_change"`
-	EmailChangeConfirmStatus sql.NullInt32  `json:"email_change_confirm_status"`
-	EmailChangeSentAt        sql.NullString `json:"email_change_sent_at"`
-	EmailChangeTokenCurrent  sql.NullString `json:"email_change_token_current"`
-	EmailChangeTokenNew      sql.NullString `json:"email_change_token_new"`
-	EmailConfirmedAt         sql.NullString `json:"email_confirmed_at"`
-	EncryptedPassword        sql.NullString `json:"encrypted_password"`
-	Id                       sql.NullString `json:"id"`
-	InstanceId               sql.NullString `json:"instance_id"`
-	InvitedAt                sql.NullString `json:"invited_at"`
-	IsAnonymous              sql.NullBool   `json:"is_anonymous"`
-	IsSsoUser                sql.NullBool   `json:"is_sso_user"`
-	IsSuperAdmin             sql.NullBool   `json:"is_super_admin"`
-	LastSignInAt             sql.NullString `json:"last_sign_in_at"`
-	Phone                    sql.NullString `json:"phone"`
-	PhoneChange              sql.NullString `json:"phone_change"`
-	PhoneChangeSentAt        sql.NullString `json:"phone_change_sent_at"`
-	PhoneChangeToken         sql.NullString `json:"phone_change_token"`
-	PhoneConfirmedAt         sql.NullString `json:"phone_confirmed_at"`
-	RawAppMetaData           interface{}    `json:"raw_app_meta_data"`
-	RawUserMetaData          interface{}    `json:"raw_user_meta_data"`
-	ReauthenticationSentAt   sql.NullString `json:"reauthentication_sent_at"`
-	ReauthenticationToken    sql.NullString `json:"reauthentication_token"`
-	RecoverySentAt           sql.NullString `json:"recovery_sent_at"`
-	RecoveryToken            sql.NullString `json:"recovery_token"`
-	Role                     sql.NullString `json:"role"`
-	UpdatedAt                sql.NullString `json:"updated_at"`
-}
-
-type AuthRefreshTokensSelect struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         int64          `json:"id"`
-	InstanceId sql.NullString `json:"instance_id"`
-	Parent     sql.NullString `json:"parent"`
-	Revoked    sql.NullBool   `json:"revoked"`
-	SessionId  sql.NullString `json:"session_id"`
-	Token      sql.NullString `json:"token"`
-	UpdatedAt  sql.NullString `json:"updated_at"`
-	UserId     sql.NullString `json:"user_id"`
-}
-
-type AuthRefreshTokensInsert struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         sql.NullInt64  `json:"id"`
-	InstanceId sql.NullString `json:"instance_id"`
-	Parent     sql.NullString `json:"parent"`
-	Revoked    sql.NullBool   `json:"revoked"`
-	SessionId  sql.NullString `json:"session_id"`
-	Token      sql.NullString `json:"token"`
-	UpdatedAt  sql.NullString `json:"updated_at"`
-	UserId     sql.NullString `json:"user_id"`
-}
-
-type AuthRefreshTokensUpdate struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         sql.NullInt64  `json:"id"`
-	InstanceId sql.NullString `json:"instance_id"`
-	Parent     sql.NullString `json:"parent"`
-	Revoked    sql.NullBool   `json:"revoked"`
-	SessionId  sql.NullString `json:"session_id"`
-	Token      sql.NullString `json:"token"`
-	UpdatedAt  sql.NullString `json:"updated_at"`
-	UserId     sql.NullString `json:"user_id"`
-}
-
-type AuthInstancesSelect struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	Id            string         `json:"id"`
-	RawBaseConfig sql.NullString `json:"raw_base_config"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-	Uuid          sql.NullString `json:"uuid"`
-}
-
-type AuthInstancesInsert struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	Id            string         `json:"id"`
-	RawBaseConfig sql.NullString `json:"raw_base_config"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-	Uuid          sql.NullString `json:"uuid"`
-}
-
-type AuthInstancesUpdate struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	Id            sql.NullString `json:"id"`
-	RawBaseConfig sql.NullString `json:"raw_base_config"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-	Uuid          sql.NullString `json:"uuid"`
-}
-
-type AuthAuditLogEntriesSelect struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         string         `json:"id"`
-	InstanceId sql.NullString `json:"instance_id"`
-	IpAddress  string         `json:"ip_address"`
-	Payload    interface{}    `json:"payload"`
-}
-
-type AuthAuditLogEntriesInsert struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         string         `json:"id"`
-	InstanceId sql.NullString `json:"instance_id"`
-	IpAddress  sql.NullString `json:"ip_address"`
-	Payload    interface{}    `json:"payload"`
-}
-
-type AuthAuditLogEntriesUpdate struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         sql.NullString `json:"id"`
-	InstanceId sql.NullString `json:"instance_id"`
-	IpAddress  sql.NullString `json:"ip_address"`
-	Payload    interface{}    `json:"payload"`
-}
-
-type AuthIdentitiesSelect struct {
-	CreatedAt    sql.NullString `json:"created_at"`
-	Email        sql.NullString `json:"email"`
-	Id           string         `json:"id"`
-	IdentityData interface{}    `json:"identity_data"`
-	LastSignInAt sql.NullString `json:"last_sign_in_at"`
-	Provider     string         `json:"provider"`
-	ProviderId   string         `json:"provider_id"`
-	UpdatedAt    sql.NullString `json:"updated_at"`
-	UserId       string         `json:"user_id"`
-}
-
-type AuthIdentitiesInsert struct {
-	CreatedAt    sql.NullString `json:"created_at"`
-	Email        sql.NullString `json:"email"`
-	Id           sql.NullString `json:"id"`
-	IdentityData interface{}    `json:"identity_data"`
-	LastSignInAt sql.NullString `json:"last_sign_in_at"`
-	Provider     string         `json:"provider"`
-	ProviderId   string         `json:"provider_id"`
-	UpdatedAt    sql.NullString `json:"updated_at"`
-	UserId       string         `json:"user_id"`
-}
-
-type AuthIdentitiesUpdate struct {
-	CreatedAt    sql.NullString `json:"created_at"`
-	Email        sql.NullString `json:"email"`
-	Id           sql.NullString `json:"id"`
-	IdentityData interface{}    `json:"identity_data"`
-	LastSignInAt sql.NullString `json:"last_sign_in_at"`
-	Provider     sql.NullString `json:"provider"`
-	ProviderId   sql.NullString `json:"provider_id"`
-	UpdatedAt    sql.NullString `json:"updated_at"`
-	UserId       sql.NullString `json:"user_id"`
-}
-
-type AuthSessionsSelect struct {
-	Aal         sql.NullString `json:"aal"`
-	CreatedAt   sql.NullString `json:"created_at"`
-	FactorId    sql.NullString `json:"factor_id"`
-	Id          string         `json:"id"`
-	Ip          interface{}    `json:"ip"`
-	NotAfter    sql.NullString `json:"not_after"`
-	RefreshedAt sql.NullString `json:"refreshed_at"`
-	Tag         sql.NullString `json:"tag"`
-	UpdatedAt   sql.NullString `json:"updated_at"`
-	UserAgent   sql.NullString `json:"user_agent"`
-	UserId      string         `json:"user_id"`
-}
-
-type AuthSessionsInsert struct {
-	Aal         sql.NullString `json:"aal"`
-	CreatedAt   sql.NullString `json:"created_at"`
-	FactorId    sql.NullString `json:"factor_id"`
-	Id          string         `json:"id"`
-	Ip          interface{}    `json:"ip"`
-	NotAfter    sql.NullString `json:"not_after"`
-	RefreshedAt sql.NullString `json:"refreshed_at"`
-	Tag         sql.NullString `json:"tag"`
-	UpdatedAt   sql.NullString `json:"updated_at"`
-	UserAgent   sql.NullString `json:"user_agent"`
-	UserId      string         `json:"user_id"`
-}
-
-type AuthSessionsUpdate struct {
-	Aal         sql.NullString `json:"aal"`
-	CreatedAt   sql.NullString `json:"created_at"`
-	FactorId    sql.NullString `json:"factor_id"`
-	Id          sql.NullString `json:"id"`
-	Ip          interface{}    `json:"ip"`
-	NotAfter    sql.NullString `json:"not_after"`
-	RefreshedAt sql.NullString `json:"refreshed_at"`
-	Tag         sql.NullString `json:"tag"`
-	UpdatedAt   sql.NullString `json:"updated_at"`
-	UserAgent   sql.NullString `json:"user_agent"`
-	UserId      sql.NullString `json:"user_id"`
-}
-
-type AuthMfaFactorsSelect struct {
-	CreatedAt          string         `json:"created_at"`
-	FactorType         string         `json:"factor_type"`
-	FriendlyName       sql.NullString `json:"friendly_name"`
-	Id                 string         `json:"id"`
-	LastChallengedAt   sql.NullString `json:"last_challenged_at"`
-	Phone              sql.NullString `json:"phone"`
-	Secret             sql.NullString `json:"secret"`
-	Status             string         `json:"status"`
-	UpdatedAt          string         `json:"updated_at"`
-	UserId             string         `json:"user_id"`
-	WebAuthnAaguid     sql.NullString `json:"web_authn_aaguid"`
-	WebAuthnCredential interface{}    `json:"web_authn_credential"`
-}
-
-type AuthMfaFactorsInsert struct {
-	CreatedAt          string         `json:"created_at"`
-	FactorType         string         `json:"factor_type"`
-	FriendlyName       sql.NullString `json:"friendly_name"`
-	Id                 string         `json:"id"`
-	LastChallengedAt   sql.NullString `json:"last_challenged_at"`
-	Phone              sql.NullString `json:"phone"`
-	Secret             sql.NullString `json:"secret"`
-	Status             string         `json:"status"`
-	UpdatedAt          string         `json:"updated_at"`
-	UserId             string         `json:"user_id"`
-	WebAuthnAaguid     sql.NullString `json:"web_authn_aaguid"`
-	WebAuthnCredential interface{}    `json:"web_authn_credential"`
-}
-
-type AuthMfaFactorsUpdate struct {
-	CreatedAt          sql.NullString `json:"created_at"`
-	FactorType         sql.NullString `json:"factor_type"`
-	FriendlyName       sql.NullString `json:"friendly_name"`
-	Id                 sql.NullString `json:"id"`
-	LastChallengedAt   sql.NullString `json:"last_challenged_at"`
-	Phone              sql.NullString `json:"phone"`
-	Secret             sql.NullString `json:"secret"`
-	Status             sql.NullString `json:"status"`
-	UpdatedAt          sql.NullString `json:"updated_at"`
-	UserId             sql.NullString `json:"user_id"`
-	WebAuthnAaguid     sql.NullString `json:"web_authn_aaguid"`
-	WebAuthnCredential interface{}    `json:"web_authn_credential"`
-}
-
-type AuthMfaChallengesSelect struct {
-	CreatedAt           string         `json:"created_at"`
-	FactorId            string         `json:"factor_id"`
-	Id                  string         `json:"id"`
-	IpAddress           interface{}    `json:"ip_address"`
-	OtpCode             sql.NullString `json:"otp_code"`
-	VerifiedAt          sql.NullString `json:"verified_at"`
-	WebAuthnSessionData interface{}    `json:"web_authn_session_data"`
-}
-
-type AuthMfaChallengesInsert struct {
-	CreatedAt           string         `json:"created_at"`
-	FactorId            string         `json:"factor_id"`
-	Id                  string         `json:"id"`
-	IpAddress           interface{}    `json:"ip_address"`
-	OtpCode             sql.NullString `json:"otp_code"`
-	VerifiedAt          sql.NullString `json:"verified_at"`
-	WebAuthnSessionData interface{}    `json:"web_authn_session_data"`
-}
-
-type AuthMfaChallengesUpdate struct {
-	CreatedAt           sql.NullString `json:"created_at"`
-	FactorId            sql.NullString `json:"factor_id"`
-	Id                  sql.NullString `json:"id"`
-	IpAddress           interface{}    `json:"ip_address"`
-	OtpCode             sql.NullString `json:"otp_code"`
-	VerifiedAt          sql.NullString `json:"verified_at"`
-	WebAuthnSessionData interface{}    `json:"web_authn_session_data"`
-}
-
-type AuthMfaAmrClaimsSelect struct {
-	AuthenticationMethod string `json:"authentication_method"`
-	CreatedAt            string `json:"created_at"`
-	Id                   string `json:"id"`
-	SessionId            string `json:"session_id"`
-	UpdatedAt            string `json:"updated_at"`
-}
-
-type AuthMfaAmrClaimsInsert struct {
-	AuthenticationMethod string `json:"authentication_method"`
-	CreatedAt            string `json:"created_at"`
-	Id                   string `json:"id"`
-	SessionId            string `json:"session_id"`
-	UpdatedAt            string `json:"updated_at"`
-}
-
-type AuthMfaAmrClaimsUpdate struct {
-	AuthenticationMethod sql.NullString `json:"authentication_method"`
-	CreatedAt            sql.NullString `json:"created_at"`
-	Id                   sql.NullString `json:"id"`
-	SessionId            sql.NullString `json:"session_id"`
-	UpdatedAt            sql.NullString `json:"updated_at"`
-}
-
-type AuthSsoProvidersSelect struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         string         `json:"id"`
-	ResourceId sql.NullString `json:"resource_id"`
-	UpdatedAt  sql.NullString `json:"updated_at"`
-}
-
-type AuthSsoProvidersInsert struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         string         `json:"id"`
-	ResourceId sql.NullString `json:"resource_id"`
-	UpdatedAt  sql.NullString `json:"updated_at"`
-}
-
-type AuthSsoProvidersUpdate struct {
-	CreatedAt  sql.NullString `json:"created_at"`
-	Id         sql.NullString `json:"id"`
-	ResourceId sql.NullString `json:"resource_id"`
-	UpdatedAt  sql.NullString `json:"updated_at"`
-}
-
-type AuthSsoDomainsSelect struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	Domain        string         `json:"domain"`
-	Id            string         `json:"id"`
-	SsoProviderId string         `json:"sso_provider_id"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-}
-
-type AuthSsoDomainsInsert struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	Domain        string         `json:"domain"`
-	Id            string         `json:"id"`
-	SsoProviderId string         `json:"sso_provider_id"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-}
-
-type AuthSsoDomainsUpdate struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	Domain        sql.NullString `json:"domain"`
-	Id            sql.NullString `json:"id"`
-	SsoProviderId sql.NullString `json:"sso_provider_id"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-}
-
-type AuthSamlProvidersSelect struct {
-	AttributeMapping interface{}    `json:"attribute_mapping"`
-	CreatedAt        sql.NullString `json:"created_at"`
-	EntityId         string         `json:"entity_id"`
-	Id               string         `json:"id"`
-	MetadataUrl      sql.NullString `json:"metadata_url"`
-	MetadataXml      string         `json:"metadata_xml"`
-	NameIdFormat     sql.NullString `json:"name_id_format"`
-	SsoProviderId    string         `json:"sso_provider_id"`
-	UpdatedAt        sql.NullString `json:"updated_at"`
-}
-
-type AuthSamlProvidersInsert struct {
-	AttributeMapping interface{}    `json:"attribute_mapping"`
-	CreatedAt        sql.NullString `json:"created_at"`
-	EntityId         string         `json:"entity_id"`
-	Id               string         `json:"id"`
-	MetadataUrl      sql.NullString `json:"metadata_url"`
-	MetadataXml      string         `json:"metadata_xml"`
-	NameIdFormat     sql.NullString `json:"name_id_format"`
-	SsoProviderId    string         `json:"sso_provider_id"`
-	UpdatedAt        sql.NullString `json:"updated_at"`
-}
-
-type AuthSamlProvidersUpdate struct {
-	AttributeMapping interface{}    `json:"attribute_mapping"`
-	CreatedAt        sql.NullString `json:"created_at"`
-	EntityId         sql.NullString `json:"entity_id"`
-	Id               sql.NullString `json:"id"`
-	MetadataUrl      sql.NullString `json:"metadata_url"`
-	MetadataXml      sql.NullString `json:"metadata_xml"`
-	NameIdFormat     sql.NullString `json:"name_id_format"`
-	SsoProviderId    sql.NullString `json:"sso_provider_id"`
-	UpdatedAt        sql.NullString `json:"updated_at"`
-}
-
-type AuthSamlRelayStatesSelect struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	FlowStateId   sql.NullString `json:"flow_state_id"`
-	ForEmail      sql.NullString `json:"for_email"`
-	Id            string         `json:"id"`
-	RedirectTo    sql.NullString `json:"redirect_to"`
-	RequestId     string         `json:"request_id"`
-	SsoProviderId string         `json:"sso_provider_id"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-}
-
-type AuthSamlRelayStatesInsert struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	FlowStateId   sql.NullString `json:"flow_state_id"`
-	ForEmail      sql.NullString `json:"for_email"`
-	Id            string         `json:"id"`
-	RedirectTo    sql.NullString `json:"redirect_to"`
-	RequestId     string         `json:"request_id"`
-	SsoProviderId string         `json:"sso_provider_id"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-}
-
-type AuthSamlRelayStatesUpdate struct {
-	CreatedAt     sql.NullString `json:"created_at"`
-	FlowStateId   sql.NullString `json:"flow_state_id"`
-	ForEmail      sql.NullString `json:"for_email"`
-	Id            sql.NullString `json:"id"`
-	RedirectTo    sql.NullString `json:"redirect_to"`
-	RequestId     sql.NullString `json:"request_id"`
-	SsoProviderId sql.NullString `json:"sso_provider_id"`
-	UpdatedAt     sql.NullString `json:"updated_at"`
-}
-
-type AuthFlowStateSelect struct {
-	AuthCode             string         `json:"auth_code"`
-	AuthCodeIssuedAt     sql.NullString `json:"auth_code_issued_at"`
-	AuthenticationMethod string         `json:"authentication_method"`
-	CodeChallenge        string         `json:"code_challenge"`
-	CodeChallengeMethod  string         `json:"code_challenge_method"`
-	CreatedAt            sql.NullString `json:"created_at"`
-	Id                   string         `json:"id"`
-	ProviderAccessToken  sql.NullString `json:"provider_access_token"`
-	ProviderRefreshToken sql.NullString `json:"provider_refresh_token"`
-	ProviderType         string         `json:"provider_type"`
-	UpdatedAt            sql.NullString `json:"updated_at"`
-	UserId               sql.NullString `json:"user_id"`
-}
-
-type AuthFlowStateInsert struct {
-	AuthCode             string         `json:"auth_code"`
-	AuthCodeIssuedAt     sql.NullString `json:"auth_code_issued_at"`
-	AuthenticationMethod string         `json:"authentication_method"`
-	CodeChallenge        string         `json:"code_challenge"`
-	CodeChallengeMethod  string         `json:"code_challenge_method"`
-	CreatedAt            sql.NullString `json:"created_at"`
-	Id                   string         `json:"id"`
-	ProviderAccessToken  sql.NullString `json:"provider_access_token"`
-	ProviderRefreshToken sql.NullString `json:"provider_refresh_token"`
-	ProviderType         string         `json:"provider_type"`
-	UpdatedAt            sql.NullString `json:"updated_at"`
-	UserId               sql.NullString `json:"user_id"`
-}
-
-type AuthFlowStateUpdate struct {
-	AuthCode             sql.NullString `json:"auth_code"`
-	AuthCodeIssuedAt     sql.NullString `json:"auth_code_issued_at"`
-	AuthenticationMethod sql.NullString `json:"authentication_method"`
-	CodeChallenge        sql.NullString `json:"code_challenge"`
-	CodeChallengeMethod  sql.NullString `json:"code_challenge_method"`
-	CreatedAt            sql.NullString `json:"created_at"`
-	Id                   sql.NullString `json:"id"`
-	ProviderAccessToken  sql.NullString `json:"provider_access_token"`
-	ProviderRefreshToken sql.NullString `json:"provider_refresh_token"`
-	ProviderType         sql.NullString `json:"provider_type"`
-	UpdatedAt            sql.NullString `json:"updated_at"`
-	UserId               sql.NullString `json:"user_id"`
-}
-
-type AuthOneTimeTokensSelect struct {
-	CreatedAt string `json:"created_at"`
-	Id        string `json:"id"`
-	RelatesTo string `json:"relates_to"`
-	TokenHash string `json:"token_hash"`
-	TokenType string `json:"token_type"`
-	UpdatedAt string `json:"updated_at"`
-	UserId    string `json:"user_id"`
-}
-
-type AuthOneTimeTokensInsert struct {
-	CreatedAt sql.NullString `json:"created_at"`
-	Id        string         `json:"id"`
-	RelatesTo string         `json:"relates_to"`
-	TokenHash string         `json:"token_hash"`
-	TokenType string         `json:"token_type"`
-	UpdatedAt sql.NullString `json:"updated_at"`
-	UserId    string         `json:"user_id"`
-}
-
-type AuthOneTimeTokensUpdate struct {
-	CreatedAt sql.NullString `json:"created_at"`
-	Id        sql.NullString `json:"id"`
-	RelatesTo sql.NullString `json:"relates_to"`
-	TokenHash sql.NullString `json:"token_hash"`
-	TokenType sql.NullString `json:"token_type"`
-	UpdatedAt sql.NullString `json:"updated_at"`
-	UserId    sql.NullString `json:"user_id"`
-}
-
-type PublicSchemaMigrationsSelect struct {
-	Dirty   bool  `json:"dirty"`
-	Version int64 `json:"version"`
-}
-
-type PublicSchemaMigrationsInsert struct {
-	Dirty   bool  `json:"dirty"`
-	Version int64 `json:"version"`
-}
-
-type PublicSchemaMigrationsUpdate struct {
-	Dirty   sql.NullBool  `json:"dirty"`
-	Version sql.NullInt64 `json:"version"`
+type ApiOemConfigsUpdate struct {
+	ApiVersion sql.NullString         `json:"api_version"`
+	Id         sql.NullInt32          `json:"id"`
+	Kind       sql.NullString         `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
 }
 
 type ApiWorkspacesSelect struct {
@@ -614,6 +74,60 @@ type ApiWorkspacesUpdate struct {
 	Id         sql.NullInt32          `json:"id"`
 	Kind       sql.NullString         `json:"kind"`
 	Metadata   map[string]interface{} `json:"metadata"`
+	Status     map[string]interface{} `json:"status"`
+}
+
+type ApiRoleAssignmentsSelect struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         int32                  `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
+}
+
+type ApiRoleAssignmentsInsert struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         sql.NullInt32          `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
+}
+
+type ApiRoleAssignmentsUpdate struct {
+	ApiVersion sql.NullString         `json:"api_version"`
+	Id         sql.NullInt32          `json:"id"`
+	Kind       sql.NullString         `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
+}
+
+type ApiEndpointsSelect struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         int32                  `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
+}
+
+type ApiEndpointsInsert struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         sql.NullInt32          `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
+}
+
+type ApiEndpointsUpdate struct {
+	ApiVersion sql.NullString         `json:"api_version"`
+	Id         sql.NullInt32          `json:"id"`
+	Kind       sql.NullString         `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
 	Status     map[string]interface{} `json:"status"`
 }
 
@@ -644,7 +158,37 @@ type ApiRolesUpdate struct {
 	Status     map[string]interface{} `json:"status"`
 }
 
-type ApiRoleAssignmentsSelect struct {
+type ApiApiKeysSelect struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         string                 `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
+	UserId     string                 `json:"user_id"`
+}
+
+type ApiApiKeysInsert struct {
+	ApiVersion string                 `json:"api_version"`
+	Id         sql.NullString         `json:"id"`
+	Kind       string                 `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
+	UserId     string                 `json:"user_id"`
+}
+
+type ApiApiKeysUpdate struct {
+	ApiVersion sql.NullString         `json:"api_version"`
+	Id         sql.NullString         `json:"id"`
+	Kind       sql.NullString         `json:"kind"`
+	Metadata   map[string]interface{} `json:"metadata"`
+	Spec       map[string]interface{} `json:"spec"`
+	Status     map[string]interface{} `json:"status"`
+	UserId     sql.NullString         `json:"user_id"`
+}
+
+type ApiClustersSelect struct {
 	ApiVersion string                 `json:"api_version"`
 	Id         int32                  `json:"id"`
 	Kind       string                 `json:"kind"`
@@ -653,7 +197,7 @@ type ApiRoleAssignmentsSelect struct {
 	Status     map[string]interface{} `json:"status"`
 }
 
-type ApiRoleAssignmentsInsert struct {
+type ApiClustersInsert struct {
 	ApiVersion string                 `json:"api_version"`
 	Id         sql.NullInt32          `json:"id"`
 	Kind       string                 `json:"kind"`
@@ -662,7 +206,7 @@ type ApiRoleAssignmentsInsert struct {
 	Status     map[string]interface{} `json:"status"`
 }
 
-type ApiRoleAssignmentsUpdate struct {
+type ApiClustersUpdate struct {
 	ApiVersion sql.NullString         `json:"api_version"`
 	Id         sql.NullInt32          `json:"id"`
 	Kind       sql.NullString         `json:"kind"`
@@ -698,34 +242,31 @@ type ApiUserProfilesUpdate struct {
 	Status     map[string]interface{} `json:"status"`
 }
 
-type ApiApiKeysSelect struct {
+type ApiImageRegistriesSelect struct {
 	ApiVersion string                 `json:"api_version"`
-	Id         string                 `json:"id"`
+	Id         int32                  `json:"id"`
 	Kind       string                 `json:"kind"`
 	Metadata   map[string]interface{} `json:"metadata"`
 	Spec       map[string]interface{} `json:"spec"`
 	Status     map[string]interface{} `json:"status"`
-	UserId     string                 `json:"user_id"`
 }
 
-type ApiApiKeysInsert struct {
+type ApiImageRegistriesInsert struct {
 	ApiVersion string                 `json:"api_version"`
-	Id         sql.NullString         `json:"id"`
+	Id         sql.NullInt32          `json:"id"`
 	Kind       string                 `json:"kind"`
 	Metadata   map[string]interface{} `json:"metadata"`
 	Spec       map[string]interface{} `json:"spec"`
 	Status     map[string]interface{} `json:"status"`
-	UserId     string                 `json:"user_id"`
 }
 
-type ApiApiKeysUpdate struct {
+type ApiImageRegistriesUpdate struct {
 	ApiVersion sql.NullString         `json:"api_version"`
-	Id         sql.NullString         `json:"id"`
+	Id         sql.NullInt32          `json:"id"`
 	Kind       sql.NullString         `json:"kind"`
 	Metadata   map[string]interface{} `json:"metadata"`
 	Spec       map[string]interface{} `json:"spec"`
 	Status     map[string]interface{} `json:"status"`
-	UserId     sql.NullString         `json:"user_id"`
 }
 
 type ApiApiUsageRecordsSelect struct {
@@ -764,87 +305,6 @@ type ApiApiUsageRecordsUpdate struct {
 	Workspace    sql.NullString `json:"workspace"`
 }
 
-type ApiApiDailyUsageSelect struct {
-	ApiVersion string                 `json:"api_version"`
-	Id         int32                  `json:"id"`
-	Kind       string                 `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiApiDailyUsageInsert struct {
-	ApiVersion string                 `json:"api_version"`
-	Id         sql.NullInt32          `json:"id"`
-	Kind       string                 `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiApiDailyUsageUpdate struct {
-	ApiVersion sql.NullString         `json:"api_version"`
-	Id         sql.NullInt32          `json:"id"`
-	Kind       sql.NullString         `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiEndpointsSelect struct {
-	ApiVersion string                 `json:"api_version"`
-	Id         int32                  `json:"id"`
-	Kind       string                 `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiEndpointsInsert struct {
-	ApiVersion string                 `json:"api_version"`
-	Id         sql.NullInt32          `json:"id"`
-	Kind       string                 `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiEndpointsUpdate struct {
-	ApiVersion sql.NullString         `json:"api_version"`
-	Id         sql.NullInt32          `json:"id"`
-	Kind       sql.NullString         `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiImageRegistriesSelect struct {
-	ApiVersion string                 `json:"api_version"`
-	Id         int32                  `json:"id"`
-	Kind       string                 `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiImageRegistriesInsert struct {
-	ApiVersion string                 `json:"api_version"`
-	Id         sql.NullInt32          `json:"id"`
-	Kind       string                 `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiImageRegistriesUpdate struct {
-	ApiVersion sql.NullString         `json:"api_version"`
-	Id         sql.NullInt32          `json:"id"`
-	Kind       sql.NullString         `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
 type ApiModelRegistriesSelect struct {
 	ApiVersion string                 `json:"api_version"`
 	Id         int32                  `json:"id"`
@@ -870,6 +330,33 @@ type ApiModelRegistriesUpdate struct {
 	Metadata   map[string]interface{} `json:"metadata"`
 	Spec       map[string]interface{} `json:"spec"`
 	Status     map[string]interface{} `json:"status"`
+}
+
+type ApiOemConfigSelect struct {
+	BrandName           sql.NullString `json:"brand_name"`
+	CreatedAt           sql.NullString `json:"created_at"`
+	Id                  int32          `json:"id"`
+	LogoBase64          sql.NullString `json:"logo_base64"`
+	LogoCollapsedBase64 sql.NullString `json:"logo_collapsed_base64"`
+	UpdatedAt           sql.NullString `json:"updated_at"`
+}
+
+type ApiOemConfigInsert struct {
+	BrandName           sql.NullString `json:"brand_name"`
+	CreatedAt           sql.NullString `json:"created_at"`
+	Id                  sql.NullInt32  `json:"id"`
+	LogoBase64          sql.NullString `json:"logo_base64"`
+	LogoCollapsedBase64 sql.NullString `json:"logo_collapsed_base64"`
+	UpdatedAt           sql.NullString `json:"updated_at"`
+}
+
+type ApiOemConfigUpdate struct {
+	BrandName           sql.NullString `json:"brand_name"`
+	CreatedAt           sql.NullString `json:"created_at"`
+	Id                  sql.NullInt32  `json:"id"`
+	LogoBase64          sql.NullString `json:"logo_base64"`
+	LogoCollapsedBase64 sql.NullString `json:"logo_collapsed_base64"`
+	UpdatedAt           sql.NullString `json:"updated_at"`
 }
 
 type ApiEnginesSelect struct {
@@ -899,7 +386,7 @@ type ApiEnginesUpdate struct {
 	Status     map[string]interface{} `json:"status"`
 }
 
-type ApiClustersSelect struct {
+type ApiApiDailyUsageSelect struct {
 	ApiVersion string                 `json:"api_version"`
 	Id         int32                  `json:"id"`
 	Kind       string                 `json:"kind"`
@@ -908,7 +395,7 @@ type ApiClustersSelect struct {
 	Status     map[string]interface{} `json:"status"`
 }
 
-type ApiClustersInsert struct {
+type ApiApiDailyUsageInsert struct {
 	ApiVersion string                 `json:"api_version"`
 	Id         sql.NullInt32          `json:"id"`
 	Kind       string                 `json:"kind"`
@@ -917,34 +404,7 @@ type ApiClustersInsert struct {
 	Status     map[string]interface{} `json:"status"`
 }
 
-type ApiClustersUpdate struct {
-	ApiVersion sql.NullString         `json:"api_version"`
-	Id         sql.NullInt32          `json:"id"`
-	Kind       sql.NullString         `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiModelCatalogsSelect struct {
-	ApiVersion string                 `json:"api_version"`
-	Id         int32                  `json:"id"`
-	Kind       string                 `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiModelCatalogsInsert struct {
-	ApiVersion string                 `json:"api_version"`
-	Id         sql.NullInt32          `json:"id"`
-	Kind       string                 `json:"kind"`
-	Metadata   map[string]interface{} `json:"metadata"`
-	Spec       map[string]interface{} `json:"spec"`
-	Status     map[string]interface{} `json:"status"`
-}
-
-type ApiModelCatalogsUpdate struct {
+type ApiApiDailyUsageUpdate struct {
 	ApiVersion sql.NullString         `json:"api_version"`
 	Id         sql.NullInt32          `json:"id"`
 	Kind       sql.NullString         `json:"kind"`
@@ -1144,4 +604,10 @@ type ApiModelCatalogStatus struct {
 	Phase              string      `json:"phase"`
 	LastTransitionTime interface{} `json:"last_transition_time"`
 	ErrorMessage       string      `json:"error_message"`
+}
+
+type ApiOemConfigSpec struct {
+	BrandName           string `json:"brand_name"`
+	LogoBase64          string `json:"logo_base64"`
+	LogoCollapsedBase64 string `json:"logo_collapsed_base64"`
 }

--- a/db/migrations/008_oem_config.down.sql
+++ b/db/migrations/008_oem_config.down.sql
@@ -1,0 +1,10 @@
+-- ----------------------
+-- Remove system permissions from permission_action enum
+-- ----------------------
+
+UPDATE api.roles 
+SET spec = ROW(
+    (spec).preset_key, 
+    array_remove((spec).permissions, 'system:admin'::api.permission_action)
+)::api.role_spec
+WHERE (metadata).name = 'admin';

--- a/db/migrations/008_oem_config.up.sql
+++ b/db/migrations/008_oem_config.up.sql
@@ -1,0 +1,6 @@
+-- ----------------------
+-- Add system permissions to permission_action enum
+-- ----------------------
+
+ALTER TYPE api.permission_action
+  ADD VALUE IF NOT EXISTS 'system:admin';

--- a/db/migrations/009_oem_config.down.sql
+++ b/db/migrations/009_oem_config.down.sql
@@ -1,0 +1,20 @@
+-- Drop OEM configuration resource and related objects
+
+-- Drop validation triggers
+DROP TRIGGER IF EXISTS validate_name_on_oem_configs ON api.oem_configs;
+
+-- Drop policies
+DROP POLICY IF EXISTS "oem_config delete policy" ON api.oem_configs;
+DROP POLICY IF EXISTS "oem_config update policy" ON api.oem_configs;
+DROP POLICY IF EXISTS "oem_config create policy" ON api.oem_configs;
+DROP POLICY IF EXISTS "oem_config read policy" ON api.oem_configs;
+
+-- Drop timestamp triggers
+DROP TRIGGER IF EXISTS set_oem_configs_default_timestamp ON api.oem_configs;
+DROP TRIGGER IF EXISTS update_oem_configs_update_timestamp ON api.oem_configs;
+
+-- Drop table
+DROP TABLE IF EXISTS api.oem_configs;
+
+-- Drop types
+DROP TYPE IF EXISTS api.oem_config_spec;

--- a/db/migrations/009_oem_config.up.sql
+++ b/db/migrations/009_oem_config.up.sql
@@ -1,0 +1,59 @@
+-- ----------------------
+-- Resource: OEM Configuration
+-- ----------------------
+CREATE TYPE api.oem_config_spec AS (
+    brand_name TEXT,
+    logo_base64 TEXT,
+    logo_collapsed_base64 TEXT
+);
+
+CREATE TABLE api.oem_configs (
+    id SERIAL PRIMARY KEY,
+    api_version TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    metadata api.metadata,
+    spec api.oem_config_spec
+);
+
+CREATE TRIGGER update_oem_configs_update_timestamp
+    BEFORE UPDATE ON api.oem_configs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_metadata_update_timestamp_column();
+
+CREATE TRIGGER set_oem_configs_default_timestamp
+    BEFORE INSERT ON api.oem_configs
+    FOR EACH ROW
+    EXECUTE FUNCTION set_default_metadata_timestamp_column();
+
+-- Add constraint to ensure only one OEM config exists globally
+CREATE UNIQUE INDEX oem_configs_global_unique_idx
+    ON api.oem_configs ((TRUE));
+
+ALTER TABLE api.oem_configs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "oem_config read policy" ON api.oem_configs
+    FOR SELECT
+    USING (auth.role() = 'api_user');
+
+CREATE POLICY "oem_config create policy" ON api.oem_configs
+    FOR INSERT
+    WITH CHECK (
+        api.has_permission(auth.uid(), 'system:admin', NULL)
+    );
+
+CREATE POLICY "oem_config update policy" ON api.oem_configs
+    FOR UPDATE
+    USING (
+        api.has_permission(auth.uid(), 'system:admin', NULL)
+    );
+
+CREATE POLICY "oem_config delete policy" ON api.oem_configs
+    FOR DELETE
+    USING (
+        api.has_permission(auth.uid(), 'system:admin', NULL)
+    );
+
+CREATE TRIGGER validate_name_on_oem_configs
+    BEFORE INSERT OR UPDATE ON api.oem_configs
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_metadata_name();


### PR DESCRIPTION
## Issues


## Changes

The OEM feature is simple in the backend; we are just adding a new resource `oem_configs`, and letting the client side customize the config and display the content in the UI.
Also, we can re-use the export/import features in the client to port an OEM config from one neutree to another neutree.

We also add a new permission action `system:admin` to control the RLS of this resource, which only lets the admin user customize the OEM config by default.

We are using a unique index to ensure that only one OEM configuration exists.

## Test

Posted a test video in our internal channel.