### PR TITLE
refactor(e2e): migrate templates from os.Expand to text/template

### DIFF
--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -34,7 +34,7 @@ var _ = Describe("CLI", Ordered, Label("cli"), func() {
 
 			// Multi-doc YAML in REVERSE dependency order: Cluster(2) before ImageRegistry(1).
 			// CLI apply sorts by KindPriority: ImageRegistry first, then Cluster.
-			clusterPath := renderSSHClusterYAML(map[string]string{
+			clusterPath := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"image_registry":  irName,
 				"head_ip":         headIP,
@@ -42,7 +42,7 @@ var _ = Describe("CLI", Ordered, Label("cli"), func() {
 				"ssh_private_key": sshPrivateKey,
 			})
 
-			irPath := renderImageRegistryYAML(map[string]string{
+			irPath := renderImageRegistryYAML(map[string]any{
 				"name": irName,
 			})
 
@@ -84,7 +84,7 @@ var _ = Describe("CLI", Ordered, Label("cli"), func() {
 			})
 
 			// Create resource first.
-			irDefaults := map[string]string{
+			irDefaults := map[string]any{
 				"E2E_IMAGE_REGISTRY":      name,
 				"E2E_IMAGE_REGISTRY_REPO": "original-repo",
 			}
@@ -166,7 +166,7 @@ spec: {}
 			irName2 = "e2e-cli-get-2-" + Cfg.RunID
 
 			for _, name := range []string{irName1, irName2} {
-				yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+				yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
 					"E2E_IMAGE_REGISTRY": name,
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -240,7 +240,7 @@ spec: {}
 				RunCLI("delete", "imageregistry", name, "-w", profileWorkspace(), "--force", "--ignore-not-found")
 			})
 
-			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
 				"E2E_IMAGE_REGISTRY": name,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -261,7 +261,7 @@ spec: {}
 		It("should exit 0 when waiting for delete and resource is deleted", Label("C2642190"), func() {
 			name := "e2e-cli-waitdel-" + Cfg.RunID
 
-			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
 				"E2E_IMAGE_REGISTRY": name,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -300,7 +300,7 @@ spec: {}
 		It("should delete a single resource", Label("C2642192"), func() {
 			name := "e2e-cli-del-" + Cfg.RunID
 
-			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
 				"E2E_IMAGE_REGISTRY": name,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -325,8 +325,8 @@ spec: {}
 			headIP, _, sshUser, sshPrivateKey := requireSSHProfile()
 
 			// Multi-doc: ImageRegistry(priority 1) + Cluster(priority 2).
-			irPath := renderImageRegistryYAML(map[string]string{"name": irName})
-			clusterPath := renderSSHClusterYAML(map[string]string{
+			irPath := renderImageRegistryYAML(map[string]any{"name": irName})
+			clusterPath := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"image_registry":  irName,
 				"head_ip":         headIP,

--- a/tests/e2e/cluster_k8s_config_test.go
+++ b/tests/e2e/cluster_k8s_config_test.go
@@ -42,7 +42,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			kubeconfig = requireK8sProfile()
 			clusterName = "e2e-k8s-verify-" + Cfg.RunID
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":       clusterName,
 				"kubeconfig": kubeconfig,
 			})
@@ -222,13 +222,13 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 				ClusterH.EnsureDeleted(clusterB)
 			})
 
-			yamlA := renderK8sClusterYAML(map[string]string{
+			yamlA := renderK8sClusterYAML(map[string]any{
 				"name": clusterA, "kubeconfig": kubeconfig,
 			})
 			r := ClusterH.Apply(yamlA)
 			ExpectSuccess(r)
 
-			yamlB := renderK8sClusterYAML(map[string]string{
+			yamlB := renderK8sClusterYAML(map[string]any{
 				"name": clusterB, "kubeconfig": kubeconfig,
 			})
 			r = ClusterH.Apply(yamlB)
@@ -272,7 +272,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			kubeconfig = requireK8sProfile()
 			clusterName = "e2e-k8s-rt-edit-" + Cfg.RunID
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":            clusterName,
 				"kubeconfig":      kubeconfig,
 				"router_cpu":      "1",
@@ -302,7 +302,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			r := ClusterH.WaitForPhase(clusterName, v1.ClusterPhaseRunning, TerminalPhaseTimeout)
 			ExpectSuccess(r)
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":          clusterName,
 				"kubeconfig":    kubeconfig,
 				"router_cpu":    "500m",
@@ -329,7 +329,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			r := ClusterH.WaitForPhase(clusterName, v1.ClusterPhaseRunning, TerminalPhaseTimeout)
 			ExpectSuccess(r)
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":          clusterName,
 				"kubeconfig":    kubeconfig,
 				"router_cpu":    "500m",
@@ -356,7 +356,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			r := ClusterH.WaitForPhase(clusterName, v1.ClusterPhaseRunning, TerminalPhaseTimeout)
 			ExpectSuccess(r)
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":            clusterName,
 				"kubeconfig":      kubeconfig,
 				"router_cpu":      "500m",
@@ -378,7 +378,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 		})
 
 		It("should reject invalid router CPU value", Label("C2612834"), func() {
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":          clusterName,
 				"kubeconfig":    kubeconfig,
 				"router_cpu":    "invalid-cpu",
@@ -389,7 +389,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 		})
 
 		It("should reject invalid router memory value", Label("C2612836"), func() {
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":          clusterName,
 				"kubeconfig":    kubeconfig,
 				"router_cpu":    "500m",
@@ -400,7 +400,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 		})
 
 		It("should reject invalid router replicas value", Label("C2612838"), func() {
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":            clusterName,
 				"kubeconfig":      kubeconfig,
 				"router_cpu":      "500m",
@@ -437,14 +437,12 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 
 			clusterName = "e2e-k8s-mc-edit-" + Cfg.RunID
 
-			nfsCacheYAML := fmt.Sprintf("    model_caches:\n      - name: test-cache\n        nfs:\n          server: \"%s\"\n          path: \"%s\"",
-				fakeNFSServer,
-				profile.ModelCache.NFSPath)
-
-			yaml := renderK8sClusterYAML(map[string]string{
-				"name":              clusterName,
-				"kubeconfig":        kubeconfig,
-				"model_caches_yaml": nfsCacheYAML,
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":       clusterName,
+				"kubeconfig": kubeconfig,
+				"model_caches": []ModelCache{
+					{Name: "test-cache", Mode: "nfs", NFSServer: fakeNFSServer, NFSPath: profile.ModelCache.NFSPath},
+				},
 			})
 
 			r := ClusterH.Apply(yaml)
@@ -467,13 +465,12 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			oldHash := parseClusterJSON(r.Stdout).Status.ObservedSpecHash
 
 			// Switch from the fake initial server to the real one from profile.
-			nfsCacheYAML := fmt.Sprintf("    model_caches:\n      - name: test-cache\n        nfs:\n          server: \"%s\"\n          path: \"%s\"",
-				profile.ModelCache.NFSServer, profile.ModelCache.NFSPath)
-
-			yaml := renderK8sClusterYAML(map[string]string{
-				"name":              clusterName,
-				"kubeconfig":        kubeconfig,
-				"model_caches_yaml": nfsCacheYAML,
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":       clusterName,
+				"kubeconfig": kubeconfig,
+				"model_caches": []ModelCache{
+					{Name: "test-cache", Mode: "nfs", NFSServer: profile.ModelCache.NFSServer, NFSPath: profile.ModelCache.NFSPath},
+				},
 			})
 			r = ClusterH.Apply(yaml)
 			ExpectSuccess(r)
@@ -493,13 +490,12 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			ExpectSuccess(r)
 			oldHash := parseClusterJSON(r.Stdout).Status.ObservedSpecHash
 
-			nfsCacheYAML := fmt.Sprintf("    model_caches:\n      - name: test-cache\n        nfs:\n          server: \"%s\"\n          path: \"%s/subdir\"",
-				profile.ModelCache.NFSServer, profile.ModelCache.NFSPath)
-
-			yaml := renderK8sClusterYAML(map[string]string{
-				"name":              clusterName,
-				"kubeconfig":        kubeconfig,
-				"model_caches_yaml": nfsCacheYAML,
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":       clusterName,
+				"kubeconfig": kubeconfig,
+				"model_caches": []ModelCache{
+					{Name: "test-cache", Mode: "nfs", NFSServer: profile.ModelCache.NFSServer, NFSPath: profile.ModelCache.NFSPath + "/subdir"},
+				},
 			})
 			r = ClusterH.Apply(yaml)
 			ExpectSuccess(r)
@@ -516,12 +512,12 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			ExpectSuccess(r)
 			oldHash := parseClusterJSON(r.Stdout).Status.ObservedSpecHash
 
-			hostPathYAML := "    model_caches:\n      - name: test-cache\n        host_path:\n          path: /opt/neutree/model-cache-test"
-
-			yaml := renderK8sClusterYAML(map[string]string{
-				"name":              clusterName,
-				"kubeconfig":        kubeconfig,
-				"model_caches_yaml": hostPathYAML,
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":       clusterName,
+				"kubeconfig": kubeconfig,
+				"model_caches": []ModelCache{
+					{Name: "test-cache", Mode: "host_path", HostPath: "/opt/neutree/model-cache-test"},
+				},
 			})
 			r = ClusterH.Apply(yaml)
 			ExpectSuccess(r)
@@ -538,7 +534,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			ExpectSuccess(r)
 			oldHash := parseClusterJSON(r.Stdout).Status.ObservedSpecHash
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":       clusterName,
 				"kubeconfig": kubeconfig,
 			})
@@ -567,12 +563,12 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 
 			clusterName = "e2e-k8s-mc-pvc-" + Cfg.RunID
 
-			pvcYAML := fmt.Sprintf("    model_caches:\n      - name: test-pvc-cache\n        pvc:\n          storageClassName: \"%s\"\n          resources:\n            requests:\n              storage: 10Gi", profile.ModelCache.PVCStorageClass)
-
-			yaml := renderK8sClusterYAML(map[string]string{
-				"name":              clusterName,
-				"kubeconfig":        kubeconfig,
-				"model_caches_yaml": pvcYAML,
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":       clusterName,
+				"kubeconfig": kubeconfig,
+				"model_caches": []ModelCache{
+					{Name: "test-pvc-cache", Mode: "pvc", PVCStorageClass: profile.ModelCache.PVCStorageClass, PVCStorage: "10Gi"},
+				},
 			})
 
 			r := ClusterH.Apply(yaml)
@@ -637,7 +633,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			ExpectSuccess(r)
 			oldHash := parseClusterJSON(r.Stdout).Status.ObservedSpecHash
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":       clusterName,
 				"kubeconfig": kubeconfig,
 			})
@@ -662,7 +658,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			clusterName := "e2e-k8s-badcfg-" + Cfg.RunID
 			DeferCleanup(func() { ClusterH.EnsureDeleted(clusterName) })
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":       clusterName,
 				"kubeconfig": base64.StdEncoding.EncodeToString([]byte("invalid-kubeconfig-yaml")),
 			})

--- a/tests/e2e/cluster_k8s_test.go
+++ b/tests/e2e/cluster_k8s_test.go
@@ -31,7 +31,7 @@ var _ = Describe("K8s Cluster Lifecycle", Ordered, Label("cluster", "k8s", "life
 		kubeconfig = requireK8sProfile()
 		clusterName = "e2e-k8s-" + Cfg.RunID
 
-		yaml := renderK8sClusterYAML(map[string]string{
+		yaml := renderK8sClusterYAML(map[string]any{
 			"name":       clusterName,
 			"kubeconfig": kubeconfig,
 		})
@@ -70,7 +70,7 @@ var _ = Describe("K8s Cluster Lifecycle", Ordered, Label("cluster", "k8s", "life
 		ExpectSuccess(r)
 		oldHash := parseClusterJSON(r.Stdout).Status.ObservedSpecHash
 
-		yaml := renderK8sClusterYAML(map[string]string{
+		yaml := renderK8sClusterYAML(map[string]any{
 			"name":            clusterName,
 			"kubeconfig":      kubeconfig,
 			"image_registry":  testImageRegistry(),

--- a/tests/e2e/cluster_ssh_config_test.go
+++ b/tests/e2e/cluster_ssh_config_test.go
@@ -32,7 +32,7 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 		var (
 			clusterName   string
 			headIP        string
-			workerIPs     string
+			workerIPs     []string
 			sshUser       string
 			sshPrivateKey string
 			sshKeyFile    string
@@ -46,7 +46,7 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 			sshKeyFile = expandHome(profile.SSHNodes[0].KeyFile)
 			clusterName = "e2e-ssh-verify-" + Cfg.RunID
 
-			overrides := map[string]string{
+			overrides := map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"worker_ips":      workerIPs,
@@ -55,7 +55,9 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 			}
 
 			if profile.ModelCache.HostPath != "" {
-				overrides["model_caches_yaml"] = fmt.Sprintf("    model_caches:\n      - name: hp-cache\n        host_path:\n          path: \"%s\"\n", profile.ModelCache.HostPath)
+				overrides["model_caches"] = []ModelCache{
+					{Name: "hp-cache", Mode: "host_path", HostPath: profile.ModelCache.HostPath},
+				}
 			}
 
 			yaml := renderSSHClusterYAML(overrides)
@@ -77,19 +79,12 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 			ExpectSuccess(r)
 			Expect(r.Stdout).To(ContainSubstring("ray_container"))
 
-			if workerIPs != "" {
-				for _, ip := range strings.Split(workerIPs, ",") {
-					ip = strings.TrimSpace(ip)
-					if ip == "" {
-						continue
-					}
-
-					r = RunSSH(sshUser, ip, sshKeyFile,
-						"docker ps --filter name=ray_container --format '{{.Names}}'")
-					ExpectSuccess(r)
-					Expect(r.Stdout).To(ContainSubstring("ray_container"),
-						"ray_container should be running on worker %s", ip)
-				}
+			for _, ip := range workerIPs {
+				r = RunSSH(sshUser, ip, sshKeyFile,
+					"docker ps --filter name=ray_container --format '{{.Names}}'")
+				ExpectSuccess(r)
+				Expect(r.Stdout).To(ContainSubstring("ray_container"),
+					"ray_container should be running on worker %s", ip)
 			}
 		})
 
@@ -99,13 +94,7 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 				cachePath = "/opt/neutree/model-cache"
 			}
 
-			nodes := []string{headIP}
-			for _, ip := range strings.Split(workerIPs, ",") {
-				ip = strings.TrimSpace(ip)
-				if ip != "" {
-					nodes = append(nodes, ip)
-				}
-			}
+			nodes := append([]string{headIP}, workerIPs...)
 
 			for _, ip := range nodes {
 				r := RunSSH(sshUser, ip, sshKeyFile,
@@ -138,19 +127,12 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 			ExpectSuccess(r)
 			Expect(r.Stdout).NotTo(ContainSubstring("ray_container"))
 
-			if workerIPs != "" {
-				for _, ip := range strings.Split(workerIPs, ",") {
-					ip = strings.TrimSpace(ip)
-					if ip == "" {
-						continue
-					}
-
-					r = RunSSH(sshUser, ip, sshKeyFile,
-						"docker ps -a --filter name=ray_container --format '{{.Names}}'")
-					ExpectSuccess(r)
-					Expect(r.Stdout).NotTo(ContainSubstring("ray_container"),
-						"ray_container should be cleaned up from worker %s", ip)
-				}
+			for _, ip := range workerIPs {
+				r = RunSSH(sshUser, ip, sshKeyFile,
+					"docker ps -a --filter name=ray_container --format '{{.Names}}'")
+				ExpectSuccess(r)
+				Expect(r.Stdout).NotTo(ContainSubstring("ray_container"),
+					"ray_container should be cleaned up from worker %s", ip)
 			}
 		})
 
@@ -174,20 +156,20 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 		var (
 			clusterName   string
 			headIP        string
-			workerIPs     string
+			workerIPs     []string
 			sshUser       string
 			sshPrivateKey string
 		)
 
 		BeforeAll(func() {
 			headIP, workerIPs, sshUser, sshPrivateKey = requireSSHProfile()
-			if workerIPs == "" {
+			if len(workerIPs) == 0 {
 				Skip("No worker IPs configured, skipping worker edit tests")
 			}
 
 			clusterName = "e2e-ssh-edit-" + Cfg.RunID
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"ssh_user":        sshUser,
@@ -214,7 +196,7 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 			c := parseClusterJSON(r.Stdout)
 			oldNodes := c.Status.DesiredNodes
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"worker_ips":      workerIPs,
@@ -245,7 +227,7 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 			c := parseClusterJSON(r.Stdout)
 			oldNodes := c.Status.DesiredNodes
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"ssh_user":        sshUser,
@@ -275,7 +257,7 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 			clusterName   string
 			epName        string
 			headIP        string
-			workerIPs     string
+			workerIPs     []string
 			sshUser       string
 			sshPrivateKey string
 			sshKeyFile    string
@@ -298,16 +280,15 @@ var _ = Describe("SSH Cluster Config", Ordered, Label("cluster", "ssh", "config"
 			By("Setting up model registry")
 			SetupModelRegistry()
 
-			hostPathYAML := fmt.Sprintf("    model_caches:\n      - name: test-cache\n        host_path:\n          path: \"%s\"\n",
-				profile.ModelCache.HostPath)
-
-			yaml := renderSSHClusterYAML(map[string]string{
-				"name":              clusterName,
-				"head_ip":           headIP,
-				"worker_ips":        workerIPs,
-				"ssh_user":          sshUser,
-				"ssh_private_key":   sshPrivateKey,
-				"model_caches_yaml": hostPathYAML,
+			yaml := renderSSHClusterYAML(map[string]any{
+				"name":            clusterName,
+				"head_ip":         headIP,
+				"worker_ips":      workerIPs,
+				"ssh_user":        sshUser,
+				"ssh_private_key": sshPrivateKey,
+				"model_caches": []ModelCache{
+					{Name: "test-cache", Mode: "host_path", HostPath: profile.ModelCache.HostPath},
+				},
 			})
 
 			r := ClusterH.Apply(yaml)

--- a/tests/e2e/cluster_ssh_fault_test.go
+++ b/tests/e2e/cluster_ssh_fault_test.go
@@ -30,7 +30,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 		var (
 			clusterName   string
 			headIP        string
-			workerIPs     string
+			workerIPs     []string
 			sshUser       string
 			sshPrivateKey string
 			sshKeyFile    string
@@ -44,7 +44,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			sshKeyFile = expandHome(profile.SSHNodes[0].KeyFile)
 			clusterName = "e2e-ssh-fault-" + Cfg.RunID
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"worker_ips":      workerIPs,
@@ -108,7 +108,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			clusterName := "e2e-ssh-badkey-" + Cfg.RunID
 			DeferCleanup(func() { ClusterH.EnsureDeleted(clusterName) })
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"ssh_user":        "root",
@@ -126,7 +126,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			clusterName := "e2e-ssh-badip-" + Cfg.RunID
 			DeferCleanup(func() { ClusterH.EnsureDeleted(clusterName) })
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         "198.51.100.1",
 				"ssh_user":        sshUser,
@@ -144,7 +144,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			clusterName := "e2e-ssh-badwkr-" + Cfg.RunID
 			DeferCleanup(func() { ClusterH.EnsureDeleted(clusterName) })
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"worker_ips":      "198.51.100.2,198.51.100.3",
@@ -164,7 +164,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			DeferCleanup(func() { ClusterH.EnsureDeleted(clusterName) })
 
 			badRegistryName := "e2e-bad-registry-" + Cfg.RunID
-			defaults := map[string]string{
+			defaults := map[string]any{
 				"E2E_IMAGE_REGISTRY":      badRegistryName,
 				"E2E_WORKSPACE":           profileWorkspace(),
 				"E2E_IMAGE_REGISTRY_URL":  "198.51.100.99:5000",
@@ -180,7 +180,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 				RunCLI("delete", "-f", yamlPath, "--force", "--ignore-not-found")
 			})
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"ssh_user":        sshUser,
@@ -199,7 +199,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			clusterName := "e2e-bad-dep-" + Cfg.RunID
 			DeferCleanup(func() { ClusterH.EnsureDeleted(clusterName) })
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
 				"worker_ips":      workerIPs,

--- a/tests/e2e/cluster_ssh_fault_test.go
+++ b/tests/e2e/cluster_ssh_fault_test.go
@@ -147,7 +147,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"head_ip":         headIP,
-				"worker_ips":      "198.51.100.2,198.51.100.3",
+				"worker_ips":      []string{"198.51.100.2", "198.51.100.3"},
 				"ssh_user":        sshUser,
 				"ssh_private_key": sshPrivateKey,
 			})

--- a/tests/e2e/cluster_ssh_test.go
+++ b/tests/e2e/cluster_ssh_test.go
@@ -25,7 +25,7 @@ var _ = Describe("SSH Cluster Lifecycle", Ordered, Label("cluster", "ssh", "life
 	var (
 		clusterName   string
 		headIP        string
-		workerIPs     string
+		workerIPs     []string
 		sshUser       string
 		sshPrivateKey string
 	)
@@ -36,7 +36,7 @@ var _ = Describe("SSH Cluster Lifecycle", Ordered, Label("cluster", "ssh", "life
 
 		// Deliberately omit worker_ips at creation so C2642277 can add them
 		// later to trigger a real spec change.
-		yaml := renderSSHClusterYAML(map[string]string{
+		yaml := renderSSHClusterYAML(map[string]any{
 			"name":            clusterName,
 			"head_ip":         headIP,
 			"ssh_user":        sshUser,
@@ -88,7 +88,7 @@ var _ = Describe("SSH Cluster Lifecycle", Ordered, Label("cluster", "ssh", "life
 
 		// Add worker nodes — a real spec change since BeforeAll created a
 		// head-only cluster.
-		yaml := renderSSHClusterYAML(map[string]string{
+		yaml := renderSSHClusterYAML(map[string]any{
 			"name":            clusterName,
 			"head_ip":         headIP,
 			"worker_ips":      workerIPs,

--- a/tests/e2e/cluster_upgrade_test.go
+++ b/tests/e2e/cluster_upgrade_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 		var (
 			clusterName   string
 			headIP        string
-			workerIPs     string
+			workerIPs     []string
 			sshUser       string
 			sshPrivateKey string
 			oldVersion    string
@@ -71,7 +71,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			oldVersion = requireOldVersion()
 			clusterName = "e2e-ssh-upg-" + Cfg.RunID
 
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"version":         oldVersion,
 				"head_ip":         headIP,
@@ -103,7 +103,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			newVersion := profileClusterVersion()
 
 			By("Applying with new version " + newVersion)
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"version":         newVersion,
 				"head_ip":         headIP,
@@ -137,7 +137,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			clusterName   string
 			epName        string
 			headIP        string
-			workerIPs     string
+			workerIPs     []string
 			sshUser       string
 			sshPrivateKey string
 			oldVersion    string
@@ -159,7 +159,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			SetupModelRegistry()
 
 			By("Creating SSH cluster with old version " + oldVersion)
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"version":         oldVersion,
 				"head_ip":         headIP,
@@ -204,7 +204,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			newVersion := profileClusterVersion()
 
 			By("Applying cluster with new version " + newVersion)
-			yaml := renderSSHClusterYAML(map[string]string{
+			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
 				"version":         newVersion,
 				"head_ip":         headIP,
@@ -256,7 +256,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			oldVersion = requireOldVersion()
 			clusterName = "e2e-k8s-upg-" + Cfg.RunID
 
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":       clusterName,
 				"version":    oldVersion,
 				"kubeconfig": kubeconfig,
@@ -285,7 +285,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			newVersion := profileClusterVersion()
 
 			By("Applying with new version " + newVersion)
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":       clusterName,
 				"version":    newVersion,
 				"kubeconfig": kubeconfig,
@@ -335,7 +335,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			SetupModelRegistry()
 
 			By("Creating K8s cluster with old version " + oldVersion)
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":       clusterName,
 				"version":    oldVersion,
 				"kubeconfig": kubeconfig,
@@ -386,7 +386,7 @@ var _ = Describe("Cluster Upgrade", Ordered, Label("cluster", "upgrade"), func()
 			newVersion := profileClusterVersion()
 
 			By("Applying cluster with new version " + newVersion)
-			yaml := renderK8sClusterYAML(map[string]string{
+			yaml := renderK8sClusterYAML(map[string]any{
 				"name":       clusterName,
 				"version":    newVersion,
 				"kubeconfig": kubeconfig,

--- a/tests/e2e/cp_upgrade_test.go
+++ b/tests/e2e/cp_upgrade_test.go
@@ -344,7 +344,7 @@ var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgra
 func createUpgradeTestResources(irName, mrName, sshCluster, k8sCluster, sshEp, k8sEp string) {
 	By("Creating image registry")
 
-	irPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+	irPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
 		"E2E_IMAGE_REGISTRY": irName,
 	})
 	Expect(err).NotTo(HaveOccurred())
@@ -363,7 +363,7 @@ func createUpgradeTestResources(irName, mrName, sshCluster, k8sCluster, sshEp, k
 
 	By("Creating model registry")
 
-	mrPath, err := renderTemplateToTempFile("testdata/model-registry.yaml", map[string]string{
+	mrPath, err := renderTemplateToTempFile("testdata/model-registry.yaml", map[string]any{
 		"E2E_MODEL_REGISTRY": mrName,
 	})
 	Expect(err).NotTo(HaveOccurred())
@@ -376,7 +376,7 @@ func createUpgradeTestResources(irName, mrName, sshCluster, k8sCluster, sshEp, k
 	By("Creating SSH cluster with old cluster version")
 	if profileSSHHeadIP() != "" {
 		headIP, workerIPs, sshUser, sshPrivateKey := requireSSHProfile()
-		yaml := renderSSHClusterYAML(map[string]string{
+		yaml := renderSSHClusterYAML(map[string]any{
 			"name":            sshCluster,
 			"image_registry":  irName,
 			"version":         profile.Cluster.OldVersion,
@@ -405,7 +405,7 @@ func createUpgradeTestResources(irName, mrName, sshCluster, k8sCluster, sshEp, k
 	By("Creating K8s cluster with old cluster version")
 	if profileKubeconfig() != "" {
 		kubeconfig := requireK8sProfile()
-		yaml := renderK8sClusterYAML(map[string]string{
+		yaml := renderK8sClusterYAML(map[string]any{
 			"name":           k8sCluster,
 			"image_registry": irName,
 			"version":        profile.Cluster.OldVersion,

--- a/tests/e2e/endpoint_k8s_config_test.go
+++ b/tests/e2e/endpoint_k8s_config_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 
@@ -37,15 +36,13 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 		if modelCachePath == "" {
 			modelCachePath = "/data/models"
 		}
-		modelCacheYAML := fmt.Sprintf(`    model_caches:
-      - name: e2e-cache
-        host_path:
-          path: "%s"`, modelCachePath)
 
-		yaml := renderK8sClusterYAML(map[string]string{
-			"name":              clusterName,
-			"kubeconfig":        kubeconfig,
-			"model_caches_yaml": modelCacheYAML,
+		yaml := renderK8sClusterYAML(map[string]any{
+			"name":       clusterName,
+			"kubeconfig": kubeconfig,
+			"model_caches": []ModelCache{
+				{Name: "e2e-cache", Mode: "host_path", HostPath: modelCachePath},
+			},
 		})
 
 		ch := NewClusterHelper()
@@ -204,7 +201,7 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 					continue
 				}
 
-				envMap := map[string]string{}
+				envMap := map[string]any{}
 				for _, e := range c.Env {
 					envMap[e.Name] = e.Value
 				}
@@ -458,7 +455,7 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 		})
 
 		It("should deploy with all schema data types", Label("C2642246"), func() {
-			yamlPath := applyEndpoint(schemaEpName, clusterName, withEngineArgs(allSchemaTypesEngineArgsYAML()))
+			yamlPath := applyEndpoint(schemaEpName, clusterName, withEngineArgs(allSchemaTypesEngineArgs()))
 			defer os.Remove(yamlPath)
 
 			waitEndpointRunning(schemaEpName)

--- a/tests/e2e/endpoint_k8s_config_test.go
+++ b/tests/e2e/endpoint_k8s_config_test.go
@@ -81,7 +81,7 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 			epName = "e2e-ep-k8s-cfg-" + Cfg.RunID
 
 			yamlPath := applyEndpoint(epName, clusterName,
-				withCPU("1"), withMemory("2"),
+				withCPU("4"), withMemory("8"),
 				withEnv(map[string]string{
 					"E2E_TEST_KEY": "e2e_test_value",
 				}))

--- a/tests/e2e/endpoint_k8s_inference_test.go
+++ b/tests/e2e/endpoint_k8s_inference_test.go
@@ -69,7 +69,7 @@ var _ = Describe("K8s Endpoint", Ordered, Label("endpoint", "k8s"), func() {
 			By("Sending request with non-existent model name")
 			code, body, err := doInferenceRequest(ep.Status.ServiceURL, "/v1/chat/completions", map[string]any{
 				"model": "non-existent-model-name",
-				"messages": []map[string]string{
+				"messages": []map[string]any{
 					{"role": "user", "content": "hello"},
 				},
 				"max_tokens": 8,
@@ -156,7 +156,7 @@ var _ = Describe("K8s Endpoint", Ordered, Label("endpoint", "k8s"), func() {
 		})
 
 		It("should deploy with tp=2 (gpu=2) and reach Running", Label("C2613759"), func() {
-			tpArgs := engineArgsYAML() + "\n      tensor_parallel_size: 2"
+			tpArgs := append(engineArgs(), EngineArg{Key: "tensor_parallel_size", Value: "2"})
 			yamlPath := applyEndpoint(epName, clusterName,
 				withGPU("2"), withEngineArgs(tpArgs))
 			defer os.Remove(yamlPath)

--- a/tests/e2e/endpoint_model_cache_test.go
+++ b/tests/e2e/endpoint_model_cache_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 
@@ -53,18 +52,12 @@ var _ = Describe("K8s Endpoint Model Cache", Ordered, Label("endpoint", "k8s", "
 			clusterName = "e2e-mc-nfs-k8s-" + Cfg.RunID
 			epName = "e2e-ep-mc-nfs-" + Cfg.RunID
 
-			nfsCacheYAML := fmt.Sprintf(`    model_caches:
-      - name: nfs-cache
-        nfs:
-          server: "%s"
-          path: "%s"`,
-				profile.ModelCache.NFSServer,
-				profile.ModelCache.NFSPath)
-
-			yaml := renderK8sClusterYAML(map[string]string{
-				"name":              clusterName,
-				"kubeconfig":        kubeconfig,
-				"model_caches_yaml": nfsCacheYAML,
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":       clusterName,
+				"kubeconfig": kubeconfig,
+				"model_caches": []ModelCache{
+					{Name: "nfs-cache", Mode: "nfs", NFSServer: profile.ModelCache.NFSServer, NFSPath: profile.ModelCache.NFSPath},
+				},
 			})
 
 			r := ClusterH.Apply(yaml)
@@ -115,15 +108,12 @@ var _ = Describe("K8s Endpoint Model Cache", Ordered, Label("endpoint", "k8s", "
 			clusterName = "e2e-mc-hp-k8s-" + Cfg.RunID
 			epName = "e2e-ep-mc-hp-" + Cfg.RunID
 
-			hostPathYAML := fmt.Sprintf(`    model_caches:
-      - name: hp-cache
-        host_path:
-          path: "%s"`, profile.ModelCache.HostPath)
-
-			yaml := renderK8sClusterYAML(map[string]string{
-				"name":              clusterName,
-				"kubeconfig":        kubeconfig,
-				"model_caches_yaml": hostPathYAML,
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":       clusterName,
+				"kubeconfig": kubeconfig,
+				"model_caches": []ModelCache{
+					{Name: "hp-cache", Mode: "host_path", HostPath: profile.ModelCache.HostPath},
+				},
 			})
 
 			r := ClusterH.Apply(yaml)
@@ -174,18 +164,12 @@ var _ = Describe("K8s Endpoint Model Cache", Ordered, Label("endpoint", "k8s", "
 			clusterName = "e2e-mc-pvc-k8s-" + Cfg.RunID
 			epName = "e2e-ep-mc-pvc-" + Cfg.RunID
 
-			pvcYAML := fmt.Sprintf(`    model_caches:
-      - name: pvc-cache
-        pvc:
-          storageClassName: "%s"
-          resources:
-            requests:
-              storage: 10Gi`, profile.ModelCache.PVCStorageClass)
-
-			yaml := renderK8sClusterYAML(map[string]string{
-				"name":              clusterName,
-				"kubeconfig":        kubeconfig,
-				"model_caches_yaml": pvcYAML,
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":       clusterName,
+				"kubeconfig": kubeconfig,
+				"model_caches": []ModelCache{
+					{Name: "pvc-cache", Mode: "pvc", PVCStorageClass: profile.ModelCache.PVCStorageClass, PVCStorage: "10Gi"},
+				},
 			})
 
 			r := ClusterH.Apply(yaml)
@@ -262,16 +246,15 @@ var _ = Describe("SSH Endpoint Model Cache", Ordered, Label("endpoint", "ssh", "
 			clusterName = "e2e-mc-hp-ssh-" + Cfg.RunID
 			epName = "e2e-ep-mc-hp-ssh-" + Cfg.RunID
 
-			hostPathYAML := fmt.Sprintf("    model_caches:\n      - name: hp-cache\n        host_path:\n          path: \"%s\"\n",
-				profile.ModelCache.HostPath)
-
-			yaml := renderSSHClusterYAML(map[string]string{
-				"name":              clusterName,
-				"head_ip":           headIP,
-				"worker_ips":        workerIPs,
-				"ssh_user":          sshUser,
-				"ssh_private_key":   sshPrivateKey,
-				"model_caches_yaml": hostPathYAML,
+			yaml := renderSSHClusterYAML(map[string]any{
+				"name":            clusterName,
+				"head_ip":         headIP,
+				"worker_ips":      workerIPs,
+				"ssh_user":        sshUser,
+				"ssh_private_key": sshPrivateKey,
+				"model_caches": []ModelCache{
+					{Name: "hp-cache", Mode: "host_path", HostPath: profile.ModelCache.HostPath},
+				},
 			})
 
 			r := ClusterH.Apply(yaml)

--- a/tests/e2e/endpoint_ssh_config_test.go
+++ b/tests/e2e/endpoint_ssh_config_test.go
@@ -33,15 +33,16 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 		if modelCachePath == "" {
 			modelCachePath = "/data/models"
 		}
-		modelCacheYAML := "    model_caches:\n      - name: e2e-cache\n        host_path:\n          path: \"" + modelCachePath + "\"\n"
 
-		yaml := renderSSHClusterYAML(map[string]string{
-			"name":              clusterName,
-			"head_ip":           headIP,
-			"worker_ips":        workerIPs,
-			"ssh_user":          sshUser,
-			"ssh_private_key":   sshPrivateKey,
-			"model_caches_yaml": modelCacheYAML,
+		yaml := renderSSHClusterYAML(map[string]any{
+			"name":            clusterName,
+			"head_ip":         headIP,
+			"worker_ips":      workerIPs,
+			"ssh_user":        sshUser,
+			"ssh_private_key": sshPrivateKey,
+			"model_caches": []ModelCache{
+				{Name: "e2e-cache", Mode: "host_path", HostPath: modelCachePath},
+			},
 		})
 
 		ch := NewClusterHelper()
@@ -219,7 +220,7 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 		})
 
 		It("should deploy with serving-only engine_arg ignored", Label("C2644063"), func() {
-			servingArgs := engineArgsYAML() + "\n      response_role: assistant"
+			servingArgs := append(engineArgs(), EngineArg{Key: "response_role", Value: "assistant"})
 
 			yamlPath := applyEndpoint(servingEpName, clusterName,
 				withEngineArgs(servingArgs))
@@ -248,7 +249,7 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 		})
 
 		It("should deploy with all schema data types in engine_args", Label("C2642245", "C2644062"), func() {
-			yamlPath := applyEndpoint(schemaEpName, clusterName, withEngineArgs(allSchemaTypesEngineArgsYAML()))
+			yamlPath := applyEndpoint(schemaEpName, clusterName, withEngineArgs(allSchemaTypesEngineArgs()))
 			defer os.Remove(yamlPath)
 
 			waitEndpointRunning(schemaEpName)

--- a/tests/e2e/endpoint_ssh_inference_test.go
+++ b/tests/e2e/endpoint_ssh_inference_test.go
@@ -70,7 +70,7 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 			By("Sending request with non-existent model name")
 			code, body, err := doInferenceRequest(ep.Status.ServiceURL, "/v1/chat/completions", map[string]any{
 				"model": "non-existent-model-name",
-				"messages": []map[string]string{
+				"messages": []map[string]any{
 					{"role": "user", "content": "hello"},
 				},
 				"max_tokens": 8,
@@ -159,7 +159,7 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 
 		// C2642267 step 2-3: multi-GPU TP deploy + inference
 		It("should deploy with tp=2 (gpu=2) and reach Running", Label("C2613759", "C2642248", "C2642267"), func() {
-			tpArgs := engineArgsYAML() + "\n      tensor_parallel_size: 2"
+			tpArgs := append(engineArgs(), EngineArg{Key: "tensor_parallel_size", Value: "2"})
 			yamlPath := applyEndpoint(epName, clusterName,
 				withGPU("2"), withEngineArgs(tpArgs))
 			defer os.Remove(yamlPath)

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -48,7 +48,7 @@ func TeardownMockUpstream() {
 
 // SetupExternalEndpoint creates an ExternalEndpoint from the YAML template.
 func SetupExternalEndpoint() {
-	defaults := map[string]string{
+	defaults := map[string]any{
 		"E2E_EE_NAME":           testEEName(),
 		"E2E_WORKSPACE":         profileWorkspace(),
 		"E2E_MOCK_UPSTREAM_URL": mockUpstream.ExternalURL(),
@@ -407,27 +407,17 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 			eeName := "e2e-ee-lifecycle-" + Cfg.RunID
 
 			By("Applying ExternalEndpoint via CLI")
-			eeYAML := fmt.Sprintf(`apiVersion: v1
-kind: ExternalEndpoint
-metadata:
-  name: %s
-  workspace: %s
-spec:
-  upstreams:
-    - upstream:
-        url: http://example.com
-      model_mapping:
-        test-model: test-model
-`, eeName, profileWorkspace())
-
-			tmpFile, err := os.CreateTemp("", "e2e-ee-lifecycle-*.yaml")
+			yamlPath, err := renderTemplateToTempFile("testdata/external-endpoint-simple.yaml", map[string]any{
+				"E2E_EE_NAME":         eeName,
+				"E2E_WORKSPACE":       profileWorkspace(),
+				"E2E_EE_UPSTREAM_URL": "http://example.com",
+				"E2E_EE_MODEL_KEY":    "test-model",
+				"E2E_EE_MODEL_VALUE":  "test-model",
+			})
 			Expect(err).NotTo(HaveOccurred())
-			_, err = tmpFile.WriteString(eeYAML)
-			Expect(err).NotTo(HaveOccurred())
-			tmpFile.Close()
-			defer os.Remove(tmpFile.Name())
+			defer os.Remove(yamlPath)
 
-			r := RunCLI("apply", "-f", tmpFile.Name())
+			r := RunCLI("apply", "-f", yamlPath)
 			ExpectSuccess(r)
 			Expect(r.Stdout).To(ContainSubstring("created"))
 
@@ -513,46 +503,31 @@ spec:
 			Expect(userID).NotTo(BeEmpty(), "user creation should return a user ID")
 
 			By("Creating a role WITHOUT external_endpoint:read-credentials")
-			roleYAML := fmt.Sprintf(`apiVersion: v1
-kind: Role
-metadata:
-  name: %s
-  workspace: %s
-spec:
-  permissions:
-    - "external_endpoint:read"
-    - "cluster:read"
-`, roleName, profileWorkspace())
-
-			tmpFile, err := os.CreateTemp("", "e2e-role-*.yaml")
+			rolePath, err := renderTemplateToTempFile("testdata/role.yaml", map[string]any{
+				"E2E_ROLE_NAME": roleName,
+				"E2E_WORKSPACE": profileWorkspace(),
+				"E2E_ROLE_PERMISSIONS": []string{
+					"external_endpoint:read",
+					"cluster:read",
+				},
+			})
 			Expect(err).NotTo(HaveOccurred())
-			_, err = tmpFile.WriteString(roleYAML)
-			Expect(err).NotTo(HaveOccurred())
-			tmpFile.Close()
-			defer os.Remove(tmpFile.Name())
+			defer os.Remove(rolePath)
 
-			r := RunCLI("apply", "-f", tmpFile.Name())
+			r := RunCLI("apply", "-f", rolePath)
 			ExpectSuccess(r)
 
 			By("Assigning role to user")
-			raYAML := fmt.Sprintf(`apiVersion: v1
-kind: RoleAssignment
-metadata:
-  name: %s
-spec:
-  user_id: "%s"
-  role: "%s"
-  workspace: "%s"
-`, testUserName+"-ra", userID, roleName, profileWorkspace())
-
-			tmpFile2, err := os.CreateTemp("", "e2e-ra-*.yaml")
+			raPath, err := renderTemplateToTempFile("testdata/role-assignment.yaml", map[string]any{
+				"E2E_RA_NAME":      testUserName + "-ra",
+				"E2E_RA_USER_ID":   userID,
+				"E2E_RA_ROLE":      roleName,
+				"E2E_RA_WORKSPACE": profileWorkspace(),
+			})
 			Expect(err).NotTo(HaveOccurred())
-			_, err = tmpFile2.WriteString(raYAML)
-			Expect(err).NotTo(HaveOccurred())
-			tmpFile2.Close()
-			defer os.Remove(tmpFile2.Name())
+			defer os.Remove(raPath)
 
-			r = RunCLI("apply", "-f", tmpFile2.Name())
+			r = RunCLI("apply", "-f", raPath)
 			ExpectSuccess(r)
 
 			By("Logging in as the test user to get JWT")

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"text/template"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,6 +21,30 @@ import (
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
+
+// ModelCache describes one model cache entry for cluster spec.config.model_caches.
+// Mode selects which sub-block the template renders.
+type ModelCache struct {
+	Name string
+	Mode string // "host_path" | "nfs" | "pvc"
+
+	// host_path mode
+	HostPath string
+
+	// nfs mode
+	NFSServer string
+	NFSPath   string
+
+	// pvc mode
+	PVCStorageClass string
+	PVCStorage      string
+}
+
+// EngineArg is a single key/value pair for endpoint spec.variables.engine_args.
+type EngineArg struct {
+	Key   string
+	Value string
+}
 
 // --- Shared state (set by setup, used by tests) ---
 
@@ -348,13 +373,21 @@ func testImageRegistry() string {
 }
 
 // requireSSHProfile returns SSH cluster params from profile. ssh_private_key is returned as base64.
-func requireSSHProfile() (headIP, workerIPs, sshUser, sshPrivateKey string) {
+// workerIPs is returned as a slice (already split from comma-separated form).
+func requireSSHProfile() (headIP string, workerIPs []string, sshUser, sshPrivateKey string) {
 	headIP = profileSSHHeadIP()
 	if headIP == "" {
 		Skip("SSH head IP not configured in profile, skipping SSH cluster tests")
 	}
 
-	workerIPs = profileSSHWorkerIPs()
+	if raw := profileSSHWorkerIPs(); raw != "" {
+		for _, ip := range strings.Split(raw, ",") {
+			ip = strings.TrimSpace(ip)
+			if ip != "" {
+				workerIPs = append(workerIPs, ip)
+			}
+		}
+	}
 
 	sshUser = profileSSHUser()
 	if sshUser == "" {
@@ -389,7 +422,7 @@ func SetupImageRegistry() {
 		return // already set up
 	}
 
-	defaults := map[string]string{
+	defaults := map[string]any{
 		"E2E_IMAGE_REGISTRY":          testImageRegistry(),
 		"E2E_WORKSPACE":               profileWorkspace(),
 		"E2E_IMAGE_REGISTRY_URL":      profile.ImageRegistry.URL,
@@ -428,72 +461,85 @@ func TeardownImageRegistry() {
 // --- Cluster template rendering ---
 
 // renderSSHClusterYAML renders the SSH cluster template with overrides and returns the temp file path.
-func renderSSHClusterYAML(overrides map[string]string) string {
-	defaults := map[string]string{
-		"CLUSTER_NAME":            overrides["name"],
-		"CLUSTER_WORKSPACE":       profileWorkspace(),
-		"CLUSTER_IMAGE_REGISTRY":  valueOr(overrides, "image_registry", testImageRegistry()),
-		"CLUSTER_VERSION":         valueOr(overrides, "version", profileClusterVersion()),
-		"CLUSTER_SSH_HEAD_IP":     overrides["head_ip"],
-		"CLUSTER_SSH_USER":        overrides["ssh_user"],
-		"CLUSTER_SSH_PRIVATE_KEY": overrides["ssh_private_key"],
+//
+// Recognized overrides keys:
+//   - "name"            (string)         cluster name
+//   - "image_registry"  (string)         defaults to testImageRegistry()
+//   - "version"         (string)         defaults to profileClusterVersion()
+//   - "head_ip"         (string)
+//   - "ssh_user"        (string)
+//   - "ssh_private_key" (string)
+//   - "worker_ips"      ([]string)       worker IP list (template-rendered as range)
+//   - "accelerator_type"(string)         optional
+//   - "model_caches"    ([]ModelCache)   optional, template-rendered per Mode
+func renderSSHClusterYAML(overrides map[string]any) string {
+	data := map[string]any{
+		"CLUSTER_NAME":             stringOr(overrides, "name", ""),
+		"CLUSTER_WORKSPACE":        profileWorkspace(),
+		"CLUSTER_IMAGE_REGISTRY":   stringOr(overrides, "image_registry", testImageRegistry()),
+		"CLUSTER_VERSION":          stringOr(overrides, "version", profileClusterVersion()),
+		"CLUSTER_SSH_HEAD_IP":      stringOr(overrides, "head_ip", ""),
+		"CLUSTER_SSH_USER":         stringOr(overrides, "ssh_user", ""),
+		"CLUSTER_SSH_PRIVATE_KEY":  stringOr(overrides, "ssh_private_key", ""),
+		"CLUSTER_ACCELERATOR_TYPE": stringOr(overrides, "accelerator_type", ""),
+		"CLUSTER_MODEL_CACHES":     anySliceOr[ModelCache](overrides, "model_caches", nil),
+		"CLUSTER_WORKER_IPS":       anySliceOr[string](overrides, "worker_ips", nil),
 	}
 
-	if at := overrides["accelerator_type"]; at != "" {
-		defaults["CLUSTER_ACCELERATOR_TYPE_YAML"] = fmt.Sprintf("    accelerator_type: \"%s\"\n", at)
-	}
-
-	if mc := overrides["model_caches_yaml"]; mc != "" {
-		defaults["CLUSTER_MODEL_CACHES_YAML"] = mc
-	}
-
-	if workerIPs := overrides["worker_ips"]; workerIPs != "" {
-		var buf strings.Builder
-
-		buf.WriteString("        worker_ips:\n")
-
-		for _, ip := range strings.Split(workerIPs, ",") {
-			ip = strings.TrimSpace(ip)
-			if ip != "" {
-				fmt.Fprintf(&buf, "          - \"%s\"\n", ip)
-			}
-		}
-
-		defaults["CLUSTER_WORKER_IPS_YAML"] = buf.String()
-	}
-
-	path, err := renderTemplateToTempFile(filepath.Join("testdata", "ssh-cluster.yaml"), defaults)
+	path, err := renderTemplateToTempFile(filepath.Join("testdata", "ssh-cluster.yaml"), data)
 	Expect(err).NotTo(HaveOccurred(), "failed to render SSH cluster template")
 
 	return path
 }
 
 // renderK8sClusterYAML renders the K8s cluster template with overrides and returns the temp file path.
-func renderK8sClusterYAML(overrides map[string]string) string {
-	defaults := map[string]string{
-		"CLUSTER_NAME":            overrides["name"],
+//
+// Recognized overrides keys:
+//   - "name"             (string)
+//   - "image_registry"   (string)         defaults to testImageRegistry()
+//   - "version"          (string)         defaults to profileClusterVersion()
+//   - "kubeconfig"       (string)
+//   - "router_replicas"  (string)         defaults to "1"
+//   - "router_cpu"       (string)         defaults to "1"
+//   - "router_memory"    (string)         defaults to "2Gi"
+//   - "model_caches"     ([]ModelCache)   optional
+func renderK8sClusterYAML(overrides map[string]any) string {
+	data := map[string]any{
+		"CLUSTER_NAME":            stringOr(overrides, "name", ""),
 		"CLUSTER_WORKSPACE":       profileWorkspace(),
-		"CLUSTER_IMAGE_REGISTRY":  valueOr(overrides, "image_registry", testImageRegistry()),
-		"CLUSTER_VERSION":         valueOr(overrides, "version", profileClusterVersion()),
-		"CLUSTER_KUBECONFIG":      overrides["kubeconfig"],
-		"CLUSTER_ROUTER_REPLICAS": valueOr(overrides, "router_replicas", "1"),
-		"CLUSTER_ROUTER_CPU":      valueOr(overrides, "router_cpu", "1"),
-		"CLUSTER_ROUTER_MEMORY":   valueOr(overrides, "router_memory", "2Gi"),
+		"CLUSTER_IMAGE_REGISTRY":  stringOr(overrides, "image_registry", testImageRegistry()),
+		"CLUSTER_VERSION":         stringOr(overrides, "version", profileClusterVersion()),
+		"CLUSTER_KUBECONFIG":      stringOr(overrides, "kubeconfig", ""),
+		"CLUSTER_ROUTER_REPLICAS": stringOr(overrides, "router_replicas", "1"),
+		"CLUSTER_ROUTER_CPU":      stringOr(overrides, "router_cpu", "1"),
+		"CLUSTER_ROUTER_MEMORY":   stringOr(overrides, "router_memory", "2Gi"),
+		"CLUSTER_MODEL_CACHES":    anySliceOr[ModelCache](overrides, "model_caches", nil),
 	}
 
-	if mc := overrides["model_caches_yaml"]; mc != "" {
-		defaults["CLUSTER_MODEL_CACHES_YAML"] = mc
-	}
-
-	path, err := renderTemplateToTempFile(filepath.Join("testdata", "k8s-cluster.yaml"), defaults)
+	path, err := renderTemplateToTempFile(filepath.Join("testdata", "k8s-cluster.yaml"), data)
 	Expect(err).NotTo(HaveOccurred(), "failed to render K8s cluster template")
 
 	return path
 }
 
-func valueOr(m map[string]string, key, fallback string) string {
-	if v, ok := m[key]; ok && v != "" {
-		return v
+// stringOr returns m[key] as string, falling back to fallback if missing or empty.
+func stringOr(m map[string]any, key, fallback string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok && s != "" {
+			return s
+		}
+	}
+
+	return fallback
+}
+
+// anySliceOr returns m[key] coerced to []T. If the value is missing, nil, or
+// not assignable to []T, fallback is returned.
+func anySliceOr[T any](m map[string]any, key string, fallback []T) []T {
+	if v, ok := m[key]; ok && v != nil {
+		if s, ok := v.([]T); ok {
+			return s
+		}
 	}
 
 	return fallback
@@ -710,46 +756,69 @@ func profileVarMap() map[string]string {
 	}
 }
 
-// renderTemplate reads a template file and expands ${VAR} references
-// using the provided defaults map as primary source, then falling back
-// to the profile variable map, then to infrastructure env vars
-// (NEUTREE_SERVER_URL, NEUTREE_API_KEY, TESTRAIL_RUN_ID).
-func renderTemplate(templatePath string, defaults map[string]string) (string, error) {
+// renderTemplate reads a template file and renders it via text/template, using
+// the merged data map (caller > profile > env). Strict missing-key errors so
+// callers must provide every variable referenced in the template.
+func renderTemplate(templatePath string, data map[string]any) (string, error) {
 	content, err := os.ReadFile(templatePath)
 	if err != nil {
 		return "", err
 	}
 
-	pvm := profileVarMap()
+	tmpl, err := template.New(filepath.Base(templatePath)).
+		Option("missingkey=error").
+		Parse(string(content))
+	if err != nil {
+		return "", fmt.Errorf("parse template %s: %w", templatePath, err)
+	}
 
-	result := os.Expand(string(content), func(key string) string {
-		// 1. Caller-provided defaults take highest priority (including empty string).
-		if defaults != nil {
-			if v, ok := defaults[key]; ok {
-				return v
-			}
+	merged := mergeData(data, profileVarMap(), infraEnvVars())
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, merged); err != nil {
+		return "", fmt.Errorf("execute template %s: %w", templatePath, err)
+	}
+
+	return buf.String(), nil
+}
+
+// mergeData merges data with priority: caller > profile > env. Empty profile/env
+// values are skipped (so defaults can fall through), but caller values are kept
+// even when empty so callers can explicitly override profile to "".
+func mergeData(callerData map[string]any, profileVars, envVars map[string]string) map[string]any {
+	out := map[string]any{}
+
+	for k, v := range envVars {
+		if v != "" {
+			out[k] = v
 		}
+	}
 
-		// 2. Profile-derived values.
-		if v, ok := pvm[key]; ok && v != "" {
-			return v
+	for k, v := range profileVars {
+		if v != "" {
+			out[k] = v
 		}
+	}
 
-		// 3. For infrastructure env vars (server URL, API key), fall back to os env.
-		switch key {
-		case "NEUTREE_SERVER_URL", "NEUTREE_API_KEY", "TESTRAIL_RUN_ID":
-			return os.Getenv(key)
-		}
+	for k, v := range callerData {
+		out[k] = v
+	}
 
-		return ""
-	})
+	return out
+}
 
-	return result, nil
+// infraEnvVars returns infrastructure-level env vars that templates may reference.
+func infraEnvVars() map[string]string {
+	return map[string]string{
+		"NEUTREE_SERVER_URL": os.Getenv("NEUTREE_SERVER_URL"),
+		"NEUTREE_API_KEY":    os.Getenv("NEUTREE_API_KEY"),
+		"TESTRAIL_RUN_ID":    os.Getenv("TESTRAIL_RUN_ID"),
+	}
 }
 
 // renderTemplateToTempFile renders a template and writes the result to a temp file.
-func renderTemplateToTempFile(templatePath string, defaults map[string]string) (string, error) {
-	rendered, err := renderTemplate(templatePath, defaults)
+func renderTemplateToTempFile(templatePath string, data map[string]any) (string, error) {
+	rendered, err := renderTemplate(templatePath, data)
 	if err != nil {
 		return "", err
 	}
@@ -783,9 +852,12 @@ func requireImageRegistryProfile() {
 }
 
 // renderImageRegistryYAML renders an ImageRegistry YAML and returns the temp file path.
-func renderImageRegistryYAML(overrides map[string]string) string {
-	path, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
-		"E2E_IMAGE_REGISTRY": overrides["name"],
+//
+// Recognized overrides keys:
+//   - "name" (string)
+func renderImageRegistryYAML(overrides map[string]any) string {
+	path, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
+		"E2E_IMAGE_REGISTRY": stringOr(overrides, "name", ""),
 	})
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
@@ -1040,7 +1112,7 @@ func setupSSHCluster(prefix string) (clusterName string) {
 	headIP, workerIPs, sshUser, sshPrivateKey := requireSSHProfile()
 	clusterName = prefix + Cfg.RunID
 
-	yaml := renderSSHClusterYAML(map[string]string{
+	yaml := renderSSHClusterYAML(map[string]any{
 		"name":            clusterName,
 		"head_ip":         headIP,
 		"worker_ips":      workerIPs,
@@ -1072,7 +1144,7 @@ func setupK8sCluster(prefix string) (clusterName string) {
 	kubeconfig := requireK8sProfile()
 	clusterName = prefix + Cfg.RunID
 
-	yaml := renderK8sClusterYAML(map[string]string{
+	yaml := renderK8sClusterYAML(map[string]any{
 		"name":       clusterName,
 		"kubeconfig": kubeconfig,
 	})
@@ -1101,10 +1173,12 @@ func teardownCluster(clusterName string) {
 
 // --- Endpoint helpers ---
 
-// engineArgsYAML returns a YAML snippet for spec.variables.engine_args.
-func engineArgsYAML() string {
+// engineArgs parses profile engine_args ("k=v,k2=v2,...") into a structured slice
+// for direct injection into the endpoint template via {{range}}.
+func engineArgs() []EngineArg {
 	raw := profileEngineArgs()
-	var lines []string
+
+	var args []EngineArg
 
 	for _, pair := range strings.Split(raw, ",") {
 		k, v, ok := strings.Cut(strings.TrimSpace(pair), "=")
@@ -1112,10 +1186,10 @@ func engineArgsYAML() string {
 			continue
 		}
 
-		lines = append(lines, fmt.Sprintf("      %s: %s", strings.TrimSpace(k), strings.TrimSpace(v)))
+		args = append(args, EngineArg{Key: strings.TrimSpace(k), Value: strings.TrimSpace(v)})
 	}
 
-	return "\n" + strings.Join(lines, "\n")
+	return args
 }
 
 // endpointOpts holds configurable fields for applyEndpoint.
@@ -1125,7 +1199,7 @@ type endpointOpts struct {
 	model         string
 	modelVersion  string
 	task          string
-	engineArgs    string
+	engineArgs    []EngineArg
 	gpu           string
 	cpu           string
 	memory        string
@@ -1167,7 +1241,7 @@ func withTask(task string) EndpointOption {
 	return func(o *endpointOpts) { o.task = task }
 }
 
-func withEngineArgs(args string) EndpointOption {
+func withEngineArgs(args []EngineArg) EndpointOption {
 	return func(o *endpointOpts) { o.engineArgs = args }
 }
 
@@ -1199,7 +1273,7 @@ func renderEndpoint(name, cluster string, opts ...EndpointOption) (string, *endp
 		model:         profileModelName(),
 		modelVersion:  profileModelVersion(),
 		task:          profileModelTask(),
-		engineArgs:    engineArgsYAML(),
+		engineArgs:    engineArgs(),
 		gpu:           "1",
 		forceUpdate:   true,
 	}
@@ -1211,25 +1285,7 @@ func renderEndpoint(name, cluster string, opts ...EndpointOption) (string, *endp
 		o.accType, o.accProduct = getClusterAccelerator(cluster)
 	}
 
-	var envYAML string
-	if len(o.env) > 0 {
-		envYAML = "  env:\n"
-		for k, v := range o.env {
-			envYAML += fmt.Sprintf("    %s: \"%s\"\n", k, v)
-		}
-	}
-
-	resourcesYAML := fmt.Sprintf("    gpu: \"%s\"\n", o.gpu)
-
-	if o.cpu != "" {
-		resourcesYAML += fmt.Sprintf("    cpu: \"%s\"\n", o.cpu)
-	}
-
-	if o.memory != "" {
-		resourcesYAML += fmt.Sprintf("    memory: \"%s\"\n", o.memory)
-	}
-
-	defaults := map[string]string{
+	data := map[string]any{
 		"E2E_ENDPOINT_NAME":       name,
 		"E2E_WORKSPACE":           profileWorkspace(),
 		"E2E_CLUSTER_NAME":        cluster,
@@ -1241,12 +1297,14 @@ func renderEndpoint(name, cluster string, opts ...EndpointOption) (string, *endp
 		"E2E_MODEL_TASK":          o.task,
 		"E2E_ACCELERATOR_TYPE":    o.accType,
 		"E2E_ACCELERATOR_PRODUCT": o.accProduct,
-		"E2E_RESOURCES_YAML":      resourcesYAML,
-		"E2E_ENGINE_ARGS_YAML":    o.engineArgs,
-		"E2E_ENV_YAML":            envYAML,
+		"E2E_GPU":                 o.gpu,
+		"E2E_CPU":                 o.cpu,
+		"E2E_MEMORY":              o.memory,
+		"E2E_ENGINE_ARGS":         o.engineArgs,
+		"E2E_ENV":                 o.env,
 	}
 
-	yamlPath, err := renderTemplateToTempFile(filepath.Join("testdata", "endpoint.yaml"), defaults)
+	yamlPath, err := renderTemplateToTempFile(filepath.Join("testdata", "endpoint.yaml"), data)
 	Expect(err).NotTo(HaveOccurred(), "failed to render endpoint template")
 
 	return yamlPath, o
@@ -1267,15 +1325,16 @@ func applyEndpoint(name, cluster string, opts ...EndpointOption) (yamlPath strin
 	return yamlPath
 }
 
-// allSchemaTypesEngineArgsYAML returns an engine_args YAML snippet covering multiple JSON Schema data types.
-func allSchemaTypesEngineArgsYAML() string {
-	return `
-      dtype: half
-      max_model_len: 4096
-      gpu_memory_utilization: 0.85
-      enforce_eager: true
-      seed: 42
-      override_generation_config: '{"temperature": 0.8}'`
+// allSchemaTypesEngineArgs returns an engine_args slice covering multiple JSON Schema data types.
+func allSchemaTypesEngineArgs() []EngineArg {
+	return []EngineArg{
+		{Key: "dtype", Value: "half"},
+		{Key: "max_model_len", Value: "4096"},
+		{Key: "gpu_memory_utilization", Value: "0.85"},
+		{Key: "enforce_eager", Value: "true"},
+		{Key: "seed", Value: "42"},
+		{Key: "override_generation_config", Value: `'{"temperature": 0.8}'`},
+	}
 }
 
 // waitEndpointRunning waits for an endpoint to reach Running phase.

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -533,16 +533,23 @@ func stringOr(m map[string]any, key, fallback string) string {
 	return fallback
 }
 
-// anySliceOr returns m[key] coerced to []T. If the value is missing, nil, or
-// not assignable to []T, fallback is returned.
+// anySliceOr returns m[key] coerced to []T. If the value is missing or nil,
+// fallback is returned. If the value is present but NOT assignable to []T,
+// the test fails loudly — silent fallback would hide caller-side type errors
+// (e.g. passing a comma-separated string for a key that expects []string).
 func anySliceOr[T any](m map[string]any, key string, fallback []T) []T {
-	if v, ok := m[key]; ok && v != nil {
-		if s, ok := v.([]T); ok {
-			return s
-		}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return fallback
 	}
 
-	return fallback
+	s, ok := v.([]T)
+	if !ok {
+		Fail(fmt.Sprintf("anySliceOr: key %q expects []%T, got %T (value: %v)",
+			key, *new(T), v, v))
+	}
+
+	return s
 }
 
 // --- ClusterHelper ---

--- a/tests/e2e/helpers_template_test.go
+++ b/tests/e2e/helpers_template_test.go
@@ -1,0 +1,294 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTempTemplate(t *testing.T, content string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tmpl.yaml")
+
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write tmpl: %v", err)
+	}
+
+	return path
+}
+
+func TestRenderTemplate_PlainSubstitution(t *testing.T) {
+	path := writeTempTemplate(t, "name: {{ .NAME }}\nworkspace: {{ .WORKSPACE }}\n")
+
+	got, err := renderTemplate(path, map[string]any{
+		"NAME":      "alpha",
+		"WORKSPACE": "ws-1",
+	})
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+
+	want := "name: alpha\nworkspace: ws-1\n"
+	if got != want {
+		t.Fatalf("got=%q want=%q", got, want)
+	}
+}
+
+func TestRenderTemplate_MissingKeyErrors(t *testing.T) {
+	path := writeTempTemplate(t, "name: {{ .NAME }}\nmissing: {{ .NOPE }}\n")
+
+	_, err := renderTemplate(path, map[string]any{"NAME": "alpha"})
+	if err == nil {
+		t.Fatalf("expected error for missing key, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "NOPE") {
+		t.Fatalf("error should mention missing key NOPE, got: %v", err)
+	}
+}
+
+func TestRenderTemplate_RangeWorkerIPs(t *testing.T) {
+	path := writeTempTemplate(t, `worker_ips:
+{{- range .IPS }}
+  - "{{ . }}"
+{{- end }}
+`)
+
+	got, err := renderTemplate(path, map[string]any{
+		"IPS": []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+	})
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+
+	want := "worker_ips:\n  - \"10.0.0.1\"\n  - \"10.0.0.2\"\n  - \"10.0.0.3\"\n"
+	if got != want {
+		t.Fatalf("got=%q want=%q", got, want)
+	}
+}
+
+func TestRenderTemplate_IfSkipsEmpty(t *testing.T) {
+	path := writeTempTemplate(t, `config:
+{{- if .ACCEL }}
+  accelerator_type: "{{ .ACCEL }}"
+{{- end }}
+  next: line
+`)
+
+	t.Run("empty skipped", func(t *testing.T) {
+		got, err := renderTemplate(path, map[string]any{"ACCEL": ""})
+		if err != nil {
+			t.Fatalf("renderTemplate: %v", err)
+		}
+
+		want := "config:\n  next: line\n"
+		if got != want {
+			t.Fatalf("got=%q want=%q", got, want)
+		}
+	})
+
+	t.Run("non-empty rendered", func(t *testing.T) {
+		got, err := renderTemplate(path, map[string]any{"ACCEL": "nvidia_gpu"})
+		if err != nil {
+			t.Fatalf("renderTemplate: %v", err)
+		}
+
+		want := "config:\n  accelerator_type: \"nvidia_gpu\"\n  next: line\n"
+		if got != want {
+			t.Fatalf("got=%q want=%q", got, want)
+		}
+	})
+}
+
+func TestMergeData_PriorityCallerOverProfileOverEnv(t *testing.T) {
+	caller := map[string]any{"X": "from_caller"}
+	profile := map[string]string{"X": "from_profile", "Y": "from_profile_only"}
+	env := map[string]string{"X": "from_env", "Z": "from_env_only"}
+
+	got := mergeData(caller, profile, env)
+
+	if got["X"] != "from_caller" {
+		t.Errorf("X: want from_caller, got %v", got["X"])
+	}
+
+	if got["Y"] != "from_profile_only" {
+		t.Errorf("Y: want from_profile_only, got %v", got["Y"])
+	}
+
+	if got["Z"] != "from_env_only" {
+		t.Errorf("Z: want from_env_only, got %v", got["Z"])
+	}
+}
+
+func TestMergeData_CallerEmptyStringOverridesProfile(t *testing.T) {
+	caller := map[string]any{"X": ""}
+	profile := map[string]string{"X": "profile_val"}
+
+	got := mergeData(caller, profile, nil)
+
+	if got["X"] != "" {
+		t.Errorf("caller empty string should override profile, got %v", got["X"])
+	}
+}
+
+func TestMergeData_ProfileEmptyValuesSkipped(t *testing.T) {
+	profile := map[string]string{"EMPTY": "", "FILLED": "value"}
+
+	got := mergeData(nil, profile, nil)
+
+	if _, ok := got["EMPTY"]; ok {
+		t.Errorf("empty profile value should be skipped, got entry: %v", got["EMPTY"])
+	}
+
+	if got["FILLED"] != "value" {
+		t.Errorf("FILLED: want value, got %v", got["FILLED"])
+	}
+}
+
+// --- Rev 1: ModelCache structurization ---
+
+func TestRenderTemplate_ModelCachesByMode(t *testing.T) {
+	tmpl := `{{- if .CACHES -}}
+model_caches:
+{{- range .CACHES }}
+  - name: {{ .Name }}
+{{- if eq .Mode "host_path" }}
+    host_path:
+      path: "{{ .HostPath }}"
+{{- end }}
+{{- if eq .Mode "nfs" }}
+    nfs:
+      server: "{{ .NFSServer }}"
+      path: "{{ .NFSPath }}"
+{{- end }}
+{{- if eq .Mode "pvc" }}
+    pvc:
+      storageClassName: "{{ .PVCStorageClass }}"
+      resources:
+        requests:
+          storage: {{ .PVCStorage }}
+{{- end }}
+{{- end }}
+{{- end }}
+`
+	path := writeTempTemplate(t, tmpl)
+
+	cases := []struct {
+		name   string
+		caches []ModelCache
+		want   string
+	}{
+		{
+			name: "host_path",
+			caches: []ModelCache{
+				{Name: "hp-cache", Mode: "host_path", HostPath: "/data/models"},
+			},
+			want: "model_caches:\n  - name: hp-cache\n    host_path:\n      path: \"/data/models\"\n",
+		},
+		{
+			name: "nfs",
+			caches: []ModelCache{
+				{Name: "nfs-cache", Mode: "nfs", NFSServer: "10.0.0.1", NFSPath: "/exports/m"},
+			},
+			want: "model_caches:\n  - name: nfs-cache\n    nfs:\n      server: \"10.0.0.1\"\n      path: \"/exports/m\"\n",
+		},
+		{
+			name: "pvc",
+			caches: []ModelCache{
+				{Name: "pvc-cache", Mode: "pvc", PVCStorageClass: "fast-ssd", PVCStorage: "10Gi"},
+			},
+			want: "model_caches:\n  - name: pvc-cache\n    pvc:\n      storageClassName: \"fast-ssd\"\n      resources:\n        requests:\n          storage: 10Gi\n",
+		},
+		{
+			name: "multiple mixed",
+			caches: []ModelCache{
+				{Name: "a", Mode: "host_path", HostPath: "/x"},
+				{Name: "b", Mode: "nfs", NFSServer: "n", NFSPath: "/p"},
+			},
+			want: "model_caches:\n  - name: a\n    host_path:\n      path: \"/x\"\n  - name: b\n    nfs:\n      server: \"n\"\n      path: \"/p\"\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := renderTemplate(path, map[string]any{"CACHES": tc.caches})
+			if err != nil {
+				t.Fatalf("renderTemplate: %v", err)
+			}
+
+			if got != tc.want {
+				t.Fatalf("got=%q\nwant=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderTemplate_ModelCachesEmptyOmitsBlock(t *testing.T) {
+	tmpl := `before
+{{- if .CACHES }}
+model_caches: yes
+{{- end }}
+after
+`
+	path := writeTempTemplate(t, tmpl)
+
+	got, err := renderTemplate(path, map[string]any{"CACHES": []ModelCache{}})
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+
+	want := "before\nafter\n"
+	if got != want {
+		t.Fatalf("got=%q want=%q", got, want)
+	}
+}
+
+// --- Rev 2: EngineArgs and Role permissions ---
+
+func TestRenderTemplate_EngineArgsRange(t *testing.T) {
+	tmpl := `engine_args:
+{{- range .ARGS }}
+  {{ .Key }}: {{ .Value }}
+{{- end }}
+`
+	path := writeTempTemplate(t, tmpl)
+
+	got, err := renderTemplate(path, map[string]any{
+		"ARGS": []EngineArg{
+			{Key: "dtype", Value: "half"},
+			{Key: "max_model_len", Value: "4096"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+
+	want := "engine_args:\n  dtype: half\n  max_model_len: 4096\n"
+	if got != want {
+		t.Fatalf("got=%q want=%q", got, want)
+	}
+}
+
+func TestRenderTemplate_RolePermissionsRange(t *testing.T) {
+	tmpl := `permissions:
+{{- range .PERMS }}
+  - "{{ . }}"
+{{- end }}
+`
+	path := writeTempTemplate(t, tmpl)
+
+	got, err := renderTemplate(path, map[string]any{
+		"PERMS": []string{"cluster:read", "endpoint:write"},
+	})
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+
+	want := "permissions:\n  - \"cluster:read\"\n  - \"endpoint:write\"\n"
+	if got != want {
+		t.Fatalf("got=%q want=%q", got, want)
+	}
+}

--- a/tests/e2e/image_registry_test.go
+++ b/tests/e2e/image_registry_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Image Registry", Label("image-registry"), func() {
 
 			Expect(rawURL).NotTo(BeEmpty(), "stripped registry URL should not be empty")
 
-			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
 				"E2E_IMAGE_REGISTRY":     name,
 				"E2E_IMAGE_REGISTRY_URL": rawURL,
 			})
@@ -66,7 +66,7 @@ var _ = Describe("Image Registry", Label("image-registry"), func() {
 			})
 
 			By("Creating image registry WITHOUT credentials")
-			noAuthPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+			noAuthPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
 				"E2E_IMAGE_REGISTRY":          noAuthName,
 				"E2E_IMAGE_REGISTRY_USERNAME": "",
 				"E2E_IMAGE_REGISTRY_PASSWORD": "",
@@ -86,7 +86,7 @@ var _ = Describe("Image Registry", Label("image-registry"), func() {
 			ExpectFailed(r)
 
 			By("Creating image registry WITH credentials")
-			authPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]string{
+			authPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
 				"E2E_IMAGE_REGISTRY": authName,
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -18,7 +18,7 @@ var registryYAML string
 // SetupModelRegistry creates a model registry from the YAML template
 // and waits for it to reach Connected phase.
 func SetupModelRegistry() {
-	defaults := map[string]string{
+	defaults := map[string]any{
 		"E2E_MODEL_REGISTRY":     testRegistry(),
 		"E2E_WORKSPACE":          profileWorkspace(),
 		"E2E_MODEL_REGISTRY_URL": profile.ModelRegistry.URL,

--- a/tests/e2e/testdata/endpoint.yaml
+++ b/tests/e2e/testdata/endpoint.yaml
@@ -1,26 +1,40 @@
 apiVersion: v1
 kind: Endpoint
 metadata:
-  name: ${E2E_ENDPOINT_NAME}
-  workspace: ${E2E_WORKSPACE}
+  name: {{ .E2E_ENDPOINT_NAME }}
+  workspace: {{ .E2E_WORKSPACE }}
 spec:
-  cluster: ${E2E_CLUSTER_NAME}
+  cluster: {{ .E2E_CLUSTER_NAME }}
   engine:
-    engine: ${E2E_ENGINE_NAME}
-    version: ${E2E_ENGINE_VERSION}
+    engine: {{ .E2E_ENGINE_NAME }}
+    version: {{ .E2E_ENGINE_VERSION }}
   model:
-    registry: ${E2E_MODEL_REGISTRY}
-    name: ${E2E_MODEL_NAME}
-    version: ${E2E_MODEL_VERSION}
-    task: ${E2E_MODEL_TASK}
+    registry: {{ .E2E_MODEL_REGISTRY }}
+    name: {{ .E2E_MODEL_NAME }}
+    version: {{ .E2E_MODEL_VERSION }}
+    task: {{ .E2E_MODEL_TASK }}
   resources:
-${E2E_RESOURCES_YAML}
+    gpu: "{{ .E2E_GPU }}"
+{{- if .E2E_CPU }}
+    cpu: "{{ .E2E_CPU }}"
+{{- end }}
+{{- if .E2E_MEMORY }}
+    memory: "{{ .E2E_MEMORY }}"
+{{- end }}
     accelerator:
-      type: ${E2E_ACCELERATOR_TYPE}
-      product: ${E2E_ACCELERATOR_PRODUCT}
+      type: {{ .E2E_ACCELERATOR_TYPE }}
+      product: {{ .E2E_ACCELERATOR_PRODUCT }}
   variables:
-    engine_args:${E2E_ENGINE_ARGS_YAML}
-${E2E_ENV_YAML}
+    engine_args:
+{{- range .E2E_ENGINE_ARGS }}
+      {{ .Key }}: {{ .Value }}
+{{- end }}
+{{- if .E2E_ENV }}
+  env:
+{{- range $k, $v := .E2E_ENV }}
+    {{ $k }}: "{{ $v }}"
+{{- end }}
+{{- end }}
   replicas:
     num: 1
   deployment_options:

--- a/tests/e2e/testdata/external-endpoint-simple.yaml
+++ b/tests/e2e/testdata/external-endpoint-simple.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ExternalEndpoint
+metadata:
+  name: {{ .E2E_EE_NAME }}
+  workspace: {{ .E2E_WORKSPACE }}
+spec:
+  upstreams:
+    - upstream:
+        url: {{ .E2E_EE_UPSTREAM_URL }}
+      model_mapping:
+        {{ .E2E_EE_MODEL_KEY }}: {{ .E2E_EE_MODEL_VALUE }}

--- a/tests/e2e/testdata/external-endpoint.yaml
+++ b/tests/e2e/testdata/external-endpoint.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: ExternalEndpoint
 metadata:
-  name: ${E2E_EE_NAME}
-  workspace: ${E2E_WORKSPACE}
+  name: {{ .E2E_EE_NAME }}
+  workspace: {{ .E2E_WORKSPACE }}
 spec:
   upstreams:
     - upstream:
-        url: ${E2E_MOCK_UPSTREAM_URL}/v1
+        url: {{ .E2E_MOCK_UPSTREAM_URL }}/v1
       auth:
         type: bearer
-        credential: ${E2E_MOCK_AUTH_TOKEN}
+        credential: {{ .E2E_MOCK_AUTH_TOKEN }}
       model_mapping:
         fast: gpt-4o-mini
         smart: gpt-4o

--- a/tests/e2e/testdata/image-registry.yaml
+++ b/tests/e2e/testdata/image-registry.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: ImageRegistry
 metadata:
-  name: ${E2E_IMAGE_REGISTRY}
-  workspace: ${E2E_WORKSPACE}
+  name: {{ .E2E_IMAGE_REGISTRY }}
+  workspace: {{ .E2E_WORKSPACE }}
 spec:
-  url: ${E2E_IMAGE_REGISTRY_URL}
-  repository: ${E2E_IMAGE_REGISTRY_REPO}
+  url: {{ .E2E_IMAGE_REGISTRY_URL }}
+  repository: {{ .E2E_IMAGE_REGISTRY_REPO }}
   authconfig:
-    username: ${E2E_IMAGE_REGISTRY_USERNAME}
-    password: ${E2E_IMAGE_REGISTRY_PASSWORD}
+    username: {{ .E2E_IMAGE_REGISTRY_USERNAME }}
+    password: {{ .E2E_IMAGE_REGISTRY_PASSWORD }}

--- a/tests/e2e/testdata/k8s-cluster.yaml
+++ b/tests/e2e/testdata/k8s-cluster.yaml
@@ -1,20 +1,41 @@
 apiVersion: v1
 kind: Cluster
 metadata:
-  name: ${CLUSTER_NAME}
-  workspace: ${CLUSTER_WORKSPACE}
+  name: {{ .CLUSTER_NAME }}
+  workspace: {{ .CLUSTER_WORKSPACE }}
 spec:
   type: kubernetes
-  image_registry: ${CLUSTER_IMAGE_REGISTRY}
-  version: "${CLUSTER_VERSION}"
+  image_registry: {{ .CLUSTER_IMAGE_REGISTRY }}
+  version: "{{ .CLUSTER_VERSION }}"
   config:
     kubernetes_config:
-      kubeconfig: ${CLUSTER_KUBECONFIG}
+      kubeconfig: {{ .CLUSTER_KUBECONFIG }}
       router:
         access_mode: NodePort
-        replicas: ${CLUSTER_ROUTER_REPLICAS}
-        version: "${CLUSTER_VERSION}"
+        replicas: {{ .CLUSTER_ROUTER_REPLICAS }}
+        version: "{{ .CLUSTER_VERSION }}"
         resources:
-          cpu: "${CLUSTER_ROUTER_CPU}"
-          memory: ${CLUSTER_ROUTER_MEMORY}
-${CLUSTER_MODEL_CACHES_YAML}
+          cpu: "{{ .CLUSTER_ROUTER_CPU }}"
+          memory: {{ .CLUSTER_ROUTER_MEMORY }}
+{{- if .CLUSTER_MODEL_CACHES }}
+    model_caches:
+{{- range .CLUSTER_MODEL_CACHES }}
+      - name: {{ .Name }}
+{{- if eq .Mode "host_path" }}
+        host_path:
+          path: "{{ .HostPath }}"
+{{- end }}
+{{- if eq .Mode "nfs" }}
+        nfs:
+          server: "{{ .NFSServer }}"
+          path: "{{ .NFSPath }}"
+{{- end }}
+{{- if eq .Mode "pvc" }}
+        pvc:
+          storageClassName: "{{ .PVCStorageClass }}"
+          resources:
+            requests:
+              storage: {{ .PVCStorage }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/tests/e2e/testdata/model-registry.yaml
+++ b/tests/e2e/testdata/model-registry.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ModelRegistry
 metadata:
-  name: ${E2E_MODEL_REGISTRY}
-  workspace: ${E2E_WORKSPACE}
+  name: {{ .E2E_MODEL_REGISTRY }}
+  workspace: {{ .E2E_WORKSPACE }}
 spec:
-  type: ${E2E_MODEL_REGISTRY_TYPE}
-  url: ${E2E_MODEL_REGISTRY_URL}
+  type: {{ .E2E_MODEL_REGISTRY_TYPE }}
+  url: {{ .E2E_MODEL_REGISTRY_URL }}

--- a/tests/e2e/testdata/role-assignment.yaml
+++ b/tests/e2e/testdata/role-assignment.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: RoleAssignment
+metadata:
+  name: {{ .E2E_RA_NAME }}
+spec:
+  user_id: "{{ .E2E_RA_USER_ID }}"
+  role: "{{ .E2E_RA_ROLE }}"
+  workspace: "{{ .E2E_RA_WORKSPACE }}"

--- a/tests/e2e/testdata/role.yaml
+++ b/tests/e2e/testdata/role.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Role
+metadata:
+  name: {{ .E2E_ROLE_NAME }}
+  workspace: {{ .E2E_WORKSPACE }}
+spec:
+  permissions:
+{{- range .E2E_ROLE_PERMISSIONS }}
+    - "{{ . }}"
+{{- end }}

--- a/tests/e2e/testdata/ssh-cluster.yaml
+++ b/tests/e2e/testdata/ssh-cluster.yaml
@@ -1,17 +1,48 @@
 apiVersion: v1
 kind: Cluster
 metadata:
-  name: ${CLUSTER_NAME}
-  workspace: ${CLUSTER_WORKSPACE}
+  name: {{ .CLUSTER_NAME }}
+  workspace: {{ .CLUSTER_WORKSPACE }}
 spec:
   type: ssh
-  image_registry: ${CLUSTER_IMAGE_REGISTRY}
-  version: "${CLUSTER_VERSION}"
+  image_registry: {{ .CLUSTER_IMAGE_REGISTRY }}
+  version: "{{ .CLUSTER_VERSION }}"
   config:
-${CLUSTER_ACCELERATOR_TYPE_YAML}${CLUSTER_MODEL_CACHES_YAML}    ssh_config:
+{{- if .CLUSTER_ACCELERATOR_TYPE }}
+    accelerator_type: "{{ .CLUSTER_ACCELERATOR_TYPE }}"
+{{- end }}
+{{- if .CLUSTER_MODEL_CACHES }}
+    model_caches:
+{{- range .CLUSTER_MODEL_CACHES }}
+      - name: {{ .Name }}
+{{- if eq .Mode "host_path" }}
+        host_path:
+          path: "{{ .HostPath }}"
+{{- end }}
+{{- if eq .Mode "nfs" }}
+        nfs:
+          server: "{{ .NFSServer }}"
+          path: "{{ .NFSPath }}"
+{{- end }}
+{{- if eq .Mode "pvc" }}
+        pvc:
+          storageClassName: "{{ .PVCStorageClass }}"
+          resources:
+            requests:
+              storage: {{ .PVCStorage }}
+{{- end }}
+{{- end }}
+{{- end }}
+    ssh_config:
       provider:
         type: ssh
-        head_ip: "${CLUSTER_SSH_HEAD_IP}"
-${CLUSTER_WORKER_IPS_YAML}      auth:
-        ssh_user: "${CLUSTER_SSH_USER}"
-        ssh_private_key: ${CLUSTER_SSH_PRIVATE_KEY}
+        head_ip: "{{ .CLUSTER_SSH_HEAD_IP }}"
+{{- if .CLUSTER_WORKER_IPS }}
+        worker_ips:
+{{- range .CLUSTER_WORKER_IPS }}
+          - "{{ . }}"
+{{- end }}
+{{- end }}
+      auth:
+        ssh_user: "{{ .CLUSTER_SSH_USER }}"
+        ssh_private_key: {{ .CLUSTER_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Issues

- Jira: NEU-417 — E2E YAML template rendering migration: os.Expand → text/template
- Origin: PR #362 review comments C2 / C6 / C8 (model_caches / accelerator_type / worker_ips pre-rendered YAML hacks)

## Changes

Replace `renderTemplate`'s `os.Expand`-based `${VAR}` substitution with `text/template`, gaining if/range/`missingkey=error` support and eliminating all caller-side YAML string concatenation in `tests/e2e/`.

### Helpers (`tests/e2e/helpers.go`)
- New `ModelCache` and `EngineArg` types for structured template input
- `renderTemplate` now takes `map[string]any`, parses with `text/template` `Option("missingkey=error")`; merges caller > profile > env via `mergeData`
- `engineArgs()` replaces `engineArgsYAML()` (string → `[]EngineArg`)
- `allSchemaTypesEngineArgs()` replaces `allSchemaTypesEngineArgsYAML()`
- `renderSSHClusterYAML` / `renderK8sClusterYAML` / `renderEndpoint` / `renderImageRegistryYAML` take `map[string]any`; structured fields for `worker_ips ([]string)`, `accelerator_type (string)`, `model_caches ([]ModelCache)`, `engine_args ([]EngineArg)`, `env (map[string]string)`, `gpu/cpu/memory (string)`
- `requireSSHProfile` returns `workerIPs` as `[]string`
- `anySliceOr[T]` fails loudly on caller-side type mismatch (silent fallback hid one missed `worker_ips` migration during initial e2e regression)

### Templates
- All 6 existing `testdata/*.yaml` rewritten with `{{.VAR}}` / `{{if}}` / `{{range}}`
- `ssh-cluster.yaml` and `k8s-cluster.yaml` render `model_caches` in-place per `Mode` (host_path / nfs / pvc); `worker_ips` via `range`
- `endpoint.yaml` renders `engine_args` / `env` / `resources` via `if` / `range`
- 3 new templates added: `external-endpoint-simple.yaml`, `role.yaml`, `role-assignment.yaml` (replace inline manifests in `external_endpoint_test.go`)

### Tests
- New `helpers_template_test.go`: PlainSubstitution, MissingKeyErrors, RangeWorkerIPs, IfSkipsEmpty (empty/non-empty), ModelCachesByMode (host_path / nfs / pvc / multiple), ModelCachesEmptyOmitsBlock, EngineArgsRange, RolePermissionsRange, MergeData (priority / empty-skip / caller-empty-override) — 11/11 PASS
- All 14 caller test files updated to use new `map[string]any` overrides and structured slices

### Drive-by fixes (surfaced during e2e regression)
- `endpoint_k8s_config_test.go` C2613474 BeforeAll: `withMemory("2")` → `withMemory("8")` (1u/2Gi was insufficient for the test model — endpoint never reached Running). Pre-existing on main since PR #364, only surfaced when this PR's e2e regression actually exercised the spec.

### Audit
After this change, the only `fmt.Sprintf` occurrences in `tests/e2e/` are for **non-YAML** content: k8s resource names, REST URLs, shell commands. Verified by grepping for `fmt.Sprintf.*\\n[^"]*: ` and `fmt.Sprintf(\`apiVersion` patterns — both empty.

## Test

### Unit tests
`go vet ./tests/e2e/... && go test ./tests/e2e/ -run 'TestRenderTemplate_|TestMergeData_'` — **11/11 PASS** in 0.5s.

### CI
`pr-check` ✅ pass · `codecov/patch` ✅ pass

### E2E regression — full coverage across all 3 batches
| Batch | Label | Result | Duration |
|---|---|---|---|
| **1 SSH** | `(cluster \|\| endpoint) && ssh` | **47 / 47 PASS** ✅ | 67min |
| **2 K8s** | `(cluster \|\| endpoint) && k8s` | **40 / 40 PASS** ✅ (after profile + drive-by fix) | 81min |
| **3 Misc** | `external-endpoint \|\| image-registry \|\| model \|\| cli` | **32 / 33 PASS** | 8min |

**Total: 119 / 120 specs pass** (99.2%).

The 1 remaining failure (Batch 3 C2642175 OpenAI chat completion routing) is **environmental**, not renderer-related: it requires the remote test CP's Kong gateway to call back to the test runner's local `mockUpstream` Go HTTP server, which fails when CP and runner are on different LAN segments (`mock_upstream_host: host.docker.internal` profile setting only works when both colocate). Verified the renderer is byte-identical for the affected templates by diff against pre-refactor `os.Expand+fmt.Sprintf` output.

Manual verification subsumed by the e2e cases above — every rendered template path (cluster ssh / k8s, endpoint engine_args/env/resources, model_caches host_path/nfs/pvc, worker_ips range, role permissions range, external-endpoint-simple/role/role-assignment templates, image-registry/model-registry templates, cli helpers) is exercised by passing specs.