### PR TITLE
feat: introduce self-contained API key

### DIFF
--- a/db/migrations/012_self_contained_api_key.down.sql
+++ b/db/migrations/012_self_contained_api_key.down.sql
@@ -1,0 +1,75 @@
+-- Rollback to the original simple generate_api_key function and remove expires_in from api_key_spec
+
+-- Drop the new functions first to avoid signature conflicts
+DROP FUNCTION IF EXISTS api.generate_api_key(UUID, UUID, INTEGER);
+DROP FUNCTION IF EXISTS api.create_api_key(TEXT, TEXT, INTEGER, TEXT, INTEGER);
+
+-- Restore original create_api_key function signature
+CREATE OR REPLACE FUNCTION api.create_api_key(
+    p_workspace TEXT,
+    p_name TEXT,
+    p_quota INTEGER,
+    p_display_name TEXT DEFAULT NULL
+) RETURNS api.api_keys
+SECURITY DEFINER
+AS $$
+DECLARE
+    p_user_id UUID;
+    v_key_value TEXT;
+    v_result api.api_keys;
+BEGIN
+    p_user_id = auth.uid();
+
+    -- Check if the user exists
+    IF NOT EXISTS (SELECT 1 FROM api.user_profiles WHERE id = p_user_id) THEN
+        RAISE EXCEPTION 'User profile not found';
+    END IF;
+    
+    -- Use name as display_name if not provided
+    IF p_display_name IS NULL THEN
+        p_display_name := p_name;
+    END IF;
+    
+    -- Generate a new API key value using original simple method
+    v_key_value := api.generate_api_key();
+    
+    -- Insert the new API key with the generated key value in status.sk_value
+    INSERT INTO api.api_keys (
+        api_version,
+        kind,
+        metadata,
+        spec,
+        status,
+        user_id
+    ) VALUES (
+        'v1',
+        'ApiKey',
+        ROW(p_name, p_display_name, p_workspace, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json)::api.metadata,
+        ROW(p_quota)::api.api_key_spec,  -- Only quota, no expires_in
+        ROW('Pending', CURRENT_TIMESTAMP, NULL, v_key_value, 0, CURRENT_TIMESTAMP, NULL)::api.api_key_status,
+        p_user_id
+    )
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Restore original simple generate_api_key function
+CREATE OR REPLACE FUNCTION api.generate_api_key()
+RETURNS TEXT
+AS $$
+DECLARE
+    key_value TEXT;
+BEGIN
+    key_value := 'sk_' || encode(public.gen_random_bytes(24), 'hex');
+    RETURN key_value;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Remove expires_in field from api_key_spec type
+-- Note: This will reset existing API keys' spec column
+ALTER TYPE api.api_key_spec DROP ATTRIBUTE IF EXISTS expires_in;
+
+-- Update existing api_keys to use the simplified spec structure
+UPDATE api.api_keys SET spec = ROW((spec).quota)::api.api_key_spec;

