### PR TITLE
ops: support Neutree patch suffix in engine image release

### DIFF
--- a/.github/workflows/release-engine-image.yaml
+++ b/.github/workflows/release-engine-image.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Validate engine_patch_suffix
         if: ${{ github.event.inputs.engine_patch_suffix != '' }}
         run: |
-          echo '${{ github.event.inputs.engine_patch_suffix }}' | grep -qE '^[a-zA-Z0-9._-]+$' \
+          printf '%s\n' "${{ github.event.inputs.engine_patch_suffix }}" | grep -qE '^[a-zA-Z0-9._-]+$' \
             || { echo "engine_patch_suffix must match [a-zA-Z0-9._-]+"; exit 1; }
       - name: Login docker
         uses: docker/login-action@v2

--- a/.github/workflows/release-engine-image.yaml
+++ b/.github/workflows/release-engine-image.yaml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: "ray2.53.0"
+      engine_patch_suffix:
+        description: "optional Neutree patch number (e.g. '1' produces tag <engine_version>-neutree1-<ray_short_version>); empty keeps the upstream tag"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-amd64-image:
@@ -49,6 +54,7 @@ jobs:
           ENGINE_LLAMA_CPP_VERSION: ${{ github.event.inputs.engine_version }}
           RAY_VERSION: ${{ github.event.inputs.ray_version }}
           RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
+          ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}
   push-manifests:
     runs-on: ["serve-builder","X64"]
     name: merge and push manifests
@@ -73,3 +79,4 @@ jobs:
           ENGINE_VLLM_VERSION: ${{ github.event.inputs.engine_version }}
           ENGINE_LLAMA_CPP_VERSION: ${{ github.event.inputs.engine_version }}
           RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
+          ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}

--- a/.github/workflows/release-engine-image.yaml
+++ b/.github/workflows/release-engine-image.yaml
@@ -25,7 +25,7 @@ on:
         type: string
         default: "ray2.53.0"
       engine_patch_suffix:
-        description: "optional Neutree patch number (e.g. '1' produces tag <engine_version>-neutree1-<ray_short_version>); empty keeps the upstream tag"
+        description: "optional alphanumeric patch identifier appended to the output tag (e.g. '1' produces <engine_version>-neutree1-<ray_short_version>); allowed chars [a-zA-Z0-9._-]; empty keeps the upstream tag"
         required: false
         type: string
         default: ""
@@ -36,6 +36,11 @@ jobs:
     name: build amd64 engine image
     steps:
       - uses: actions/checkout@v2
+      - name: Validate engine_patch_suffix
+        if: ${{ github.event.inputs.engine_patch_suffix != '' }}
+        run: |
+          echo '${{ github.event.inputs.engine_patch_suffix }}' | grep -qE '^[a-zA-Z0-9._-]+$' \
+            || { echo "engine_patch_suffix must match [a-zA-Z0-9._-]+"; exit 1; }
       - name: Login docker
         uses: docker/login-action@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,12 @@ ENGINE_PACKAGE_OUTPUT_DIR ?= dist
 ENGINE_BASE_DIR := internal/engine
 ENGINE_NAME ?= vllm
 ENGINE_VERSION ?= v0.11.2
+# ENGINE_DIR_VERSION strips any prerelease/build suffix (e.g. -neutree1, -beta,
+# -cu130) from ENGINE_VERSION so schema.json / templates lookups always resolve
+# to the upstream version directory under internal/engine/<name>/. The full
+# ENGINE_VERSION (with suffix) is still passed to the script via -v so the
+# manifest's version field carries the patch identifier.
+ENGINE_DIR_VERSION = $(shell echo $(ENGINE_VERSION) | sed 's/-.*//')
 ENGINE_IMAGES ?= nvidia_gpu:neutree/engine-vllm:v0.11.2-ray2.53.0
 ENGINE_TASKS ?= text-generation,text-embedding,text-rerank
 ENGINE_DESCRIPTION ?= $(ENGINE_NAME) inference engine
