### PR TITLE
fix: download HF gated models failed

### DIFF
--- a/internal/orchestrator/ray/dashboard/serve.go
+++ b/internal/orchestrator/ray/dashboard/serve.go
@@ -94,6 +94,13 @@ func EndpointToApplication(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistr
 				},
 			}
 		}
+	} else if modelRegistry.Spec.Type == v1.HuggingFaceModelRegistryType {
+		app.RuntimeEnv = map[string]interface{}{
+			"env_vars": map[string]string{
+				"HF_TOKEN":    modelRegistry.Spec.Credentials,
+				"HF_ENDPOINT": strings.TrimSuffix(modelRegistry.Spec.Url, "/"),
+			},
+		}
 	}
 
 	return app


### PR DESCRIPTION
## Issues

fix: download HF gated models failed

## Changes

config `HF_TOKEN/HF_ENDPOINT` Env to ray application 

## Test

config credentials to download `google/gemma-3-4b-it `
<img width="668" alt="image" src="https://github.com/user-attachments/assets/71e7d2d0-d389-48f7-b69f-3bf89152e2de" />

