### PR TITLE
Validation/api.endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ cmd/neutree-cli/app/cmd/launch/manifests/*.tar
 out
 neutree-deploy
 __pycache__/
+
+.air.toml
+*.dev.yml

--- a/db/migrations/004_required_fields.up.sql
+++ b/db/migrations/004_required_fields.up.sql
@@ -13,14 +13,14 @@ BEGIN
     -- Validate name format (Kubernetes-style naming convention)
     IF NOT (NEW.metadata).name ~ '^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$' THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10101","message": "Invalid metadata.name format","hint": "Name must consist of lowercase alphanumeric characters, ''-'' or ''.'', must start and end with an alphanumeric character"}',
+            USING message = '{"code": "10003","message": "Invalid metadata.name format","hint": "Name must consist of lowercase alphanumeric characters, ''-'' or ''.'', must start and end with an alphanumeric character"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     
     -- Validate maximum length
     IF length((NEW.metadata).name) > 63 THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10102","message": "metadata.name is too long","hint": "Name cannot exceed 63 characters"}',
+            USING message = '{"code": "10004","message": "metadata.name is too long","hint": "Name cannot exceed 63 characters"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     
@@ -99,14 +99,14 @@ BEGIN
     -- Validate workspace format (Kubernetes-style naming convention)
     IF NOT (NEW.metadata).workspace ~ '^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$' THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10103","message": "Invalid metadata.workspace format","hint": "Workspace must consist of lowercase alphanumeric characters, ''-'' or ''.'', must start and end with an alphanumeric character"}',
+            USING message = '{"code": "10005","message": "Invalid metadata.workspace format","hint": "Workspace must consist of lowercase alphanumeric characters, ''-'' or ''.'', must start and end with an alphanumeric character"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     
     -- Validate maximum length
     IF length((NEW.metadata).workspace) > 63 THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10104","message": "metadata.workspace is too long","hint": "Workspace cannot exceed 63 characters"}',
+            USING message = '{"code": "10006","message": "metadata.workspace is too long","hint": "Workspace cannot exceed 63 characters"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     

--- a/db/migrations/004_required_fields.up.sql
+++ b/db/migrations/004_required_fields.up.sql
@@ -13,14 +13,14 @@ BEGIN
     -- Validate name format (Kubernetes-style naming convention)
     IF NOT (NEW.metadata).name ~ '^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$' THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10003","message": "Invalid metadata.name format","hint": "Name must consist of lowercase alphanumeric characters, ''-'' or ''.'', must start and end with an alphanumeric character"}',
+            USING message = '{"code": "10101","message": "Invalid metadata.name format","hint": "Name must consist of lowercase alphanumeric characters, ''-'' or ''.'', must start and end with an alphanumeric character"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     
     -- Validate maximum length
     IF length((NEW.metadata).name) > 63 THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10004","message": "metadata.name is too long","hint": "Name cannot exceed 63 characters"}',
+            USING message = '{"code": "10102","message": "metadata.name is too long","hint": "Name cannot exceed 63 characters"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     
@@ -99,14 +99,14 @@ BEGIN
     -- Validate workspace format (Kubernetes-style naming convention)
     IF NOT (NEW.metadata).workspace ~ '^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$' THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10005","message": "Invalid metadata.workspace format","hint": "Workspace must consist of lowercase alphanumeric characters, ''-'' or ''.'', must start and end with an alphanumeric character"}',
+            USING message = '{"code": "10103","message": "Invalid metadata.workspace format","hint": "Workspace must consist of lowercase alphanumeric characters, ''-'' or ''.'', must start and end with an alphanumeric character"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     
     -- Validate maximum length
     IF length((NEW.metadata).workspace) > 63 THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10006","message": "metadata.workspace is too long","hint": "Workspace cannot exceed 63 characters"}',
+            USING message = '{"code": "10104","message": "metadata.workspace is too long","hint": "Workspace cannot exceed 63 characters"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     

--- a/db/migrations/013_endpoint_validation.down.sql
+++ b/db/migrations/013_endpoint_validation.down.sql
@@ -4,9 +4,6 @@ DROP FUNCTION IF EXISTS api.validate_endpoint_model_name();
 DROP TRIGGER IF EXISTS validate_endpoint_model_version_on_endpoints ON api.endpoints;
 DROP FUNCTION IF EXISTS api.validate_endpoint_model_version();
 
-DROP TRIGGER IF EXISTS validate_endpoint_model_file_on_endpoints ON api.endpoints;
-DROP FUNCTION IF EXISTS api.validate_endpoint_model_file();
-
 DROP TRIGGER IF EXISTS validate_endpoint_replica_count_on_endpoints ON api.endpoints;
 DROP FUNCTION IF EXISTS api.validate_endpoint_replica_count();
 

--- a/db/migrations/013_endpoint_validation.down.sql
+++ b/db/migrations/013_endpoint_validation.down.sql
@@ -1,0 +1,17 @@
+DROP TRIGGER IF EXISTS validate_endpoint_model_name_on_endpoints ON api.endpoints;
+DROP FUNCTION IF EXISTS api.validate_endpoint_model_name();
+
+DROP TRIGGER IF EXISTS validate_endpoint_model_version_on_endpoints ON api.endpoints;
+DROP FUNCTION IF EXISTS api.validate_endpoint_model_version();
+
+DROP TRIGGER IF EXISTS validate_endpoint_model_file_on_endpoints ON api.endpoints;
+DROP FUNCTION IF EXISTS api.validate_endpoint_model_file();
+
+DROP TRIGGER IF EXISTS validate_endpoint_replica_count_on_endpoints ON api.endpoints;
+DROP FUNCTION IF EXISTS api.validate_endpoint_replica_count();
+
+DROP TRIGGER IF EXISTS validate_endpoint_cluster_name_on_endpoints ON api.endpoints;
+DROP FUNCTION IF EXISTS api.validate_endpoint_cluster_name();
+
+DROP TRIGGER IF EXISTS validate_endpoint_model_registry_on_endpoints ON api.endpoints;
+DROP FUNCTION IF EXISTS api.validate_endpoint_model_registry();

--- a/db/migrations/013_endpoint_validation.up.sql
+++ b/db/migrations/013_endpoint_validation.up.sql
@@ -40,25 +40,6 @@ CREATE TRIGGER validate_endpoint_model_version_on_endpoints
     FOR EACH ROW
     EXECUTE FUNCTION api.validate_endpoint_model_version();
 
-
-CREATE OR REPLACE FUNCTION api.validate_endpoint_model_file()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF (NEW.spec).model.file IS NULL OR trim((NEW.spec).model.file) = '' THEN
-        RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10009","message": "spec.model.file is required","hint": "Provide model file"}',
-            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER validate_endpoint_model_file_on_endpoints
-    BEFORE INSERT OR UPDATE ON api.endpoints
-    FOR EACH ROW
-    EXECUTE FUNCTION api.validate_endpoint_model_file();
-
-
 CREATE OR REPLACE FUNCTION api.validate_endpoint_replica_count()
 RETURNS TRIGGER AS $$
 BEGIN

--- a/db/migrations/013_endpoint_validation.up.sql
+++ b/db/migrations/013_endpoint_validation.up.sql
@@ -1,9 +1,9 @@
 CREATE OR REPLACE FUNCTION api.validate_endpoint_model_name()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF (NEW.spec).model.name IS NULL OR (NEW.spec).model.name = '' THEN
+    IF (NEW.spec).model.name IS NULL OR trim((NEW.spec).model.name) = '' THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10003","message": "spec.model.name is required","hint": "Provide model name"}',
+            USING message = '{"code": "10007","message": "spec.model.name is required","hint": "Provide model name"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
 
@@ -26,9 +26,9 @@ CREATE TRIGGER validate_endpoint_model_name_on_endpoints
 CREATE OR REPLACE FUNCTION api.validate_endpoint_model_version()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF (NEW.spec).model.version IS NULL OR (NEW.spec).model.version = '' THEN
+    IF (NEW.spec).model.version IS NULL OR trim((NEW.spec).model.version) = '' THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10004","message": "spec.model.version is required","hint": "Provide model version"}',
+            USING message = '{"code": "10008","message": "spec.model.version is required","hint": "Provide model version"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     RETURN NEW;
@@ -44,9 +44,9 @@ CREATE TRIGGER validate_endpoint_model_version_on_endpoints
 CREATE OR REPLACE FUNCTION api.validate_endpoint_model_file()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF (NEW.spec).model.file IS NULL OR (NEW.spec).model.file = '' THEN
+    IF (NEW.spec).model.file IS NULL OR trim((NEW.spec).model.file) = '' THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10005","message": "spec.model.file is required","hint": "Provide model file"}',
+            USING message = '{"code": "10009","message": "spec.model.file is required","hint": "Provide model file"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
     RETURN NEW;
@@ -79,10 +79,10 @@ CREATE TRIGGER validate_endpoint_replica_count_on_endpoints
 CREATE OR REPLACE FUNCTION api.validate_endpoint_cluster_name()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF (NEW.spec).cluster IS NULL OR (NEW.spec).cluster = ''
+    IF (NEW.spec).cluster IS NULL OR trim((NEW.spec).cluster) = ''
     THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10006","message": "spec.cluster is required","hint": "Provide cluster name"}',
+            USING message = '{"code": "10010","message": "spec.cluster is required","hint": "Provide cluster name"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
 
@@ -98,10 +98,10 @@ CREATE TRIGGER validate_endpoint_cluster_name_on_endpoints
 CREATE OR REPLACE FUNCTION api.validate_endpoint_model_registry()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF (NEW.spec).model.registry IS NULL OR (NEW.spec).model.registry = ''
+    IF (NEW.spec).model.registry IS NULL OR trim((NEW.spec).model.registry) = ''
     THEN
         RAISE sqlstate 'PGRST'
-            USING message = '{"code": "10007","message": "spec.model.registry is required","hint": "Provide model registry"}',
+            USING message = '{"code": "10011","message": "spec.model.registry is required","hint": "Provide model registry"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
     END IF;
 

--- a/db/migrations/013_endpoint_validation.up.sql
+++ b/db/migrations/013_endpoint_validation.up.sql
@@ -1,0 +1,115 @@
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_name()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.name IS NULL OR (NEW.spec).model.name = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10003","message": "spec.model.name is required","hint": "Provide model name"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    IF NOT (NEW.spec).model.name ~ '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10105","message": "Invalid model name format","hint": "Use lowercase alphanumeric and hyphens"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_endpoint_model_name_on_endpoints
+    BEFORE INSERT OR UPDATE ON api.endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_endpoint_model_name();
+
+
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_version()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.version IS NULL OR (NEW.spec).model.version = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10004","message": "spec.model.version is required","hint": "Provide model version"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_endpoint_model_version_on_endpoints
+    BEFORE INSERT OR UPDATE ON api.endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_endpoint_model_version();
+
+
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_file()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.file IS NULL OR (NEW.spec).model.file = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10005","message": "spec.model.file is required","hint": "Provide model file"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_endpoint_model_file_on_endpoints
+    BEFORE INSERT OR UPDATE ON api.endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_endpoint_model_file();
+
+
+CREATE OR REPLACE FUNCTION api.validate_endpoint_replica_count()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).replicas.num IS NULL OR (NEW.spec).replicas.num < 1 THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10106","message": "spec.replicas.num must be at least 1","hint": "Provide a valid replica count"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_endpoint_replica_count_on_endpoints
+    BEFORE INSERT OR UPDATE ON api.endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_endpoint_replica_count();
+
+CREATE OR REPLACE FUNCTION api.validate_endpoint_cluster_name()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).cluster IS NULL OR (NEW.spec).cluster = ''
+    THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10006","message": "spec.cluster is required","hint": "Provide cluster name"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_endpoint_cluster_name_on_endpoints
+    BEFORE INSERT OR UPDATE ON api.endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_endpoint_cluster_name();
+
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_registry()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.registry IS NULL OR (NEW.spec).model.registry = ''
+    THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10007","message": "spec.model.registry is required","hint": "Provide model registry"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_endpoint_model_registry_on_endpoints
+    BEFORE INSERT OR UPDATE ON api.endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_endpoint_model_registry();

--- a/db/migrations/013_endpoint_validation.up.sql
+++ b/db/migrations/013_endpoint_validation.up.sql
@@ -43,7 +43,7 @@ CREATE TRIGGER validate_endpoint_model_version_on_endpoints
 CREATE OR REPLACE FUNCTION api.validate_endpoint_replica_count()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF (NEW.spec).replicas.num IS NULL OR (NEW.spec).replicas.num < 1 THEN
+    IF (NEW.spec).replicas.num IS NOT NULL AND (NEW.spec).replicas.num < 1 THEN
         RAISE sqlstate 'PGRST'
             USING message = '{"code": "10106","message": "spec.replicas.num must be at least 1","hint": "Provide a valid replica count"}',
             detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';


### PR DESCRIPTION
## Changes

Add trigger-based validation to the api.endpoints table to enforce required fields and formats in the spec JSONB:
- spec.model.name: required, lowercase alphanumeric + hyphens
- spec.model.version: required
- spec.model.file: required
- spec.model.registry: required
- spec.cluster: required
- spec.replicas.num: must be ≥ 1

Each check raises a structured error for client-side handling.