### PR TITLE
fix: detect metrics port conflict and prevent cluster Running status

### DIFF
--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -161,7 +161,7 @@ func (c *sshRayClusterReconciler) checkHeadNodeMetricsHealth(headIP string) erro
 	var errs []error
 
 	for _, port := range headMetricsPorts {
-		url := fmt.Sprintf("http://%s:%d/metrics", headIP, port)
+		url := fmt.Sprintf("http://%s:%d", headIP, port)
 		if err := checkMetricsEndpoint(url); err != nil {
 			errs = append(errs, fmt.Errorf("metrics endpoint %s is not healthy: %w", url, err))
 		}

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -142,8 +142,13 @@ func (c *sshRayClusterReconciler) Reconcile(ctx context.Context, cluster *v1.Clu
 
 var metricsHTTPClient = &http.Client{Timeout: 5 * time.Second}
 
-func defaultCheckMetricsEndpoint(url string) error {
-	resp, err := metricsHTTPClient.Get(url) //nolint:noctx
+func defaultCheckMetricsEndpoint(ctx context.Context, url string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := metricsHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -157,12 +162,12 @@ func defaultCheckMetricsEndpoint(url string) error {
 	return nil
 }
 
-func (c *sshRayClusterReconciler) checkHeadNodeMetricsHealth(headIP string) error {
+func (c *sshRayClusterReconciler) checkHeadNodeMetricsHealth(ctx context.Context, headIP string) error {
 	var errs []error
 
 	for _, port := range headMetricsPorts {
 		url := fmt.Sprintf("http://%s:%d", headIP, port)
-		if err := checkMetricsEndpoint(url); err != nil {
+		if err := checkMetricsEndpoint(ctx, url); err != nil {
 			errs = append(errs, fmt.Errorf("metrics endpoint %s is not healthy: %w", url, err))
 		}
 	}
@@ -195,7 +200,7 @@ func (c *sshRayClusterReconciler) checkAndUpdateStatus(reconcileCtx *ReconcileCo
 	}
 
 	// Check head node metrics ports are healthy before declaring the cluster fully ready
-	if err := c.checkHeadNodeMetricsHealth(reconcileCtx.sshClusterConfig.Provider.HeadIP); err != nil {
+	if err := c.checkHeadNodeMetricsHealth(reconcileCtx.Ctx, reconcileCtx.sshClusterConfig.Provider.HeadIP); err != nil {
 		return fmt.Errorf("head node metrics health check failed: %w", err)
 	}
 

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -25,6 +26,13 @@ import (
 
 var (
 	ProvisioningWaitTime = 30 * time.Second
+
+	// checkMetricsEndpoint is a package-level function variable for TCP-dialing a metrics endpoint.
+	// It is injectable for testing.
+	checkMetricsEndpoint = defaultCheckMetricsEndpoint
+
+	// headMetricsPorts lists the metrics ports that must be healthy on the head node.
+	headMetricsPorts = []int{v1.AutoScaleMetricsPort, v1.DashboardMetricsPort, v1.RayletMetricsPort}
 )
 
 func init() { //nolint:gochecknoinits
@@ -132,6 +140,30 @@ func (c *sshRayClusterReconciler) Reconcile(ctx context.Context, cluster *v1.Clu
 	return c.checkAndUpdateStatus(reconcileCtx)
 }
 
+func defaultCheckMetricsEndpoint(address string) error {
+	conn, err := net.DialTimeout("tcp", address, 5*time.Second)
+	if err != nil {
+		return err
+	}
+
+	conn.Close()
+
+	return nil
+}
+
+func (c *sshRayClusterReconciler) checkHeadNodeMetricsHealth(headIP string) error {
+	var errs []error
+
+	for _, port := range headMetricsPorts {
+		addr := fmt.Sprintf("%s:%d", headIP, port)
+		if err := checkMetricsEndpoint(addr); err != nil {
+			errs = append(errs, fmt.Errorf("metrics endpoint %s is not healthy: %w", addr, err))
+		}
+	}
+
+	return apierrors.NewAggregate(errs)
+}
+
 func (c *sshRayClusterReconciler) checkAndUpdateStatus(reconcileCtx *ReconcileContext) error {
 	cluster := reconcileCtx.Cluster
 
@@ -158,6 +190,11 @@ func (c *sshRayClusterReconciler) checkAndUpdateStatus(reconcileCtx *ReconcileCo
 
 	cluster.Status.Initialized = true
 	cluster.Status.DashboardURL = fmt.Sprintf("http://%s:8265", reconcileCtx.sshClusterConfig.Provider.HeadIP)
+
+	// Check head node metrics ports are healthy before declaring the cluster fully ready
+	if err := c.checkHeadNodeMetricsHealth(reconcileCtx.sshClusterConfig.Provider.HeadIP); err != nil {
+		return fmt.Errorf("head node metrics health check failed: %w", err)
+	}
 
 	// Calculate resources only when cluster is ready (avoids unnecessary Ray dashboard calls during init/update)
 	resources, err := c.calculateClusterResources(reconcileCtx)

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -188,13 +188,13 @@ func (c *sshRayClusterReconciler) checkAndUpdateStatus(reconcileCtx *ReconcileCo
 		return fmt.Errorf("cluster not ready: %d/%d nodes ready", readyNodes, desiredNodes)
 	}
 
-	cluster.Status.Initialized = true
-	cluster.Status.DashboardURL = fmt.Sprintf("http://%s:8265", reconcileCtx.sshClusterConfig.Provider.HeadIP)
-
 	// Check head node metrics ports are healthy before declaring the cluster fully ready
 	if err := c.checkHeadNodeMetricsHealth(reconcileCtx.sshClusterConfig.Provider.HeadIP); err != nil {
 		return fmt.Errorf("head node metrics health check failed: %w", err)
 	}
+
+	cluster.Status.Initialized = true
+	cluster.Status.DashboardURL = fmt.Sprintf("http://%s:8265", reconcileCtx.sshClusterConfig.Provider.HeadIP)
 
 	// Calculate resources only when cluster is ready (avoids unnecessary Ray dashboard calls during init/update)
 	resources, err := c.calculateClusterResources(reconcileCtx)

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -204,6 +204,14 @@ func (c *sshRayClusterReconciler) checkAndUpdateStatus(reconcileCtx *ReconcileCo
 		return fmt.Errorf("head node metrics health check failed: %w", err)
 	}
 
+	// Check worker node metrics ports (RayletMetricsPort only) are healthy
+	for _, workerIP := range reconcileCtx.sshClusterConfig.Provider.WorkerIPs {
+		url := fmt.Sprintf("http://%s:%d", workerIP, v1.RayletMetricsPort)
+		if err := checkMetricsEndpoint(reconcileCtx.Ctx, url); err != nil {
+			return fmt.Errorf("worker node %s metrics health check failed: %w", workerIP, err)
+		}
+	}
+
 	cluster.Status.Initialized = true
 	cluster.Status.DashboardURL = fmt.Sprintf("http://%s:8265", reconcileCtx.sshClusterConfig.Provider.HeadIP)
 

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -32,7 +32,9 @@ var (
 	checkMetricsEndpoint = defaultCheckMetricsEndpoint
 
 	// headMetricsPorts lists the metrics ports that must be healthy on the head node.
-	headMetricsPorts = []int{v1.AutoScaleMetricsPort, v1.DashboardMetricsPort, v1.RayletMetricsPort}
+	// RayletMetricsPort is excluded because raylet exits immediately if the port is occupied,
+	// so the node would already be detected as unhealthy.
+	headMetricsPorts = []int{v1.AutoScaleMetricsPort, v1.DashboardMetricsPort}
 )
 
 func init() { //nolint:gochecknoinits
@@ -202,14 +204,6 @@ func (c *sshRayClusterReconciler) checkAndUpdateStatus(reconcileCtx *ReconcileCo
 	// Check head node metrics ports are healthy before declaring the cluster fully ready
 	if err := c.checkHeadNodeMetricsHealth(reconcileCtx.Ctx, reconcileCtx.sshClusterConfig.Provider.HeadIP); err != nil {
 		return fmt.Errorf("head node metrics health check failed: %w", err)
-	}
-
-	// Check worker node metrics ports (RayletMetricsPort only) are healthy
-	for _, workerIP := range reconcileCtx.sshClusterConfig.Provider.WorkerIPs {
-		url := fmt.Sprintf("http://%s:%d", workerIP, v1.RayletMetricsPort)
-		if err := checkMetricsEndpoint(reconcileCtx.Ctx, url); err != nil {
-			return fmt.Errorf("worker node %s metrics health check failed: %w", workerIP, err)
-		}
 	}
 
 	cluster.Status.Initialized = true

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -27,7 +27,7 @@ import (
 var (
 	ProvisioningWaitTime = 30 * time.Second
 
-	// checkMetricsEndpoint is a package-level function variable for TCP-dialing a metrics endpoint.
+	// checkMetricsEndpoint checks whether a metrics HTTP endpoint is healthy.
 	// It is injectable for testing.
 	checkMetricsEndpoint = defaultCheckMetricsEndpoint
 
@@ -140,13 +140,19 @@ func (c *sshRayClusterReconciler) Reconcile(ctx context.Context, cluster *v1.Clu
 	return c.checkAndUpdateStatus(reconcileCtx)
 }
 
-func defaultCheckMetricsEndpoint(address string) error {
-	conn, err := net.DialTimeout("tcp", address, 5*time.Second)
+var metricsHTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+func defaultCheckMetricsEndpoint(url string) error {
+	resp, err := metricsHTTPClient.Get(url) //nolint:noctx
 	if err != nil {
 		return err
 	}
 
-	conn.Close()
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
 
 	return nil
 }
@@ -155,9 +161,9 @@ func (c *sshRayClusterReconciler) checkHeadNodeMetricsHealth(headIP string) erro
 	var errs []error
 
 	for _, port := range headMetricsPorts {
-		addr := fmt.Sprintf("%s:%d", headIP, port)
-		if err := checkMetricsEndpoint(addr); err != nil {
-			errs = append(errs, fmt.Errorf("metrics endpoint %s is not healthy: %w", addr, err))
+		url := fmt.Sprintf("http://%s:%d/metrics", headIP, port)
+		if err := checkMetricsEndpoint(url); err != nil {
+			errs = append(errs, fmt.Errorf("metrics endpoint %s is not healthy: %w", url, err))
 		}
 	}
 

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"testing"
 	"time"
 
@@ -993,22 +992,22 @@ func TestDetectClusterAcceleratorType(t *testing.T) {
 func TestCheckHeadNodeMetricsHealth(t *testing.T) {
 	tests := []struct {
 		name           string
-		mockEndpoint   func(address string) error
+		mockEndpoint   func(url string) error
 		wantErr        bool
 		errMsgContains string
 	}{
 		{
 			name: "all healthy",
-			mockEndpoint: func(address string) error {
+			mockEndpoint: func(url string) error {
 				return nil
 			},
 			wantErr: false,
 		},
 		{
 			name: "single port fails",
-			mockEndpoint: func(address string) error {
-				if address == fmt.Sprintf("10.0.0.1:%d", v1.AutoScaleMetricsPort) {
-					return &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("connection refused")}
+			mockEndpoint: func(url string) error {
+				if url == fmt.Sprintf("http://10.0.0.1:%d/metrics", v1.AutoScaleMetricsPort) {
+					return fmt.Errorf("connection refused")
 				}
 				return nil
 			},
@@ -1017,8 +1016,8 @@ func TestCheckHeadNodeMetricsHealth(t *testing.T) {
 		},
 		{
 			name: "all ports fail",
-			mockEndpoint: func(address string) error {
-				return &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("connection refused")}
+			mockEndpoint: func(url string) error {
+				return fmt.Errorf("connection refused")
 			},
 			wantErr:        true,
 			errMsgContains: "connection refused",
@@ -1087,8 +1086,8 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
 				}, nil)
 			},
-			mockCheck: func(address string) error {
-				if address == fmt.Sprintf("10.0.0.1:%d", v1.AutoScaleMetricsPort) {
+			mockCheck: func(url string) error {
+				if url == fmt.Sprintf("http://10.0.0.1:%d/metrics", v1.AutoScaleMetricsPort) {
 					return fmt.Errorf("connection refused")
 				}
 				return nil

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -1152,6 +1152,8 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.False(t, reconcileCtx.Cluster.Status.Initialized)
+				assert.Empty(t, reconcileCtx.Cluster.Status.DashboardURL)
 			} else {
 				assert.NoError(t, err)
 				assert.True(t, reconcileCtx.Cluster.Status.Initialized)

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -1006,7 +1006,7 @@ func TestCheckHeadNodeMetricsHealth(t *testing.T) {
 		{
 			name: "single port fails",
 			mockEndpoint: func(url string) error {
-				if url == fmt.Sprintf("http://10.0.0.1:%d/metrics", v1.AutoScaleMetricsPort) {
+				if url == fmt.Sprintf("http://10.0.0.1:%d", v1.AutoScaleMetricsPort) {
 					return fmt.Errorf("connection refused")
 				}
 				return nil
@@ -1087,7 +1087,7 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 				}, nil)
 			},
 			mockCheck: func(url string) error {
-				if url == fmt.Sprintf("http://10.0.0.1:%d/metrics", v1.AutoScaleMetricsPort) {
+				if url == fmt.Sprintf("http://10.0.0.1:%d", v1.AutoScaleMetricsPort) {
 					return fmt.Errorf("connection refused")
 				}
 				return nil

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -992,20 +993,20 @@ func TestDetectClusterAcceleratorType(t *testing.T) {
 func TestCheckHeadNodeMetricsHealth(t *testing.T) {
 	tests := []struct {
 		name           string
-		mockEndpoint   func(url string) error
+		mockEndpoint   func(ctx context.Context, url string) error
 		wantErr        bool
 		errMsgContains string
 	}{
 		{
 			name: "all healthy",
-			mockEndpoint: func(url string) error {
+			mockEndpoint: func(ctx context.Context, url string) error {
 				return nil
 			},
 			wantErr: false,
 		},
 		{
 			name: "single port fails",
-			mockEndpoint: func(url string) error {
+			mockEndpoint: func(ctx context.Context, url string) error {
 				if url == fmt.Sprintf("http://10.0.0.1:%d", v1.AutoScaleMetricsPort) {
 					return fmt.Errorf("connection refused")
 				}
@@ -1016,7 +1017,7 @@ func TestCheckHeadNodeMetricsHealth(t *testing.T) {
 		},
 		{
 			name: "all ports fail",
-			mockEndpoint: func(url string) error {
+			mockEndpoint: func(ctx context.Context, url string) error {
 				return fmt.Errorf("connection refused")
 			},
 			wantErr:        true,
@@ -1031,7 +1032,7 @@ func TestCheckHeadNodeMetricsHealth(t *testing.T) {
 			defer func() { checkMetricsEndpoint = original }()
 
 			r := &sshRayClusterReconciler{}
-			err := r.checkHeadNodeMetricsHealth("10.0.0.1")
+			err := r.checkHeadNodeMetricsHealth(context.Background(), "10.0.0.1")
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -1047,7 +1048,7 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 	tests := []struct {
 		name      string
 		setupMock func(*dashboardmocks.MockDashboardService, *acceleratormocks.MockManager)
-		mockCheck func(string) error
+		mockCheck func(context.Context, string) error
 		headIP    string
 		workerIPs []string
 		wantErr   bool
@@ -1067,7 +1068,7 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 				}, nil)
 				acceleratorMgr.On("GetAllParsers").Return(map[string]plugin.ResourceParser{})
 			},
-			mockCheck: func(address string) error {
+			mockCheck: func(ctx context.Context, url string) error {
 				return nil
 			},
 			headIP:  "10.0.0.1",
@@ -1086,7 +1087,7 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
 				}, nil)
 			},
-			mockCheck: func(url string) error {
+			mockCheck: func(ctx context.Context, url string) error {
 				if url == fmt.Sprintf("http://10.0.0.1:%d", v1.AutoScaleMetricsPort) {
 					return fmt.Errorf("connection refused")
 				}
@@ -1105,7 +1106,7 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
 				}, nil)
 			},
-			mockCheck: func(address string) error {
+			mockCheck: func(ctx context.Context, url string) error {
 				t.Fatal("metrics check should not be called when nodes are not ready")
 				return nil
 			},
@@ -1131,6 +1132,7 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 			}
 
 			reconcileCtx := &ReconcileContext{
+				Ctx: context.Background(),
 				Cluster: &v1.Cluster{
 					Metadata: &v1.Metadata{
 						Name: "test",

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -1098,53 +1098,6 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 			errMsg:  "head node metrics health check failed",
 		},
 		{
-			name: "head and worker nodes metrics healthy",
-			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
-				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
-					{IP: "10.0.0.1", Raylet: v1.Raylet{State: v1.AliveNodeState, IsHeadNode: true}},
-					{IP: "10.0.0.2", Raylet: v1.Raylet{State: v1.AliveNodeState}},
-				}, nil)
-				dashboardSvc.On("GetClusterStatus").Return(v1.RayAPIClusterStatus{
-					AutoscalerReport: v1.AutoscalerReport{ActiveNodes: map[string]int{"head": 1, "worker": 1}},
-				}, nil)
-				dashboardSvc.On("GetClusterMetadata").Return(&dashboard.ClusterMetadataResponse{
-					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
-				}, nil)
-				acceleratorMgr.On("GetAllParsers").Return(map[string]plugin.ResourceParser{})
-			},
-			mockCheck: func(ctx context.Context, url string) error {
-				return nil
-			},
-			headIP:    "10.0.0.1",
-			workerIPs: []string{"10.0.0.2"},
-			wantErr:   false,
-		},
-		{
-			name: "worker node metrics unhealthy prevents Running status",
-			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
-				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
-					{IP: "10.0.0.1", Raylet: v1.Raylet{State: v1.AliveNodeState, IsHeadNode: true}},
-					{IP: "10.0.0.2", Raylet: v1.Raylet{State: v1.AliveNodeState}},
-				}, nil)
-				dashboardSvc.On("GetClusterStatus").Return(v1.RayAPIClusterStatus{
-					AutoscalerReport: v1.AutoscalerReport{ActiveNodes: map[string]int{"head": 1, "worker": 1}},
-				}, nil)
-				dashboardSvc.On("GetClusterMetadata").Return(&dashboard.ClusterMetadataResponse{
-					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
-				}, nil)
-			},
-			mockCheck: func(ctx context.Context, url string) error {
-				if url == fmt.Sprintf("http://10.0.0.2:%d", v1.RayletMetricsPort) {
-					return fmt.Errorf("connection refused")
-				}
-				return nil
-			},
-			headIP:    "10.0.0.1",
-			workerIPs: []string{"10.0.0.2"},
-			wantErr:   true,
-			errMsg:    "worker node 10.0.0.2 metrics health check failed",
-		},
-		{
 			name: "nodes not ready returns error before metrics check",
 			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
 				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{}, nil)

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -985,6 +986,178 @@ func TestDetectClusterAcceleratorType(t *testing.T) {
 			}
 
 			acceleratorMgr.AssertExpectations(t)
+		})
+	}
+}
+
+func TestCheckHeadNodeMetricsHealth(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockEndpoint   func(address string) error
+		wantErr        bool
+		errMsgContains string
+	}{
+		{
+			name: "all healthy",
+			mockEndpoint: func(address string) error {
+				return nil
+			},
+			wantErr: false,
+		},
+		{
+			name: "single port fails",
+			mockEndpoint: func(address string) error {
+				if address == fmt.Sprintf("10.0.0.1:%d", v1.AutoScaleMetricsPort) {
+					return &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("connection refused")}
+				}
+				return nil
+			},
+			wantErr:        true,
+			errMsgContains: fmt.Sprintf("10.0.0.1:%d", v1.AutoScaleMetricsPort),
+		},
+		{
+			name: "all ports fail",
+			mockEndpoint: func(address string) error {
+				return &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("connection refused")}
+			},
+			wantErr:        true,
+			errMsgContains: "connection refused",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := checkMetricsEndpoint
+			checkMetricsEndpoint = tt.mockEndpoint
+			defer func() { checkMetricsEndpoint = original }()
+
+			r := &sshRayClusterReconciler{}
+			err := r.checkHeadNodeMetricsHealth("10.0.0.1")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsgContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckAndUpdateStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupMock func(*dashboardmocks.MockDashboardService, *acceleratormocks.MockManager)
+		mockCheck func(string) error
+		headIP    string
+		workerIPs []string
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name: "nodes ready and metrics healthy",
+			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
+				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
+					{IP: "10.0.0.1", Raylet: v1.Raylet{State: v1.AliveNodeState, IsHeadNode: true}},
+				}, nil)
+				dashboardSvc.On("GetClusterStatus").Return(v1.RayAPIClusterStatus{
+					AutoscalerReport: v1.AutoscalerReport{ActiveNodes: map[string]int{"head": 1}},
+				}, nil)
+				dashboardSvc.On("GetClusterMetadata").Return(&dashboard.ClusterMetadataResponse{
+					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
+				}, nil)
+				acceleratorMgr.On("GetAllParsers").Return(map[string]plugin.ResourceParser{})
+			},
+			mockCheck: func(address string) error {
+				return nil
+			},
+			headIP:  "10.0.0.1",
+			wantErr: false,
+		},
+		{
+			name: "metrics port unhealthy prevents Running status",
+			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
+				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
+					{IP: "10.0.0.1", Raylet: v1.Raylet{State: v1.AliveNodeState, IsHeadNode: true}},
+				}, nil)
+				dashboardSvc.On("GetClusterStatus").Return(v1.RayAPIClusterStatus{
+					AutoscalerReport: v1.AutoscalerReport{ActiveNodes: map[string]int{"head": 1}},
+				}, nil)
+				dashboardSvc.On("GetClusterMetadata").Return(&dashboard.ClusterMetadataResponse{
+					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
+				}, nil)
+			},
+			mockCheck: func(address string) error {
+				if address == fmt.Sprintf("10.0.0.1:%d", v1.AutoScaleMetricsPort) {
+					return fmt.Errorf("connection refused")
+				}
+				return nil
+			},
+			headIP:  "10.0.0.1",
+			wantErr: true,
+			errMsg:  "head node metrics health check failed",
+		},
+		{
+			name: "nodes not ready returns error before metrics check",
+			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
+				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{}, nil)
+				dashboardSvc.On("GetClusterStatus").Return(v1.RayAPIClusterStatus{}, nil)
+				dashboardSvc.On("GetClusterMetadata").Return(&dashboard.ClusterMetadataResponse{
+					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
+				}, nil)
+			},
+			mockCheck: func(address string) error {
+				t.Fatal("metrics check should not be called when nodes are not ready")
+				return nil
+			},
+			headIP:    "10.0.0.1",
+			workerIPs: []string{"10.0.0.2"},
+			wantErr:   true,
+			errMsg:    "cluster not ready",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := checkMetricsEndpoint
+			checkMetricsEndpoint = tt.mockCheck
+			defer func() { checkMetricsEndpoint = original }()
+
+			dashboardSvc := &dashboardmocks.MockDashboardService{}
+			acceleratorMgr := acceleratormocks.NewMockManager(t)
+			tt.setupMock(dashboardSvc, acceleratorMgr)
+
+			r := &sshRayClusterReconciler{
+				acceleratorManager: acceleratorMgr,
+			}
+
+			reconcileCtx := &ReconcileContext{
+				Cluster: &v1.Cluster{
+					Metadata: &v1.Metadata{
+						Name: "test",
+					},
+					Status: &v1.ClusterStatus{},
+				},
+				sshClusterConfig: &v1.RaySSHProvisionClusterConfig{
+					Provider: v1.Provider{
+						HeadIP:    tt.headIP,
+						WorkerIPs: tt.workerIPs,
+					},
+				},
+				rayService: dashboardSvc,
+			}
+
+			err := r.checkAndUpdateStatus(reconcileCtx)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, reconcileCtx.Cluster.Status.Initialized)
+			}
+
+			dashboardSvc.AssertExpectations(t)
 		})
 	}
 }

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -1098,6 +1098,53 @@ func TestCheckAndUpdateStatus(t *testing.T) {
 			errMsg:  "head node metrics health check failed",
 		},
 		{
+			name: "head and worker nodes metrics healthy",
+			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
+				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
+					{IP: "10.0.0.1", Raylet: v1.Raylet{State: v1.AliveNodeState, IsHeadNode: true}},
+					{IP: "10.0.0.2", Raylet: v1.Raylet{State: v1.AliveNodeState}},
+				}, nil)
+				dashboardSvc.On("GetClusterStatus").Return(v1.RayAPIClusterStatus{
+					AutoscalerReport: v1.AutoscalerReport{ActiveNodes: map[string]int{"head": 1, "worker": 1}},
+				}, nil)
+				dashboardSvc.On("GetClusterMetadata").Return(&dashboard.ClusterMetadataResponse{
+					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
+				}, nil)
+				acceleratorMgr.On("GetAllParsers").Return(map[string]plugin.ResourceParser{})
+			},
+			mockCheck: func(ctx context.Context, url string) error {
+				return nil
+			},
+			headIP:    "10.0.0.1",
+			workerIPs: []string{"10.0.0.2"},
+			wantErr:   false,
+		},
+		{
+			name: "worker node metrics unhealthy prevents Running status",
+			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
+				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
+					{IP: "10.0.0.1", Raylet: v1.Raylet{State: v1.AliveNodeState, IsHeadNode: true}},
+					{IP: "10.0.0.2", Raylet: v1.Raylet{State: v1.AliveNodeState}},
+				}, nil)
+				dashboardSvc.On("GetClusterStatus").Return(v1.RayAPIClusterStatus{
+					AutoscalerReport: v1.AutoscalerReport{ActiveNodes: map[string]int{"head": 1, "worker": 1}},
+				}, nil)
+				dashboardSvc.On("GetClusterMetadata").Return(&dashboard.ClusterMetadataResponse{
+					Data: v1.RayClusterMetadataData{RayVersion: "2.9.0"},
+				}, nil)
+			},
+			mockCheck: func(ctx context.Context, url string) error {
+				if url == fmt.Sprintf("http://10.0.0.2:%d", v1.RayletMetricsPort) {
+					return fmt.Errorf("connection refused")
+				}
+				return nil
+			},
+			headIP:    "10.0.0.1",
+			workerIPs: []string{"10.0.0.2"},
+			wantErr:   true,
+			errMsg:    "worker node 10.0.0.2 metrics health check failed",
+		},
+		{
 			name: "nodes not ready returns error before metrics check",
 			setupMock: func(dashboardSvc *dashboardmocks.MockDashboardService, acceleratorMgr *acceleratormocks.MockManager) {
 				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{}, nil)


### PR DESCRIPTION
## Issues

NEU-245: When the Ray autoscaler metrics server fails to start because port 44217 is already occupied, the cluster still shows as "Running". `checkAndUpdateStatus()` only checks the dashboard API (port 8265), which works independently. The metrics port health is never checked.

## Changes

- Add `checkMetricsEndpoint` function variable (injectable for testing) with `defaultCheckMetricsEndpoint` using HTTP GET with 5s timeout
- Add `checkHeadNodeMetricsHealth(headIP)` method that checks head node metrics ports: `AutoScaleMetricsPort` (44217) and `DashboardMetricsPort` (44227)
- `RayletMetricsPort` (54311) is excluded — raylet exits immediately if the port is occupied, so the node is already detected as unhealthy through normal node readiness check
- Integrate the health check into `checkAndUpdateStatus()` after nodes are confirmed ready but before setting `Initialized=true` — returns error if any metrics port is unreachable, preventing the cluster from transitioning to Running

## Test

- `TestCheckHeadNodeMetricsHealth` — all healthy / single port fail / all fail
- `TestCheckAndUpdateStatus` — nodes ready + metrics healthy / head metrics fail blocks Running / nodes not ready skips metrics check
- All existing cluster tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)