### PR TITLE
fix: aggregate version-level supported_tasks into Engine.Spec on CLI import

### DIFF
--- a/api/v1/engine_types.go
+++ b/api/v1/engine_types.go
@@ -19,6 +19,24 @@ const (
 	EngineNameLlamaCpp = "llama-cpp"
 )
 
+// knownModelTasks is the canonical set of task identifiers consumed by Neutree
+// engine deploy templates (vLLM / llama-cpp). Values outside this set are
+// silently ignored by the templates and must be rejected at ingestion time
+// (see internal/cli/packageimport for import-side enforcement).
+var knownModelTasks = map[string]struct{}{
+	TextGenerationModelTask: {},
+	TextEmbeddingModelTask:  {},
+	TextRerankModelTask:     {},
+}
+
+// IsKnownModelTask reports whether task is one of the values understood by
+// Neutree's engine deploy templates. Use this at any boundary that ingests
+// user-supplied task identifiers (CLI imports, API server validation).
+func IsKnownModelTask(task string) bool {
+	_, ok := knownModelTasks[task]
+	return ok
+}
+
 // EngineVersion represents a specific version of an engine with its configuration schema,
 // deployment templates, and supported accelerators.
 //

--- a/api/v1/engine_types.go
+++ b/api/v1/engine_types.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"encoding/base64"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -35,6 +36,21 @@ var knownModelTasks = map[string]struct{}{
 func IsKnownModelTask(task string) bool {
 	_, ok := knownModelTasks[task]
 	return ok
+}
+
+// KnownModelTasks returns the canonical set of task identifiers in a stable
+// sorted order. Single source of truth shared by IsKnownModelTask and any
+// caller that needs to render the accepted set (e.g. error messages),
+// preventing drift between validation and what we tell users is accepted.
+func KnownModelTasks() []string {
+	tasks := make([]string, 0, len(knownModelTasks))
+	for t := range knownModelTasks {
+		tasks = append(tasks, t)
+	}
+
+	sort.Strings(tasks)
+
+	return tasks
 }
 
 // EngineVersion represents a specific version of an engine with its configuration schema,

--- a/api/v1/engine_types_test.go
+++ b/api/v1/engine_types_test.go
@@ -315,3 +315,41 @@ func TestEngineVersion_SupportsAccelerator(t *testing.T) {
 		})
 	}
 }
