### PR TITLE
Add Validation for `role_assignment_spec` Composite Type

### DIFF
--- a/db/migrations/016_role_assignments.down.sql
+++ b/db/migrations/016_role_assignments.down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS validate_role_assignments_on_role_assignments on api.role_assignments;
+DROP FUNCTION IF EXISTS api.validate_role_assignments();

--- a/db/migrations/016_role_assignments.up.sql
+++ b/db/migrations/016_role_assignments.up.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION api.validate_role_assignments()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).user_id IS NULL THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10032","message": "spec.user_id is required","hint": "Provide User Information"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    
+    IF (NEW.spec).role IS NULL OR TRIM((NEW.spec).role) = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10033","message": "spec.role is required","hint": "Provide Role Name"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    
+    -- Validation: workspace should not be null or empty when global is false (error code: 10034)
+    IF (NEW.spec).global = false AND ((NEW.spec).workspace IS NULL OR TRIM((NEW.spec).workspace) = '') THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10034","message": "spec.workspace is required","hint": "Provide Workspace Name"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_role_assignments_on_role_assignments
+    BEFORE INSERT OR UPDATE ON api.role_assignments
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_role_assignments();


### PR DESCRIPTION
### Added Validations

| Field               | Error Code | Validation Logic                                                             |
|--------------------|------------|------------------------------------------------------------------------------|
| `spec.user_id`     | 10032      | Must not be null                                                             |
| `spec.role`        | 10033      | Must not be null or empty                                                    |
| `spec.workspace`   | 10034      | Must not be null or empty **when** `spec.global` is `true`                   |

---

### Behavior
- If any of the above validations fail:
  - A specific **error code** is returned (10032–10034)
  - The request is rejected with HTTP **400 Bad Request**
  - The error includes a detailed message and a helpful hint
