### PR TITLE
fix: limit upload latest version model

### DIFF
--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -12,6 +12,7 @@ import (
 	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/cobra"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/pkg/client"
 	"github.com/neutree-ai/neutree/pkg/model_registry/bentoml"
 )
@@ -40,6 +41,10 @@ func NewPushCmd() *cobra.Command {
 			// If model name is not specified, use directory name
 			if modelName == "" {
 				modelName = filepath.Base(modelPath)
+			}
+
+			if version == v1.LatestVersion {
+				return fmt.Errorf("cannot use 'latest' as version, please specify a concrete version or leave it empty for auto-generation")
 			}
 
 			// Auto‑generate version if not provided

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -477,7 +477,7 @@ func TestRayOrchestrator_CreateEndpoint_ApplicationNameConsistency(t *testing.T)
 				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
 					Applications: map[string]dashboard.RayServeApplicationStatus{},
 				}, nil)
-				
+
 				// Verify the application name is correct when creating new application
 				mockDashboard.On("UpdateServeApplications", mock.MatchedBy(func(req dashboard.RayServeApplicationsRequest) bool {
 					if len(req.Applications) != 1 {
@@ -527,7 +527,7 @@ func TestRayOrchestrator_CreateEndpoint_ApplicationNameConsistency(t *testing.T)
 						},
 					},
 				}, nil)
-				
+
 				// Verify the application name remains consistent when updating
 				mockDashboard.On("UpdateServeApplications", mock.MatchedBy(func(req dashboard.RayServeApplicationsRequest) bool {
 					if len(req.Applications) != 1 {
@@ -545,7 +545,7 @@ func TestRayOrchestrator_CreateEndpoint_ApplicationNameConsistency(t *testing.T)
 		t.Run(tt.name, func(t *testing.T) {
 			mockDashboard := dashboardmocks.NewMockDashboardService(t)
 			mockStorage := storagemocks.NewMockStorage(t)
-			
+
 			if tt.setupMock != nil {
 				tt.setupMock(mockDashboard, mockStorage)
 			}


### PR DESCRIPTION
## Issues


## Changes

1. limit upload latest version model
2. recreate latest tag when model upload success
3. fix the abnormal permissions of the model version directory file

## Test

The test model was uploaded and the inference was successful using the model.