@@ -337,8 +343,8 @@ build-engine-package: ## Build engine package (configurable via ENGINE_NAME, ENG
 		-v $(ENGINE_VERSION) \
 		-i "$(ENGINE_IMAGES)" \
 		-s "$(ENGINE_TASKS)" \
-		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_VERSION)/schema.json),-c $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_VERSION)/schema.json) \
-		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_VERSION)/templates),-t $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_VERSION)/templates) \
+		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/schema.json),-c $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/schema.json) \
+		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/templates),-t $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/templates) \
 		-o $(ENGINE_NAME)-$(ENGINE_VERSION).tar.gz \
 		-d "$(ENGINE_DESCRIPTION)"
 
@@ -350,8 +356,8 @@ build-engine-manifest: ## Build engine manifest only (no Docker image export, co
 		-v $(ENGINE_VERSION) \
 		-i "$(ENGINE_IMAGES)" \
 		-s "$(ENGINE_TASKS)" \
-		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_VERSION)/schema.json),-c $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_VERSION)/schema.json) \
-		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_VERSION)/templates),-t $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_VERSION)/templates) \
+		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/schema.json),-c $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/schema.json) \
+		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/templates),-t $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/templates) \
 		-d "$(ENGINE_DESCRIPTION)"
 
 .PHONY: sync-images-list

--- a/cluster-image-builder/Makefile
+++ b/cluster-image-builder/Makefile
@@ -31,7 +31,7 @@ RAY_SHORT_VERSION ?= ray2.53.0
 # Use = (recursive) so the value is re-evaluated each time it is referenced,
 # removing any ordering dependency on ENGINE_PATCH_SUFFIX.
 ENGINE_PATCH_SUFFIX ?=
-ENGINE_PATCH_TAG = $(if $(ENGINE_PATCH_SUFFIX),-neutree$(ENGINE_PATCH_SUFFIX))
+ENGINE_PATCH_TAG = $(if $(strip $(ENGINE_PATCH_SUFFIX)),-neutree$(strip $(ENGINE_PATCH_SUFFIX)))
 
 .PHONY: docker-build
 docker-build: ## Run docker-build-* targets for all the images

--- a/cluster-image-builder/Makefile
+++ b/cluster-image-builder/Makefile
@@ -24,6 +24,13 @@ ENGINE_LLAMA_CPP_VERSION ?= v0.3.7
 ENGINE_LLAMA_CPP_DIR_VERSION ?= $(shell echo $(ENGINE_LLAMA_CPP_VERSION) | sed 's/-.*//' | tr '.' '_')
 RAY_SHORT_VERSION ?= ray2.53.0
 
+# Optional Neutree-side patch suffix appended only to the output image tag.
+# Empty (default) keeps the upstream tag unchanged. Setting e.g. "1" produces
+# tags like "v0.11.2-neutree1-ray2.53.0" while base image, ENGINE_VERSION_DIR,
+# and pip install version still resolve to the upstream version.
+ENGINE_PATCH_SUFFIX ?=
+ENGINE_PATCH_TAG := $(if $(ENGINE_PATCH_SUFFIX),-neutree$(ENGINE_PATCH_SUFFIX))
+
 .PHONY: docker-build
 docker-build: ## Run docker-build-* targets for all the images
 	$(MAKE) ARCH=$(ARCH) $(addprefix docker-build-,$(ACCELERATORS))
@@ -45,17 +52,17 @@ docker-build-amd-gpu: prepare ## Build the AMD GPU cluster image
 .PHONY: docker-build-engine-vllm
 docker-build-engine-vllm: prepare ## Build the vLLM engine image (NVIDIA)
 	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_BASE_IMAGE_REPO):$(ENGINE_VLLM_VERSION) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
-		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)-$(RAY_SHORT_VERSION) .
+		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-build-engine-vllm-rocm
 docker-build-engine-vllm-rocm: prepare ## Build the vLLM engine image (ROCm)
 	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_ROCM_BASE_IMAGE_REPO):$(ENGINE_VLLM_VERSION) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
