### PR TITLE
fix: Kubernetes cpu cluster mount all gpu device on node to container

### DIFF
--- a/internal/accelerator/manager.go
+++ b/internal/accelerator/manager.go
@@ -275,8 +275,15 @@ func (a *manager) GetNodeRuntimeConfig(ctx context.Context, acceleratorType stri
 
 func (a *manager) GetKubernetesContainerRuntimeConfig(ctx context.Context, acceleratorType string, container corev1.Container) (v1.RuntimeConfig, error) {
 	resource := acceleratorType
+
+	// if acceleratorType is empty string, means it was cpu cluster,
+	// cpu cluster use default cuda base image, so set NVIDIA_VISIBLE_DEVICES=void to avoid nvidia-container-runtime mount all gpu on node to container.
 	if resource == "" {
-		return v1.RuntimeConfig{}, nil
+		return v1.RuntimeConfig{
+			Env: map[string]string{
+				"NVIDIA_VISIBLE_DEVICES": "void",
+			},
+		}, nil
 	}
 
 	value, ok := a.acceleratorsMap.Load(resource)

--- a/internal/accelerator/manager.go
+++ b/internal/accelerator/manager.go
@@ -276,8 +276,8 @@ func (a *manager) GetNodeRuntimeConfig(ctx context.Context, acceleratorType stri
 func (a *manager) GetKubernetesContainerRuntimeConfig(ctx context.Context, acceleratorType string, container corev1.Container) (v1.RuntimeConfig, error) {
 	resource := acceleratorType
 
-	// if acceleratorType is empty string, means it was cpu cluster,
-	// cpu cluster use default cuda base image, so set NVIDIA_VISIBLE_DEVICES=void to avoid nvidia-container-runtime mount all gpu on node to container.
+	// If acceleratorType is an empty string, it means it is a CPU cluster.
+	// CPU clusters use default CUDA base images, so set NVIDIA_VISIBLE_DEVICES=void to avoid nvidia-container-runtime mounting all GPUs on the node to the container.
 	if resource == "" {
 		return v1.RuntimeConfig{
 			Env: map[string]string{

--- a/internal/accelerator/manager_test.go
+++ b/internal/accelerator/manager_test.go
@@ -1,10 +1,16 @@
 package accelerator
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestManager_registerAcceleratorPlugin(t *testing.T) {
@@ -27,4 +33,81 @@ func TestManager_registerAcceleratorPlugin(t *testing.T) {
 	rp, ok = value.(registerPlugin)
 	assert.True(t, ok)
 	assert.NotEqual(t, rt, rp.lastRegisterTime)
+}
+
+func TestManager_GetKubernetesContainerRuntimeConfig(t *testing.T) {
+	tests := []struct {
+		name                  string
+		acceleratorType       string
+		container             corev1.Container
+		setup                 func(*manager)
+		expectedRuntimeConfig v1.RuntimeConfig
+		wantErr               bool
+	}{
+		{
+			name:            "empty accelerator type",
+			acceleratorType: "",
+			container:       corev1.Container{},
+			expectedRuntimeConfig: v1.RuntimeConfig{
+				Env: map[string]string{
+					"NVIDIA_VISIBLE_DEVICES": "void",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "accelerator plugin not found",
+			acceleratorType: "gpu",
+			container:       corev1.Container{},
+			setup: func(m *manager) {
+				m.acceleratorsMap = sync.Map{}
+			},
+			wantErr: true,
+		},
+		{
+			name:            "success get container runtime config",
+			acceleratorType: "gpu",
+			setup: func(m *manager) {
+				m.acceleratorsMap = sync.Map{}
+				gpuPlugin := &plugin.GPUAcceleratorPlugin{}
+				m.acceleratorsMap.Store("gpu", registerPlugin{
+					resource:         gpuPlugin.Resource(),
+					plugin:           gpuPlugin,
+					lastRegisterTime: time.Now(),
+				})
+			},
+			container: corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						"nvidia.com/gpu": *resource.NewQuantity(1, resource.DecimalSI),
+					},
+					Requests: corev1.ResourceList{
+						"nvidia.com/gpu": *resource.NewQuantity(1, resource.DecimalSI),
+					},
+				},
+			},
+			expectedRuntimeConfig: v1.RuntimeConfig{
+				Env: map[string]string{
+					"ACCELERATOR_TYPE": "gpu",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &manager{}
+			if tt.setup != nil {
+				tt.setup(manager)
+			}
+			resp, err := manager.GetKubernetesContainerRuntimeConfig(context.Background(), tt.acceleratorType, tt.container)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedRuntimeConfig, resp)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Issues

cpu cluster use default cuda base image, when pod schedule to gpu node, nvidia-container-runtime will mount all gpu to container even has no gpu request.

## Changes

kubernetes cpu cluster add `NVIDIA_VISIBLE_DEVICES=void` env.

## Test

all ray pod schedule to gpu node
<img width="1020" height="96" alt="image" src="https://github.com/user-attachments/assets/5493b6c9-7e60-435c-9f1f-61f929bf6323" />

ray cluster detect zero gpu

<img width="1132" height="557" alt="image" src="https://github.com/user-attachments/assets/274a44cf-da7e-47a4-a20f-8cee0072656c" />