+
+func TestIsKnownModelTask(t *testing.T) {
+	tests := []struct {
+		task string
+		want bool
+	}{
+		{"text-generation", true},
+		{"text-embedding", true},
+		{"text-rerank", true},
+		{"chat", false},
+		{"", false},
+		{" text-generation", false}, // leading whitespace not silently accepted
+		{"TEXT-GENERATION", false},  // case sensitive
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.task, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsKnownModelTask(tt.task))
+		})
+	}
+}
+
+func TestKnownModelTasks(t *testing.T) {
+	got := KnownModelTasks()
+
+	// Stable sorted order — protects callers that render the set in error
+	// messages from observing different orderings across runs.
+	assert.Equal(t, []string{
+		TextEmbeddingModelTask,
+		TextGenerationModelTask,
+		TextRerankModelTask,
+	}, got)
+
+	// Length matches IsKnownModelTask truth table.
+	for _, task := range got {
+		assert.True(t, IsKnownModelTask(task), "KnownModelTasks must list a known task: %q", task)
+	}
+}

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/docker/docker/api/types/registry"
@@ -182,6 +184,15 @@ func (i *Importer) registerEngines(ctx context.Context, opts *ImportOptions, man
 	if len(manifest.Engines) > 0 {
 		klog.Infof("Engines to import: %d", len(manifest.Engines))
 
+		// Reject unknown task identifiers up-front so partial DB writes never
+		// happen. We validate every engine in the manifest before touching any.
+		for _, engine := range manifest.Engines {
+			if err := validateModelTasks(engine); err != nil {
+				result.Errors = append(result.Errors, err)
+				return result, err
+			}
+		}
+
 		for _, engine := range manifest.Engines {
 			if err := i.updateEngine(ctx, engine, opts); err != nil {
 				result.Errors = append(result.Errors, err)
@@ -269,6 +280,57 @@ func (i *Importer) validateOptions(opts *ImportOptions) error {
 	}
 
 	return nil
+}
+
+// validateModelTasks rejects an EngineMetadata whose top-level or any per-version
+// supported_tasks contains an identifier not in v1.IsKnownModelTask. All
+// offending values are collected so the user gets one error listing every
+// problem instead of fixing them one at a time. Empty / whitespace-only values
+// are silently tolerated (aggregateSupportedTasks skips them downstream).
+func validateModelTasks(em *EngineMetadata) error {
+	if em == nil {
+		return nil
+	}
+
+	type bad struct {
+		where string
+		task  string
+	}
+	var bads []bad
+
+	for _, t := range em.SupportedTasks {
+		if strings.TrimSpace(t) == "" {
+			continue
+		}
+		if !v1.IsKnownModelTask(t) {
+			bads = append(bads, bad{where: "engines[" + em.Name + "].supported_tasks", task: t})
+		}
+	}
+	for _, v := range em.EngineVersions {
+		if v == nil {
+			continue
+		}
+		for _, t := range v.SupportedTasks {
+			if strings.TrimSpace(t) == "" {
+				continue
+			}
+			if !v1.IsKnownModelTask(t) {
+				bads = append(bads, bad{where: "engines[" + em.Name + "].engine_versions[" + v.Version + "].supported_tasks", task: t})
+			}
+		}
+	}
+
+	if len(bads) == 0 {
+		return nil
+	}
+
+	parts := make([]string, 0, len(bads))
+	for _, b := range bads {
+		parts = append(parts, b.where+`=`+strconv.Quote(b.task))
+	}
+	return fmt.Errorf("unknown model task value(s) — only %q, %q, %q are accepted: %s",
+		v1.TextGenerationModelTask, v1.TextEmbeddingModelTask, v1.TextRerankModelTask,
+		strings.Join(parts, "; "))
 }
 
 // aggregateSupportedTasks unions the manifest top-level supported_tasks with each

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -271,6 +271,50 @@ func (i *Importer) validateOptions(opts *ImportOptions) error {
 	return nil
 }
 
+// aggregateSupportedTasks unions the manifest top-level supported_tasks with each
+// engine_versions[*].supported_tasks. The build script (build-engine-package.sh)
+// only emits version-level supported_tasks; the parser does not aggregate; so the
+// importer is responsible for producing the engine-level union. Order: top-level
+// first, then version-level by version order. Duplicates and empty/whitespace
+// entries are skipped while preserving first-occurrence order.
+func aggregateSupportedTasks(em *EngineMetadata) []string {
+	if em == nil {
+		return nil
+	}
+	var out []string
+	out = unionStrings(out, em.SupportedTasks)
+	for _, v := range em.EngineVersions {
+		if v == nil {
+			continue
+		}
+		out = unionStrings(out, v.SupportedTasks)
+	}
+	return out
+}
+
+// unionStrings returns existing extended with each non-empty trimmed entry of
+// incoming that is not already present. existing's order is preserved; new
+// entries are appended in incoming order. Returns nil only when both inputs
+// produce no kept entries.
+func unionStrings(existing, incoming []string) []string {
+	seen := make(map[string]struct{}, len(existing)+len(incoming))
+	out := existing
+	for _, s := range existing {
+		seen[s] = struct{}{}
+	}
+	for _, s := range incoming {
+		if strings.TrimSpace(s) == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
 // updateEngine updates the engine with the new version
 func (i *Importer) updateEngine(_ context.Context, engineMetadata *EngineMetadata, opts *ImportOptions) error {
 	newEngine := &v1.Engine{
@@ -282,7 +326,7 @@ func (i *Importer) updateEngine(_ context.Context, engineMetadata *EngineMetadat
 		},
 		Spec: &v1.EngineSpec{
 			Versions:       engineMetadata.EngineVersions,
-			SupportedTasks: engineMetadata.SupportedTasks,
+			SupportedTasks: aggregateSupportedTasks(engineMetadata),
 		},
 	}
 
@@ -323,6 +367,14 @@ func (i *Importer) updateEngine(_ context.Context, engineMetadata *EngineMetadat
 			existedEngine.Spec.Versions = append(existedEngine.Spec.Versions, newVersion)
 		}
 	}
+
+	// Union newly imported tasks into the existing engine's SupportedTasks.
+	// We never drop tasks already on the existing engine (NEU-427): users may
+	// have set them via prior imports or hand-patched the resource.
+	existedEngine.Spec.SupportedTasks = unionStrings(
+		existedEngine.Spec.SupportedTasks,
+		aggregateSupportedTasks(engineMetadata),
+	)
 
 	return i.apiClient.Engines.Update(existedEngine.GetID(), existedEngine)
 }

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -333,8 +333,8 @@ func validateModelTasks(em *EngineMetadata) error {
 		parts = append(parts, b.where+`=`+strconv.Quote(b.task))
 	}
 
-	return fmt.Errorf("unknown model task value(s) — only %q, %q, %q are accepted: %s",
-		v1.TextGenerationModelTask, v1.TextEmbeddingModelTask, v1.TextRerankModelTask,
+	return fmt.Errorf("unknown model task value(s) — only %v are accepted: %s",
+		v1.KnownModelTasks(),
 		strings.Join(parts, "; "))
 }
 
@@ -362,10 +362,15 @@ func aggregateSupportedTasks(em *EngineMetadata) []string {
 	return out
 }
 
-// unionStrings returns existing extended with each non-empty trimmed entry of
-// incoming that is not already present. existing's order is preserved; new
-// entries are appended in incoming order. Returns nil only when both inputs
-// produce no kept entries.
+// unionStrings returns existing extended with each entry from incoming that
+// (a) is not whitespace-only and (b) is not already present in existing.
+// Strings are stored verbatim — no leading/trailing whitespace is stripped
+// from kept entries; trimming is used only to detect "empty" entries to skip.
+// existing's order is preserved as-is (existing duplicates and any leading/
+// trailing whitespace in existing entries are kept untouched — this helper
+// is intentionally non-destructive); new entries are appended in incoming
+// order. Returns existing's value (which may be nil) when no incoming entries
+// are kept.
 func unionStrings(existing, incoming []string) []string {
 	seen := make(map[string]struct{}, len(existing)+len(incoming))
 	out := existing

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -302,18 +302,22 @@ func validateModelTasks(em *EngineMetadata) error {
 		if strings.TrimSpace(t) == "" {
 			continue
 		}
+
 		if !v1.IsKnownModelTask(t) {
 			bads = append(bads, bad{where: "engines[" + em.Name + "].supported_tasks", task: t})
 		}
 	}
+
 	for _, v := range em.EngineVersions {
 		if v == nil {
 			continue
 		}
+
 		for _, t := range v.SupportedTasks {
 			if strings.TrimSpace(t) == "" {
 				continue
 			}
+
 			if !v1.IsKnownModelTask(t) {
 				bads = append(bads, bad{where: "engines[" + em.Name + "].engine_versions[" + v.Version + "].supported_tasks", task: t})
 			}
@@ -328,6 +332,7 @@ func validateModelTasks(em *EngineMetadata) error {
 	for _, b := range bads {
 		parts = append(parts, b.where+`=`+strconv.Quote(b.task))
 	}
+
 	return fmt.Errorf("unknown model task value(s) — only %q, %q, %q are accepted: %s",
 		v1.TextGenerationModelTask, v1.TextEmbeddingModelTask, v1.TextRerankModelTask,
 		strings.Join(parts, "; "))
@@ -343,14 +348,17 @@ func aggregateSupportedTasks(em *EngineMetadata) []string {
 	if em == nil {
 		return nil
 	}
-	var out []string
-	out = unionStrings(out, em.SupportedTasks)
+
+	out := unionStrings(nil, em.SupportedTasks)
+
 	for _, v := range em.EngineVersions {
 		if v == nil {
 			continue
 		}
+
 		out = unionStrings(out, v.SupportedTasks)
 	}
+
 	return out
 }
 
@@ -361,19 +369,24 @@ func aggregateSupportedTasks(em *EngineMetadata) []string {
 func unionStrings(existing, incoming []string) []string {
 	seen := make(map[string]struct{}, len(existing)+len(incoming))
 	out := existing
+
 	for _, s := range existing {
 		seen[s] = struct{}{}
 	}
+
 	for _, s := range incoming {
 		if strings.TrimSpace(s) == "" {
 			continue
 		}
+
 		if _, ok := seen[s]; ok {
 			continue
 		}
+
 		seen[s] = struct{}{}
 		out = append(out, s)
 	}
+
 	return out
 }
 

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -384,6 +384,7 @@ func unionStrings(existing, incoming []string) []string {
 		}
 
 		seen[s] = struct{}{}
+
 		out = append(out, s)
 	}
 

--- a/internal/cli/packageimport/importer_test.go
+++ b/internal/cli/packageimport/importer_test.go
@@ -4,9 +4,129 @@ import (
 	"os"
 	"testing"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAggregateSupportedTasks(t *testing.T) {
+	tests := []struct {
+		name string
+		em   *EngineMetadata
+		want []string
+	}{
+		{
+			name: "nil top + nil versions returns nil",
+			em: &EngineMetadata{
+				SupportedTasks: nil,
+				EngineVersions: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "empty everywhere returns nil",
+			em: &EngineMetadata{
+				SupportedTasks: []string{},
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", SupportedTasks: []string{}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "top-level only",
+			em: &EngineMetadata{
+				SupportedTasks: []string{"a", "b"},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "version-level only with dedup across versions, preserves first occurrence",
+			em: &EngineMetadata{
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", SupportedTasks: []string{"a"}},
+					{Version: "v2", SupportedTasks: []string{"b", "a"}},
+				},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "top + versions, top takes precedence in ordering",
+			em: &EngineMetadata{
+				SupportedTasks: []string{"a"},
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", SupportedTasks: []string{"b", "a"}},
+					{Version: "v2", SupportedTasks: []string{"c"}},
+				},
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "skips empty and whitespace-only strings",
+			em: &EngineMetadata{
+				SupportedTasks: []string{"a", "", "  ", "b"},
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", SupportedTasks: []string{"", "c"}},
+				},
+			},
+			want: []string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := aggregateSupportedTasks(tt.em)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUnionStrings(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []string
+		incoming []string
+		want     []string
+	}{
+		{
+			name:     "both nil returns nil",
+			existing: nil,
+			incoming: nil,
+			want:     nil,
+		},
+		{
+			name:     "preserves existing order, appends only new uniques",
+			existing: []string{"chat", "embedding"},
+			incoming: []string{"embedding", "rerank", "chat"},
+			want:     []string{"chat", "embedding", "rerank"},
+		},
+		{
+			name:     "empty existing returns dedup of incoming",
+			existing: nil,
+			incoming: []string{"a", "b", "a"},
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "empty incoming returns existing as-is",
+			existing: []string{"a", "b"},
+			incoming: nil,
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "skips empty/whitespace from incoming",
+			existing: []string{"a"},
+			incoming: []string{"", "  ", "b"},
+			want:     []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unionStrings(tt.existing, tt.incoming)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestIsManifestFile(t *testing.T) {
 	tests := []struct {

--- a/internal/cli/packageimport/importer_test.go
+++ b/internal/cli/packageimport/importer_test.go
@@ -71,12 +71,110 @@ func TestAggregateSupportedTasks(t *testing.T) {
 			},
 			want: []string{"a", "b", "c"},
 		},
+		{
+			name: "tolerates a nil EngineVersion entry in the slice",
+			em: &EngineMetadata{
+				SupportedTasks: []string{"a"},
+				EngineVersions: []*v1.EngineVersion{
+					nil,
+					{Version: "v1", SupportedTasks: []string{"b"}},
+				},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "second version cannot reorder tasks that the first already introduced",
+			em: &EngineMetadata{
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", SupportedTasks: []string{"a", "b"}},
+					{Version: "v2", SupportedTasks: []string{"b", "c"}},
+				},
+			},
+			want: []string{"a", "b", "c"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := aggregateSupportedTasks(tt.em)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidateModelTasks(t *testing.T) {
+	tests := []struct {
+		name        string
+		em          *EngineMetadata
+		expectError bool
+		errorParts  []string // substrings that must appear in the error message
+	}{
+		{
+			name: "all known tasks at top + version → ok",
+			em: &EngineMetadata{
+				Name:           "vllm",
+				SupportedTasks: []string{v1.TextGenerationModelTask},
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", SupportedTasks: []string{v1.TextEmbeddingModelTask, v1.TextRerankModelTask}},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty everywhere → ok (validation does not require any tasks)",
+			em: &EngineMetadata{
+				Name: "vllm",
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "unknown task at top-level → error names the offending value",
+			em: &EngineMetadata{
+				Name:           "vllm",
+				SupportedTasks: []string{"chat"},
+			},
+			expectError: true,
+			errorParts:  []string{"chat", "engines[vllm]"},
+		},
+		{
+			name: "unknown task at version-level → error names version + value",
+			em: &EngineMetadata{
+				Name: "vllm",
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1.0.0", SupportedTasks: []string{"text-generation", "embedding"}},
+				},
+			},
+			expectError: true,
+			errorParts:  []string{"embedding", "v1.0.0"},
+		},
+		{
+			name: "multiple unknown values are all reported",
+			em: &EngineMetadata{
+				Name:           "vllm",
+				SupportedTasks: []string{"chat"},
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1.0.0", SupportedTasks: []string{"speech"}},
+				},
+			},
+			expectError: true,
+			errorParts:  []string{"chat", "speech"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateModelTasks(tt.em)
+			if !tt.expectError {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, part := range tt.errorParts {
+				assert.Contains(t, err.Error(), part)
+			}
 		})
 	}
 }

--- a/tests/e2e/engine_test.go
+++ b/tests/e2e/engine_test.go
@@ -427,7 +427,7 @@ var _ = Describe("Engine", Ordered, func() {
 				Name:           name,
 				Version:        "v1.0.0",
 				Images:         map[string][2]string{"nvidia_gpu": {"e2e/engine-cuda", "v1.0.0"}},
-				SupportedTasks: []string{"text-generation", "embedding"},
+				SupportedTasks: []string{"text-generation", "text-embedding"},
 			})
 			defer os.Remove(pkg)
 
@@ -437,8 +437,8 @@ var _ = Describe("Engine", Ordered, func() {
 			r = EngineH.Get(name)
 			ExpectSuccess(r)
 			e := parseEngineJSON(r.Stdout)
-			Expect(e.Spec.SupportedTasks).To(ConsistOf("text-generation", "embedding"))
-			Expect(e.Spec.Versions[0].SupportedTasks).To(ConsistOf("text-generation", "embedding"))
+			Expect(e.Spec.SupportedTasks).To(ConsistOf("text-generation", "text-embedding"))
+			Expect(e.Spec.Versions[0].SupportedTasks).To(ConsistOf("text-generation", "text-embedding"))
 		})
 
 		// NEU-427: TestRail C2649201
@@ -450,7 +450,7 @@ var _ = Describe("Engine", Ordered, func() {
 				Name:           name,
 				Version:        "v1.0.0",
 				Images:         map[string][2]string{"nvidia_gpu": {"e2e/engine-cuda", "v1.0.0"}},
-				SupportedTasks: []string{"chat"},
+				SupportedTasks: []string{"text-generation"},
 			})
 			defer os.Remove(pkg1)
 			r := EngineH.ImportSkipImage(pkg1)
@@ -458,13 +458,13 @@ var _ = Describe("Engine", Ordered, func() {
 
 			r = EngineH.Get(name)
 			ExpectSuccess(r)
-			Expect(parseEngineJSON(r.Stdout).Spec.SupportedTasks).To(ConsistOf("chat"))
+			Expect(parseEngineJSON(r.Stdout).Spec.SupportedTasks).To(ConsistOf("text-generation"))
 
 			pkg2 := buildEnginePackage(engineManifest{
 				Name:           name,
 				Version:        "v2.0.0",
 				Images:         map[string][2]string{"nvidia_gpu": {"e2e/engine-cuda", "v2.0.0"}},
-				SupportedTasks: []string{"embedding"},
+				SupportedTasks: []string{"text-embedding"},
 			})
 			defer os.Remove(pkg2)
 			r = EngineH.ImportSkipImage(pkg2)
@@ -473,9 +473,9 @@ var _ = Describe("Engine", Ordered, func() {
 			r = EngineH.Get(name)
 			ExpectSuccess(r)
 			tasks := parseEngineJSON(r.Stdout).Spec.SupportedTasks
-			Expect(tasks).To(ConsistOf("chat", "embedding"))
+			Expect(tasks).To(ConsistOf("text-generation", "text-embedding"))
 			// Existing-first ordering: union must not drop or reorder existing tasks.
-			Expect(tasks[0]).To(Equal("chat"))
+			Expect(tasks[0]).To(Equal("text-generation"))
 		})
 
 		It("should add a new engine version via CLI import", Label("C2613216"), func() {

--- a/tests/e2e/engine_test.go
+++ b/tests/e2e/engine_test.go
@@ -415,6 +415,69 @@ var _ = Describe("Engine", Ordered, func() {
 			Expect(e.Spec.Versions[0].Images).To(HaveKey("nvidia_gpu"))
 		})
 
+		// NEU-427: TestRail C2649200
+		It("should populate Engine.Spec.SupportedTasks from version-level supported_tasks on create", Label("C2649200"), func() {
+			name := "e2e-engine-tasks-create"
+			DeferCleanup(EngineH.EnsureDeleted, name)
+
+			// buildEnginePackage emits supported_tasks at engine_versions[0] level
+			// (mimics scripts/builder/build-engine-package.sh shape) — no engine
+			// top-level supported_tasks. Pre-fix this leaves Engine.Spec.SupportedTasks empty.
+			pkg := buildEnginePackage(engineManifest{
+				Name:           name,
+				Version:        "v1.0.0",
+				Images:         map[string][2]string{"nvidia_gpu": {"e2e/engine-cuda", "v1.0.0"}},
+				SupportedTasks: []string{"text-generation", "embedding"},
+			})
+			defer os.Remove(pkg)
+
+			r := EngineH.ImportSkipImage(pkg)
+			ExpectSuccess(r)
+
+			r = EngineH.Get(name)
+			ExpectSuccess(r)
+			e := parseEngineJSON(r.Stdout)
+			Expect(e.Spec.SupportedTasks).To(ConsistOf("text-generation", "embedding"))
+			Expect(e.Spec.Versions[0].SupportedTasks).To(ConsistOf("text-generation", "embedding"))
+		})
+
+		// NEU-427: TestRail C2649201
+		It("should union version-level supported_tasks into existing Engine.Spec.SupportedTasks on re-import", Label("C2649201"), func() {
+			name := "e2e-engine-tasks-union"
+			DeferCleanup(EngineH.EnsureDeleted, name)
+
+			pkg1 := buildEnginePackage(engineManifest{
+				Name:           name,
+				Version:        "v1.0.0",
+				Images:         map[string][2]string{"nvidia_gpu": {"e2e/engine-cuda", "v1.0.0"}},
+				SupportedTasks: []string{"chat"},
+			})
+			defer os.Remove(pkg1)
+			r := EngineH.ImportSkipImage(pkg1)
+			ExpectSuccess(r)
+
+			r = EngineH.Get(name)
+			ExpectSuccess(r)
+			Expect(parseEngineJSON(r.Stdout).Spec.SupportedTasks).To(ConsistOf("chat"))
+
+			pkg2 := buildEnginePackage(engineManifest{
+				Name:           name,
+				Version:        "v2.0.0",
+				Images:         map[string][2]string{"nvidia_gpu": {"e2e/engine-cuda", "v2.0.0"}},
+				SupportedTasks: []string{"embedding"},
+			})
+			defer os.Remove(pkg2)
+			r = EngineH.ImportSkipImage(pkg2)
+			ExpectSuccess(r)
+
+			r = EngineH.Get(name)
+			ExpectSuccess(r)
+			tasks := parseEngineJSON(r.Stdout).Spec.SupportedTasks
+			Expect(tasks).To(ConsistOf("chat", "embedding"))
+			// Existing-first ordering: union must not drop or reorder existing tasks.
+			Expect(tasks[0]).To(Equal("chat"))
+		})
+
 		It("should add a new engine version via CLI import", Label("C2613216"), func() {
 			name := "e2e-engine-newver"
 			DeferCleanup(EngineH.EnsureDeleted, name)


### PR DESCRIPTION
## Issues

- NEU-427 — CLI engine import does not derive `Engine.Spec.SupportedTasks` from `engine_versions[*].supported_tasks` when creating a new Engine, leaving downstream task-type filters unable to see any tasks for freshly imported engines. The update path also fails to backfill the field.
- Design doc (merged): `neutree-dev-docs/bugfix/NEU-427-rca-zh.md` (GitLab MR !4 + rev2 !6 adding `IsKnownModelTask` validation step)

## Changes

- `api/v1/engine_types.go`
  - Expose `IsKnownModelTask(task string) bool` over the canonical `{text-generation, text-embedding, text-rerank}` set so other layers can reuse it
- `internal/cli/packageimport/importer.go`
  - Add `validateModelTasks` to fail-fast when a manifest carries a task identifier outside the canonical enum (review surfaced that the type is `[]string` with no validation, so unknown values previously flowed silently into the DB and were ignored by deploy templates)
  - Add `aggregateSupportedTasks(em *EngineMetadata) []string` — top-level union per-version, dedup with first-occurrence order, skip empty / whitespace
  - Add `unionStrings(existing, incoming)` — order-preserving append-uniques helper
  - Create branch: `Spec.SupportedTasks = aggregateSupportedTasks(metadata)`
  - Update branch: union aggregated tasks into existing `Spec.SupportedTasks`; existing tasks are never dropped (backward compatible with hand-patched resources)
  - Wire `validateModelTasks` into `registerEngines` before any DB write so partial state never lands
- `internal/cli/packageimport/importer_test.go`
  - `TestAggregateSupportedTasks` (8 sub-cases): nil/empty handling, top-only, version-only with cross-version dedup, top + versions ordering, whitespace skip, nil version slice element, second version cannot reorder existing tasks
  - `TestUnionStrings` (5 sub-cases)
  - `TestValidateModelTasks` (5 sub-cases): valid, empty-tolerant, top-only unknown, version-only unknown, multi-unknown reporting
- `tests/e2e/engine_test.go`
  - `C2649200` — bug reproduction on create branch
  - `C2649201` — union + ordering assertion on update branch

Parser and build script intentionally untouched: aggregation is the importer's responsibility per the existing layered design.

## Test plan

- [x] Unit (race): `go test -race ./internal/cli/packageimport/` — **18 subtests pass**
- [x] E2E build: `go build ./tests/e2e/...`
- [x] `go vet ./internal/cli/packageimport/... ./api/v1/...`
- [x] E2E run on test env — before/after comparison captured below

### Before-fix vs after-fix E2E evidence

Both runs against the same control plane (`192.168.16.91:3000`), identical profile, identical CLI test harness; only the importer.go / engine_types.go fix differs.

| State | Branch | Filter | C2649200 | C2649201 | Outcome |
|---|---|---|---|---|---|
| **Before fix** | main @ `e5e90fee` (e2e cases cherry-picked, fix not applied) | `--ginkgo.label-filter='C2649200 \|\| C2649201'` | **FAIL** (24.95s) | skipped (Ordered fail-fast on first failure) | Bug reproduces — `Spec.SupportedTasks` returns empty/nil instead of `["text-generation", "text-embedding"]` |
| **After fix** | `fix-NEU-427` | `LABEL_FILTER='engine && import'` (full Import block) | **PASS** (16.27s) | **PASS** (21.58s) | All 12 import specs PASS |

Before-fix failure detail (concrete, from the `--ginkgo.no-color` log):

```
[FAIL] Engine Import [It] should populate Engine.Spec.SupportedTasks from
       version-level supported_tasks on create [engine, import, C2649200]
the missing elements were
    <[]string | len:2, cap:2>: ["text-generation", "text-embedding"]
```

After-fix Import block summary:

```
Ran 12 of 209 Specs in 226.168 seconds
SUCCESS! -- 12 Passed | 0 Failed | 0 Pending | 197 Skipped
```

Notes for reviewers:
- `golangci-lint` on this machine reports stdlib typecheck failures (`min` / `max` / `tar.Reader` undefined) due to a local lint-binary ↔ Go-toolchain version mismatch unrelated to this PR. CI lint is the source of truth (PR CI passing).
- TestRail run 6567 only had 5 of the 7 import cases linked; the 2 NEU-427 cases (C2649200, C2649201) need to be added to the run by the test plan owner — the cases themselves are already created under suite 2420 / Engine section.