### PR TITLE
feat: optimize model management

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -111,6 +111,9 @@ linters-settings:
     allow-trailing-comment: true
     # Allow leading comments to be separated with empty liens
     allow-separated-leading-comment: true
+  gosec:
+    excludes:
+      - G115
 
 issues:
   exclude-files:

--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -20,10 +20,11 @@ func NewPushCmd() *cobra.Command {
 	var labelsFlag []string
 
 	cmd := &cobra.Command{
-		Use:   "push [local_model_path]",
-		Short: "Push a model to the registry",
-		Long:  `Push a local model to the registry with specified metadata`,
-		Args:  cobra.ExactArgs(1),
+		Use:          "push [local_model_path]",
+		Short:        "Push a model to the registry",
+		Long:         `Push a local model to the registry with specified metadata`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			modelPath := args[0]
 
@@ -63,15 +64,18 @@ func NewPushCmd() *cobra.Command {
 				// Calculate directory size for progress bar
 				totalSize, _, err := calculateDirectorySize(modelPath)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to calculate directory size: %w", err)
 				}
+
+				// Add some buffer for YAML file modifications and compression overhead
+				totalSize = totalSize + 100*1024
 
 				// Create progress bar for archive
 				archiveBar := progressbar.DefaultBytes(totalSize, "Creating archive")
 
 				archivePath, err := bentoml.CreateArchiveWithProgress(modelPath, modelName, version, archiveBar)
 				if err != nil {
-					return err
+					return fmt.Errorf("failed to create archive: %w", err)
 				}
 
 				modelPath = archivePath
@@ -84,7 +88,7 @@ func NewPushCmd() *cobra.Command {
 			// Get file size for progress bar
 			fileInfo, err := os.Stat(modelPath)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to get model file info: %w", err)
 			}
 
 			// Create progress bar for upload

--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -98,7 +98,6 @@ func NewPushCmd() *cobra.Command {
 				return fmt.Errorf("failed to push model: %w", err)
 			}
 
-			fmt.Printf("Model %s:%s pushed successfully\n", modelName, version)
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/kong/go-kong v0.65.1
 	github.com/pkg/errors v0.9.1
 	github.com/ray-project/kuberay/ray-operator v1.3.1
+	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
@@ -80,6 +81,7 @@ require (
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
+	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
@@ -95,6 +97,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kong/semver/v4 v4.0.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCN
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chengxilo/virtualterm v1.0.4 h1:Z6IpERbRVlfB8WkOmtbHiDbBANU7cimRIof7mk9/PwM=
+github.com/chengxilo/virtualterm v1.0.4/go.mod h1:DyxxBZz/x1iqJjFxTFcr6/x+jSpqN0iwWCOK1q10rlY=
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
@@ -143,8 +145,12 @@ github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
+github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -185,6 +191,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ray-project/kuberay/ray-operator v1.3.1 h1:XrUN5BGyYb44k2rg/rjBp579rS8lxMWUkreUsKqNfm4=
 github.com/ray-project/kuberay/ray-operator v1.3.1/go.mod h1:vsO1hQC2BiQNvqWUs67HfzrbAOtbG+GqqYbnI/Ddyk8=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
@@ -192,6 +200,8 @@ github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
 github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
+github.com/schollz/progressbar/v3 v3.18.0 h1:uXdoHABRFmNIjUfte/Ex7WtuyVslrw2wVPQmCN62HpA=
+github.com/schollz/progressbar/v3 v3.18.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
+github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
+github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
 github.com/kong/go-kong v0.65.1 h1:CM+8NlF+VbJckTxP2hGmSPKhA1GMliitXjQ7vJiPkaE=
 github.com/kong/go-kong v0.65.1/go.mod h1:sqdysTKrXIJ6mpxHwTwjgZhLW7jR1/puczTXHLUwJaE=

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -151,8 +151,9 @@ func (s *ModelsService) PushWithProgress(
 			reader = io.TeeReader(file, progressWriter)
 		}
 
-		// Copy with progress tracking
-		_, err := io.Copy(part, reader)
+		buf := make([]byte, 16*1024*1024)
+
+		_, err := io.CopyBuffer(part, reader, buf)
 		if err != nil {
 			pw.CloseWithError(err)
 			return

--- a/pkg/model_registry/file_based.go
+++ b/pkg/model_registry/file_based.go
@@ -137,8 +137,9 @@ func (f *localFile) SaveUploadedModel(reader io.Reader, name, version, tempDir s
 
 	defer out.Close()
 
-	// Copy the uploaded model to the temporary file
-	_, err = io.Copy(out, reader)
+	buf := make([]byte, 16*1024*1024)
+
+	_, err = io.CopyBuffer(out, reader, buf)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to save uploaded model")
 	}
@@ -234,8 +235,9 @@ func (n *nfsFile) SaveUploadedModel(reader io.Reader, name, version, tempDir str
 
 	defer out.Close()
 
-	// Copy the uploaded model to the temporary file
-	_, err = io.Copy(out, reader)
+	buf := make([]byte, 16*1024*1024)
+
+	_, err = io.CopyBuffer(out, reader, buf)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to save uploaded model")
 	}

--- a/pkg/model_registry/file_based.go
+++ b/pkg/model_registry/file_based.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -110,8 +109,8 @@ func (f *localFile) DeleteModel(name, version string) error {
 	return bentoml.DeleteModel(f.path, name, version)
 }
 
-func (f *localFile) ImportModel(modelPath string) error {
-	return bentoml.ImportModel(f.path, modelPath)
+func (f *localFile) ImportModel(reader io.Reader, name, version string, progress io.Writer) error {
+	return bentoml.ImportModel(f.path, reader, name, version, true, progress)
 }
 
 func (f *localFile) ExportModel(name, version, outputPath string) error {
@@ -120,31 +119,6 @@ func (f *localFile) ExportModel(name, version, outputPath string) error {
 
 func (f *localFile) GetModelPath(name, version string) (string, error) {
 	return bentoml.GetModelPath(f.path, name, version)
-}
-
-func (f *localFile) SaveUploadedModel(reader io.Reader, name, version, tempDir string) (string, error) {
-	// Create a temporary file to store the uploaded model
-	if err := os.MkdirAll(tempDir, 0755); err != nil {
-		return "", errors.Wrap(err, "failed to create temporary directory")
-	}
-
-	tempFile := filepath.Join(tempDir, name+"-"+version+".bentomodel")
-
-	out, err := os.Create(tempFile)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create temporary file")
-	}
-
-	defer out.Close()
-
-	buf := make([]byte, 16*1024*1024)
-
-	_, err = io.CopyBuffer(out, reader, buf)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to save uploaded model")
-	}
-
-	return tempFile, nil
 }
 
 func (f *localFile) HealthyCheck() bool {
@@ -208,8 +182,8 @@ func (n *nfsFile) DeleteModel(name, version string) error {
 	return bentoml.DeleteModel(n.targetPath, name, version)
 }
 
-func (n *nfsFile) ImportModel(modelPath string) error {
-	return bentoml.ImportModel(n.targetPath, modelPath)
+func (n *nfsFile) ImportModel(reader io.Reader, name, version string, progress io.Writer) error {
+	return bentoml.ImportModel(n.targetPath, reader, name, version, true, progress)
 }
 
 func (n *nfsFile) ExportModel(name, version, outputPath string) error {
@@ -218,31 +192,6 @@ func (n *nfsFile) ExportModel(name, version, outputPath string) error {
 
 func (n *nfsFile) GetModelPath(name, version string) (string, error) {
 	return bentoml.GetModelPath(n.targetPath, name, version)
-}
-
-func (n *nfsFile) SaveUploadedModel(reader io.Reader, name, version, tempDir string) (string, error) {
-	// Create a temporary file to store the uploaded model
-	if err := os.MkdirAll(tempDir, 0755); err != nil {
-		return "", errors.Wrap(err, "failed to create temporary directory")
-	}
-
-	tempFile := filepath.Join(tempDir, name+"-"+version+".bentomodel")
-
-	out, err := os.Create(tempFile)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create temporary file")
-	}
-
-	defer out.Close()
-
-	buf := make([]byte, 16*1024*1024)
-
-	_, err = io.CopyBuffer(out, reader, buf)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to save uploaded model")
-	}
-
-	return tempFile, nil
 }
 
 func (n *nfsFile) HealthyCheck() bool {

--- a/pkg/model_registry/hugging_face.go
+++ b/pkg/model_registry/hugging_face.go
@@ -156,7 +156,7 @@ func (hf *huggingFace) DeleteModel(name, version string) error {
 }
 
 // ImportModel returns an error for HuggingFace as it's read-only
-func (hf *huggingFace) ImportModel(modelPath string) error {
+func (hf *huggingFace) ImportModel(reader io.Reader, name, version string, progress io.Writer) error {
 	return errors.New(errHuggingFaceNotSupported)
 }
 
@@ -167,10 +167,5 @@ func (hf *huggingFace) ExportModel(name, version, outputPath string) error {
 
 // GetModelPath returns an error for HuggingFace as it's read-only
 func (hf *huggingFace) GetModelPath(name, version string) (string, error) {
-	return "", errors.New(errHuggingFaceNotSupported)
-}
-
-// SaveUploadedModel returns an error for HuggingFace as it's read-only
-func (hf *huggingFace) SaveUploadedModel(reader io.Reader, name, version, tempDir string) (string, error) {
 	return "", errors.New(errHuggingFaceNotSupported)
 }

--- a/pkg/model_registry/mocks/mock_model_registry.go
+++ b/pkg/model_registry/mocks/mock_model_registry.go
@@ -370,17 +370,17 @@ func (_c *MockModelRegistry_HealthyCheck_Call) RunAndReturn(run func() bool) *Mo
 	return _c
 }
 
-// ImportModel provides a mock function with given fields: modelPath
-func (_m *MockModelRegistry) ImportModel(modelPath string) error {
-	ret := _m.Called(modelPath)
+// ImportModel provides a mock function with given fields: reader, name, version, progress
+func (_m *MockModelRegistry) ImportModel(reader io.Reader, name string, version string, progress io.Writer) error {
+	ret := _m.Called(reader, name, version, progress)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ImportModel")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(modelPath)
+	if rf, ok := ret.Get(0).(func(io.Reader, string, string, io.Writer) error); ok {
+		r0 = rf(reader, name, version, progress)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -394,14 +394,17 @@ type MockModelRegistry_ImportModel_Call struct {
 }
 
 // ImportModel is a helper method to define mock.On call
-//   - modelPath string
-func (_e *MockModelRegistry_Expecter) ImportModel(modelPath interface{}) *MockModelRegistry_ImportModel_Call {
-	return &MockModelRegistry_ImportModel_Call{Call: _e.mock.On("ImportModel", modelPath)}
+//   - reader io.Reader
+//   - name string
+//   - version string
+//   - progress io.Writer
+func (_e *MockModelRegistry_Expecter) ImportModel(reader interface{}, name interface{}, version interface{}, progress interface{}) *MockModelRegistry_ImportModel_Call {
+	return &MockModelRegistry_ImportModel_Call{Call: _e.mock.On("ImportModel", reader, name, version, progress)}
 }
 
-func (_c *MockModelRegistry_ImportModel_Call) Run(run func(modelPath string)) *MockModelRegistry_ImportModel_Call {
+func (_c *MockModelRegistry_ImportModel_Call) Run(run func(reader io.Reader, name string, version string, progress io.Writer)) *MockModelRegistry_ImportModel_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(io.Reader), args[1].(string), args[2].(string), args[3].(io.Writer))
 	})
 	return _c
 }
@@ -411,7 +414,7 @@ func (_c *MockModelRegistry_ImportModel_Call) Return(_a0 error) *MockModelRegist
 	return _c
 }
 
-func (_c *MockModelRegistry_ImportModel_Call) RunAndReturn(run func(string) error) *MockModelRegistry_ImportModel_Call {
+func (_c *MockModelRegistry_ImportModel_Call) RunAndReturn(run func(io.Reader, string, string, io.Writer) error) *MockModelRegistry_ImportModel_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -470,65 +473,6 @@ func (_c *MockModelRegistry_ListModels_Call) Return(_a0 []v1.GeneralModel, _a1 e
 }
 
 func (_c *MockModelRegistry_ListModels_Call) RunAndReturn(run func(model_registry.ListOption) ([]v1.GeneralModel, error)) *MockModelRegistry_ListModels_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SaveUploadedModel provides a mock function with given fields: reader, name, version, tempDir
-func (_m *MockModelRegistry) SaveUploadedModel(reader io.Reader, name string, version string, tempDir string) (string, error) {
-	ret := _m.Called(reader, name, version, tempDir)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SaveUploadedModel")
-	}
-
-	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(io.Reader, string, string, string) (string, error)); ok {
-		return rf(reader, name, version, tempDir)
-	}
-	if rf, ok := ret.Get(0).(func(io.Reader, string, string, string) string); ok {
-		r0 = rf(reader, name, version, tempDir)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	if rf, ok := ret.Get(1).(func(io.Reader, string, string, string) error); ok {
-		r1 = rf(reader, name, version, tempDir)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockModelRegistry_SaveUploadedModel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveUploadedModel'
-type MockModelRegistry_SaveUploadedModel_Call struct {
-	*mock.Call
-}
-
-// SaveUploadedModel is a helper method to define mock.On call
-//   - reader io.Reader
-//   - name string
-//   - version string
-//   - tempDir string
-func (_e *MockModelRegistry_Expecter) SaveUploadedModel(reader interface{}, name interface{}, version interface{}, tempDir interface{}) *MockModelRegistry_SaveUploadedModel_Call {
-	return &MockModelRegistry_SaveUploadedModel_Call{Call: _e.mock.On("SaveUploadedModel", reader, name, version, tempDir)}
-}
-
-func (_c *MockModelRegistry_SaveUploadedModel_Call) Run(run func(reader io.Reader, name string, version string, tempDir string)) *MockModelRegistry_SaveUploadedModel_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(io.Reader), args[1].(string), args[2].(string), args[3].(string))
-	})
-	return _c
-}
-
-func (_c *MockModelRegistry_SaveUploadedModel_Call) Return(_a0 string, _a1 error) *MockModelRegistry_SaveUploadedModel_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockModelRegistry_SaveUploadedModel_Call) RunAndReturn(run func(io.Reader, string, string, string) (string, error)) *MockModelRegistry_SaveUploadedModel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/model_registry/model_registry.go
+++ b/pkg/model_registry/model_registry.go
@@ -24,10 +24,9 @@ type ModelRegistry interface {
 	// Model operations
 	GetModelVersion(name, version string) (*v1.ModelVersion, error)
 	DeleteModel(name, version string) error
-	ImportModel(modelPath string) error
+	ImportModel(reader io.Reader, name, version string, progress io.Writer) error
 	ExportModel(name, version, outputPath string) error
 	GetModelPath(name, version string) (string, error)
-	SaveUploadedModel(reader io.Reader, name, version, tempDir string) (string, error)
 }
 
 type NewModelRegistryFunc func(registry *v1.ModelRegistry) (ModelRegistry, error)


### PR DESCRIPTION
## Issues

Previously, we used the `bentoml` Python CLI to manage the models on the server side and implement our own APIs and client/CLI on top of it.

However, the UX suffered because there are no indicators about the lengthy task, and the task's speed is also slow.

## Changes

We've built multiple improvements to the model management UX in this patch:

1. Add progress bars to the model push command, including archiving, uploading, and server-side importing.
2. Optimize the speed of the push command.
  - Use a larger buffer(16mb) for the copy process.
  - Use the pgzip lib to do parallel gzip, which is good for large model files.
  - Implement the alternative to `bentoml model import` in Go, which removes the slow Python implementation.
  - Remove some duplicate IO paths.
3. Since the model list command is also used frequently, we also rewrite the Python implementation in Go.

## Test

I've posted the testing video in our Slack channel, now the push command has a 10x end-to-end speed up, and the list command becomes a ms-level command.