### PR TITLE
fix: ray worker pod qos class is not Guaranteed

### DIFF
--- a/internal/orchestrator/ray/cluster/kubernetes.go
+++ b/internal/orchestrator/ray/cluster/kubernetes.go
@@ -810,6 +810,16 @@ func (c *kubeRayClusterManager) mutateModelCaches(podTemplate *corev1.PodTemplat
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: pointy.Bool(true),
 		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
 		VolumeMounts: []corev1.VolumeMount{},
 	}
 


### PR DESCRIPTION
## Issues

Now we never set `modifyPermissionContainer` resource, it will cause ray worker pod QOS is `Burstable`, and On Kubernetes, only pods with `Guaranteed` QOS support CPU exclusivity.

## Changes

add `modifyPermissionContainer` resource config.

## Test

Test worker Pod passed