### PR TITLE
feat: add --registry-project flag to import command

### DIFF
--- a/cmd/neutree-cli/app/cmd/packageimport/cluster.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/cluster.go
@@ -77,6 +77,7 @@ func runClusterImport(opts *ClusterImportOptions) error {
 	// if not importLocal, set registry info
 	if !opts.importLocal {
 		importOpts.MirrorRegistry = mirrorRegistry
+		importOpts.RegistryProject = registryProject
 		importOpts.RegistryUser = registryUsername
 		importOpts.RegistryPassword = registryPassword
 	} else {

--- a/cmd/neutree-cli/app/cmd/packageimport/controlplane.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/controlplane.go
@@ -81,6 +81,7 @@ func runControlPlaneImport(opts *ControlPlaneImportOptions) error {
 	// if not importLocal, set registry info
 	if !opts.importLocal {
 		importOpts.MirrorRegistry = mirrorRegistry
+		importOpts.RegistryProject = registryProject
 		importOpts.RegistryUser = registryUsername
 		importOpts.RegistryPassword = registryPassword
 	} else {

--- a/cmd/neutree-cli/app/cmd/packageimport/engine.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/engine.go
@@ -111,6 +111,7 @@ func runEngineImport(opts *EngineImportOptions) error {
 	importOpts := &engine.ImportOptions{
 		PackagePath:      opts.packagePath,
 		MirrorRegistry:   mirrorRegistry,
+		RegistryProject:  registryProject,
 		RegistryUser:     registryUsername,
 		RegistryPassword: registryPassword,
 		Workspace:        workspace,

--- a/cmd/neutree-cli/app/cmd/packageimport/import.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/import.go
@@ -5,6 +5,7 @@ import "github.com/spf13/cobra"
 // import-specific flag variables
 var (
 	mirrorRegistry   string
+	registryProject  string
 	registryUsername string
 	registryPassword string
 	workspace        string
@@ -30,6 +31,7 @@ Use the appropriate subcommand based on the package type you want to import.
 	// import-specific flags
 	importCmd.PersistentFlags().StringVar(&workspace, "workspace", "default", "Workspace")
 	importCmd.PersistentFlags().StringVar(&mirrorRegistry, "mirror-registry", "", "Container image registry to push images to (if required)")
+	importCmd.PersistentFlags().StringVar(&registryProject, "registry-project", "", "Project/namespace in the registry to push images to (e.g., 'neutree-ai')")
 	importCmd.PersistentFlags().StringVar(&registryUsername, "registry-username", "", "Username for the container image registry (if required)")
 	importCmd.PersistentFlags().StringVar(&registryPassword, "registry-password", "", "Password for the container image registry (if required)")
 

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -139,7 +139,12 @@ func (i *Importer) pushImages(ctx context.Context, opts *ImportOptions, manifest
 
 	registryAuth := base64.URLEncoding.EncodeToString(authConfigBytes)
 
-	pushedImages, err := imagePusher.PushImagesToMirrorRegistry(ctx, mirrorRegistry, registryAuth, manifest)
+	imagePrefix := mirrorRegistry
+	if opts.RegistryProject != "" {
+		imagePrefix = mirrorRegistry + "/" + opts.RegistryProject
+	}
+
+	pushedImages, err := imagePusher.PushImagesToMirrorRegistry(ctx, imagePrefix, registryAuth, manifest)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to push images to mirror registry")
 	}

--- a/internal/cli/packageimport/importer_test.go
+++ b/internal/cli/packageimport/importer_test.go
@@ -99,6 +99,26 @@ func TestImportOptionsValidation(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "with mirror registry and registry project when not skipping push",
+			setupFunc: func() string {
+				tmpFile, _ := os.CreateTemp("", "test-*.tar.gz")
+				tmpFile.Close()
+				return tmpFile.Name()
+			},
+			cleanupFunc: func(path string) {
+				os.Remove(path)
+			},
+			opts: &ImportOptions{
+				PackagePath:      "", // Will be set by setupFunc
+				SkipImagePush:    false,
+				MirrorRegistry:   "registry.mirror.com",
+				RegistryProject:  "neutree-ai",
+				RegistryUser:     "user",
+				RegistryPassword: "pass",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/packageimport/types.go
+++ b/internal/cli/packageimport/types.go
@@ -73,6 +73,10 @@ type ImportOptions struct {
 	// This field is required when SkipImagePush is false (i.e., when pushing images).
 	MirrorRegistry string
 
+	// RegistryProject is the project/namespace in the registry to push images to.
+	// When set, images are pushed to MirrorRegistry/RegistryProject/imageName.
+	RegistryProject string
+
 	// RegistryUser is the username for the mirror image registry
 	RegistryUser string
 


### PR DESCRIPTION
## Issues

The `--mirror-registry` parameter serves a dual role: it can be a pure registry address (`registry.smtx.io`) or a registry + project path (`registry.smtx.io/neutree-ai`). This ambiguity makes the parameter semantics unclear.

## Changes

- Add `--registry-project` persistent flag to the `import` command to separate registry address from project/namespace path
- Add `RegistryProject` field to `ImportOptions` struct
- In `pushImages()`, compose `imagePrefix` from `MirrorRegistry/RegistryProject` when project is set, keeping `ServerAddress` in Docker auth config as the raw `MirrorRegistry`
- Pass `RegistryProject` through all import subcommands (engine, cluster, controlplane)

## Test

- `go vet` passes on changed packages
- `go test ./internal/cli/packageimport/...` passes with new test case for `RegistryProject`