### PR TITLE
fix: vllm download model failed due to HF token is empty string

### DIFF
--- a/api/v1/model_registry_types.go
+++ b/api/v1/model_registry_types.go
@@ -25,8 +25,12 @@ const (
 	BentoMLModelRegistryConnectTypeFile = "file"
 )
 
+// The environment variable name for model registry
 const (
-	HFHomeEnv      = "HF_HOME"
+	HFHomeEnv  = "HF_HOME"
+	HFTokenEnv = "HF_TOKEN"
+	HFEndpoint = "HF_ENDPOINT"
+
 	BentoMLHomeEnv = "BENTOML_HOME"
 )
 

--- a/internal/orchestrator/ray/dashboard/serve.go
+++ b/internal/orchestrator/ray/dashboard/serve.go
@@ -85,6 +85,7 @@ func EndpointToApplication(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistr
 	}
 
 	applicationEnv := map[string]string{}
+
 	if modelRegistry.Spec.Type == v1.BentoMLModelRegistryType {
 		url, _ := url.Parse(modelRegistry.Spec.Url) // nolint: errcheck
 		// todo: support local file type env set


### PR DESCRIPTION
## Issues


## Changes

remove `HF_TOKEN` env when huggingface model registry credentials is empty string

## Test

credentials is not empty string
<img width="911" alt="image" src="https://github.com/user-attachments/assets/eb41dd39-ef85-44d6-af69-97385005c330" />

credentials is empty string
<img width="827" alt="image" src="https://github.com/user-attachments/assets/14c81e9a-ed6f-4d21-aeb7-55884a3aa614" />
