### PR TITLE
feat: add validation function and trigger for cluster configuration

### DIFF
--- a/db/migrations/015_cluster_validation.down.sql
+++ b/db/migrations/015_cluster_validation.down.sql
@@ -1,2 +1,3 @@
 DROP TRIGGER IF EXISTS validate_cluster_config_on_clusters ON api.clusters;
 DROP FUNCTION IF EXISTS api.validate_cluster_config();
+DROP FUNCTION IF EXISTS api.validate_accelerator_resources(JSONB, TEXT, TEXT, TEXT);


### PR DESCRIPTION
## PostgreSQL Cluster Configuration Validation

### Overview
A PostgreSQL trigger and function have been implemented to validate cluster configurations during **INSERT** and **UPDATE** operations on the `api.clusters` table. The validation supports two cluster types:

- **SSH Clusters**
- **Kubernetes Clusters**

---

### General Validations
These validations apply to **all cluster types**:

| Field              | Error Code | Validation                  |
|-------------------|------------|-----------------------------|
| `spec.type`       | 10014      | Must not be null or empty   |
| `spec.image_registry` | 10015  | Must not be null or empty   |
| `spec.config`     | 10016      | Must not be null            |

---

### SSH Cluster Validations
For clusters with `spec.type = 'ssh'`:

| Field                        | Error Code | Validation                  |
|-----------------------------|------------|-----------------------------|
| `spec.config.provider`      | 10017      | Must not be null            |
| `spec.config.provider.head_ip` | 10018   | Must not be null or empty   |
| `spec.config.auth`          | 10019      | Must not be null            |
| `spec.config.auth.ssh_user` | 10020      | Must not be null or empty   |

---

### Kubernetes Cluster Validations
For clusters with `spec.type = 'kubernetes'`:

#### Basic Configuration

| Field                              | Error Code | Validation                  |
|-----------------------------------|------------|-----------------------------|
| `spec.config.kubeconfig`          | 10021      | Must not be null or empty   |
| `spec.config.head_node_spec`      | 10022      | Must not be null            |
| `spec.config.head_node_spec.access_mode` | 10023 | Must not be null or empty   |

#### Head Node Resources

| Field                                        | Error Code | Validation                                  |
|---------------------------------------------|------------|---------------------------------------------|
| `spec.config.head_node_spec.resources`      | 10024      | Must not be null                            |
| `spec.config.head_node_spec.resources.cpu`  | 10025      | Must not be null or empty                   |
| `spec.config.head_node_spec.resources.memory` | 10026    | Must not be null or empty                   |
| `spec.config.head_node_spec.resources.memory` | 10114    | Must follow Kubernetes format (e.g., 4Gi)   |
| `spec.config.head_node_spec.resources.*`    | 10110      | Accelerator resources must be integers      |
| `spec.config.head_node_spec.resources.*`    | 10111      | Accelerator resources must be >= 1          |

#### Worker Group Resources

| Field                                                | Error Code | Validation                                  |
|-----------------------------------------------------|------------|---------------------------------------------|
| `spec.config.worker_group_specs`                    | 10027      | Must not be null                            |
| `spec.config.worker_group_specs`                    | 10028      | Must have at least one element              |
| `spec.config.worker_group_specs[0].resources`       | 10029      | Must not be null                            |
| `spec.config.worker_group_specs[0].resources.cpu`   | 10030      | Must not be null or empty                   |
| `spec.config.worker_group_specs[0].resources.memory`| 10031      | Must not be null or empty                   |
| `spec.config.worker_group_specs[0].resources.memory`| 10115      | Must follow Kubernetes format (e.g., 4Gi)   |
| `spec.config.worker_group_specs[0].resources.*`     | 10112      | Accelerator resources must be integers      |
| `spec.config.worker_group_specs[0].resources.*`     | 10113      | Accelerator resources must be >= 1          |

---

### Migration Files

- **Up Migration**: `015_cluster_validation.up.sql`  
  Creates the validation function and trigger

- **Down Migration**: `015_cluster_validation.down.sql`  
  Drops the validation function and trigger