### PR TITLE
fix: check init container status in K8s endpoint failure detection

### DIFF
--- a/internal/orchestrator/kubernetes_orchestrator.go
+++ b/internal/orchestrator/kubernetes_orchestrator.go
@@ -358,48 +358,72 @@ func (k *kubernetesOrchestrator) listPods(ctrlClient client.Client, namespace st
 	return podList.Items, nil
 }
 
+// checkContainerStatuses checks a slice of container statuses for critical failures.
+// containerType should be "Container" or "Init Container" for error message clarity.
+func checkContainerStatuses(podName string, statuses []corev1.ContainerStatus, containerType string) (bool, []string) {
+	var (
+		failed   bool
+		errorMsg []string
+	)
+
+	for _, cs := range statuses {
+		// Check for OOMKilled
+		if cs.LastTerminationState.Terminated != nil {
+			if cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
+				failed = true
+
+				errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' %s '%s' was killed due to OOM (Out of Memory)",
+					podName, containerType, cs.Name))
+
+				continue
+			}
+		}
+
+		// Check for CrashLoopBackOff with restart count >= 5
+		if cs.State.Waiting != nil {
+			reason := cs.State.Waiting.Reason
+
+			if reason == "CrashLoopBackOff" && cs.RestartCount >= 5 {
+				failed = true
+
+				errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' %s '%s' in CrashLoopBackOff (restarted %d times): %s",
+					podName, containerType, cs.Name, cs.RestartCount, cs.State.Waiting.Message))
+
+				continue
+			}
+			// Check for ImagePullBackOff
+			if reason == "ImagePullBackOff" || reason == "ErrImagePull" {
+				failed = true
+
+				errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' %s '%s' failed to pull image: %s",
+					podName, containerType, cs.Name, cs.State.Waiting.Message))
+
+				continue
+			}
+		}
+	}
+
+	return failed, errorMsg
+}
+
 // checkPodFailures checks if any pods have critical failures like CrashLoopBackOff
 func (k *kubernetesOrchestrator) checkPodFailures(pods []corev1.Pod) (bool, string) {
 	failed := false
 	var errorMsg []string
 
 	for _, pod := range pods {
+		// Check init container statuses
+		if f, msgs := checkContainerStatuses(pod.Name, pod.Status.InitContainerStatuses, "Init Container"); f {
+			failed = true
+
+			errorMsg = append(errorMsg, msgs...)
+		}
+
 		// Check container statuses
-		for _, cs := range pod.Status.ContainerStatuses {
-			// Check for OOMKilled
-			if cs.LastTerminationState.Terminated != nil {
-				if cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
-					failed = true
+		if f, msgs := checkContainerStatuses(pod.Name, pod.Status.ContainerStatuses, "Container"); f {
+			failed = true
 
-					errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' Container '%s' was killed due to OOM (Out of Memory)",
-						pod.Name, cs.Name))
-
-					continue
-				}
-			}
-
-			// Check for CrashLoopBackOff with restart count >= 5
-			if cs.State.Waiting != nil {
-				reason := cs.State.Waiting.Reason
-
-				if reason == "CrashLoopBackOff" && cs.RestartCount >= 5 {
-					failed = true
-
-					errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' Container '%s' in CrashLoopBackOff (restarted %d times): %s",
-						pod.Name, cs.Name, cs.RestartCount, cs.State.Waiting.Message))
-
-					continue
-				}
-				// Check for ImagePullBackOff
-				if reason == "ImagePullBackOff" || reason == "ErrImagePull" {
-					failed = true
-
-					errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' Container '%s' failed to pull image: %s",
-						pod.Name, cs.Name, cs.State.Waiting.Message))
-
-					continue
-				}
-			}
+			errorMsg = append(errorMsg, msgs...)
 		}
 
 		// Check for pod scheduling failures

--- a/internal/orchestrator/kubernetes_orchestrator.go
+++ b/internal/orchestrator/kubernetes_orchestrator.go
@@ -367,16 +367,17 @@ func checkContainerStatuses(podName string, statuses []corev1.ContainerStatus, c
 	)
 
 	for _, cs := range statuses {
-		// Check for OOMKilled
-		if cs.LastTerminationState.Terminated != nil {
-			if cs.LastTerminationState.Terminated.Reason == "OOMKilled" {
-				failed = true
+		// Check for OOMKilled in both current state and last termination state.
+		// The first OOM kill appears in State.Terminated before any restart;
+		// subsequent OOM kills appear in LastTerminationState.Terminated.
+		if (cs.State.Terminated != nil && cs.State.Terminated.Reason == "OOMKilled") ||
+			(cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Reason == "OOMKilled") {
+			failed = true
 
-				errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' %s '%s' was killed due to OOM (Out of Memory)",
-					podName, containerType, cs.Name))
+			errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' %s '%s' was killed due to OOM (Out of Memory)",
+				podName, containerType, cs.Name))
 