-		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)-$(RAY_SHORT_VERSION) .
+		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-build-engine-llama-cpp
 docker-build-engine-llama-cpp: prepare ## Build the llama-cpp-python engine image
 	docker build --build-arg LLAMA_CPP_VERSION=$(shell echo $(ENGINE_LLAMA_CPP_VERSION) | sed 's/^v//') --build-arg ENGINE_VERSION_DIR=$(ENGINE_LLAMA_CPP_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
-		-f Dockerfile.engine-llama-cpp -t $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)-$(RAY_SHORT_VERSION) .
+		-f Dockerfile.engine-llama-cpp -t $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-push
 docker-push: ## Run docker-push-* targets for all the images
@@ -71,23 +78,23 @@ docker-push-amd-gpu: ## Push the AMD GPU image
 
 .PHONY: docker-push-engine-vllm
 docker-push-engine-vllm: ## Push the vLLM engine image (NVIDIA)
-	docker push $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)-$(RAY_SHORT_VERSION)
+	docker push $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
 
 .PHONY: docker-push-engine-vllm-rocm
 docker-push-engine-vllm-rocm: ## Push the vLLM engine image (ROCm)
-	docker push $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)-$(RAY_SHORT_VERSION)
+	docker push $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
 
 .PHONY: docker-push-engine-llama-cpp
 docker-push-engine-llama-cpp: ## Push the llama-cpp-python engine image
-	docker push $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)-$(RAY_SHORT_VERSION)
+	docker push $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
 
 .PHONY: docker-push-manifest-engine-vllm
 docker-push-manifest-engine-vllm: ## Push the vLLM engine manifest image
-	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm:$(ENGINE_VLLM_VERSION)-$(RAY_SHORT_VERSION)~g")
+	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
 
 .PHONY: docker-push-manifest-engine-llama-cpp
 docker-push-manifest-engine-llama-cpp: ## Push the llama-cpp engine manifest image
-	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)-$(RAY_SHORT_VERSION)~g")
+	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
 
 .PHONY: docker-push-manifest
 docker-push-manifest: $(addprefix docker-push-manifest-,$(ACCELERATORS))

--- a/cluster-image-builder/Makefile
+++ b/cluster-image-builder/Makefile
@@ -28,8 +28,10 @@ RAY_SHORT_VERSION ?= ray2.53.0
 # Empty (default) keeps the upstream tag unchanged. Setting e.g. "1" produces
 # tags like "v0.11.2-neutree1-ray2.53.0" while base image, ENGINE_VERSION_DIR,
 # and pip install version still resolve to the upstream version.
+# Use = (recursive) so the value is re-evaluated each time it is referenced,
+# removing any ordering dependency on ENGINE_PATCH_SUFFIX.
 ENGINE_PATCH_SUFFIX ?=
-ENGINE_PATCH_TAG := $(if $(ENGINE_PATCH_SUFFIX),-neutree$(ENGINE_PATCH_SUFFIX))
+ENGINE_PATCH_TAG = $(if $(ENGINE_PATCH_SUFFIX),-neutree$(ENGINE_PATCH_SUFFIX))
 
 .PHONY: docker-build
 docker-build: ## Run docker-build-* targets for all the images


### PR DESCRIPTION
## Issues

