### PR TITLE
fix: align auth service restart policy with postgres/postgrest

### DIFF
--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    restart: on-failure
+    restart: always
     healthcheck:
       test:
         [


### PR DESCRIPTION
## Issues

NEU-431 — docker-compose auth (supabase/gotrue) `restart: on-failure` is inconsistent with the other long-running infrastructure services (`postgres`, `postgrest`), which both use `restart: always`. `on-failure` only restarts on non-zero exit codes, so when the auth container exits with code 0 (OOM kill, host reboot, Docker daemon restart) it is not brought back automatically and the API authentication chain stays broken.

## Changes

- `deploy/docker/neutree-core/docker-compose.yml`: change auth service `restart: on-failure` → `restart: always` so the container is recovered in the same scenarios where `postgres` and `postgrest` are recovered.

No other docker-compose deployment defines this auth service (`db/docker-compose.test.yml` is for tests only and intentionally uses `restart: "no"`; the Helm chart relies on the K8s lifecycle, not Docker `restart` policy), so the change is scoped to the production compose file only.

## Test

- [x] `git diff` shows a single line change matching the fix described in the ticket.