### PR TITLE
Add CLI and image registry E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,11 +164,12 @@ test: prepare-build-cli mockgen fmt vet lint ## Run unit test
 	go test -coverprofile coverage.out -covermode=atomic $(shell go list ./... | grep -v 'e2e\|mocks\|db/dbtest')
 
 LABEL_FILTER ?=
+E2E_TIMEOUT ?= 30m
 
 .PHONY: e2e-test
 e2e-test: ## Run E2E tests (requires NEUTREE_SERVER_URL and NEUTREE_API_KEY)
-	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 10m ./tests/e2e/... \
-		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips $(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")
+	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 6h ./tests/e2e/... \
+		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips --ginkgo.timeout=$(E2E_TIMEOUT) $(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")
 
 ##@ Database Testing
 

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -1,0 +1,386 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+var _ = Describe("CLI", Label("cli"), func() {
+	BeforeAll(func() {
+		requireImageRegistryProfile()
+	})
+
+	// --- apply ---
+
+	Describe("apply", Label("apply"), func() {
+
+		It("should create resources from multi-doc YAML with dependency ordering", Label("C2642183"), func() {
+			irName := "e2e-cli-ir-" + Cfg.RunID
+			clusterName := "e2e-cli-cls-" + Cfg.RunID
+
+			headIP, _, sshUser, sshPrivateKey := requireSSHEnv()
+
+			DeferCleanup(func() {
+				RunCLI("delete", "cluster", clusterName, "-w", profileWorkspace(), "--force", "--ignore-not-found")
+				RunCLI("delete", "imageregistry", irName, "-w", profileWorkspace(), "--force", "--ignore-not-found")
+			})
+
+			// Multi-doc YAML in REVERSE dependency order: Cluster(2) before ImageRegistry(1).
+			// CLI apply sorts by KindPriority: ImageRegistry first, then Cluster.
+			clusterPath := renderSSHClusterYAML(map[string]string{
+				"name":            clusterName,
+				"image_registry":  irName,
+				"head_ip":         headIP,
+				"ssh_user":        sshUser,
+				"ssh_private_key": sshPrivateKey,
+			})
+
+			irPath := renderImageRegistryYAML(map[string]string{
+				"name": irName,
+			})
+
+			// Concatenate in reverse order: Cluster(2) → ImageRegistry(1)
+			multiDocPath := writeMultiDocYAML(clusterPath, irPath)
+			defer func() {
+				os.Remove(multiDocPath)
+				os.Remove(clusterPath)
+				os.Remove(irPath)
+			}()
+
+			r := RunCLI("apply", "-f", multiDocPath)
+			ExpectSuccess(r)
+
+			// Verify dependency ordering: ImageRegistry(1) created before Cluster(2).
+			lines := strings.Split(r.Stdout, "\n")
+			irIdx, clsIdx := -1, -1
+
+			for i, line := range lines {
+				if strings.Contains(line, "ImageRegistry") && strings.Contains(line, "created") {
+					irIdx = i
+				}
+
+				if strings.Contains(line, "Cluster") && strings.Contains(line, "created") {
+					clsIdx = i
+				}
+			}
+
+			Expect(irIdx).To(BeNumerically(">=", 0), "ImageRegistry should be created")
+			Expect(clsIdx).To(BeNumerically(">=", 0), "Cluster should be created")
+			Expect(irIdx).To(BeNumerically("<", clsIdx),
+				"ImageRegistry (priority 1) should be created before Cluster (priority 2)")
+		})
+
+		It("should update existing resources with --force-update", Label("C2642184"), func() {
+			name := "e2e-cli-upd-" + Cfg.RunID
+			DeferCleanup(func() {
+				RunCLI("delete", "imageregistry", name, "-w", profileWorkspace(), "--force", "--ignore-not-found")
+			})
+
+			// Create resource first.
+			irDefaults := map[string]string{
+				"E2E_IMAGE_REGISTRY":      name,
+				"E2E_IMAGE_REGISTRY_REPO": "original-repo",
+			}
+
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", irDefaults)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(yamlPath)
+
+			r := RunCLI("apply", "-f", yamlPath)
+			ExpectSuccess(r)
+			Expect(r.Stdout).To(ContainSubstring("created"))
+
+			// Update with --force-update and new repository.
+			irDefaults["E2E_IMAGE_REGISTRY_REPO"] = "updated-repo"
+
+			yamlPath2, err := renderTemplateToTempFile("testdata/image-registry.yaml", irDefaults)
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(yamlPath2)
+
+			r = RunCLI("apply", "-f", yamlPath2, "--force-update")
+			ExpectSuccess(r)
+			Expect(r.Stdout).To(ContainSubstring("updated"))
+
+			// Verify the update took effect via typed struct comparison.
+			r = RunCLI("get", "imageregistry", name, "-w", profileWorkspace(), "-o", "json")
+			ExpectSuccess(r)
+
+			var updated v1.ImageRegistry
+			Expect(json.Unmarshal([]byte(r.Stdout), &updated)).To(Succeed())
+			Expect(updated.Spec).NotTo(BeNil())
+			Expect(updated.Spec.Repository).To(Equal("updated-repo"),
+				"repository should be updated to 'updated-repo' after --force-update")
+
+			// Without --force-update, should skip.
+			r = RunCLI("apply", "-f", yamlPath2)
+			ExpectSuccess(r)
+			Expect(r.Stdout).To(ContainSubstring("skipped"))
+		})
+
+		It("should fail on invalid kind or malformed YAML", Label("C2642185"), func() {
+			// Invalid kind.
+			yamlBadKind := `apiVersion: v1
+kind: FooBar
+metadata:
+  name: test
+  workspace: default
+spec: {}
+`
+			tmpFile, err := os.CreateTemp("", "e2e-cli-badkind-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = tmpFile.WriteString(yamlBadKind)
+			Expect(err).NotTo(HaveOccurred())
+			tmpFile.Close()
+			defer os.Remove(tmpFile.Name())
+
+			r := RunCLI("apply", "-f", tmpFile.Name())
+			ExpectFailed(r)
+
+			// Malformed YAML.
+			tmpFile2, err := os.CreateTemp("", "e2e-cli-badyaml-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = tmpFile2.WriteString("not: valid: yaml: {{{}}")
+			Expect(err).NotTo(HaveOccurred())
+			tmpFile2.Close()
+			defer os.Remove(tmpFile2.Name())
+
+			r = RunCLI("apply", "-f", tmpFile2.Name())
+			ExpectFailed(r)
+		})
+	})
+
+	// --- get ---
+
+	Describe("get", Ordered, Label("get"), func() {
+		var irName1, irName2 string
+
+		BeforeAll(func() {
+			irName1 = "e2e-cli-get-1-" + Cfg.RunID
+			irName2 = "e2e-cli-get-2-" + Cfg.RunID
+
+			for _, name := range []string{irName1, irName2} {
+				yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+					"E2E_IMAGE_REGISTRY": name,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				r := RunCLI("apply", "-f", yamlPath)
+				ExpectSuccess(r)
+				os.Remove(yamlPath)
+			}
+		})
+
+		AfterAll(func() {
+			RunCLI("delete", "imageregistry", irName1, "-w", profileWorkspace(), "--force", "--ignore-not-found")
+			RunCLI("delete", "imageregistry", irName2, "-w", profileWorkspace(), "--force", "--ignore-not-found")
+		})
+
+		It("should list resources in table format", Label("C2642186"), func() {
+			r := RunCLI("get", "imageregistry", "-w", profileWorkspace())
+			ExpectSuccess(r)
+			Expect(r.Stdout).To(ContainSubstring("NAME"))
+			Expect(r.Stdout).To(ContainSubstring("WORKSPACE"))
+			Expect(r.Stdout).To(ContainSubstring(irName1))
+			Expect(r.Stdout).To(ContainSubstring(irName2))
+		})
+
+		It("should output single resource as JSON and YAML", Label("C2642187"), func() {
+			By("JSON output")
+			r := RunCLI("get", "imageregistry", irName1, "-w", profileWorkspace(), "-o", "json")
+			ExpectSuccess(r)
+
+			var ir v1.ImageRegistry
+			Expect(json.Unmarshal([]byte(r.Stdout), &ir)).To(Succeed())
+
+			Expect(ir.Metadata).NotTo(BeNil())
+			Expect(ir.Metadata.Name).To(Equal(irName1))
+			Expect(ir.Metadata.Workspace).To(Equal(profileWorkspace()))
+			Expect(ir.Spec).NotTo(BeNil())
+			Expect(ir.Spec.URL).To(Equal(profile.ImageRegistry.URL))
+			Expect(ir.Spec.Repository).To(Equal(profile.ImageRegistry.Repository))
+
+			By("YAML output")
+			r = RunCLI("get", "imageregistry", irName1, "-w", profileWorkspace(), "-o", "yaml")
+			ExpectSuccess(r)
+
+			var irYAML v1.ImageRegistry
+			Expect(yaml.Unmarshal([]byte(r.Stdout), &irYAML)).To(Succeed())
+
+			Expect(irYAML.Metadata).NotTo(BeNil())
+			Expect(irYAML.Metadata.Name).To(Equal(irName1))
+			Expect(irYAML.Metadata.Workspace).To(Equal(profileWorkspace()))
+			Expect(irYAML.Spec).NotTo(BeNil())
+			Expect(irYAML.Spec.URL).To(Equal(profile.ImageRegistry.URL))
+			Expect(irYAML.Spec.Repository).To(Equal(profile.ImageRegistry.Repository))
+		})
+
+		It("should fail for non-existent resource", func() {
+			r := RunCLI("get", "imageregistry", "nonexistent-"+Cfg.RunID, "-w", profileWorkspace())
+			ExpectFailed(r)
+		})
+	})
+
+	// --- wait ---
+
+	Describe("wait", Label("wait"), func() {
+
+		It("should exit 0 when jsonpath condition is already met", Label("C2642189"), func() {
+			// Use ImageRegistry which reaches Connected within seconds — this tests the
+			// CLI wait mechanism itself (jsonpath matching + polling + exit code), not the
+			// duration of the wait. The wait command is resource-agnostic.
+			name := "e2e-cli-wait-" + Cfg.RunID
+			DeferCleanup(func() {
+				RunCLI("delete", "imageregistry", name, "-w", profileWorkspace(), "--force", "--ignore-not-found")
+			})
+
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+				"E2E_IMAGE_REGISTRY": name,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(yamlPath)
+
+			r := RunCLI("apply", "-f", yamlPath)
+			ExpectSuccess(r)
+
+			// Wait for status.phase=Connected (image registry should connect quickly).
+			r = RunCLI("wait", "imageregistry", name,
+				"-w", profileWorkspace(),
+				"--for", "jsonpath=.status.phase=Connected",
+				"--timeout", "3m",
+			)
+			ExpectSuccess(r)
+		})
+
+		It("should exit 0 when waiting for delete and resource is deleted", Label("C2642190"), func() {
+			name := "e2e-cli-waitdel-" + Cfg.RunID
+
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+				"E2E_IMAGE_REGISTRY": name,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(yamlPath)
+
+			r := RunCLI("apply", "-f", yamlPath)
+			ExpectSuccess(r)
+
+			// Delete the resource.
+			RunCLI("delete", "imageregistry", name, "-w", profileWorkspace(), "--force")
+
+			// Wait for delete should succeed.
+			r = RunCLI("wait", "imageregistry", name,
+				"-w", profileWorkspace(),
+				"--for", "delete",
+				"--timeout", "2m",
+			)
+			ExpectSuccess(r)
+		})
+
+		It("should exit non-zero on timeout", Label("C2642191"), func() {
+			// Wait for a condition that will never be met, with short timeout.
+			r := RunCLI("wait", "workspace", profileWorkspace(),
+				"--for", "jsonpath=.status.phase=NeverGonnaHappen",
+				"--timeout", "5s",
+			)
+			ExpectFailed(r)
+			Expect(r.Stdout).To(ContainSubstring("timeout"))
+		})
+	})
+
+	// --- delete ---
+
+	Describe("delete", Label("delete"), func() {
+
+		It("should delete a single resource", Label("C2642192"), func() {
+			name := "e2e-cli-del-" + Cfg.RunID
+
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+				"E2E_IMAGE_REGISTRY": name,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(yamlPath)
+
+			r := RunCLI("apply", "-f", yamlPath)
+			ExpectSuccess(r)
+
+			// Delete by kind + name.
+			r = RunCLI("delete", "imageregistry", name, "-w", profileWorkspace(), "--force")
+			ExpectSuccess(r)
+
+			// Verify deleted.
+			r = RunCLI("get", "imageregistry", name, "-w", profileWorkspace())
+			ExpectFailed(r)
+		})
+
+		It("should delete resources from YAML file in reverse dependency order", Label("C2642193"), func() {
+			irName := "e2e-cli-delf-ir-" + Cfg.RunID
+			clusterName := "e2e-cli-delf-cls-" + Cfg.RunID
+
+			headIP, _, sshUser, sshPrivateKey := requireSSHEnv()
+
+			// Multi-doc: ImageRegistry(priority 1) + Cluster(priority 2).
+			irPath := renderImageRegistryYAML(map[string]string{"name": irName})
+			clusterPath := renderSSHClusterYAML(map[string]string{
+				"name":            clusterName,
+				"image_registry":  irName,
+				"head_ip":         headIP,
+				"ssh_user":        sshUser,
+				"ssh_private_key": sshPrivateKey,
+			})
+
+			multiDocPath := writeMultiDocYAML(irPath, clusterPath)
+			defer func() {
+				os.Remove(multiDocPath)
+				os.Remove(irPath)
+				os.Remove(clusterPath)
+			}()
+
+			// Create resources.
+			r := RunCLI("apply", "-f", multiDocPath)
+			ExpectSuccess(r)
+
+			// Delete from file — reverse dependency: Cluster(2) before ImageRegistry(1).
+			r = RunCLI("delete", "-f", multiDocPath, "--force")
+			ExpectSuccess(r)
+
+			// Verify deletion order: Cluster deleted before ImageRegistry.
+			lines := strings.Split(r.Stdout, "\n")
+			clsIdx, irIdx := -1, -1
+
+			for i, line := range lines {
+				if strings.Contains(line, "Cluster") && strings.Contains(line, "delet") {
+					clsIdx = i
+				}
+
+				if strings.Contains(line, "ImageRegistry") && strings.Contains(line, "delet") {
+					irIdx = i
+				}
+			}
+
+			Expect(clsIdx).To(BeNumerically(">=", 0), "Cluster should be deleted")
+			Expect(irIdx).To(BeNumerically(">=", 0), "ImageRegistry should be deleted")
+			Expect(clsIdx).To(BeNumerically("<", irIdx),
+				"Cluster (priority 2) should be deleted before ImageRegistry (priority 1)")
+
+			// Verify both deleted.
+			r = RunCLI("get", "cluster", clusterName, "-w", profileWorkspace())
+			ExpectFailed(r)
+
+			r = RunCLI("get", "imageregistry", irName, "-w", profileWorkspace())
+			ExpectFailed(r)
+		})
+
+		It("should silently skip with --ignore-not-found", Label("C2642194"), func() {
+			r := RunCLI("delete", "imageregistry", "nonexistent-"+Cfg.RunID,
+				"-w", profileWorkspace(), "--force", "--ignore-not-found")
+			ExpectSuccess(r)
+		})
+	})
+
+})

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -326,6 +326,9 @@ func testRegistry() string {
 // This replaces the old approach of reading env vars for template expansion.
 func profileVarMap() map[string]string {
 	return map[string]string{
+		// Workspace
+		"E2E_WORKSPACE": profileWorkspace(),
+
 		// SSH
 		"E2E_SSH_HEAD_IP":     profileSSHHeadIP(),
 		"E2E_SSH_USER":        profileSSHUser(),
@@ -336,11 +339,14 @@ func profileVarMap() map[string]string {
 		"E2E_KUBECONFIG": profileKubeconfig(),
 
 		// Image registry
-		"E2E_IMAGE_REGISTRY_URL":  profile.ImageRegistry.URL,
-		"E2E_IMAGE_REGISTRY_REPO": profile.ImageRegistry.Repository,
+		"E2E_IMAGE_REGISTRY_URL":      profile.ImageRegistry.URL,
+		"E2E_IMAGE_REGISTRY_REPO":     profile.ImageRegistry.Repository,
+		"E2E_IMAGE_REGISTRY_USERNAME": profile.ImageRegistry.Username,
+		"E2E_IMAGE_REGISTRY_PASSWORD": profile.ImageRegistry.Password,
 
 		// Model registry
-		"E2E_MODEL_REGISTRY_URL": profile.ModelRegistry.URL,
+		"E2E_MODEL_REGISTRY_TYPE": profile.ModelRegistry.Type,
+		"E2E_MODEL_REGISTRY_URL":  profile.ModelRegistry.URL,
 
 		// Engine
 		"E2E_ENGINE_NAME":    profileEngineName(),
@@ -371,9 +377,9 @@ func renderTemplate(templatePath string, defaults map[string]string) (string, er
 	pvm := profileVarMap()
 
 	result := os.Expand(string(content), func(key string) string {
-		// 1. Caller-provided defaults take highest priority.
+		// 1. Caller-provided defaults take highest priority (including empty string).
 		if defaults != nil {
-			if v, ok := defaults[key]; ok && v != "" {
+			if v, ok := defaults[key]; ok {
 				return v
 			}
 		}
@@ -417,4 +423,50 @@ func renderTemplateToTempFile(templatePath string, defaults map[string]string) (
 	tmpFile.Close()
 
 	return tmpFile.Name(), nil
+}
+
+// requireImageRegistryProfile skips the test if image registry is not fully configured in profile.
+func requireImageRegistryProfile() {
+	if profile.ImageRegistry.URL == "" {
+		Skip("ImageRegistry.URL not configured in profile")
+	}
+
+	if profile.ImageRegistry.Repository == "" {
+		Skip("ImageRegistry.Repository not configured in profile")
+	}
+}
+
+// renderImageRegistryYAML renders an ImageRegistry YAML and returns the temp file path.
+func renderImageRegistryYAML(overrides map[string]string) string {
+	path, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+		"E2E_IMAGE_REGISTRY": overrides["name"],
+	})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	return path
+}
+
+// writeMultiDocYAML reads multiple rendered YAML temp files, concatenates them into
+// a single multi-document YAML file separated by "---", and returns the combined file path.
+// Callers are responsible for cleaning up the input files.
+func writeMultiDocYAML(paths ...string) string {
+	var parts []string
+
+	for _, p := range paths {
+		content, err := os.ReadFile(p)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "failed to read %s", p)
+
+		parts = append(parts, string(content))
+	}
+
+	combined := strings.Join(parts, "---\n")
+
+	tmpFile, err := os.CreateTemp("", "e2e-multi-*.yaml")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	_, err = tmpFile.WriteString(combined)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	tmpFile.Close()
+
+	return tmpFile.Name()
 }

--- a/tests/e2e/image_registry_test.go
+++ b/tests/e2e/image_registry_test.go
@@ -1,0 +1,107 @@
+package e2e
+
+import (
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Image Registry", Label("image-registry"), func() {
+
+	Describe("No-Protocol URL", Label("no-protocol"), func() {
+		It("should create image registry with URL without protocol prefix", Label("C2642281"), func() {
+			requireImageRegistryProfile()
+
+			name := "e2e-ir-noproto-" + Cfg.RunID
+			rawURL := profile.ImageRegistry.URL
+			rawURL = strings.TrimPrefix(rawURL, "https://")
+			rawURL = strings.TrimPrefix(rawURL, "http://")
+
+			Expect(rawURL).NotTo(BeEmpty(), "stripped registry URL should not be empty")
+
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+				"E2E_IMAGE_REGISTRY":     name,
+				"E2E_IMAGE_REGISTRY_URL": rawURL,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(yamlPath)
+
+			DeferCleanup(func() {
+				RunCLI("delete", "imageregistry", name,
+					"-w", profileWorkspace(), "--force", "--ignore-not-found")
+			})
+
+			By("Applying image registry with no-protocol URL: " + rawURL)
+			r := RunCLI("apply", "-f", yamlPath)
+			ExpectSuccess(r)
+
+			By("Waiting for Connected phase")
+			r = RunCLI("wait", "imageregistry", name,
+				"-w", profileWorkspace(),
+				"--for", "jsonpath=.status.phase=Connected",
+				"--timeout", "2m",
+			)
+			ExpectSuccess(r)
+		})
+	})
+
+	Describe("Authenticated Registry", Label("auth"), func() {
+		It("should fail without credentials on auth-required registry", Label("C2612048"), func() {
+			requireImageRegistryProfile()
+
+			if profile.ImageRegistry.Username == "" || profile.ImageRegistry.Password == "" {
+				Skip("ImageRegistry username/password not configured in profile")
+			}
+
+			noAuthName := "e2e-ir-noauth-" + Cfg.RunID
+			authName := "e2e-ir-auth-" + Cfg.RunID
+
+			DeferCleanup(func() {
+				RunCLI("delete", "imageregistry", noAuthName,
+					"-w", profileWorkspace(), "--force", "--ignore-not-found")
+				RunCLI("delete", "imageregistry", authName,
+					"-w", profileWorkspace(), "--force", "--ignore-not-found")
+			})
+
+			By("Creating image registry WITHOUT credentials")
+			noAuthPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+				"E2E_IMAGE_REGISTRY":          noAuthName,
+				"E2E_IMAGE_REGISTRY_USERNAME": "",
+				"E2E_IMAGE_REGISTRY_PASSWORD": "",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(noAuthPath)
+
+			r := RunCLI("apply", "-f", noAuthPath)
+			ExpectSuccess(r)
+
+			By("Verifying registry does NOT reach Connected without credentials")
+			r = RunCLI("wait", "imageregistry", noAuthName,
+				"-w", profileWorkspace(),
+				"--for", "jsonpath=.status.phase=Connected",
+				"--timeout", "30s",
+			)
+			ExpectFailed(r)
+
+			By("Creating image registry WITH credentials")
+			authPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+				"E2E_IMAGE_REGISTRY": authName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(authPath)
+
+			r = RunCLI("apply", "-f", authPath)
+			ExpectSuccess(r)
+
+			By("Verifying registry reaches Connected with credentials")
+			r = RunCLI("wait", "imageregistry", authName,
+				"-w", profileWorkspace(),
+				"--for", "jsonpath=.status.phase=Connected",
+				"--timeout", "2m",
+			)
+			ExpectSuccess(r)
+		})
+	})
+})

--- a/tests/e2e/testdata/image-registry.yaml
+++ b/tests/e2e/testdata/image-registry.yaml
@@ -6,3 +6,6 @@ metadata:
 spec:
   url: ${E2E_IMAGE_REGISTRY_URL}
   repository: ${E2E_IMAGE_REGISTRY_REPO}
+  authconfig:
+    username: ${E2E_IMAGE_REGISTRY_USERNAME}
+    password: ${E2E_IMAGE_REGISTRY_PASSWORD}

--- a/tests/e2e/testdata/model-registry.yaml
+++ b/tests/e2e/testdata/model-registry.yaml
@@ -4,5 +4,5 @@ metadata:
   name: ${E2E_MODEL_REGISTRY}
   workspace: ${E2E_WORKSPACE}
 spec:
-  type: bentoml
+  type: ${E2E_MODEL_REGISTRY_TYPE}
   url: ${E2E_MODEL_REGISTRY_URL}

--- a/tests/e2e/testrail.go
+++ b/tests/e2e/testrail.go
@@ -28,6 +28,7 @@ type CaseResult struct {
 // runID is resolved by the caller via profileTestrailRunID(), which checks
 // the TESTRAIL_RUN_ID env var first, then falls back to the profile value.
 // If any credentials are missing, it silently skips reporting.
+// Cases not present in the run are filtered out to avoid API errors.
 func ReportToTestRail(runID string, caseResults []CaseResult) error {
 	url := profile.Testrail.URL
 	user := profile.Testrail.User
@@ -36,6 +37,16 @@ func ReportToTestRail(runID string, caseResults []CaseResult) error {
 	if url == "" || user == "" || password == "" {
 		fmt.Println("TestRail credentials not fully configured, skipping report")
 		return nil
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	// Fetch case IDs that exist in this run.
+	validCases, err := fetchRunCaseIDs(url, user, password, runID, client)
+	if err != nil {
+		fmt.Printf("Warning: failed to fetch run cases, reporting all results: %v\n", err)
+
+		validCases = nil // nil means skip filtering
 	}
 
 	type trResult struct {
@@ -47,6 +58,8 @@ func ReportToTestRail(runID string, caseResults []CaseResult) error {
 	payload := struct {
 		Results []trResult `json:"results"`
 	}{}
+
+	var skippedCount int
 
 	for _, r := range caseResults {
 		statusID := trStatusPassed
@@ -62,7 +75,17 @@ func ReportToTestRail(runID string, caseResults []CaseResult) error {
 		caseIDInt, err := strconv.Atoi(caseID)
 		if err != nil {
 			fmt.Printf("Skipping invalid case ID %q: %v\n", r.CaseID, err)
+
 			continue
+		}
+
+		// Skip cases not in the run (if we successfully fetched the list).
+		if validCases != nil {
+			if _, ok := validCases[caseIDInt]; !ok {
+				skippedCount++
+
+				continue
+			}
 		}
 
 		payload.Results = append(payload.Results, trResult{
@@ -70,6 +93,15 @@ func ReportToTestRail(runID string, caseResults []CaseResult) error {
 			StatusID: statusID,
 			Comment:  r.Comment,
 		})
+	}
+
+	if skippedCount > 0 {
+		fmt.Printf("Skipped %d case(s) not present in TestRail run %s\n", skippedCount, runID)
+	}
+
+	if len(payload.Results) == 0 {
+		fmt.Println("No matching cases to report to TestRail")
+		return nil
 	}
 
 	body, err := json.Marshal(payload)
@@ -87,8 +119,6 @@ func ReportToTestRail(runID string, caseResults []CaseResult) error {
 	req.SetBasicAuth(user, password)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 30 * time.Second}
-
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send TestRail results: %w", err)
@@ -100,7 +130,45 @@ func ReportToTestRail(runID string, caseResults []CaseResult) error {
 		return fmt.Errorf("TestRail API returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	fmt.Printf("Successfully reported %d results to TestRail run %s\n", len(caseResults), runID)
+	fmt.Printf("Successfully reported %d results to TestRail run %s\n", len(payload.Results), runID)
 
 	return nil
+}
+
+// fetchRunCaseIDs fetches all case IDs present in a TestRail run.
+func fetchRunCaseIDs(baseURL, user, password, runID string, client *http.Client) (map[int]struct{}, error) {
+	endpoint := fmt.Sprintf("%s/index.php?/api/v2/get_tests/%s", baseURL, runID)
+
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(user, password)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get_tests returned status %d", resp.StatusCode)
+	}
+
+	var tests []struct {
+		CaseID int `json:"case_id"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&tests); err != nil {
+		return nil, fmt.Errorf("failed to decode get_tests response: %w", err)
+	}
+
+	result := make(map[int]struct{}, len(tests))
+	for _, t := range tests {
+		result[t.CaseID] = struct{}{}
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
## Issues

Part of E2E test expansion for v1.0.1-rc. Covers CLI operations and image registry management.

## Changes

**New test files:**
- `cli_test.go`: 12 cases covering CLI apply, get, wait, delete
  - C2642183: Multi-doc YAML apply with dependency ordering (Cluster before ImageRegistry)
  - C2642184: `--force-update` with typed `v1.ImageRegistry` struct verification
  - C2642185: Invalid kind and malformed YAML rejection
  - C2642186: List resources in table format with workspace-level resources
  - C2642187: JSON and YAML output with typed struct verification
  - C2642189: Wait with jsonpath condition
  - C2642190: Wait for delete
  - C2642191: Wait timeout exits non-zero
  - C2642192: Delete single resource
  - C2642193: Delete from file in reverse dependency order (Cluster before ImageRegistry)
  - C2642194: `--ignore-not-found` silent skip
- `image_registry_test.go`: 2 cases
  - C2642281: No-protocol URL registry creation and connectivity
  - C2612048: Authenticated registry (no-auth fails, with-auth connects)

**Infrastructure additions to `helpers.go`:**
- `requireImageRegistryProfile()`: Skip guard checking URL + Repository
- `renderImageRegistryYAML()`: Template-based YAML rendering (returns temp file path)
- `writeMultiDocYAML()`: Read and concatenate multiple rendered YAML files into multi-doc format
- `profileVarMap()`: Added `E2E_WORKSPACE`, `E2E_IMAGE_REGISTRY_USERNAME/PASSWORD`, `E2E_MODEL_REGISTRY_TYPE`
- `renderTemplate()`: Explicit empty string in defaults now overrides profile fallback

**Other changes:**
- `Makefile`: Configurable `E2E_TIMEOUT` (default 30m), `go test -timeout 6h` for process-level safety
- `testrail.go`: Reporter filters cases not in run, avoids API errors
- `testdata/model-registry.yaml`: Type field uses `${E2E_MODEL_REGISTRY_TYPE}` variable
- `testdata/image-registry.yaml`: Added authconfig fields

## Test

- All 14 cases passed on remote test server (server profile)
- `go build`, `go vet`, `gofmt` all pass
- CI checks pass (pr-check + codecov)
- No existing tests broken