Need a way to release engine images that fix Neutree-side bugs (in `cluster-image-builder/serve/<engine>/<dir>/`) without bumping the upstream engine version. Today, `engine_version` (in the release-engine-image workflow) and `ENGINE_VERSION` (in the root Makefile's engine package targets) each drive multiple things at once — base image tag, serve directory, schema/templates lookup path, and output tag — so any tag bump forces the others to move too.

Design doc: http://gitlab.smartx.com/wei.huang/neutree-dev-docs/-/merge_requests/1 (merged)

## Changes

### Engine image build (`cluster-image-builder/Makefile` + `release-engine-image.yaml`)

- Add optional `ENGINE_PATCH_SUFFIX` (default empty) and a derived `ENGINE_PATCH_TAG := -neutree<suffix>` that is appended only to the output docker tag in 8 targets (build / push / manifest for vllm, vllm-rocm, llama-cpp). Wrapped with `$(strip ...)` to tolerate whitespace in the env value.
- Add an optional `engine_patch_suffix` workflow input with regex validation (`[a-zA-Z0-9._-]+`) and wire it into both `build-amd64-image` and `push-manifests` jobs as the `ENGINE_PATCH_SUFFIX` env variable.
- The upstream base image (`ENGINE_BASE_IMAGE`), the serve subdirectory (`ENGINE_VERSION_DIR`), and the llama-cpp pip install version (`LLAMA_CPP_VERSION`) are all left untouched — they continue to resolve to the upstream version.

### Engine package / manifest build (`Makefile`)

- Add a derived `ENGINE_DIR_VERSION` that strips any prerelease/build suffix from `ENGINE_VERSION` (e.g. `v0.11.2-neutree1` → `v0.11.2`) and use it only for the `internal/engine/<name>/<version>/{schema.json,templates}` lookup path in both `build-engine-package` and `build-engine-manifest` targets.
- The full `ENGINE_VERSION` (with patch suffix) is still passed to the script via `-v` so the manifest's `version` field carries the patch identifier, and is still used in the output tar filename.

### Runtime (no changes needed)

`internal/orchestrator/ray_orchestrator.go:472-481` already handles the resulting `vX.Y.Z-neutreeN` engine version transparently: it strips prerelease/build suffixes via `semver.BaseVersion` so the import path resolves to `serve/<engine>/vX_Y_Z/`.

### Behavior

| Knob | Upstream resolves to | Output tag / version |
|---|---|---|
| `engine_patch_suffix=` (empty) | `v0.11.2` | `v0.11.2-ray2.53.0` (image), `v0.11.2` (manifest) — unchanged |
| `engine_patch_suffix=1` | `v0.11.2` | `v0.11.2-neutree1-ray2.53.0` (image) |
| `ENGINE_VERSION=v0.11.2-neutree1` | `internal/engine/vllm/v0.11.2/` | `v0.11.2-neutree1` (manifest) |

## Test

Verified via `make --just-print` dry-run (no real docker build / package emit needed since changes are confined to Makefile variable composition + workflow yaml):

- [x] Empty suffix produces `v0.11.2-ray2.53.0` for vllm — current behavior preserved
- [x] `ENGINE_PATCH_SUFFIX=1` produces `v0.11.2-neutree1-ray2.53.0` for vllm
- [x] `--build-arg ENGINE_BASE_IMAGE` and `ENGINE_VERSION_DIR` are unaffected by the suffix (still `v0.11.2` / `v0_11_2`)
- [x] vllm-rocm follows the same pattern
- [x] llama-cpp default + with suffix produces `v0.3.7-ray2.53.0` and `v0.3.7-neutree2-ray2.53.0` respectively
- [x] llama-cpp `LLAMA_CPP_VERSION` (pip install) is unaffected — still `0.3.7`
- [x] `docker push` and `docker buildx imagetools create` tags are consistent with build tags
- [x] `$(strip ...)` correctly handles whitespace-only / leading-trailing-whitespace suffix values
- [x] `build-engine-manifest` with `ENGINE_VERSION=v0.11.2-neutree1` resolves schema/templates to `internal/engine/vllm/v0.11.2/` while passing `-v v0.11.2-neutree1` to the script
- [x] `build-engine-manifest` with `ENGINE_VERSION=v0.99.0-neutree1` (non-existent upstream) omits `-c` and `-t` flags as before — no regression
- [x] `build-engine-package` mirrors the same fix
- [x] (verified pre-merge via run 25003142756 with empty-suffix logic — validation step is gated `if: != ${SUFFIX} != ""`, default-empty path identical to pre-change yaml)
- [x] (verified pre-merge via run 25003142756) workflow_dispatch with `engine_patch_suffix=1`, `ray_version=ray-2.53.0-neutree-fix` produced tag `v0.11.2-neutree1-ray2.53.0` end-to-end (build / push / manifest); `ENGINE_BASE_IMAGE` and `ENGINE_VERSION_DIR` correctly resolved to upstream `v0.11.2` / `v0_11_2`