### PR TITLE
fix: gate ENGINE_NAME/ENGINE_VERSION env vars behind new cluster version check

### DIFF
--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -598,21 +598,19 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 
 	setEngineSpecialEnv(endpoint, deployedCluster, applicationEnv)
 
-	// Inject engine identity for metrics labeling (used by NeutreeRayStatLogger / _SanitizedRayStatLogger)
-	if endpoint.Spec.Engine != nil {
-		applicationEnv["ENGINE_NAME"] = endpoint.Spec.Engine.Engine
-		applicationEnv["ENGINE_VERSION"] = endpoint.Spec.Engine.Version
-	}
-
 	app.RuntimeEnv = map[string]interface{}{
 		"env_vars": applicationEnv,
 	}
 
-	// Generate runtime_env.container for engine version isolation (SSH clusters > v1.0.0).
-	// The engine image runs as a sibling container on the host via docker.sock.
-	// Clusters <= v1.0.0 run the engine inside ray_container directly.
+	// Features gated on new cluster version (> v1.0.0):
+	//   - ENGINE_NAME / ENGINE_VERSION env vars for metrics labeling
+	//   - runtime_env.container for engine version isolation
 	//
-	// Two container configs are produced:
+	// Old clusters (<= v1.0.0) run the engine inside ray_container directly and
+	// never had these env vars; injecting them unconditionally would cause a
+	// spurious serve-application diff during CP upgrades.
+	//
+	// Two container configs are produced for new clusters:
 	//   - baseConfig → app.RuntimeEnv["container"]: engine image + --rm only,
 	//     inherited by app_builder and Controller (no GPU required).
 	//   - backendConfig → app.Args["backend_container"]: full config with GPU
@@ -625,6 +623,12 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 	}
 
 	if isNewCluster {
+		// Inject engine identity for metrics labeling (used by NeutreeRayStatLogger / _SanitizedRayStatLogger).
+		if endpoint.Spec.Engine != nil {
+			applicationEnv["ENGINE_NAME"] = endpoint.Spec.Engine.Engine
+			applicationEnv["ENGINE_VERSION"] = endpoint.Spec.Engine.Version
+		}
+
 		baseConfig, backendConfig, err := buildEngineContainerConfigs(endpoint, engine, imageRegistry, acceleratorMgr, modelCaches, modelRegistry)
 		if err != nil {
 			return dashboard.RayServeApplication{}, errors.Wrapf(err, "failed to build engine container config for endpoint %s", endpoint.Metadata.WorkspaceName())

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -930,10 +930,8 @@ func TestEndpointToApplication_setModelArgs(t *testing.T) {
 				"path":          filepath.Join(v1.DefaultSSHClusterModelCacheMountPath, v1.DefaultModelCacheRelativePath, "llama-2-7b", "v1.0"),
 				"registry_path": filepath.Join("/mnt", "default", "llama-endpoint", "models", "llama-2-7b", "v1.0"),
 			},
-			expectedEnvs: map[string]string{
-				"ENGINE_NAME": "", "ENGINE_VERSION": "",
-			},
-			wantErr: false,
+			expectedEnvs: map[string]string{},
+			wantErr:      false,
 		},
 		{
 			name: "BentoML modelRegistry - specific version - with cluster model cache",
@@ -986,10 +984,8 @@ func TestEndpointToApplication_setModelArgs(t *testing.T) {
 				"path":          filepath.Join(v1.DefaultSSHClusterModelCacheMountPath, "test-cache", "llama-2-7b", "v1.0"),
 				"registry_path": filepath.Join("/mnt", "default", "llama-endpoint", "models", "llama-2-7b", "v1.0"),
 			},
-			expectedEnvs: map[string]string{
-				"ENGINE_NAME": "", "ENGINE_VERSION": "",
-			},
-			wantErr: false,
+			expectedEnvs: map[string]string{},
+			wantErr:      false,
 		},
 		{
 			name: "BentoML modelRegistry - specific version - with cluster multi model cache - only use the first one",
@@ -1046,10 +1042,8 @@ func TestEndpointToApplication_setModelArgs(t *testing.T) {
 				"path":          filepath.Join(v1.DefaultSSHClusterModelCacheMountPath, "test-cache-1", "llama-2-7b", "v1.0"),
 				"registry_path": filepath.Join("/mnt", "default", "llama-endpoint", "models", "llama-2-7b", "v1.0"),
 			},
-			expectedEnvs: map[string]string{
-				"ENGINE_NAME": "", "ENGINE_VERSION": "",
-			},
-			wantErr: false,
+			expectedEnvs: map[string]string{},
+			wantErr:      false,
 		},
 		{
 			name: "HuggingFace modelRegistry - specific version",
@@ -1092,9 +1086,8 @@ func TestEndpointToApplication_setModelArgs(t *testing.T) {
 				"registry_path": "llama-2-7b",
 			},
 			expectedEnvs: map[string]string{
-				v1.HFEndpoint:    "https://huggingface.co",
-				v1.HFTokenEnv:    "test-token",
-				"ENGINE_NAME": "", "ENGINE_VERSION": "",
+				v1.HFEndpoint: "https://huggingface.co",
+				v1.HFTokenEnv: "test-token",
 			},
 			wantErr: false,
 		},
@@ -1138,9 +1131,8 @@ func TestEndpointToApplication_setModelArgs(t *testing.T) {
 				"registry_path": "llama-2-7b",
 			},
 			expectedEnvs: map[string]string{
-				v1.HFEndpoint:    "https://huggingface.co",
-				v1.HFTokenEnv:    "test-token",
-				"ENGINE_NAME": "", "ENGINE_VERSION": "",
+				v1.HFEndpoint: "https://huggingface.co",
+				v1.HFTokenEnv: "test-token",
 			},
 			wantErr: false,
 		},
@@ -1774,8 +1766,8 @@ func TestEndpointToApplication_ContainerConfig(t *testing.T) {
 				return mgr
 			},
 			expectContainer:       false,
-			expectedEngineName:    "vllm",
-			expectedEngineVersion: "v0.12.0",
+			expectedEngineName:    "",
+			expectedEngineVersion: "",
 		},
 		{
 			name: "empty cluster version treated as old cluster",
@@ -1790,8 +1782,8 @@ func TestEndpointToApplication_ContainerConfig(t *testing.T) {
 			},
 			cluster:               &v1.Cluster{},
 			expectContainer:       false,
-			expectedEngineName:    "vllm",
-			expectedEngineVersion: "v0.12.0",
+			expectedEngineName:    "",
+			expectedEngineVersion: "",
 		},
 		{
 			name: "CPU endpoint on new cluster generates container without GPU options",


### PR DESCRIPTION
## Issues

During CP upgrades, existing endpoints are unexpectedly updated because `ENGINE_NAME` and `ENGINE_VERSION` env vars are injected unconditionally into the serve application config. Old clusters (<= v1.0.0) never had these in their deployed config, so `util.JsonEqual()` detects a diff and triggers unnecessary Ray Serve application updates.

## Changes

- Move `ENGINE_NAME`/`ENGINE_VERSION` injection inside the existing `isNewClusterVersion()` gate in `EndpointToApplication()`, so these env vars are only added for clusters > v1.0.0
- This is consistent with how container configs (`runtime_env.container`, `backend_container`) are already gated
- Update tests to reflect that old/empty-version clusters no longer include these env vars

## Test

- [x] `go vet ./internal/orchestrator/...` passes
- [x] `go test ./internal/orchestrator/...` — all tests pass