--- a/db/migrations/012_self_contained_api_key.up.sql
+++ b/db/migrations/012_self_contained_api_key.up.sql
@@ -1,0 +1,117 @@
+-- Add expires_in field to api_key_spec and update API key generation to use compact binary encoding
+
+-- Drop existing functions first to avoid signature conflicts
+DROP FUNCTION IF EXISTS api.generate_api_key();
+DROP FUNCTION IF EXISTS api.create_api_key(TEXT, TEXT, INTEGER, TEXT);
+
+-- Add expires_in field to api_key_spec 
+ALTER TYPE api.api_key_spec ADD ATTRIBUTE expires_in INTEGER;
+
+-- Update generate_api_key function to create compact self-contained encrypted API keys
+CREATE OR REPLACE FUNCTION api.generate_api_key(
+    p_user_id UUID,
+    p_key_id UUID,
+    p_expires_in INTEGER DEFAULT NULL
+)
+RETURNS TEXT
+AS $$
+DECLARE
+    key_value TEXT;
+    payload_binary BYTEA;
+    encrypted_payload BYTEA;
+    signature BYTEA;
+    jwt_secret TEXT;
+    expires_at BIGINT;
+BEGIN
+    -- Get JWT secret from PostgREST settings
+    jwt_secret := current_setting('app.settings.jwt_secret', true);
+    
+    -- Fallback if secret is not available
+    IF jwt_secret IS NULL OR jwt_secret = '' THEN
+        RAISE EXCEPTION 'JWT secret not available in app.settings.jwt_secret';
+    END IF;
+    
+    -- Calculate expiration timestamp
+    IF p_expires_in IS NULL THEN
+        expires_at := 0;  -- Never expires
+    ELSE
+        expires_at := extract(epoch from now())::bigint + p_expires_in;
+    END IF;
+    
+    -- Create compact binary payload: user_id (16 bytes) + key_id (16 bytes) + expires_at (8 bytes) = 40 bytes
+    payload_binary := decode(replace(p_user_id::text, '-', ''), 'hex') || 
+                      decode(replace(p_key_id::text, '-', ''), 'hex') ||
+                      substring(int8send(expires_at), 1, 8);  -- 8-byte big-endian timestamp
+    
+    -- Encrypt using AES (more compact than PGP)
+    encrypted_payload := public.encrypt(payload_binary, jwt_secret::bytea, 'aes');
+    
+    -- Create HMAC signature (truncated to 16 bytes for compactness)
+    signature := substring(public.hmac(encrypted_payload, jwt_secret::bytea, 'sha256'), 1, 16);
+    
+    -- Format: sk_<base64url_encrypted_payload><base64url_signature> (no separator for compactness)
+    -- Use base64url encoding (URL-safe, no padding, no newlines)
+    key_value := 'sk_' || 
+                rtrim(translate(replace(encode(encrypted_payload || signature, 'base64'), E'\n', ''), '+/', '-_'), '=');
+    
+    RETURN key_value;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update create_api_key function to support expires_in parameter
+CREATE OR REPLACE FUNCTION api.create_api_key(
+    p_workspace TEXT,
+    p_name TEXT,
+    p_quota INTEGER,
+    p_display_name TEXT DEFAULT NULL,
+    p_expires_in INTEGER DEFAULT NULL  -- Expiration time in seconds, NULL = never expires
+) RETURNS api.api_keys
+SECURITY DEFINER
+AS $$
+DECLARE
+    p_user_id UUID;
+    v_key_id UUID;
+    v_key_value TEXT;
+    v_result api.api_keys;
+BEGIN
+    p_user_id = auth.uid();
+
+    -- Check if the user exists
+    IF NOT EXISTS (SELECT 1 FROM api.user_profiles WHERE id = p_user_id) THEN
+        RAISE EXCEPTION 'User profile not found';
+    END IF;
+    
+    -- Use name as display_name if not provided
+    IF p_display_name IS NULL THEN
+        p_display_name := p_name;
+    END IF;
+    
+    -- Generate UUID for this API key
+    v_key_id := gen_random_uuid();
+    
+    -- Generate a new self-contained API key value
+    v_key_value := api.generate_api_key(p_user_id, v_key_id, p_expires_in);
+    
+    -- Insert the new API key with the generated key value in status.sk_value
+    INSERT INTO api.api_keys (
+        id,
+        api_version,
+        kind,
+        metadata,
+        spec,
+        status,
+        user_id
+    ) VALUES (
+        v_key_id,
+        'v1',
+        'ApiKey',
+        ROW(p_name, p_display_name, p_workspace, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json)::api.metadata,
+        ROW(p_quota, p_expires_in)::api.api_key_spec,
+        ROW('Pending', CURRENT_TIMESTAMP, NULL, v_key_value, 0, CURRENT_TIMESTAMP, NULL)::api.api_key_status,
+        p_user_id
+    )
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;

--- a/deploy/chart/neutree/templates/postgrest-deployment.yaml
+++ b/deploy/chart/neutree/templates/postgrest-deployment.yaml
@@ -43,6 +43,8 @@ spec:
               value: "6432"
             - name: PGRST_JWT_SECRET
               value: "{{.Values.jwtSecret }}"
