### PR TITLE
fix:  model import and list query behavior is inconsistent with bentoml

### DIFF
--- a/pkg/model_registry/bentoml/bentoml.go
+++ b/pkg/model_registry/bentoml/bentoml.go
@@ -84,11 +84,13 @@ func ImportModel(homePath string, reader io.Reader, name, version string, force 
 		return errors.New("model name and version are required")
 	}
 
-	finalDir := filepath.Join(homePath, "models", name, version)
+	lname := strings.ToLower(name)
+	lversion := strings.ToLower(version)
+	finalDir := filepath.Join(homePath, "models", lname, lversion)
 
 	if exists(finalDir) {
 		if !force {
-			return errors.Errorf("model %s:%s already exists", name, version)
+			return errors.Errorf("model %s:%s already exists", lname, lversion)
 		}
 		// Remove old version to replace.
 		if err := os.RemoveAll(finalDir); err != nil {
@@ -228,7 +230,7 @@ func ListModels(homePath string) ([]Model, error) {
 		}
 
 		models = append(models, Model{
-			Tag:          fmt.Sprintf("%s:%s", meta.Name, meta.Version),
+			Tag:          fmt.Sprintf("%s:%s", strings.ToLower(meta.Name), strings.ToLower(meta.Version)),
 			Module:       meta.Module,
 			Size:         meta.Size,
 			CreationTime: meta.CreationTime,


### PR DESCRIPTION
## Changes


bentoml converts model names and model versions to lowercase, we should keep the behavior consistent

## Test

import model
<img width="764" height="118" alt="image" src="https://github.com/user-attachments/assets/cfcddf46-8513-470c-88d4-5523f0532038" />

model list
<img width="781" height="274" alt="image" src="https://github.com/user-attachments/assets/bbe798cd-a4c3-4182-a331-002f89d678eb" />
