### PR TITLE
fix: use nested ErrorResponse access pattern in vLLM v0.11.2 and v0.17.1 serve apps

### DIFF
--- a/cluster-image-builder/serve/vllm/v0_11_2/app.py
+++ b/cluster-image-builder/serve/vllm/v0_11_2/app.py
@@ -20,7 +20,7 @@ from ray.serve.handle import DeploymentHandle, DeploymentResponseGenerator
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.entrypoints.openai.protocol import (
-    ChatCompletionRequest, ErrorResponse,
+    ChatCompletionRequest, ErrorResponse, ErrorInfo,
     RerankRequest,
     EmbeddingCompletionRequest,
 )
@@ -249,8 +249,11 @@ class Backend:
         except (TypeError, ValueError) as e:
             logging.error(f"Invalid payload for EmbeddingCompletionRequest: {e}")
             return ErrorResponse(
-                message={"error": "Invalid payload for EmbeddingCompletionRequest", "details": str(e)},
-                status_code=400,
+                error=ErrorInfo(
+                    message=f"Invalid payload for EmbeddingCompletionRequest: {e}",
+                    type="invalid_request_error",
+                    code=400,
+                )
             )
         return await self.openai_serving_embedding.create_embedding(request, None)
 

--- a/cluster-image-builder/serve/vllm/v0_11_2/app.py
+++ b/cluster-image-builder/serve/vllm/v0_11_2/app.py
@@ -225,14 +225,14 @@ class Backend:
 
         if isinstance(result, ErrorResponse):
             if is_stream:
-                logging.error(f"Error during chat completion: {result.message}")
+                logging.error(f"Error during chat completion: {result.error.message}")
                 async def error_generator():
                     import json
                     error_data = {
                         "error": {
                             "message": "Request processing failed",
                             "type": "internal_server_error",
-                            "details": str(result.message)
+                            "details": str(result.error.message)
                         }
                     }
                     yield f"data: {json.dumps(error_data)}\n\n"
@@ -321,7 +321,7 @@ class Controller:
             # Handle non-streaming response as before
             result = await self.backend.options(stream=False).generate.remote(req_obj)
             if isinstance(result, ErrorResponse):
-                return JSONResponse(content=result.model_dump(), status_code=result.code)
+                return JSONResponse(content=result.model_dump(), status_code=result.error.code)
             return JSONResponse(content=result.model_dump())
 
     @app.post("/v1/embeddings")
@@ -330,7 +330,7 @@ class Controller:
         req_obj = await request.json()
         result = await self.backend.options(stream=False).generate_embeddings.remote(req_obj)
         if isinstance(result, ErrorResponse):
-            return JSONResponse(content=result.model_dump(), status_code=result.code)
+            return JSONResponse(content=result.model_dump(), status_code=result.error.code)
         return JSONResponse(content=result.model_dump())
 
     @app.post("/v1/rerank")
@@ -339,7 +339,7 @@ class Controller:
         req_obj = await request.json()
         result = await self.backend.options(stream=False).rerank.remote(req_obj)
         if isinstance(result, ErrorResponse):
-            return JSONResponse(content=result.model_dump(), status_code=result.code)
+            return JSONResponse(content=result.model_dump(), status_code=result.error.code)
         return JSONResponse(content=result.model_dump())
 
     @app.get("/v1/models")

--- a/cluster-image-builder/serve/vllm/v0_17_1/app.py
+++ b/cluster-image-builder/serve/vllm/v0_17_1/app.py
@@ -254,14 +254,14 @@ class Backend:
 
         if isinstance(result, ErrorResponse):
             if is_stream:
-                logging.error(f"Error during chat completion: {result.message}")
+                logging.error(f"Error during chat completion: {result.error.message}")
                 async def error_generator():
                     import json
                     error_data = {
                         "error": {
                             "message": "Request processing failed",
                             "type": "internal_server_error",
-                            "details": str(result.message)
+                            "details": str(result.error.message)
                         }
                     }
                     yield f"data: {json.dumps(error_data)}\n\n"
@@ -350,7 +350,7 @@ class Controller:
             # Handle non-streaming response as before
             result = await self.backend.options(stream=False).generate.remote(req_obj)
             if isinstance(result, ErrorResponse):
-                return JSONResponse(content=result.model_dump(), status_code=result.code)
+                return JSONResponse(content=result.model_dump(), status_code=result.error.code)
             return JSONResponse(content=result.model_dump())
 
     @app.post("/v1/embeddings")
@@ -359,7 +359,7 @@ class Controller:
         req_obj = await request.json()
         result = await self.backend.options(stream=False).generate_embeddings.remote(req_obj)
         if isinstance(result, ErrorResponse):
-            return JSONResponse(content=result.model_dump(), status_code=result.code)
+            return JSONResponse(content=result.model_dump(), status_code=result.error.code)
         return JSONResponse(content=result.model_dump())
 
     @app.post("/v1/rerank")
@@ -368,7 +368,7 @@ class Controller:
         req_obj = await request.json()
         result = await self.backend.options(stream=False).rerank.remote(req_obj)
         if isinstance(result, ErrorResponse):
-            return JSONResponse(content=result.model_dump(), status_code=result.code)
+            return JSONResponse(content=result.model_dump(), status_code=result.error.code)
         return JSONResponse(content=result.model_dump())
 
     @app.get("/v1/models")

--- a/cluster-image-builder/serve/vllm/v0_17_1/app.py
+++ b/cluster-image-builder/serve/vllm/v0_17_1/app.py
@@ -21,7 +21,7 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.v1.engine.async_llm import AsyncLLM
 # v0.17.1: modules reorganized into sub-packages
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse, ErrorInfo
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
@@ -278,8 +278,11 @@ class Backend:
         except (TypeError, ValueError) as e:
             logging.error(f"Invalid payload for EmbeddingCompletionRequest: {e}")
             return ErrorResponse(
-                message={"error": "Invalid payload for EmbeddingCompletionRequest", "details": str(e)},
-                status_code=400,
+                error=ErrorInfo(
+                    message=f"Invalid payload for EmbeddingCompletionRequest: {e}",
+                    type="invalid_request_error",
+                    code=400,
+                )
             )
         return await self.openai_serving_embedding.create_embedding(request, None)
 


### PR DESCRIPTION
## Issues

vLLM changed `ErrorResponse` from a flat structure to a nested structure at v0.10.1. The v0_11_2 and v0_17_1 app.py files still accessed `result.message` / `result.code` (flat), which would fail at runtime when an error response is returned. Additionally, the `ErrorResponse` constructor in the embeddings validation catch block used the old flat keyword arguments.

## Changes

- Update `v0_11_2/app.py` and `v0_17_1/app.py` to use `result.error.message` and `result.error.code` (nested structure)
- Fix `ErrorResponse` constructor in embeddings validation to use `ErrorInfo` nested structure
- Import `ErrorInfo` from the appropriate vLLM module in both files

## Test

- Code inspection: verified no remaining flat-access patterns (`result.message`, `result.code`) in v0_11_2 and v0_17_1
- v0_8_5 unchanged (correctly uses flat structure for pre-v0.10.1 vLLM)