-				continue
-			}
+			continue
 		}
 
 		// Check for CrashLoopBackOff with restart count >= 5

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -270,6 +270,111 @@ func (f *FakeK8sClient) WithPodOOMKilled(containerName string) *FakeK8sClient {
 	return f
 }
 
+func (f *FakeK8sClient) WithInitContainerInCrashLoopBackOff(containerName string, restartCount int32) *FakeK8sClient {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-init-crash",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app":      "inference",
+				"endpoint": "chat-model",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         containerName,
+					Ready:        false,
+					RestartCount: restartCount,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "CrashLoopBackOff",
+							Message: "Init container is crashing",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := f.Client.Create(context.Background(), pod)
+	if err != nil {
+		f.t.Fatalf("failed to create pod: %v", err)
+	}
+	return f
+}
+
+func (f *FakeK8sClient) WithInitContainerInImagePullBackOff(containerName string) *FakeK8sClient {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-init-image-pull",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app":      "inference",
+				"endpoint": "chat-model",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  containerName,
+					Ready: false,
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ImagePullBackOff",
+							Message: "Failed to pull init container image",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := f.Client.Create(context.Background(), pod)
+	if err != nil {
+		f.t.Fatalf("failed to create pod: %v", err)
+	}
+	return f
+}
+
+func (f *FakeK8sClient) WithInitContainerOOMKilled(containerName string) *FakeK8sClient {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-init-oom",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app":      "inference",
+				"endpoint": "chat-model",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  containerName,
+					Ready: false,
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:  "OOMKilled",
+							Message: "Out of memory",
+						},
+					},
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "CrashLoopBackOff",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := f.Client.Create(context.Background(), pod)
+	if err != nil {
+		f.t.Fatalf("failed to create pod: %v", err)
+	}
+	return f
+}
+
 func (f *FakeK8sClient) WithUnschedulablePod(message string) *FakeK8sClient {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2674,6 +2779,48 @@ func TestKubernetesOrchestrator_getEndpointStats(t *testing.T) {
 			},
 			expectedPhase:  v1.EndpointPhaseFAILED,
 			expectErrorMsg: "unschedulable",
+			expectError:    false,
+		},
+		{
+			name: "return Failed for init container in CrashLoopBackOff with high restart count",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(t *testing.T) *FakeK8sClient {
+				return NewFakeK8sClient(t).
+					WithDeployment(newEndpoint().Metadata.Name, 1, 0, 0).
+					WithInitContainerInCrashLoopBackOff("model-downloader", 5)
+			},
+			expectedPhase:  v1.EndpointPhaseFAILED,
+			expectErrorMsg: "Init Container",
+			expectError:    false,
+		},
+		{
+			name: "return Failed for init container with ImagePullBackOff",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(t *testing.T) *FakeK8sClient {
+				return NewFakeK8sClient(t).
+					WithDeployment(newEndpoint().Metadata.Name, 1, 0, 0).
+					WithInitContainerInImagePullBackOff("model-downloader")
+			},
+			expectedPhase:  v1.EndpointPhaseFAILED,
+			expectErrorMsg: "Init Container",
+			expectError:    false,
+		},
+		{
+			name: "return Failed for init container with OOMKilled",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(t *testing.T) *FakeK8sClient {
+				return NewFakeK8sClient(t).
+					WithDeployment(newEndpoint().Metadata.Name, 1, 0, 0).
+					WithInitContainerOOMKilled("model-downloader")
+			},
+			expectedPhase:  v1.EndpointPhaseFAILED,
+			expectErrorMsg: "Init Container",
 			expectError:    false,
 		},
 		{


### PR DESCRIPTION
## Issues

K8s endpoint deployment only checks regular container statuses for failures (OOM, CrashLoopBackOff, ImagePullBackOff). Init container statuses (`pod.Status.InitContainerStatuses`) are not checked, causing endpoints to remain stuck in "Deploying" phase indefinitely when init containers fail (e.g., model-downloader fails to pull model).

## Changes

- Extract `checkContainerStatuses()` helper from `checkPodFailures()` to avoid code duplication
- Apply the helper to both `InitContainerStatuses` and `ContainerStatuses`
- Error messages distinguish "Init Container" from "Container" for operator clarity
- Init containers are checked before regular containers (matching K8s lifecycle order)
- Check both `State.Terminated` and `LastTerminationState.Terminated` for OOMKilled detection

## Test

- Added 3 unit test cases for init container failures: CrashLoopBackOff, ImagePullBackOff, OOMKilled
- Added 3 test helpers: `WithInitContainerInCrashLoopBackOff`, `WithInitContainerInImagePullBackOff`, `WithInitContainerOOMKilled`
- All existing tests pass unchanged (backward compatible)
- `go test -race`, `go vet`, `golangci-lint` all clean
- Manually verified on 10.255.1.136: triggered init container failure, endpoint correctly transitions to Failed phase with "Init Container" error message