### PR TITLE
fix: ray head pod request no gpu resource but mount all node gpu device

### DIFF
--- a/internal/accelerator/plugin/gpu.go
+++ b/internal/accelerator/plugin/gpu.go
@@ -140,7 +140,16 @@ func (p *GPUAcceleratorPlugin) GetKubernetesContainerRuntimeConfig(ctx context.C
 	acclerators := p.getKubernetesContainerAcceleratorInfo(request.Container)
 
 	if len(acclerators) == 0 {
-		return &v1.GetContainerRuntimeConfigResponse{}, nil
+		return &v1.GetContainerRuntimeConfigResponse{
+			RuntimeConfig: v1.RuntimeConfig{
+				// cuda base image has NVIDIA_VISIBLE_DEVICES=all env, it will cause the nvidia-container-runtime
+				// mount all gpu to container even has no gpu request,
+				// so set NVIDIA_VISIBLE_DEVICES=void to avoid this problem.
+				Env: map[string]string{
+					"NVIDIA_VISIBLE_DEVICES": "void",
+				},
+			},
+		}, nil
 	}
 
 	return &v1.GetContainerRuntimeConfigResponse{

--- a/internal/accelerator/plugin/gpu_test.go
+++ b/internal/accelerator/plugin/gpu_test.go
@@ -112,7 +112,7 @@ func TestGPUAcceleratorPlugin_GetKubernetesContainerRuntimeConfig(t *testing.T) 
 			if tt.expectGPUEnv {
 				assert.Equal(t, "gpu", response.RuntimeConfig.Env["ACCELERATOR_TYPE"])
 			} else {
-				assert.Empty(t, response.RuntimeConfig.Env)
+				assert.Equal(t, "void", response.RuntimeConfig.Env["NVIDIA_VISIBLE_DEVICES"])
 			}
 		})
 	}


### PR DESCRIPTION
## Issues


## Changes

set `"NVIDIA_VISIBLE_DEVICES": "void"` Env on no gpu request container 


## Test

the head node pod which request no gpu resource never has gpu resource even if scheduled to the GPU k8s node.

<img width="861" height="393" alt="image" src="https://github.com/user-attachments/assets/2b4c6c14-9305-4e8f-afc9-7b50e438b9e0" />

