### PR TITLE
fix: login page also need OEM config

### DIFF
--- a/db/migrations/010_oem_config_read_policy.down.sql
+++ b/db/migrations/010_oem_config_read_policy.down.sql
@@ -1,0 +1,8 @@
+-- Rollback OEM config read policy to original state
+-- Drop the current read policy
+DROP POLICY "oem_config read policy" ON api.oem_configs;
+
+-- Restore original read policy that requires api_user role
+CREATE POLICY "oem_config read policy" ON api.oem_configs
+    FOR SELECT
+    USING (auth.role() = 'api_user');

--- a/db/migrations/010_oem_config_read_policy.up.sql
+++ b/db/migrations/010_oem_config_read_policy.up.sql
@@ -1,0 +1,8 @@
+-- Update OEM config read policy to allow access for login page
+-- Drop the existing read policy
+DROP POLICY "oem_config read policy" ON api.oem_configs;
+
+-- Create new read policy that allows all users to read OEM configs
+CREATE POLICY "oem_config read policy" ON api.oem_configs
+    FOR SELECT
+    USING (TRUE);


### PR DESCRIPTION
## Issues

The login page(not authenticated yet) also needs to fetch the OEM config and display the logo and brand name.

## Changes


## Test
