### PR TITLE
fix: guard tool_calls with is_table() in Anthropic conversion paths

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -465,7 +465,7 @@ local function convert_response(openai_resp, request_model)
         }
     end
 
-    if message.tool_calls then
+    if is_table(message.tool_calls) then
         for _, tc in ipairs(message.tool_calls) do
             local input = {}
             if tc["function"] and tc["function"].arguments then
@@ -780,7 +780,7 @@ local function handle_anthropic_stream_body()
             output_parts[#output_parts + 1] = sse_frame("content_block_delta", make_content_block_delta_text(0, delta.content))
         end
 
-        if delta.tool_calls then
+        if is_table(delta.tool_calls) then
             for _, tc in ipairs(delta.tool_calls) do
                 local tc_index = tc.index or 0
                 if tc_index ~= ctx.current_tool_index then

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -241,7 +241,7 @@ local function convert_tool_choice(tc)
 end
 
 local function convert_tools(tools)
-    if tools == nil then return nil end
+    if not is_table(tools) then return nil end
     local result = {}
     for i, tool in ipairs(tools) do
         result[i] = {

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -290,6 +290,84 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 			Expect(upstreamReq["model"]).To(Equal("gpt-4o"))
 			Expect(upstreamReq["stream"]).To(BeTrue())
 		})
+
+		// NEU-428: when an OpenAI-compatible upstream returns "tool_calls": null
+		// (a JSON null sentinel rather than a missing field), the Anthropic
+		// conversion path used to crash with
+		//   bad argument #1 to 'ipairs' (table expected, got userdata)
+		// because cjson decodes JSON null to a userdata sentinel that is truthy
+		// in Lua. The fix is to gate ipairs() with the existing is_table() helper
+		// in handler.lua. These two cases reproduce the bug and lock in the fix.
+		Context("when upstream emits tool_calls: null", Label("tool-calls-null"), func() {
+			BeforeEach(func() {
+				mockUpstream.SetEmitNullToolCalls(true)
+				mockUpstream.ClearRequests()
+			})
+
+			AfterEach(func() {
+				mockUpstream.SetEmitNullToolCalls(false)
+			})
+
+			It("should handle non-stream Messages without ipairs failure", Label("C2649427"), func() {
+				msg, err := anthropicClient.Messages.New(context.Background(), anthropic.MessageNewParams{
+					Model:     "fast",
+					MaxTokens: 100,
+					Messages: []anthropic.MessageParam{
+						anthropic.NewUserMessage(anthropic.NewTextBlock("hello tool_calls null")),
+					},
+				})
+				Expect(err).NotTo(HaveOccurred(),
+					"Anthropic conversion must not fail when upstream returns tool_calls: null")
+
+				Expect(string(msg.Role)).To(Equal("assistant"))
+				Expect(string(msg.Type)).To(Equal("message"))
+				Expect(len(msg.Content)).To(BeNumerically(">", 0))
+				Expect(msg.StopReason).To(Equal(anthropic.StopReasonEndTurn))
+				Expect(msg.Usage.InputTokens).To(BeNumerically(">", 0))
+
+				// No tool_use blocks should be emitted because there is no real
+				// tool call — only an explicit null sentinel from the upstream.
+				for _, block := range msg.Content {
+					Expect(string(block.Type)).NotTo(Equal("tool_use"),
+						"null tool_calls must not produce a tool_use block")
+				}
+
+				last, _ := waitForUpstreamRequest()
+				Expect(last.Path).To(Equal("/v1/chat/completions"))
+				Expect(last.Body).To(ContainSubstring(`"tool_calls":null`),
+					"sanity check: mock upstream must actually emit tool_calls: null")
+			})
+
+			It("should handle stream Messages without ipairs failure", Label("C2649428"), func() {
+				stream := anthropicClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+					Model:     "smart",
+					MaxTokens: 100,
+					Messages: []anthropic.MessageParam{
+						anthropic.NewUserMessage(anthropic.NewTextBlock("hello stream tool_calls null")),
+					},
+				})
+				defer stream.Close()
+
+				var message anthropic.Message
+				for stream.Next() {
+					event := stream.Current()
+					err := message.Accumulate(event)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				// Key assertion: body_filter must not abort the stream on null
+				// tool_calls deltas. Pre-fix, this returns a body_filter error
+				// and the stream is truncated.
+				Expect(stream.Err()).NotTo(HaveOccurred(),
+					"stream must complete cleanly when chunks contain delta.tool_calls: null")
+
+				Expect(string(message.Role)).To(Equal("assistant"))
+				Expect(len(message.Content)).To(BeNumerically(">", 0))
+
+				last, upstreamReq := waitForUpstreamRequest()
+				Expect(last.Path).To(Equal("/v1/chat/completions"))
+				Expect(upstreamReq["stream"]).To(BeTrue())
+			})
+		})
 	})
 
 	// Credential masking is implemented by stripping the credential field entirely

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -334,8 +334,6 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 
 				last, _ := waitForUpstreamRequest()
 				Expect(last.Path).To(Equal("/v1/chat/completions"))
