### PR TITLE
chore: bump daily build tag and default cluster version to v1.1.0

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -21,9 +21,9 @@ jobs:
         id: create_nightly_tag
         run: |
           DATE=$(date +'%Y%m%d')
-          git tag v1.0.1-nightly-$DATE -m v1.0.1-nightly-$DATE
-          git push origin v1.0.1-nightly-$DATE
-          echo "tag=v1.0.1-nightly-$DATE" >> $GITHUB_OUTPUT
+          git tag v1.1.0-nightly-$DATE -m v1.1.0-nightly-$DATE
+          git push origin v1.1.0-nightly-$DATE
+          echo "tag=v1.1.0-nightly-$DATE" >> $GITHUB_OUTPUT
       - name: Trigger Workflow
         uses: actions/github-script@v6
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 VERSION ?= $(shell git describe --tags --always --dirty)
 UI_VERSION ?= main
-CLUSTER_VERSION ?= v1.0.0
+CLUSTER_VERSION ?= v1.1.0
 LATEST ?= false
 
 IMAGE_REPO ?= docker.io


### PR DESCRIPTION
## Issues

N/A

## Changes

- Update daily build nightly tag base version from `v1.0.1` to `v1.1.0` in `.github/workflows/daily-build.yaml`
- Update default `CLUSTER_VERSION` from `v1.0.0` to `v1.1.0` in `Makefile`

## Test

- [x] Verify daily build workflow creates `v1.1.0-nightly-YYYYMMDD` tags
- [x] Verify release build uses correct cluster version