+            - name: PGRST_APP_SETTINGS_JWT_SECRET
+              value: "{{.Values.jwtSecret }}"
             - name: PGRST_DB_EXTRA_SEARCH_PATH
               value: "auth"
             - name: PGRST_DB_AGGREGATES_ENABLED

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -100,6 +100,7 @@ services:
       PGRST_SERVER_HOST: 0.0.0.0
       PGRST_SERVER_PORT: 6432
       PGRST_JWT_SECRET: {{ .JwtSecret}}
+      PGRST_APP_SETTINGS_JWT_SECRET: {{ .JwtSecret}}
       PGRST_DB_EXTRA_SEARCH_PATH: auth
       PGRST_DB_AGGREGATES_ENABLED: 1
       PGRST_DB_ANON_ROLE: anonymous

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,21 +1,23 @@
 package middleware
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
-	"k8s.io/klog/v2"
-
-	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 type Dependencies struct {
-	Config  AuthConfig
-	Storage storage.Storage
+	Config AuthConfig
 }
 
 // AuthConfig holds the configuration for JWT authentication
@@ -32,6 +34,13 @@ type Claims struct {
 
 type ParsedInfo struct {
 	UserID string `json:"user_id"`
+}
+
+type SelfContainedPayload struct {
+	UserID    string `json:"user_id"`
+	KeyID     string `json:"key_id"`
+	IssuedAt  int64  `json:"iat"`
+	ExpiresAt int64  `json:"exp"`
 }
 
 func Auth(deps Dependencies) gin.HandlerFunc {
@@ -54,7 +63,7 @@ func Auth(deps Dependencies) gin.HandlerFunc {
 		case strings.HasPrefix(authHeader, "Bearer "):
 			parsedInfo, err = parseBearerToken(deps.Config, authHeader)
 		case strings.HasPrefix(authHeader, "sk_"):
-			parsedInfo, err = parseApiKey(deps.Storage, authHeader)
+			parsedInfo, err = parseApiKey(authHeader, deps.Config)
 		default:
 			err = errors.New("invalid Authorization header format")
 		}
@@ -70,8 +79,6 @@ func Auth(deps Dependencies) gin.HandlerFunc {
 
 		// Set user information in context
 		c.Set("user_id", parsedInfo.UserID)
-
-		klog.V(4).Infof("Authenticated user: %s", parsedInfo.UserID)
 
 		c.Next()
 	}
@@ -95,7 +102,6 @@ func parseBearerToken(config AuthConfig, authHeader string) (*ParsedInfo, error)
 	})
 
 	if err != nil || !token.Valid {
-		klog.V(4).Infof("JWT validation failed: %v", err)
 		return nil, errors.New("invalid token")
 	}
 
@@ -110,28 +116,179 @@ func parseBearerToken(config AuthConfig, authHeader string) (*ParsedInfo, error)
 	}, nil
 }
 
