### PR TITLE
fix: relax endpoint model name rules (uppercase, dot, underscore, slash)

### DIFF
--- a/db/migrations/017_model_name_validation_patch.down.sql
+++ b/db/migrations/017_model_name_validation_patch.down.sql
@@ -1,0 +1,19 @@
+-- Restore old strict lowercase + hyphen format from migration 013
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_name()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.name IS NULL OR trim((NEW.spec).model.name) = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10007","message": "spec.model.name is required","hint": "Provide model name"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    IF NOT (NEW.spec).model.name ~ '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10105","message": "Invalid model name format","hint": "Use lowercase alphanumeric and hyphens"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/db/migrations/017_model_name_validation_patch.up.sql
+++ b/db/migrations/017_model_name_validation_patch.up.sql
@@ -1,0 +1,19 @@
+-- Patch model name validation to allow uppercase, slash, and hyphen in segments
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_name()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.name IS NULL OR trim((NEW.spec).model.name) = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10007","message": "spec.model.name is required","hint": "Provide model name"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    IF NOT (NEW.spec).model.name ~ '^[A-Za-z0-9]+(?:[._\-A-Za-z0-9]*[A-Za-z0-9])?(?:/[A-Za-z0-9]+(?:[._\-A-Za-z0-9]*[A-Za-z0-9])?)*$' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10105","message": "Invalid model name format","hint": "Use alphanumeric, dots, underscores, hyphens, and optional slash-separated segments"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
### Summary
This PR relaxes the *endpoint model name* validation rules from the 013 migration file.

**Original (013):**
- Lowercase alphanumeric only, may contain hyphens
- Single segment only

**New (017):**
- Allows uppercase (A–Z)
- Allows dots (.)
- Allows underscores (_)
- Allows slash-separated segments (/), with each segment starting and ending with alphanumeric
- Hyphen (-) still allowed within segments

### Examples now accepted:
- `bartowski/Llama-3.2_1B-Instruct`
- `huggingface/transformers_test-model`
- `MetaOrg/Model.v2`
- `Org/abc_def`