### PR TITLE
fix: list model should success when model registry dir is empty

### DIFF
--- a/pkg/model_registry/bentoml/bentoml.go
+++ b/pkg/model_registry/bentoml/bentoml.go
@@ -20,6 +20,7 @@ import (
 	"github.com/klauspost/pgzip"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
+	"k8s.io/klog/v2"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
@@ -182,6 +183,11 @@ func ListModels(homePath string) ([]Model, error) {
 
 	stat, err := os.Stat(root)
 	if err != nil {
+		if os.IsNotExist(err) {
+			klog.Warningf("Model store %s not found, returning empty list", root)
+			return nil, nil
+		}
+
 		return nil, errors.Wrap(err, "model store not found")
 	}
 


### PR DESCRIPTION
## Issues

When the models directory does not exist, the model registry status changes between Connected and Failed

## Changes



## Test

- model registry status is in Connected when models directory does not exist