-func parseApiKey(s storage.Storage, authHeader string) (*ParsedInfo, error) {
-	apiKey, err := s.ListApiKey(storage.ListOption{
-		Filters: []storage.Filter{
-			{
-				Column:   "status->sk_value",
-				Operator: "eq",
-				Value:    strconv.Quote(authHeader),
-			},
-		},
-	})
-
+func parseApiKey(authHeader string, config AuthConfig) (*ParsedInfo, error) {
+	payload, err := parseSelfContainedAPIKey(authHeader, config.JwtSecret)
 	if err != nil {
-		return nil, errors.Join(err, errors.New("failed to list API keys"))
-	}
-
-	if len(apiKey) == 0 {
-		return nil, errors.New("API key not found")
+		return nil, err
 	}
 
 	return &ParsedInfo{
-		UserID: apiKey[0].UserID,
+		UserID: payload.UserID,
 	}, nil
+}
+
+func parseSelfContainedAPIKey(apiKey string, jwtSecret string) (*SelfContainedPayload, error) {
+	if !strings.HasPrefix(apiKey, "sk_") {
+		return nil, errors.New("invalid API key format")
+	}
+
+	if jwtSecret == "" {
+		return nil, errors.New("JWT secret not provided")
+	}
+
+	// Decode base64url (convert back from URL-safe encoding)
+	b64Data := strings.ReplaceAll(strings.ReplaceAll(apiKey[3:], "-", "+"), "_", "/")
+	// Add padding if needed
+	for len(b64Data)%4 != 0 {
+		b64Data += "="
+	}
+
+	combinedData, err := base64.StdEncoding.DecodeString(b64Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode API key data: %w", err)
+	}
+
+	// The last 16 bytes are the truncated HMAC signature
+	if len(combinedData) < 16 {
+		return nil, errors.New("invalid API key: too short")
+	}
+
+	encryptedData := combinedData[:len(combinedData)-16]
+	signature := combinedData[len(combinedData)-16:]
+
+	// Verify HMAC signature (compare truncated signatures)
+	expectedSignature := createHMAC(encryptedData, jwtSecret)[:16]
+
+	if !hmac.Equal(signature, expectedSignature) {
+		return nil, errors.New("invalid API key signature")
+	}
+
+	// Decrypt using AES
+	payloadBytes, err := decryptAESPayload(encryptedData, jwtSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt payload: %w", err)
+	}
+
+	// Parse binary payload: user_id (16 bytes) + key_id (16 bytes) + expires_at (8 bytes)
+	if len(payloadBytes) != 40 {
+		return nil, fmt.Errorf("invalid payload length: expected 40 bytes, got %d", len(payloadBytes))
+	}
+
+	// Extract UUIDs (add hyphens back)
+	userIDBytes := payloadBytes[0:16]
+	keyIDBytes := payloadBytes[16:32]
+	expiresAtBytes := payloadBytes[32:40]
+
+	userID := fmt.Sprintf("%x-%x-%x-%x-%x",
+		userIDBytes[0:4], userIDBytes[4:6], userIDBytes[6:8], userIDBytes[8:10], userIDBytes[10:16])
+	keyID := fmt.Sprintf("%x-%x-%x-%x-%x",
+		keyIDBytes[0:4], keyIDBytes[4:6], keyIDBytes[6:8], keyIDBytes[8:10], keyIDBytes[10:16])
+
+	// Extract expires_at (8-byte big-endian timestamp)
+	expiresAt := int64(0)
+	for i := 0; i < 8; i++ {
+		expiresAt = (expiresAt << 8) | int64(expiresAtBytes[i])
+	}
+
+	// Check expiration
+	if expiresAt > 0 && time.Now().Unix() > expiresAt {
+		return nil, errors.New("API key has expired")
+	}
+
+	return &SelfContainedPayload{
+		UserID:    userID,
+		KeyID:     keyID,
+		IssuedAt:  0, // Not stored in compact format
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+func decryptAESPayload(encryptedData []byte, secret string) ([]byte, error) {
+	// PostgreSQL's encrypt() function uses AES-CBC with PKCS padding and all-zero IV by default
+	key := []byte(secret)
+
+	// Match PostgreSQL's key length handling for AES variant selection
+	// PostgreSQL uses AES-128 (16 bytes), AES-192 (24 bytes), or AES-256 (32 bytes)
+	var finalKey []byte
+
+	switch {
+	case len(key) <= 16:
+		// Pad to 16 bytes for AES-128
+		finalKey = make([]byte, 16)
+		copy(finalKey, key)
+	case len(key) <= 24:
+		// Pad to 24 bytes for AES-192
+		finalKey = make([]byte, 24)
+		copy(finalKey, key)
+	default:
+		// Use exactly 32 bytes for AES-256 (or truncate if longer)
+		finalKey = make([]byte, 32)
+		copy(finalKey, key)
+	}
+
+	key = finalKey
+
+	// Create AES cipher
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	// Check minimum length (must be at least one block)
+	if len(encryptedData) < aes.BlockSize {
+		return nil, errors.New("encrypted data too short")
+	}
+
+	// Check if data length is multiple of block size (required for CBC)
+	if len(encryptedData)%aes.BlockSize != 0 {
+		return nil, errors.New("encrypted data length is not a multiple of block size")
+	}
+
+	// PostgreSQL's encrypt() uses all-zero IV by default
+	iv := make([]byte, aes.BlockSize)
+
+	// Create CBC decrypter
+	mode := cipher.NewCBCDecrypter(block, iv)
+
+	// Decrypt in-place
+	decrypted := make([]byte, len(encryptedData))
+	mode.CryptBlocks(decrypted, encryptedData)
+
+	// Remove PKCS#7 padding
+	return removePKCS7Padding(decrypted)
+}
+
+func removePKCS7Padding(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, errors.New("data is empty")
+	}
+
+	// Last byte indicates padding length
+	paddingLen := int(data[len(data)-1])
+
+	// Validate padding length
+	if paddingLen > len(data) || paddingLen == 0 {
+		return nil, errors.New("invalid padding length")
+	}
+
+	// Check that all padding bytes have the same value
+	for i := len(data) - paddingLen; i < len(data); i++ {
+		if data[i] != byte(paddingLen) {
+			return nil, errors.New("invalid padding")
+		}
+	}
+
+	// Return data without padding
+	result := data[:len(data)-paddingLen]
+
+	return result, nil
+}
+
+func createHMAC(data []byte, secret string) []byte {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write(data)
+
+	return h.Sum(nil)
 }
 
 // GetUserID extracts user ID from Gin context

--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -68,8 +68,7 @@ func RegisterRoutes(r *gin.Engine, deps *Dependencies) {
 
 	// Create JWT middleware
 	authMiddleware := middleware.Auth(middleware.Dependencies{
-		Config:  deps.AuthConfig,
-		Storage: deps.Storage,
+		Config: deps.AuthConfig,
 	})
 
 	// Workspace-scoped model registry routes with authentication

--- a/internal/routes/proxies/proxies.go
+++ b/internal/routes/proxies/proxies.go
@@ -57,8 +57,7 @@ func CreateProxyHandler(targetURL string, path string, modifyRequest func(*http.
 func RegisterRoutes(r *gin.Engine, deps *Dependencies) {
 	// Create JWT middleware
 	authMiddleware := middleware.Auth(middleware.Dependencies{
-		Config:  deps.AuthConfig,
-		Storage: deps.Storage,
+		Config: deps.AuthConfig,
 	})
 
 	// todo: support workspace

--- a/internal/routes/system/system.go
+++ b/internal/routes/system/system.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/neutree-ai/neutree/internal/middleware"
-	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 // Dependencies defines the dependencies for system handlers
@@ -21,7 +20,6 @@ type Dependencies struct {
 	Version string
 	// AuthConfig is the JWT authentication configuration (required)
 	AuthConfig middleware.AuthConfig
-	Storage    storage.Storage
 }
 
 // SystemInfo represents the system information response
@@ -37,8 +35,7 @@ func RegisterRoutes(r *gin.Engine, deps *Dependencies) {
 	apiV1 := r.Group("/api/v1")
 
 	authMiddleware := middleware.Auth(middleware.Dependencies{
-		Config:  deps.AuthConfig,
-		Storage: deps.Storage,
+		Config: deps.AuthConfig,
 	})
 	apiV1.Use(authMiddleware)
 


### PR DESCRIPTION
## Issues

Improves API key authentication performance by implementing self-contained API keys that eliminate database queries during authentication, similar to JWT tokens.

## Changes

- Database Changes:
  - Added expires_in field to api_key_spec type
  - Implemented compact binary encoding for API keys: user_id (16 bytes) + key_id (16 bytes) + expires_at (8
bytes)
  - Updated generate_api_key() function to use AES-256 encryption with PostgreSQL's encrypt() function
  - Added HMAC signature verification (truncated to 16 bytes for compactness)
  - Updated create_api_key() function to support optional expiration time
- Go Authentication Middleware:
  - Implemented parseSelfContainedAPIKey() function with AES-256/CBC decryption
  - Added proper key length handling to match PostgreSQL's AES variant selection (AES-128/192/256)
  - Implemented decryptAESPayload() with PKCS#7 padding removal
  - Added removePKCS7Padding() helper function
- Performance Improvements:
  - Self-contained API keys eliminate database queries during authentication
  - Authentication performance now matches JWT token validation

## Test

- Updated unit tests in internal/middleware/auth_test.go
- End-to-end testing confirmed successful API key generation, validation, and user authentication
- Verified compatibility between PostgreSQL AES encryption and Go AES decryption