-				Expect(last.Body).To(ContainSubstring(`"tool_calls":null`),
-					"sanity check: mock upstream must actually emit tool_calls: null")
 			})
 
 			It("should handle stream Messages without ipairs failure", Label("C2649428"), func() {

--- a/tests/e2e/mock_upstream.go
+++ b/tests/e2e/mock_upstream.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 )
 
 // RecordedRequest stores key parts of an HTTP request received by MockUpstream.
@@ -25,6 +26,18 @@ type MockUpstream struct {
 
 	mu       sync.Mutex
 	requests []RecordedRequest
+
+	// emitNullToolCalls makes the mock include "tool_calls": null in chat
+	// completion responses (both non-stream message and stream deltas) to
+	// reproduce the cjson.null userdata bug in the Anthropic conversion path.
+	emitNullToolCalls atomic.Bool
+}
+
+// SetEmitNullToolCalls toggles whether chat completion responses explicitly
+// include "tool_calls": null. Tests that need the original happy-path payload
+// must reset this back to false (e.g. in AfterEach).
+func (m *MockUpstream) SetEmitNullToolCalls(v bool) {
+	m.emitNullToolCalls.Store(v)
 }
 
 // StartMockUpstream creates and starts a MockUpstream on a random port.
@@ -148,6 +161,14 @@ func (m *MockUpstream) handleChatCompletions(w http.ResponseWriter, r *http.Requ
 }
 
 func (m *MockUpstream) writeChatJSON(w http.ResponseWriter, model string) {
+	message := map[string]any{
+		"role":    "assistant",
+		"content": "Hello from mock upstream!",
+	}
+	if m.emitNullToolCalls.Load() {
+		message["tool_calls"] = json.RawMessage("null")
+	}
+
 	resp := map[string]any{
 		"id":      "chatcmpl-mock-001",
 		"object":  "chat.completion",
@@ -155,11 +176,8 @@ func (m *MockUpstream) writeChatJSON(w http.ResponseWriter, model string) {
 		"created": 1700000000,
 		"choices": []map[string]any{
 			{
-				"index": 0,
-				"message": map[string]any{
-					"role":    "assistant",
-					"content": "Hello from mock upstream!",
-				},
+				"index":         0,
+				"message":       message,
 				"finish_reason": "stop",
 			},
 		},
@@ -185,13 +203,22 @@ func (m *MockUpstream) writeChatStream(w http.ResponseWriter, model string) {
 		return
 	}
 
+	delta1 := map[string]any{"role": "assistant"}
+	delta2 := map[string]any{"content": "Hello from mock!"}
+	delta3 := map[string]any{}
+	if m.emitNullToolCalls.Load() {
+		delta1["tool_calls"] = json.RawMessage("null")
+		delta2["tool_calls"] = json.RawMessage("null")
+		delta3["tool_calls"] = json.RawMessage("null")
+	}
+
 	chunks := []map[string]any{
 		// chunk 1: role
 		{
 			"id": "chatcmpl-mock-stream", "object": "chat.completion.chunk",
 			"model": model, "created": 1700000000,
 			"choices": []map[string]any{
-				{"index": 0, "delta": map[string]any{"role": "assistant"}},
+				{"index": 0, "delta": delta1},
 			},
 		},
 		// chunk 2: content
@@ -199,7 +226,7 @@ func (m *MockUpstream) writeChatStream(w http.ResponseWriter, model string) {
 			"id": "chatcmpl-mock-stream", "object": "chat.completion.chunk",
 			"model": model, "created": 1700000000,
 			"choices": []map[string]any{
-				{"index": 0, "delta": map[string]any{"content": "Hello from mock!"}},
+				{"index": 0, "delta": delta2},
 			},
 		},
 		// chunk 3: finish + usage
@@ -207,7 +234,7 @@ func (m *MockUpstream) writeChatStream(w http.ResponseWriter, model string) {
 			"id": "chatcmpl-mock-stream", "object": "chat.completion.chunk",
 			"model": model, "created": 1700000000,
 			"choices": []map[string]any{
-				{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"},
+				{"index": 0, "delta": delta3, "finish_reason": "stop"},
 			},
 			"usage": map[string]any{
 				"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14,


### PR DESCRIPTION
## Issues

- NEU-428 — Kong AI Gateway plugin throws `bad argument #1 to 'ipairs' (table expected, got userdata)` in the Anthropic conversion path when an OpenAI-compatible upstream returns `"tool_calls": null`.

## Changes

**`gateway/kong/plugins/neutree-ai-gateway/handler.lua`** — guard three `tool_calls` / `tools` truthy checks with the existing `is_table()` helper (same pattern already used for `usage` fields throughout this file):

- `convert_response` (non-stream Anthropic response), where `message.tool_calls` can be the cjson.null userdata sentinel — direct fix for NEU-428.
- `handle_anthropic_stream_body` (stream Anthropic response), where `delta.tool_calls` has the same issue — direct fix for NEU-428.
- `convert_tools` (inbound request side) — **defensive bundle from code review**: same crash class on the request path if any non-conformant Anthropic client sends `"tools": null` instead of omitting the field. No production occurrence observed and not exercised by the e2e cases below; included on this PR to keep the cjson.null guard consistent across the file.

Root cause: `cjson.decode` maps JSON `null` to a userdata sentinel that is truthy in Lua and is not equal to Lua `nil`. The original guards (`if x.tool_calls then` / `if tools == nil`) let userdata through, and `ipairs(...)` then rejected it. Other nullable fields in the same file (`*.usage`, `*.content`) already use `is_table` / `~= cjson.null`; `tool_calls` and `tools` were the missing pairs.

**`tests/e2e/mock_upstream.go`** — add `SetEmitNullToolCalls(bool)` so tests can opt-in to a response shape that explicitly emits `"tool_calls": null` in both non-stream `message` and stream `delta` chunks. Default behavior of existing tests is unchanged.

**`tests/e2e/external_endpoint_test.go`** — add a `Context("when upstream emits tool_calls: null")` block under `Describe("Anthropic Compatibility")` with two new cases:

- `C2649427` — non-stream Messages must succeed and produce only text content (no `tool_use` blocks) when the upstream returns `tool_calls: null`.
- `C2649428` — streaming Messages must complete cleanly (`stream.Err() == nil`) when chunk deltas contain `tool_calls: null`.

`BeforeEach` enables the toggle, `AfterEach` resets it to avoid leaking into other anthropic cases.

## Test

- [x] `go vet ./tests/e2e/...`
- [x] `go build ./tests/e2e/...`
- [x] **E2E `--ginkgo.label-filter='external-endpoint && anthropic'` (5 specs):**
  - **Pre-fix run** on the existing v1.0.1 deployment (Kong with the buggy in-memory Lua) — `C2649427` failed with `Post ".../anthropic/v1/messages": EOF`, matching the production stack trace in the ticket; `C2649428` was skipped due to the `Ordered` describe (3 existing anthropic cases still passed → no regression).
  - **Post-fix run** after `make build-neutree-cli` on this branch (vendir sync → tar → embed → go build, with the fixed Lua verified inside the embed tar) and `./bin/neutree-cli launch neutree-core --version=v1.0.1 --admin-password=… --jwt-secret=… --db-password=… --grafana-url=… --metrics-remote-write-url=…` — **5 of 5 anthropic cases pass** (3 existing regressions + 2 new bug-repro `C2649427` / `C2649428`), 31s wall-clock.
  - **Regression run** after the `convert_tools` defensive fix — same 5/5 pass, 29.7s wall-clock; no behavior change on the response-side cases.

## Verification steps for the verifier

1. Deploy the fixed `neutree-cli` and re-launch `neutree-core` (no Go binary version bump required; only the embed tar contents change for the gateway plugin).
2. From an Anthropic SDK client, hit `/workspace/<ws>/external-endpoint/<provider>/anthropic/v1/messages` against an OpenAI-compatible upstream that returns `"tool_calls": null` in either the non-stream `message` or stream `delta` chunks.
3. Expected: 200 with a valid Anthropic `message` payload (no `tool_use` blocks for the null case); stream variant completes without `body_filter` errors.
4. Inverse check: Kong error_log should not contain `bad argument #1 to 'ipairs' (table expected, got userdata)` after the request.