### PR TITLE
Add SGLang v0.5.10 inference engine support

### DIFF
--- a/.github/workflows/release-engine-image.yaml
+++ b/.github/workflows/release-engine-image.yaml
@@ -1,5 +1,10 @@
 name: release-engine-image
 
+# This workflow only builds NVIDIA-accelerated images. ROCm targets exist in
+# the Makefile (docker-build-engine-vllm-rocm, docker-build-engine-sglang-rocm)
+# and can be invoked manually for ad-hoc builds, but the workflow does not
+# expose them yet — see the follow-up ticket for splitting into per-engine
+# workflows with first-class accelerator + base-image-tag overrides.
 on:
   workflow_dispatch:
     inputs:
@@ -10,8 +15,9 @@ on:
         options:
           - vllm
           - llama-cpp
+          - sglang
       engine_version:
-        description: "engine version (e.g: v0.11.2 for vllm, v0.3.7 for llama-cpp)"
+        description: "engine version (e.g: v0.11.2 for vllm, v0.3.7 for llama-cpp, v0.5.10 for sglang)"
         required: true
         type: string
       ray_version:
@@ -57,6 +63,7 @@ jobs:
           ARCH: amd64
           ENGINE_VLLM_VERSION: ${{ github.event.inputs.engine_version }}
           ENGINE_LLAMA_CPP_VERSION: ${{ github.event.inputs.engine_version }}
+          ENGINE_SGLANG_VERSION: ${{ github.event.inputs.engine_version }}
           RAY_VERSION: ${{ github.event.inputs.ray_version }}
           RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
           ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}
@@ -83,5 +90,6 @@ jobs:
           ALL_ARCH: amd64
           ENGINE_VLLM_VERSION: ${{ github.event.inputs.engine_version }}
           ENGINE_LLAMA_CPP_VERSION: ${{ github.event.inputs.engine_version }}
+          ENGINE_SGLANG_VERSION: ${{ github.event.inputs.engine_version }}
           RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
           ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ deploy/chart/neutree/init-scripts
 
 scripts/dashboard/ray-upstream
 scripts/dashboard/vllm-upstream
+scripts/dashboard/sglang-upstream
 scripts/dashboard/output
 
 cluster-image-builder/downloader

--- a/api/v1/engine_types.go
+++ b/api/v1/engine_types.go
@@ -18,6 +18,7 @@ const (
 	// Engine name constants
 	EngineNameVLLM     = "vllm"
 	EngineNameLlamaCpp = "llama-cpp"
+	EngineNameSGLang   = "sglang"
 )
 
 // knownModelTasks is the canonical set of task identifiers consumed by Neutree

--- a/cluster-image-builder/Dockerfile.engine-sglang
+++ b/cluster-image-builder/Dockerfile.engine-sglang
@@ -1,0 +1,70 @@
+ARG RAY_COMMIT
+ARG COMMON_WORKDIR=/app
+ARG RAY_REPO
+ARG ENGINE_BASE_IMAGE=lmsysorg/sglang:v0.5.10
+ARG ENGINE_VERSION_DIR=v0_5_10
+ARG RAY_BUILD_BASE_IMAGE="quay.io/pypa/manylinux2014_x86_64:2024-07-02-9ac04ee"
+
+# --- Ray source fetch ---
+FROM alpine/git:v2.47.2 AS ray_fetch
+ARG RAY_REPO
+ARG RAY_COMMIT
+ARG COMMON_WORKDIR
+WORKDIR ${COMMON_WORKDIR}
+RUN git clone ${RAY_REPO} \
+        && cd ray \
+        && git checkout ${RAY_COMMIT}
+
+# --- Ray wheel build ---
+FROM ${RAY_BUILD_BASE_IMAGE} AS build_ray
+ARG COMMON_WORKDIR
+ARG RAY_COMMIT
+ENV BUILDKITE_COMMIT=${RAY_COMMIT}
+ENV TRAVIS_COMMIT=${BUILDKITE_COMMIT}
+ENV BUILD_ONE_PYTHON_ONLY=py312
+ENV RAY_DISABLE_EXTRA_CPP=1
+WORKDIR /ray
+COPY --from=ray_fetch ${COMMON_WORKDIR}/ray /ray
+RUN /ray/python/build-wheel-manylinux2014.sh
+
+# --- Engine image ---
+FROM ${ENGINE_BASE_IMAGE}
+
+ENV HOME=/home/ray
+WORKDIR ${HOME}
+
+# Install Ray neutree fork (same version as cluster image).
+# The wheel is built for py312 (see BUILD_ONE_PYTHON_ONLY above); the SGLang
+# base image must provide a py312-compatible interpreter.
+# --break-system-packages bypasses PEP 668 (the Debian-based base image marks
+# the system Python as externally-managed); intentional inside this dedicated
+# engine container.
+RUN --mount=type=bind,from=build_ray,src=/ray,target=/install \
+    cd /install \
+    && whl=$(ls .whl/*.whl) \
+    && pip install --no-cache-dir --break-system-packages "${whl}[serve,cgraph]"
+
+# Install common serve-layer dependencies
+RUN --mount=type=bind,src=requirements,target=requirements \
+    pip install --no-cache-dir --break-system-packages -r requirements/common.txt
+
+# Copy Neutree serve layer code (shared + specified engine version only)
+ARG ENGINE_VERSION_DIR
+COPY serve/_metrics ./serve/_metrics
+COPY serve/_replica_scheduler ./serve/_replica_scheduler
+COPY serve/_utils ./serve/_utils
+COPY serve/sglang/${ENGINE_VERSION_DIR} ./serve/sglang/${ENGINE_VERSION_DIR}
+COPY downloader ./downloader
+# Intentionally do NOT install downloader/requirements.txt: SGLang base
+# already ships compatible huggingface_hub/transformers versions, and
+# re-resolving against downloader's <1.0 hf_hub upper bound would
+# downgrade hf_hub past the API surface SGLang's transformers needs
+# (e.g. is_offline_mode), breaking Backend startup.
+
+# Ensure "python" is in PATH (some base images only provide "python3")
+RUN ln -sf $(which python3) /usr/bin/python 2>/dev/null || true
+
+# Reset ENTRYPOINT from base image (sglang base image sets python -m sglang.launch_server)
+# so that Ray can execute its own commands in this container.
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/cluster-image-builder/Makefile
+++ b/cluster-image-builder/Makefile
@@ -22,6 +22,15 @@ ENGINE_VLLM_VERSION ?= v0.11.2
 ENGINE_VLLM_DIR_VERSION ?= $(shell echo $(ENGINE_VLLM_VERSION) | sed 's/-.*//' | tr '.' '_')
 ENGINE_LLAMA_CPP_VERSION ?= v0.3.7
 ENGINE_LLAMA_CPP_DIR_VERSION ?= $(shell echo $(ENGINE_LLAMA_CPP_VERSION) | sed 's/-.*//' | tr '.' '_')
+# SGLang base image. ENGINE_SGLANG_VERSION is the upstream tag prefix used as
+# the *Neutree* image tag prefix (per design doc 4.x): for NVIDIA pull
+# lmsysorg/sglang:<ENGINE_SGLANG_VERSION>; for ROCm pull
+# lmsysorg/sglang:<ENGINE_SGLANG_ROCM_TAG> (preserves the rocm720-mi30x suffix
+# in the resulting Neutree image tag, e.g. v0.5.10-rocm720-mi30x-ray2.53.0).
+ENGINE_SGLANG_BASE_IMAGE_REPO ?= lmsysorg/sglang
+ENGINE_SGLANG_VERSION ?= v0.5.10
+ENGINE_SGLANG_ROCM_TAG ?= $(ENGINE_SGLANG_VERSION)-rocm720-mi30x
+ENGINE_SGLANG_DIR_VERSION ?= $(shell echo $(ENGINE_SGLANG_VERSION) | sed 's/-.*//' | tr '.' '_')
 RAY_SHORT_VERSION ?= ray2.53.0
 
 # Optional Neutree-side patch suffix appended only to the output image tag.
@@ -66,6 +75,16 @@ docker-build-engine-llama-cpp: prepare ## Build the llama-cpp-python engine imag
 	docker build --build-arg LLAMA_CPP_VERSION=$(shell echo $(ENGINE_LLAMA_CPP_VERSION) | sed 's/^v//') --build-arg ENGINE_VERSION_DIR=$(ENGINE_LLAMA_CPP_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
 		-f Dockerfile.engine-llama-cpp -t $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
+.PHONY: docker-build-engine-sglang
+docker-build-engine-sglang: prepare ## Build the SGLang engine image (NVIDIA)
+	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_SGLANG_BASE_IMAGE_REPO):$(ENGINE_SGLANG_VERSION) --build-arg ENGINE_VERSION_DIR=$(ENGINE_SGLANG_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
+		-f Dockerfile.engine-sglang -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
+
+.PHONY: docker-build-engine-sglang-rocm
+docker-build-engine-sglang-rocm: prepare ## Build the SGLang engine image (AMD ROCm, MI300x)
+	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_SGLANG_BASE_IMAGE_REPO):$(ENGINE_SGLANG_ROCM_TAG) --build-arg ENGINE_VERSION_DIR=$(ENGINE_SGLANG_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
+		-f Dockerfile.engine-sglang -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_ROCM_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
+
 .PHONY: docker-push
 docker-push: ## Run docker-push-* targets for all the images
 	$(MAKE) ARCH=$(ARCH) $(addprefix docker-push-,$(ACCELERATORS))
@@ -90,6 +109,14 @@ docker-push-engine-vllm-rocm: ## Push the vLLM engine image (ROCm)
 docker-push-engine-llama-cpp: ## Push the llama-cpp-python engine image
 	docker push $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
 
+.PHONY: docker-push-engine-sglang
+docker-push-engine-sglang: ## Push the SGLang engine image (NVIDIA)
+	docker push $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
+
+.PHONY: docker-push-engine-sglang-rocm
+docker-push-engine-sglang-rocm: ## Push the SGLang engine image (AMD ROCm, MI300x)
+	docker push $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_ROCM_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
+
 .PHONY: docker-push-manifest-engine-vllm
 docker-push-manifest-engine-vllm: ## Push the vLLM engine manifest image
 	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
@@ -97,6 +124,14 @@ docker-push-manifest-engine-vllm: ## Push the vLLM engine manifest image
 .PHONY: docker-push-manifest-engine-llama-cpp
 docker-push-manifest-engine-llama-cpp: ## Push the llama-cpp engine manifest image
 	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
+
+.PHONY: docker-push-manifest-engine-sglang
+docker-push-manifest-engine-sglang: ## Push the SGLang engine manifest image (NVIDIA)
+	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
+
+.PHONY: docker-push-manifest-engine-sglang-rocm
+docker-push-manifest-engine-sglang-rocm: ## Push the SGLang engine manifest image (AMD ROCm)
+	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_ROCM_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-sglang:$(ENGINE_SGLANG_ROCM_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
 
 .PHONY: docker-push-manifest
 docker-push-manifest: $(addprefix docker-push-manifest-,$(ACCELERATORS))

--- a/cluster-image-builder/serve/_metrics/sglang_ray_bridge.py
+++ b/cluster-image-builder/serve/_metrics/sglang_ray_bridge.py
@@ -1,0 +1,250 @@
+"""Pump SGLang ``prometheus_client`` metrics through Ray's prometheus exporter.
+
+Background
+----------
+SGLang's ``launch_server`` exposes ``/metrics`` by mounting a
+``CollectorRegistry`` + ``MultiProcessCollector`` on a FastAPI route — see
+SGLang ``python/sglang/srt/utils/common.py:add_prometheus_middleware``::
+
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
+    app.routes.append(Mount("/metrics", make_asgi_app(registry=registry)))
+
+When we run SGLang via :class:`sglang.srt.entrypoints.engine.Engine` inside a
+Ray Serve actor we do not get that route, but we **do** inherit the same
+``PROMETHEUS_MULTIPROC_DIR`` environment variable (``Engine.__init__`` calls
+``set_prometheus_multiproc_dir()`` when ``enable_metrics=True``). Constructing
+an identical registry from the same shared dir gives us byte-for-byte
+identical aggregated samples to what SGLang would have served externally —
+no SGLang internal API is involved.
+
+This module polls that registry on a fixed cadence and re-emits each sample
+through ``ray.util.metrics`` so Ray's prometheus exporter (already scraped by
+vmagent's ``file_sd_configs``) sees SGLang metrics under the canonical
+``ray_<name>`` path. Three Ray Serve replica context labels (``deployment``,
+``replica``, ``application``) are attached at metric-create time so
+dashboards can multi-tenant filter the same way they do for vLLM (which uses
+``NeutreeRayStatLogger`` to inject the same triple).
+
+The bridge never reaches into SGLang internals; it relies only on
+``prometheus_client``'s documented multiprocess API and ``ray.util.metrics``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict, Tuple
+
+from ray import serve
+from ray.util.metrics import (
+    Counter as RayCounter,
+    Gauge as RayGauge,
+)
+
+logger = logging.getLogger("ray.serve")
+
+
+def _sanitize_metric_name(name: str) -> str:
+    """Replace characters Ray's metric API rejects.
+
+    SGLang emits ``sglang:cache_config_info`` (colon-separated namespace), but
+    ``ray.util.metrics`` rejects ``:`` since the move to OpenTelemetry naming.
+    Replace with underscore so the Ray-exported name is ``sglang_<suffix>`` —
+    aligned with the vmagent relabel rule (``ray_sglang[:_]<name>`` →
+    ``sglang_<name>``) and with the Grafana dashboard filters.
+    """
+    return name.replace(":", "_")
+
+
+def _replica_tags() -> Dict[str, str]:
+    """Snapshot Ray Serve replica context once; tags are stable for the actor lifetime."""
+    try:
+        ctx = serve.get_replica_context()
+        return {
+            "deployment": ctx.deployment,
+            "replica": ctx.replica_tag,
+            "application": getattr(ctx, "app_name", ""),
+        }
+    except RuntimeError:
+        # Ran outside a Serve replica (unit tests, REPL); skip context labels.
+        return {}
+
+
+class PromToRayBridge:
+    """Pumps SGLang-emitted prometheus samples into Ray's metric API on a fixed cadence.
+
+    The aggregated samples come from ``prometheus_client``'s
+    ``MultiProcessCollector`` pointed at ``PROMETHEUS_MULTIPROC_DIR`` — the same
+    mechanism SGLang's launch_server uses for its ``/metrics`` HTTP route.
+
+    Parameters
+    ----------
+    prefix_allowlist:
+        Only metric families whose names start with one of these prefixes are
+        forwarded. Defaults to ``("sglang",)`` because Ray Serve already
+        exports its own ``ray_serve_*`` metrics natively and we don't want to
+        double-emit them.
+    interval_s:
+        Poll cadence. The default of 5s matches Ray's prometheus scrape
+        granularity.
+    """
+
+    def __init__(
+        self,
+        prefix_allowlist: Tuple[str, ...] = ("sglang",),
+        interval_s: float = 5.0,
+    ) -> None:
+        # Lazy import: PROMETHEUS_MULTIPROC_DIR must be set before
+        # ``prometheus_client`` is loaded for multiprocess mode to take effect.
+        from prometheus_client import CollectorRegistry, multiprocess
+
+        self.registry = CollectorRegistry()
+        multiprocess.MultiProcessCollector(self.registry)
+        self.allowlist = tuple(prefix_allowlist)
+        self.interval = float(interval_s)
+        self._extra_tags = _replica_tags()
+        self._extra_tag_keys: Tuple[str, ...] = tuple(self._extra_tags.keys())
+
+        # Ray metrics are created lazily on first sight of each (name, label-set)
+        # pair, so the bridge automatically picks up new metrics added by future
+        # SGLang releases. tag_keys is fixed at construction in OpenCensus, so
+        # different label-sets get separate Ray metric instances.
+        self._counters: Dict[Tuple[str, Tuple[str, ...]], RayCounter] = {}
+        self._gauges: Dict[Tuple[str, Tuple[str, ...]], RayGauge] = {}
+
+        # SGLang uses ``multiprocess_mode="mostrecent"`` for every metric; that
+        # means counter samples carry absolute totals, not increments. We
+        # diff against the previous tick to recover delta semantics.
+        self._counter_prev: Dict[Tuple[str, Tuple[Tuple[str, str], ...]], float] = {}
+
+        logger.info(
+            "[PromToRayBridge] init: allowlist=%s interval=%ss replica_tags=%s",
+            self.allowlist,
+            self.interval,
+            list(self._extra_tag_keys),
+        )
+
+    async def run(self) -> None:
+        """Cooperative poll loop; cancel the asyncio task to stop."""
+        while True:
+            try:
+                await asyncio.sleep(self.interval)
+                self._tick()
+            except asyncio.CancelledError:
+                logger.info("[PromToRayBridge] cancelled, exiting")
+                raise
+            except Exception:
+                # Best-effort: never crash the actor over a metric blip.
+                logger.exception("[PromToRayBridge] tick failed")
+
+    # ---- internals ---------------------------------------------------------
+
+    def _tick(self) -> None:
+        for fam in self.registry.collect():
+            if not any(fam.name.startswith(p) for p in self.allowlist):
+                continue
+            kind = fam.type
+            if kind == "counter":
+                self._emit_counter(fam)
+            elif kind == "gauge":
+                self._emit_gauge(fam)
+            elif kind == "histogram":
+                self._emit_histogram(fam)
+            # summary / info / unknown silently dropped — SGLang doesn't use them.
+
+    def _emit_counter(self, fam) -> None:
+        for sample in fam.samples:
+            # prometheus_client emits both ``<name>_total`` (the value) and
+            # ``<name>_created`` (a metadata gauge). Drop the metadata.
+            if sample.name.endswith("_created"):
+                continue
+            label_keys = tuple(sorted(sample.labels.keys()))
+            metric = self._get_or_create_counter(fam.name, label_keys)
+            key = (sample.name, tuple(sorted(sample.labels.items())))
+            prev = self._counter_prev.get(key, 0.0)
+            delta = sample.value - prev
+            if delta < 0:
+                # Counter reset (worker restart): re-baseline, do not emit
+                # a negative inc().
+                delta = sample.value
+            self._counter_prev[key] = sample.value
+            if delta > 0:
+                metric.inc(delta, tags=self._full_tags(sample.labels))
+
+    def _emit_gauge(self, fam) -> None:
+        for sample in fam.samples:
+            if sample.name.endswith("_created"):
+                continue
+            label_keys = tuple(sorted(sample.labels.keys()))
+            metric = self._get_or_create_gauge(fam.name, label_keys)
+            metric.set(sample.value, tags=self._full_tags(sample.labels))
+
+    def _emit_histogram(self, fam) -> None:
+        # Mirrors ray-project/ray#63123: emit raw `<name>_bucket{le=...}`,
+        # `<name>_sum`, `<name>_count` samples as gauges. The `le` label is
+        # carried through verbatim, so PromQL `histogram_quantile()` on the
+        # consumer side reconstructs the histogram without observation
+        # replay.
+        #
+        # Avoids `RayHistogram.observe()` — its API takes one value at a
+        # time (no batch path through the Cython binding). At high QPS the
+        # replay loop is O(observations) and CPU-bound; emitting cumulative
+        # gauge values is O(buckets) per scrape regardless of rate. The
+        # tradeoff is that downstream sees the metric typed as a gauge
+        # rather than a histogram — fine for vmagent + Prometheus / Grafana
+        # where `histogram_quantile()` only needs the `le`-labeled
+        # timeseries.
+        for sample in fam.samples:
+            # `_created` is prometheus_client metadata (family creation
+            # timestamp); we don't expose it.
+            if sample.name.endswith("_created"):
+                continue
+            label_keys = tuple(sorted(sample.labels.keys()))
+            # Use sample.name (not fam.name) so each suffix lands on its own
+            # Ray gauge: `<name>_bucket`, `<name>_sum`, `<name>_count`. For
+            # bucket samples this preserves the `le` label as a tag key,
+            # which is exactly what `histogram_quantile()` needs.
+            metric = self._get_or_create_gauge(sample.name, label_keys)
+            metric.set(sample.value, tags=self._full_tags(sample.labels))
+
+    # ---- ray.util.metrics get-or-create -----------------------------------
+
+    def _get_or_create_counter(
+        self, name: str, label_keys: Tuple[str, ...]
+    ) -> RayCounter:
+        ray_name = _sanitize_metric_name(name)
+        key = (ray_name, label_keys)
+        m = self._counters.get(key)
+        if m is None:
+            m = RayCounter(
+                name=ray_name,
+                description=name,
+                tag_keys=label_keys + self._extra_tag_keys,
+            )
+            self._counters[key] = m
+        return m
+
+    def _get_or_create_gauge(
+        self, name: str, label_keys: Tuple[str, ...]
+    ) -> RayGauge:
+        ray_name = _sanitize_metric_name(name)
+        key = (ray_name, label_keys)
+        m = self._gauges.get(key)
+        if m is None:
+            m = RayGauge(
+                name=ray_name,
+                description=name,
+                tag_keys=label_keys + self._extra_tag_keys,
+            )
+            self._gauges[key] = m
+        return m
+
+    # ---- tag helpers -------------------------------------------------------
+
+    def _full_tags(self, sample_labels) -> Dict[str, str]:
+        # ``sample_labels`` is a frozen dict-like from prometheus_client; copy and
+        # overlay replica-context tags so the returned dict is a fresh value.
+        tags = dict(sample_labels)
+        tags.update(self._extra_tags)
+        return tags

--- a/cluster-image-builder/serve/sglang/v0_5_10/app.py
+++ b/cluster-image-builder/serve/sglang/v0_5_10/app.py
@@ -1,0 +1,524 @@
+"""Ray Serve deployment for SGLang v0.5.10 inference (Neutree static cluster path).
+
+Mirrors the vLLM v0.11.2 / llama_cpp v0.3.7 app structure so the Go
+ray_orchestrator can drive it via ``serve.sglang.v0_5_10.app:app_builder``.
+
+Architecture:
+    Controller (FastAPI ingress, CPU-only)
+        - HTTP routing, request id middleware, optional custom replica scheduler
+        - Forwards to Backend handles (streaming or one-shot)
+    Backend (SGLang Engine + OpenAI serving handlers, GPU)
+        - Owns ``sglang.srt.entrypoints.engine.Engine`` (multi-process under the hood)
+        - Lazy-instantiates OpenAI serving handlers (chat/completion/embedding)
+        - Splits each endpoint into non-streaming + streaming variants because
+          SGLang's StreamingResponse is not Ray-serialisable across actors.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import json
+import logging
+from typing import Any, AsyncGenerator, Dict, Optional
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.responses import JSONResponse, StreamingResponse
+from starlette_context.middleware import RawContextMiddleware
+from starlette_context.plugins import RequestIdPlugin
+
+from ray import serve
+from ray.serve import Application
+from ray.serve.config import RequestRouterConfig
+from ray.serve.handle import DeploymentHandle, DeploymentResponseGenerator
+
+from downloader import build_request_from_model_args, get_downloader
+from serve._metrics.sglang_ray_bridge import PromToRayBridge
+from serve._utils import coerce_args, filter_engine_args
+from serve._utils.runtime_env import build_backend_runtime_env
+
+logger = logging.getLogger("ray.serve")
+
+
+class SchedulerType(str, enum.Enum):
+    POW2 = "pow2"
+    STATIC_HASH = "static_hash"
+    CONSISTENT_HASH = "consistent_hash"
+
+
+# Mapping from scheduler type to request router class path
+SCHEDULER_CLASS_PATHS = {
+    SchedulerType.STATIC_HASH: "serve._replica_scheduler.static_hash_scheduler:StaticHashReplicaScheduler",
+    SchedulerType.CONSISTENT_HASH: "serve._replica_scheduler.chwbl_scheduler:ConsistentHashReplicaScheduler",
+}
+
+
+def _build_request_router_config(scheduler_config: Dict[str, Any]) -> Optional[RequestRouterConfig]:
+    """Build RequestRouterConfig based on scheduler configuration.
+
+    See vLLM v0.11.2 app for full documentation of supported scheduler types.
+    """
+    scheduler_type = scheduler_config.get("type", SchedulerType.POW2)
+
+    if scheduler_type == SchedulerType.POW2:
+        logger.info("[app_builder] Using default POW2 scheduler")
+        return None
+
+    router_class_path = SCHEDULER_CLASS_PATHS.get(scheduler_type)
+    if not router_class_path:
+        logger.warning(
+            f"[app_builder] Unknown scheduler type: {scheduler_type}, falling back to default POW2"
+        )
+        return None
+
+    router_kwargs: Dict[str, Any] = {}
+    if scheduler_type == SchedulerType.CONSISTENT_HASH:
+        router_kwargs = {
+            "virtual_nodes_per_replica": scheduler_config.get("virtual_nodes", 100),
+            "load_factor": scheduler_config.get("load_factor", 1.25),
+            "max_user_messages_for_cache": scheduler_config.get("max_user_messages_for_cache", 2),
+        }
+
+    logger.info(
+        f"[app_builder] Using custom scheduler: {scheduler_type}, "
+        f"class: {router_class_path}, kwargs: {router_kwargs}"
+    )
+
+    return RequestRouterConfig(
+        request_router_class=router_class_path,
+        request_router_kwargs=router_kwargs,
+    )
+
+
+class _FakeRawRequest:
+    """Minimal stand-in for FastAPI Request used when invoking SGLang's
+    OpenAIServingBase from a Ray actor where no live HTTP request exists.
+
+    SGLang serving handlers call ``raw_request.is_disconnected()`` to abort
+    generation when the client disappears; passing ``None`` would raise
+    ``AttributeError``. This shim returns ``False`` so generation always
+    runs to completion (the Controller still owns the real client connection).
+    """
+
+    headers: Dict[str, str] = {}
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+def _extract_serializable(result) -> Any:
+    """Convert a serving-handler result to a Ray-serialisable Python value."""
+    try:
+        from fastapi.responses import ORJSONResponse
+        if isinstance(result, ORJSONResponse):
+            import orjson
+            return orjson.loads(result.body)
+    except ImportError:
+        pass
+
+    if isinstance(result, StreamingResponse):
+        raise RuntimeError(
+            "Non-streaming request returned StreamingResponse — "
+            "verify stream=False in the payload."
+        )
+
+    if hasattr(result, "model_dump"):
+        return result.model_dump()
+
+    return result
+
+
+async def _iter_response_body(result) -> AsyncGenerator[str, None]:
+    """Yield SSE chunks (as strings) from a serving-handler StreamingResponse.
+
+    Bytes chunks are decoded so the result can be safely sent over the Ray
+    actor boundary as Python strings.
+    """
+    if isinstance(result, StreamingResponse):
+        async for chunk in result.body_iterator:
+            if isinstance(chunk, bytes):
+                chunk = chunk.decode("utf-8")
+            yield chunk
+        return
+
+    # If the handler returned an error response (ORJSONResponse) instead of
+    # streaming, wrap it as a single SSE error frame followed by [DONE].
+    try:
+        from fastapi.responses import ORJSONResponse
+        if isinstance(result, ORJSONResponse):
+            import orjson
+            error_data = orjson.loads(result.body)
+            yield f"data: {json.dumps(error_data)}\n\n"
+            yield "data: [DONE]\n\n"
+            return
+    except ImportError:
+        pass
+
+    data = result.model_dump() if hasattr(result, "model_dump") else result
+    yield f"data: {json.dumps(data)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+def _to_json_response(result) -> JSONResponse:
+    """Wrap a backend-returned serialisable value in a JSONResponse."""
+    if isinstance(result, dict):
+        # SGLang error payloads use object='error' and include an HTTP code.
+        if result.get("object") == "error":
+            status = result.get("code", 400)
+            return JSONResponse(content=result, status_code=status)
+        return JSONResponse(content=result)
+    if hasattr(result, "model_dump"):
+        return JSONResponse(content=result.model_dump())
+    return JSONResponse(content=result)
+
+
+@serve.deployment(
+    ray_actor_options={"num_cpus": 1, "num_gpus": 1},
+    graceful_shutdown_timeout_s=30,
+)
+class Backend:
+    def __init__(
+        self,
+        # Model config parameters
+        model_registry_type: str,
+        model_name: str,
+        model_version: str,
+        model_file: str = "",
+        model_task: str = "",
+        model_registry_path: str = "",
+        model_path: str = "",
+        model_serve_name: str = "",
+        **engine_kwargs,
+    ):
+        """Backend deployment for SGLang inference.
+
+        Args:
+            model_registry_type: Type of model registry ("bentoml" or "hugging-face")
+            model_name: Name of the model in the registry
+            model_version: Version of the model
+            model_file: Specific model file name (registry-dependent)
+            model_task: Task type (e.g., "text-generation", "text-embedding")
+            **engine_kwargs: Additional keyword arguments forwarded to ServerArgs
+        """
+        backend, dl_req = build_request_from_model_args({
+            "registry_type": model_registry_type,
+            "name": model_name,
+            "version": model_version,
+            "file": model_file,
+            "task": model_task,
+            "registry_path": model_registry_path,
+            "path": model_path,
+        })
+
+        downloader = get_downloader(backend)
+        logger.info(
+            f"[Backend] Downloading model using backend={backend} "
+            f"from source={dl_req.source} to dest={dl_req.dest}"
+        )
+        downloader.download(
+            dl_req.source,
+            dl_req.dest,
+            credentials=dl_req.credentials,
+            recursive=dl_req.recursive,
+            overwrite=dl_req.overwrite,
+            retries=dl_req.retries,
+            timeout=dl_req.timeout,
+            metadata=dl_req.metadata,
+        )
+        logger.info("[Backend] Model download completed.")
+
+        self.model_path = dl_req.dest if dl_req.dest else model_path
+        self.model_task = model_task
+        self.served_model_name = model_serve_name or self.model_path
+
+        # SGLang exposes an `is_embedding` flag for embedding models; map it
+        # from the registry-level model_task so users don't have to set it
+        # twice.
+        if model_task == "text-embedding":
+            engine_kwargs.setdefault("is_embedding", True)
+
+        # Force Prometheus multiprocess mode on so the bridge below can read
+        # SGLang's metric .db files via PROMETHEUS_MULTIPROC_DIR. SGLang's
+        # set_prometheus_multiproc_dir() is gated on enable_metrics, and the
+        # bridge silently sees an empty registry if this flag is left off.
+        engine_kwargs.setdefault("enable_metrics", True)
+
+        # Build ServerArgs kwargs with model identity injected.
+        from sglang.srt.server_args import ServerArgs
+
+        args: Dict[str, Any] = dict(
+            model_path=self.model_path,
+            served_model_name=self.served_model_name,
+        )
+        args.update(engine_kwargs)
+
+        # Coerce JSON-string values for dict/list fields (SSH/Ray path lacks
+        # argparse) and drop unknown keys to prevent Engine() TypeError.
+        coerce_args(args, ServerArgs)
+        filter_engine_args(args, ServerArgs)
+
+        from sglang.srt.entrypoints.engine import Engine
+
+        logger.info(
+            f"[Backend] Initializing SGLang Engine with args: {sorted(args.keys())}"
+        )
+        # Engine.__init__ launches scheduler/detokenizer subprocesses and
+        # blocks until all are ready before returning. By this point
+        # PROMETHEUS_MULTIPROC_DIR is set in our env, so the bridge below
+        # can construct an identical CollectorRegistry.
+        self.engine = Engine(**args)
+        logger.info("[Backend] SGLang Engine initialized.")
+
+        # Lazy-init OpenAI serving handlers — created on first request.
+        self._chat = None
+        self._completion = None
+        self._embedding = None
+
+        # Spin up the SGLang prometheus -> Ray prometheus bridge. The bridge
+        # task survives until __del__ cancels it on actor preemption.
+        self._metrics_bridge = PromToRayBridge()
+        self._metrics_task = asyncio.get_event_loop().create_task(
+            self._metrics_bridge.run()
+        )
+
+    def __del__(self):
+        # Belt-and-braces cleanup: Engine registers its own atexit handler,
+        # but Ray actors that receive SIGKILL skip atexit. Calling shutdown
+        # here lets graceful preemption clean up scheduler/detokenizer
+        # subprocesses so they don't linger holding GPU memory.
+        try:
+            task = getattr(self, "_metrics_task", None)
+            if task is not None:
+                task.cancel()
+        except Exception:  # nosec - best-effort cleanup
+            pass
+        try:
+            engine = getattr(self, "engine", None)
+            if engine is not None:
+                engine.shutdown()
+        except Exception:  # nosec - best-effort cleanup
+            pass
+
+    # ---- Lazy serving-handler factories ----
+
+    def _ensure_chat(self):
+        if self._chat is None:
+            from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+            self._chat = OpenAIServingChat(
+                self.engine.tokenizer_manager,
+                self.engine.template_manager,
+            )
+        return self._chat
+
+    def _ensure_completion(self):
+        if self._completion is None:
+            from sglang.srt.entrypoints.openai.serving_completions import OpenAIServingCompletion
+            self._completion = OpenAIServingCompletion(
+                self.engine.tokenizer_manager,
+                self.engine.template_manager,
+            )
+        return self._completion
+
+    def _ensure_embedding(self):
+        if self._embedding is None:
+            from sglang.srt.entrypoints.openai.serving_embedding import OpenAIServingEmbedding
+            self._embedding = OpenAIServingEmbedding(
+                self.engine.tokenizer_manager,
+                self.engine.template_manager,
+            )
+        return self._embedding
+
+    # ---- Public methods invoked by Controller via DeploymentHandle ----
+    #
+    # SGLang's handle_request returns StreamingResponse for stream=True, which
+    # cannot be serialised across the Ray actor boundary. Each endpoint is
+    # therefore split into a non-streaming method (returns dict / pydantic
+    # dump) and a streaming method (async generator yielding SSE strings).
+
+    async def chat_completion(self, payload: Dict[str, Any]) -> Any:
+        from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+        payload = {**payload, "stream": False}
+        result = await self._ensure_chat().handle_request(
+            ChatCompletionRequest(**payload), _FakeRawRequest()
+        )
+        return _extract_serializable(result)
+
+    async def chat_completion_stream(self, payload: Dict[str, Any]) -> AsyncGenerator[str, None]:
+        from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
+        payload = {**payload, "stream": True}
+        result = await self._ensure_chat().handle_request(
+            ChatCompletionRequest(**payload), _FakeRawRequest()
+        )
+        async for chunk in _iter_response_body(result):
+            yield chunk
+
+    async def completion(self, payload: Dict[str, Any]) -> Any:
+        from sglang.srt.entrypoints.openai.protocol import CompletionRequest
+        payload = {**payload, "stream": False}
+        result = await self._ensure_completion().handle_request(
+            CompletionRequest(**payload), _FakeRawRequest()
+        )
+        return _extract_serializable(result)
+
+    async def completion_stream(self, payload: Dict[str, Any]) -> AsyncGenerator[str, None]:
+        from sglang.srt.entrypoints.openai.protocol import CompletionRequest
+        payload = {**payload, "stream": True}
+        result = await self._ensure_completion().handle_request(
+            CompletionRequest(**payload), _FakeRawRequest()
+        )
+        async for chunk in _iter_response_body(result):
+            yield chunk
+
+    async def embedding(self, payload: Dict[str, Any]) -> Any:
+        from sglang.srt.entrypoints.openai.protocol import EmbeddingRequest
+        result = await self._ensure_embedding().handle_request(
+            EmbeddingRequest(**payload), _FakeRawRequest()
+        )
+        return _extract_serializable(result)
+
+    def get_model_info(self) -> Dict[str, Any]:
+        tm = self.engine.tokenizer_manager
+        context_len = None
+        model_config = getattr(tm, "model_config", None)
+        if model_config is not None:
+            context_len = getattr(model_config, "context_len", None)
+        return {
+            "model_path": self.model_path,
+            "served_model_name": self.served_model_name,
+            "model_task": self.model_task,
+            "context_len": context_len,
+            "is_generation": getattr(tm, "is_generation", True),
+        }
+
+
+app = FastAPI()
+app.add_middleware(RawContextMiddleware, plugins=(RequestIdPlugin(),))
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@serve.deployment(ray_actor_options={"num_cpus": 0.1})
+@serve.ingress(app)
+class Controller:
+    def __init__(self, backend: DeploymentHandle):
+        self.backend = backend
+        logger.info("[Controller] Initialized with backend handle")
+
+    @app.post("/v1/chat/completions")
+    async def chat(self, request: Request):
+        payload = await request.json()
+        if payload.get("stream", False):
+            gen: DeploymentResponseGenerator = (
+                self.backend.options(stream=True).chat_completion_stream.remote(payload)
+            )
+            return StreamingResponse(content=gen, media_type="text/event-stream")
+        result = await self.backend.options(stream=False).chat_completion.remote(payload)
+        return _to_json_response(result)
+
+    @app.post("/v1/completions")
+    async def completions(self, request: Request):
+        payload = await request.json()
+        if payload.get("stream", False):
+            gen: DeploymentResponseGenerator = (
+                self.backend.options(stream=True).completion_stream.remote(payload)
+            )
+            return StreamingResponse(content=gen, media_type="text/event-stream")
+        result = await self.backend.options(stream=False).completion.remote(payload)
+        return _to_json_response(result)
+
+    @app.post("/v1/embeddings")
+    async def embeddings(self, request: Request):
+        payload = await request.json()
+        result = await self.backend.options(stream=False).embedding.remote(payload)
+        return _to_json_response(result)
+
+    @app.get("/v1/models")
+    async def models(self, request: Request):
+        info = await self.backend.get_model_info.remote()
+        return JSONResponse(content={
+            "object": "list",
+            "data": [{
+                "id": info["served_model_name"],
+                "object": "model",
+                # `created` is a UNIX timestamp; older OpenAI Python SDK versions
+                # access this field unconditionally, so emit a zero rather than
+                # omit it. Real model creation time is not tracked here.
+                "created": 0,
+                "owned_by": "neutree",
+                "permission": [],
+                "root": info["model_path"],
+                "parent": None,
+                "max_model_len": info.get("context_len"),
+            }],
+        })
+
+    @app.get("/health")
+    async def health(self):
+        return {"status": "ok"}
+
+
+def app_builder(args: Dict[str, Any]) -> Application:
+    """Application builder that assembles the Backend + Controller deployments.
+
+    Mirrors the vLLM v0.11.2 / llama_cpp v0.3.7 builders so the Go
+    ray_orchestrator can drive it without engine-specific branches.
+    """
+    model = args.get("model", {})
+    deployment_options = args.get("deployment_options", {})
+    engine_args = args.get("engine_args") or {}
+
+    backend_options = deployment_options.get("backend", {})
+    controller_options = deployment_options.get("controller", {})
+
+    scheduler_config = deployment_options.get("scheduler", {})
+    request_router_config = _build_request_router_config(scheduler_config)
+
+    backend_deploy_options: Dict[str, Any] = {
+        "max_ongoing_requests": backend_options.get("max_ongoing_requests", 100),
+        "num_replicas": backend_options.get("num_replicas", 1),
+        "ray_actor_options": {
+            "num_cpus": backend_options.get("num_cpus", 1),
+            "num_gpus": backend_options.get("num_gpus", 1),
+            "memory": backend_options.get("memory", None),
+            "resources": backend_options.get("resources", {}),
+        },
+    }
+
+    if request_router_config is not None:
+        backend_deploy_options["request_router_config"] = request_router_config
+
+    backend_container = args.get("backend_container")
+    if backend_container:
+        backend_deploy_options["ray_actor_options"]["runtime_env"] = build_backend_runtime_env(backend_container)
+
+    backend_deployment = Backend.options(**backend_deploy_options).bind(
+        model_registry_type=model.get("registry_type"),
+        model_name=model.get("name"),
+        model_version=model.get("version"),
+        model_file=model.get("file", ""),
+        model_task=model.get("task"),
+        model_registry_path=model.get("registry_path", ""),
+        model_path=model.get("path", ""),
+        model_serve_name=model.get("serve_name", ""),
+        **engine_args,
+    )
+
+    controller_deployment = Controller.options(
+        max_ongoing_requests=(
+            backend_options.get("max_ongoing_requests", 100)
+            * backend_options.get("num_replicas", 1)
+        ),
+        num_replicas=controller_options.get("num_replicas", 1),
+        ray_actor_options={
+            "num_cpus": controller_options.get("num_cpus", 0.1),
+            "num_gpus": controller_options.get("num_gpus", 0),
+        },
+    ).bind(backend=backend_deployment)
+
+    return controller_deployment

--- a/internal/engine/builtin.go
+++ b/internal/engine/builtin.go
@@ -26,6 +26,11 @@ func GetBuiltinEngines() ([]*v1.Engine, error) {
 		return nil, err
 	}
 
+	sglangV0_5_10EngineSchema, err := GetSGLangV0_5_10EngineSchema()
+	if err != nil {
+		return nil, err
+	}
+
 	engines := []*v1.Engine{
 		{
 			APIVersion: "v1",
@@ -112,6 +117,36 @@ func GetBuiltinEngines() ([]*v1.Engine, error) {
 					},
 				},
 				SupportedTasks: []string{v1.TextGenerationModelTask, v1.TextEmbeddingModelTask, v1.TextRerankModelTask},
+			},
+		},
+		{
+			APIVersion: "v1",
+			Kind:       "Engine",
+			Metadata: &v1.Metadata{
+				Name: v1.EngineNameSGLang,
+			},
+			Spec: &v1.EngineSpec{
+				Versions: []*v1.EngineVersion{
+					{
+						Version:      "v0.5.10",
+						ValuesSchema: sglangV0_5_10EngineSchema,
+						Images: map[string]*v1.EngineImage{
+							"nvidia_gpu": {
+								ImageName: "neutree/engine-sglang",
+								Tag:       "v0.5.10-ray2.53.0",
+							},
+						},
+						DeployTemplate: map[string]map[string]string{
+							"kubernetes": {
+								"default": GetSGLangV0_5_10DeployTemplate(),
+							},
+						},
+					},
+				},
+				// SGLang's /v1/rerank does not match the Cohere/Jina shape
+				// Neutree clients expect (bare list with `score`, top_n<=0
+				// rejected). Steer users to vLLM for rerank workloads.
+				SupportedTasks: []string{v1.TextGenerationModelTask, v1.TextEmbeddingModelTask},
 			},
 		},
 	}

--- a/internal/engine/builtin_test.go
+++ b/internal/engine/builtin_test.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"testing"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
 func TestGetBuiltinEngines(t *testing.T) {
@@ -10,8 +12,8 @@ func TestGetBuiltinEngines(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(engines) != 2 {
-		t.Fatalf("expected 2 built-in engines, got %d", len(engines))
+	if len(engines) != 3 {
+		t.Fatalf("expected 3 built-in engines, got %d", len(engines))
 	}
 
 	engineNames := make(map[string]bool)
@@ -25,6 +27,10 @@ func TestGetBuiltinEngines(t *testing.T) {
 
 	if !engineNames["llama-cpp"] {
 		t.Error("expected llama-cpp engine to be registered")
+	}
+
+	if !engineNames["sglang"] {
+		t.Error("expected sglang engine to be registered")
 	}
 
 	// Verify vllm versions have nvidia_gpu image and deploy template
@@ -44,6 +50,57 @@ func TestGetBuiltinEngines(t *testing.T) {
 				} else if _, ok := k8sTemplates["default"]; !ok {
 					t.Errorf("vllm %s missing default kubernetes deploy template", v.Version)
 				}
+			}
+		}
+	}
+
+	// Verify sglang v0.5.10 has nvidia_gpu image, k8s default template, and supported tasks (rerank excluded).
+	for _, e := range engines {
+		if e.Metadata.Name != "sglang" {
+			continue
+		}
+
+		if got, want := len(e.Spec.Versions), 1; got != want {
+			t.Errorf("sglang versions: got %d, want %d", got, want)
+		}
+
+		v := e.Spec.Versions[0]
+		if v.Version != "v0.5.10" {
+			t.Errorf("sglang version: got %q, want %q", v.Version, "v0.5.10")
+		}
+		nvidiaImg, ok := v.Images["nvidia_gpu"]
+		if !ok {
+			t.Errorf("sglang %s missing nvidia_gpu image", v.Version)
+		} else {
+			// Lock the tag scheme so a Makefile bump or builtin.go drift never
+			// silently routes traffic to a stale image.
+			if got, want := nvidiaImg.Tag, v.Version+"-ray2.53.0"; got != want {
+				t.Errorf("sglang %s nvidia_gpu tag mismatch: got %q, want %q", v.Version, got, want)
+			}
+			if got, want := nvidiaImg.ImageName, "neutree/engine-sglang"; got != want {
+				t.Errorf("sglang %s nvidia_gpu image name mismatch: got %q, want %q", v.Version, got, want)
+			}
+		}
+		if _, ok := v.Images["amd_gpu"]; ok {
+			t.Errorf("sglang %s should not register amd_gpu (no AMD test cluster available)", v.Version)
+		}
+		if k8sTemplates, ok := v.DeployTemplate["kubernetes"]; !ok {
+			t.Errorf("sglang %s missing kubernetes deploy template", v.Version)
+		} else if _, ok := k8sTemplates["default"]; !ok {
+			t.Errorf("sglang %s missing default kubernetes deploy template", v.Version)
+		}
+
+		wantTasks := map[string]bool{"text-generation": true, "text-embedding": true}
+		for _, task := range e.Spec.SupportedTasks {
+			delete(wantTasks, task)
+		}
+		if len(wantTasks) != 0 {
+			t.Errorf("sglang missing supported tasks: %v", wantTasks)
+		}
+
+		for _, task := range e.Spec.SupportedTasks {
+			if task == v1.TextRerankModelTask {
+				t.Errorf("sglang must not advertise text-rerank")
 			}
 		}
 	}

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -18,6 +18,9 @@ var vllmV0_17_1EngineSchema []byte
 //go:embed llama-cpp/v0.3.7/schema.json
 var llamaCppV0_3_7EngineSchema []byte
 
+//go:embed sglang/v0.5.10/schema.json
+var sglangV0_5_10EngineSchema []byte
+
 // GetVLLMV0_8_5EngineSchema returns the parsed JSON schema for vLLM V0.8.5 engine
 func GetVLLMV0_8_5EngineSchema() (map[string]interface{}, error) {
 	var schema map[string]interface{}
@@ -57,12 +60,23 @@ func GetLlamaCppDefaultEngineSchema() (map[string]interface{}, error) {
 	return schema, nil
 }
 
+// GetSGLangV0_5_10EngineSchema returns the parsed JSON schema for SGLang V0.5.10 engine
+func GetSGLangV0_5_10EngineSchema() (map[string]interface{}, error) {
+	var schema map[string]interface{}
+	if err := json.Unmarshal(sglangV0_5_10EngineSchema, &schema); err != nil {
+		return nil, fmt.Errorf("failed to parse SGLang v0.5.10 engine schema: %w", err)
+	}
+
+	return schema, nil
+}
+
 // EngineSchemas contains all available engine schemas
 var EngineSchemas = map[string]func() (map[string]interface{}, error){
 	"vllm-v0.8.5":      GetVLLMV0_8_5EngineSchema,
 	"llama-cpp-v0.3.7": GetLlamaCppDefaultEngineSchema,
 	"vllm-v0.11.2":     GetVLLMV0_11_2EngineSchema,
 	"vllm-v0.17.1":     GetVLLMV0_17_1EngineSchema,
+	"sglang-v0.5.10":   GetSGLangV0_5_10EngineSchema,
 }
 
 // GetEngineSchema returns the schema for a specific engine

--- a/internal/engine/schema_test.go
+++ b/internal/engine/schema_test.go
@@ -43,3 +43,32 @@ func TestGetLlamaCppDefaultEngineSchema(t *testing.T) {
 		t.Fatal("expected schema to be non-nil")
 	}
 }
+
+func TestGetSGLangV0_5_10EngineSchema(t *testing.T) {
+	schema, err := GetSGLangV0_5_10EngineSchema()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema == nil {
+		t.Fatal("expected schema to be non-nil")
+	}
+
+	// Spot-check a handful of fields documented in the design doc to catch
+	// schema drift early. Field names use underscore form (matches
+	// ServerArgs Python kwargs verbatim — SSH/Ray path); the K8s deploy
+	// template applies sprig replace "_" "-" at render time so SGLang's
+	// kebab-only argparse on the CLI side gets the right flag names.
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("schema.properties missing or wrong type")
+	}
+	for _, key := range []string{
+		"tp_size", "mem_fraction_static", "dtype", "is_embedding",
+		"attention_backend", "cuda_graph_max_bs", "preferred_sampling_params",
+		"json_model_override_args", "tool_call_parser", "served_model_name",
+	} {
+		if _, ok := props[key].(map[string]interface{}); !ok {
+			t.Errorf("schema missing required property %q", key)
+		}
+	}
+}

--- a/internal/engine/sglang/v0.5.10/schema.json
+++ b/internal/engine/sglang/v0.5.10/schema.json
@@ -1,0 +1,1975 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "SGLang v0.5.10 Engine Configuration",
+  "description": "Schema for SGLang v0.5.10 engine_args. JSON keys are ServerArgs dataclass field names \u2014 these match the Python kwargs the SSH/Ray static-cluster path forwards to ServerArgs verbatim. The K8s deploy template applies sprig replace \"_\" \"-\" so the same dict drives kebab-case CLI flags (SGLang's argparse registers either the dataclass-aligned alias such as --tp-size or the dest-form long option such as --tensor-parallel-size; the underscore\u2192dash render reaches the alias either way).",
+  "properties": {
+    "abort_on_priority_when_disabled": {
+      "description": "If set, abort requests that specify a priority when priority scheduling is disabled.",
+      "type": "boolean",
+      "default": false
+    },
+    "admin_api_key": {
+      "description": "Set admin API key for sensitive management endpoints (e.g. /clear_hicache_storage_backend). When set, admin endpoints require this key and do NOT accept --api-key.",
+      "type": "string"
+    },
+    "allow_auto_truncate": {
+      "description": "Allow automatically truncating requests that exceed the maximum input length instead of returning an error.",
+      "type": "boolean",
+      "default": false
+    },
+    "api_key": {
+      "description": "Set API key of the server. It is also used in the OpenAI API compatible server.",
+      "type": "string"
+    },
+    "attention_backend": {
+      "description": "Choose the kernels for attention layers.",
+      "type": "string",
+      "enum": [
+        "aiter",
+        "ascend",
+        "cutlass_mla",
+        "dual_chunk_flash_attn",
+        "fa3",
+        "fa4",
+        "flashinfer",
+        "flashmla",
+        "flex_attention",
+        "intel_amx",
+        "intel_xpu",
+        "nsa",
+        "torch_native",
+        "triton",
+        "trtllm_mha",
+        "trtllm_mla",
+        "wave"
+      ]
+    },
+    "attn_cp_size": {
+      "description": "The attention context parallelism size.",
+      "type": "integer",
+      "default": 1
+    },
+    "base_gpu_id": {
+      "description": "The base GPU ID to start allocating GPUs from. Useful when running multiple instances on the same machine.",
+      "type": "integer",
+      "default": 0
+    },
+    "chat_template": {
+      "description": "The buliltin chat template name or the path of the chat template file. This is only used for OpenAI-compatible API server.",
+      "type": "string"
+    },
+    "checkpoint_engine_wait_weights_before_ready": {
+      "description": "If set, the server will wait for initial weights to be loaded via checkpoint-engine or other update methods before serving inference requests.",
+      "type": "boolean",
+      "default": false
+    },
+    "chunked_prefill_size": {
+      "description": "The maximum number of tokens in a chunk for the chunked prefill. Setting this to -1 means disabling chunked prefill.",
+      "type": "integer"
+    },
+    "collect_tokens_histogram": {
+      "description": "Collect prompt/generation tokens histogram.",
+      "type": "boolean",
+      "default": false
+    },
+    "completion_template": {
+      "description": "The buliltin completion template name or the path of the completion template file. This is only used for OpenAI-compatible API server. only for code completion currently.",
+      "type": "string"
+    },
+    "constrained_json_disable_any_whitespace": {
+      "description": "(xgrammar and llguidance backends only) Enforce compact representation in JSON constrained output.",
+      "type": "boolean",
+      "default": false
+    },
+    "constrained_json_whitespace_pattern": {
+      "description": "(outlines and llguidance backends only) Regex pattern for syntactic whitespaces allowed in JSON constrained output. For example, to allow the model generate consecutive whitespaces, set the pattern to [ ]*",
+      "type": "string"
+    },
+    "context_length": {
+      "description": "The model's maximum context length. Defaults to None (will use the value from the model's config.json instead). Supports standard SI suffixes (k, M, G, T) and IEC suffixes (Ki, Mi, Gi, Ti). Suffixes are case-sensitive. Decimals are allowed for SI suffixes only. Examples: '1k' -> 1000 '1M' -> 1000000 '25.6k' -> 25600 '1Ki' -> 1024 '1Mi' -> 1048576",
+      "type": "integer"
+    },
+    "cpu_offload_gb": {
+      "description": "How many GBs of RAM to reserve for CPU offloading.",
+      "type": "integer",
+      "default": 0
+    },
+    "crash_dump_folder": {
+      "description": "Folder path to dump requests from the last 5 min before a crash (if any). If not specified, crash dumping is disabled.",
+      "type": "string"
+    },
+    "cuda_graph_max_bs": {
+      "description": "Set the maximum batch size for cuda graph. It will extend the cuda graph capture batch size to this value.",
+      "type": "integer"
+    },
+    "custom_sigquit_handler": {
+      "description": "Register a custom sigquit handler so you can do additional cleanup after the server is shutdown. This is only available for Engine, not for CLI.",
+      "type": "string"
+    },
+    "debug_tensor_dump_inject": {
+      "description": "Inject the outputs from jax as the input of every layer.",
+      "type": "boolean",
+      "default": false
+    },
+    "debug_tensor_dump_input_file": {
+      "description": "The input filename for dumping tensors",
+      "type": "string"
+    },
+    "debug_tensor_dump_output_folder": {
+      "description": "The output folder for dumping tensors.",
+      "type": "string"
+    },
+    "decode_attention_backend": {
+      "description": "Choose the kernels for decode attention layers (have priority over --attention-backend).",
+      "type": "string",
+      "enum": [
+        "aiter",
+        "ascend",
+        "cutlass_mla",
+        "dual_chunk_flash_attn",
+        "fa3",
+        "fa4",
+        "flashinfer",
+        "flashmla",
+        "flex_attention",
+        "intel_amx",
+        "intel_xpu",
+        "nsa",
+        "torch_native",
+        "triton",
+        "trtllm_mha",
+        "trtllm_mla",
+        "wave"
+      ]
+    },
+    "decode_log_interval": {
+      "description": "The log and metrics reporting interval (in decode iterations) for decode batches.",
+      "type": "integer",
+      "default": 40
+    },
+    "decrypted_config_file": {
+      "description": "The path of the decrypted config file.",
+      "type": "string"
+    },
+    "decrypted_draft_config_file": {
+      "description": "The path of the decrypted draft config file.",
+      "type": "string"
+    },
+    "deepep_config": {
+      "description": "Tuned DeepEP config suitable for your own cluster. It can be either a string with JSON content or a file path.",
+      "type": "string"
+    },
+    "deepep_mode": {
+      "description": "Select the mode when enable DeepEP MoE, could be `normal`, `low_latency` or `auto`. Default is `auto`, which means `low_latency` for decode batch and `normal` for prefill batch.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "low_latency",
+        "normal"
+      ],
+      "default": "auto"
+    },
+    "default_priority_value": {
+      "description": "Default priority for requests without explicit priority.",
+      "type": "integer"
+    },
+    "delete_ckpt_after_loading": {
+      "description": "Delete the model checkpoint after loading the model.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_chunked_prefix_cache": {
+      "description": "Disable chunked prefix cache feature for deepseek, which should save overhead for short sequences.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_cuda_graph": {
+      "description": "Disable cuda graph.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_cuda_graph_padding": {
+      "description": "Disable cuda graph when padding is needed. Still uses cuda graph when padding is not needed.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_custom_all_reduce": {
+      "description": "Disable the custom all-reduce kernel and fall back to NCCL.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_fast_image_processor": {
+      "description": "Adopt base image processor instead of fast image processor.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_flashinfer_autotune": {
+      "description": "Disable FlashInfer autotuning.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_flashinfer_cutlass_moe_fp4_allgather": {
+      "description": "Disables quantize before all-gather for flashinfer cutlass moe.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_hybrid_swa_memory": {
+      "description": "Disable the hybrid SWA memory pool.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_outlines_disk_cache": {
+      "description": "Disable disk cache of outlines to avoid possible crashes related to file system or high concurrency.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_overlap_schedule": {
+      "description": "Disable the overlap scheduler, which overlaps the CPU scheduler with GPU model worker.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_piecewise_cuda_graph": {
+      "description": "Disable piecewise cuda graph for extend/prefill.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_priority_preemption": {
+      "description": "Disable priority scheduling preemption.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_radix_cache": {
+      "description": "Disable RadixAttention for prefix caching.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_shared_experts_fusion": {
+      "description": "Disable shared experts fusion optimization for deepseek v3/r1.",
+      "type": "boolean",
+      "default": false
+    },
+    "disable_tokenizer_batch_decode": {
+      "description": "Disable batch decoding when decoding multiple completions.",
+      "type": "boolean",
+      "default": false
+    },
+    "disaggregation_bootstrap_port": {
+      "description": "Bootstrap server port on the prefill server. Default is 8998.",
+      "type": "integer",
+      "default": 8998
+    },
+    "disaggregation_decode_enable_offload_kvcache": {
+      "description": "Enable async KV cache offloading on decode server (PD mode).",
+      "type": "boolean",
+      "default": false
+    },
+    "disaggregation_decode_polling_interval": {
+      "description": "The interval to poll requests in decode server. Can be set to >1 to reduce the overhead of this.",
+      "type": "integer",
+      "default": 1
+    },
+    "disaggregation_ib_device": {
+      "description": "The InfiniBand devices for disaggregation transfer, accepts single device (e.g., --disaggregation-ib-device mlx5_0) or multiple comma-separated devices (e.g., --disaggregation-ib-device mlx5_0,mlx5_1). Default is None, which triggers automatic device detection when mooncake backend is enabled.",
+      "type": "string"
+    },
+    "disaggregation_mode": {
+      "description": "Only used for PD disaggregation. \"prefill\" for prefill-only server, and \"decode\" for decode-only server. If not specified, it is not PD disaggregated",
+      "type": "string",
+      "enum": [
+        "decode",
+        "null",
+        "prefill"
+      ],
+      "default": "null"
+    },
+    "disaggregation_transfer_backend": {
+      "description": "The backend for disaggregation transfer. Default is mooncake.",
+      "type": "string",
+      "enum": [
+        "ascend",
+        "fake",
+        "mooncake",
+        "mori",
+        "nixl"
+      ],
+      "default": "mooncake"
+    },
+    "dist_timeout": {
+      "description": "Set timeout for torch.distributed initialization.",
+      "type": "integer"
+    },
+    "dllm_algorithm": {
+      "description": "The diffusion LLM algorithm, such as LowConfidence.",
+      "type": "string"
+    },
+    "dllm_algorithm_config": {
+      "description": "The diffusion LLM algorithm configurations. Must be a YAML file.",
+      "type": "string"
+    },
+    "download_dir": {
+      "description": "Model download directory for huggingface.",
+      "type": "string"
+    },
+    "dp_size": {
+      "description": "The data parallelism size.",
+      "type": "integer",
+      "default": 1
+    },
+    "ds_channel_config_path": {
+      "description": "The path of the double sparsity channel config",
+      "type": "string"
+    },
+    "ds_heavy_channel_num": {
+      "description": "The number of heavy channels in double sparsity attention",
+      "type": "integer",
+      "default": 32
+    },
+    "ds_heavy_channel_type": {
+      "description": "The type of heavy channels in double sparsity attention",
+      "type": "string",
+      "default": "qk"
+    },
+    "ds_heavy_token_num": {
+      "description": "The number of heavy tokens in double sparsity attention",
+      "type": "integer",
+      "default": 256
+    },
+    "ds_sparse_decode_threshold": {
+      "description": "The minimum decode sequence length required before the double-sparsity backend switches from the dense fallback to the sparse decode kernel.",
+      "type": "integer",
+      "default": 4096
+    },
+    "dtype": {
+      "description": "Data type for model weights and activations. * \"auto\" will use FP16 precision for FP32 and FP16 models, and BF16 precision for BF16 models. * \"half\" for FP16. Recommended for AWQ quantization. * \"float16\" is the same as \"half\". * \"bfloat16\" for a balance between precision and range. * \"float\" is shorthand for FP32 precision. * \"float32\" for FP32 precision.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "bfloat16",
+        "float",
+        "float16",
+        "float32",
+        "half"
+      ],
+      "default": "auto"
+    },
+    "dynamic_batch_tokenizer_batch_size": {
+      "description": "[Only used if --enable-dynamic-batch-tokenizer is set] Maximum batch size for dynamic batch tokenizer.",
+      "type": "integer",
+      "default": 32
+    },
+    "dynamic_batch_tokenizer_batch_timeout": {
+      "description": "[Only used if --enable-dynamic-batch-tokenizer is set] Timeout in seconds for batching tokenization requests.",
+      "type": "number",
+      "default": 0.002
+    },
+    "elastic_ep_backend": {
+      "description": "Specify the collective communication backend for elastic EP. Supports 'mooncake' and 'nixl'.",
+      "type": "string",
+      "enum": [
+        "mooncake",
+        "nixl",
+        "none"
+      ]
+    },
+    "enable_adaptive_dispatch_to_encoder": {
+      "description": "When enabled, adaptively dispatch: multi-image requests go to encoder in language_only epd mode, single-image requests are processed locally.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_aiter_allreduce_fusion": {
+      "description": "Enable Aiter AllReduce Fusion.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_attn_tp_input_scattered": {
+      "description": "Allow input of attention to be scattered when only using tensor parallelism, to reduce the computational load of operations such as qkv latent.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_broadcast_mm_inputs_process": {
+      "description": "Enable broadcast mm-inputs process in scheduler.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_cache_report": {
+      "description": "Return number of cached tokens in usage.prompt_tokens_details for each openai request.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_cudagraph_gc": {
+      "description": "Enable garbage collection during CUDA graph capture. If disabled (default), GC is frozen during capture to speed up the process.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_custom_logit_processor": {
+      "description": "Enable users to pass custom logit processors to the server (disabled by default for security)",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_deterministic_inference": {
+      "description": "Enable deterministic inference mode with batch invariant ops.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_double_sparsity": {
+      "description": "Enable double sparsity attention",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_dp_attention": {
+      "description": "Enabling data parallelism for attention and tensor parallelism for FFN. The dp size should be equal to the tp size. Currently DeepSeek-V2 and Qwen 2/3 MoE models are supported.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_dp_lm_head": {
+      "description": "Enable vocabulary parallel across the attention TP group to avoid all-gather across DP groups, optimizing performance under DP attention.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_draft_weights_cpu_backup": {
+      "description": "Save draft model weights to CPU memory during release_weights_occupation and resume_weights_occupation",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_dynamic_batch_tokenizer": {
+      "description": "Enable async dynamic batch tokenizer for improved performance when multiple requests arrive concurrently.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_dynamic_chunking": {
+      "description": "Enable dynamic chunk size adjustment for pipeline parallelism. When enabled, chunk sizes are dynamically calculated based on fitted function to maintain consistent execution time across chunks.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_elastic_expert_backup": {
+      "description": "Enable elastic expert backup feature.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_eplb": {
+      "description": "Enable EPLB algorithm",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_expert_distribution_metrics": {
+      "description": "Enable logging metrics for expert balancedness",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_flashinfer_allreduce_fusion": {
+      "description": "Enable FlashInfer allreduce fusion with Residual RMSNorm.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_fp32_lm_head": {
+      "description": "If set, the LM head outputs (logits) are in FP32.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_fused_moe_sum_all_reduce": {
+      "description": "Enable fused moe triton and sum all reduce.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_fused_qk_norm_rope": {
+      "description": "Enable fused qk normalization and rope rotary embedding.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_hierarchical_cache": {
+      "description": "Enable hierarchical cache",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_hisparse": {
+      "description": "Enable hierarchical sparse attention",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_layerwise_nvtx_marker": {
+      "description": "Enable layerwise NVTX profiling annotations for the model.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_lmcache": {
+      "description": "Using LMCache as an alternative hierarchical cache solution",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_lora": {
+      "description": "Enable LoRA support for the model. This argument is automatically set to True if `--lora-paths` is provided for backward compatibility.",
+      "type": "boolean"
+    },
+    "enable_lora_overlap_loading": {
+      "description": "Enable asynchronous LoRA weight loading in order to overlap H2D transfers with GPU compute. This should be enabled if you find that your LoRA workloads are bottlenecked by adapter weight loading, for example when frequently loading large LoRA adapters.",
+      "type": "boolean"
+    },
+    "enable_memory_saver": {
+      "description": "Allow saving memory using release_memory_occupation and resume_memory_occupation",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_metrics": {
+      "description": "Enable log prometheus metrics.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_metrics_for_all_schedulers": {
+      "description": "Enable --enable-metrics-for-all-schedulers when you want schedulers on all TP ranks (not just TP 0) to record request metrics separately. This is especially useful when dp_attention is enabled, as otherwise all metrics appear to come from TP 0.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_mfu_metrics": {
+      "description": "Enable estimated MFU-related prometheus metrics.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_mixed_chunk": {
+      "description": "Enabling mixing prefill and decode in a batch when using chunked prefill.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_mm_global_cache": {
+      "description": "Enable global multimodal embedding cache to skip redundant ViT inference.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_mscclpp": {
+      "description": "Enable using mscclpp for small messages for all-reduce kernel and fall back to NCCL.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_multi_layer_eagle": {
+      "description": "Enable multi-layer Eagle speculative decoding.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_multimodal": {
+      "description": "Enable the multimodal functionality for the served model. If the model being served is not multimodal, nothing will happen",
+      "type": "boolean"
+    },
+    "enable_nan_detection": {
+      "description": "[Deprecated] Use SGLANG_SPEC_NAN_DETECTION=1 and SGLANG_SPEC_OOB_DETECTION=1 instead.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_nccl_nvls": {
+      "description": "Enable NCCL NVLS for prefill heavy requests when available.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_nsa_prefill_context_parallel": {
+      "description": "Enable context parallelism used in the long sequence prefill phase of DeepSeek v3.2.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_p2p_check": {
+      "description": "Enable P2P check for GPU access, otherwise the p2p access is allowed by default.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_pdmux": {
+      "description": "Enable PD-Multiplexing, PD running on greenctx stream.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_precise_embedding_interpolation": {
+      "description": "Enable corner alignment for resize of embeddings grid to ensure more accurate(but slower) evaluation of interpolated embedding values.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_prefill_context_parallel": {
+      "description": "Enable context parallelism used in the prefill phase",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_prefill_delayer": {
+      "description": "Enable prefill delayer for DP attention to reduce idle time.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_prefix_mm_cache": {
+      "description": "Enable prefix multimodal cache. Currently only supports mm-only.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_priority_scheduling": {
+      "description": "Enable priority scheduling. Requests with higher priority integer values will be scheduled first by default.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_profile_cuda_graph": {
+      "description": "Enable profiling of cuda graph capture.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_request_time_stats_logging": {
+      "description": "Enable per request time stats logging",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_return_hidden_states": {
+      "description": "Enable returning hidden states with responses.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_return_routed_experts": {
+      "description": "Enable returning routed experts of each layer with responses.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_single_batch_overlap": {
+      "description": "Let computation and communication overlap within one micro batch.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_ssl_refresh": {
+      "description": "Enable automatic SSL certificate hot-reloading when cert/key files change on disk. Requires --ssl-certfile and --ssl-keyfile.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_streaming_session": {
+      "description": "Enable streaming session mode and SessionAwareCache wrapper.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_symm_mem": {
+      "description": "Enable NCCL symmetric memory for fast collectives.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_tokenizer_batch_encode": {
+      "description": "Enable batch tokenization for improved performance when processing multiple text inputs. Do not use with image inputs, pre-tokenized input_ids, or input_embeds.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_torch_compile": {
+      "description": "Optimize the model with torch.compile. Experimental feature.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_torch_compile_debug_mode": {
+      "description": "Enable debug mode for torch compile",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_torch_symm_mem": {
+      "description": "Enable using torch symm mem for all-reduce kernel and fall back to NCCL. Only supports CUDA device SM90 and above. SM90 supports world size 4, 6, 8. SM100 supports world size 6, 8.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_trace": {
+      "description": "Enable opentelemetry trace",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_two_batch_overlap": {
+      "description": "Enabling two micro batches to overlap.",
+      "type": "boolean",
+      "default": false
+    },
+    "enable_weights_cpu_backup": {
+      "description": "Save model weights (both main model and draft model, if any) to CPU memory during release_weights_occupation and resume_weights_occupation",
+      "type": "boolean",
+      "default": false
+    },
+    "encoder_only": {
+      "description": "For MLLM with an encoder, launch an encoder-only server",
+      "type": "boolean",
+      "default": false
+    },
+    "encoder_transfer_backend": {
+      "description": "The backend for encoder disaggregation transfer. Default is zmq_to_scheduler.",
+      "type": "string",
+      "enum": [
+        "mooncake",
+        "zmq_to_scheduler",
+        "zmq_to_tokenizer"
+      ],
+      "default": "zmq_to_scheduler"
+    },
+    "enforce_disable_flashinfer_allreduce_fusion": {
+      "description": "Enforce disable FlashInfer allreduce fusion.",
+      "type": "boolean",
+      "default": false
+    },
+    "enforce_piecewise_cuda_graph": {
+      "description": "Enforce piecewise cuda graph, skipping all auto-disable conditions. Used for testing.",
+      "type": "boolean",
+      "default": false
+    },
+    "engine_info_bootstrap_port": {
+      "description": "Port for the engine info bootstrap server. Default is 6789. Must be set explicitly when running multiple instances on the same node.",
+      "type": "integer",
+      "default": 6789
+    },
+    "ep_dispatch_algorithm": {
+      "description": "The algorithm to choose ranks for redundant experts in expert parallel.",
+      "type": "string"
+    },
+    "ep_num_redundant_experts": {
+      "description": "Allocate this number of redundant experts in expert parallel.",
+      "type": "integer",
+      "default": 0
+    },
+    "ep_size": {
+      "description": "The expert parallelism size.",
+      "type": "integer",
+      "default": 1
+    },
+    "eplb_algorithm": {
+      "description": "Chosen EPLB algorithm",
+      "type": "string",
+      "default": "auto"
+    },
+    "eplb_min_rebalancing_utilization_threshold": {
+      "description": "Minimum threshold for GPU average utilization to trigger EPLB rebalancing. Must be in the range [0.0, 1.0].",
+      "type": "number",
+      "default": 1.0
+    },
+    "eplb_rebalance_layers_per_chunk": {
+      "description": "Number of layers to rebalance per forward pass.",
+      "type": "integer"
+    },
+    "eplb_rebalance_num_iterations": {
+      "description": "Number of iterations to automatically trigger a EPLB re-balance.",
+      "type": "integer",
+      "default": 1000
+    },
+    "expert_distribution_recorder_buffer_size": {
+      "description": "Circular buffer size of expert distribution recorder. Set to -1 to denote infinite buffer.",
+      "type": "integer"
+    },
+    "expert_distribution_recorder_mode": {
+      "description": "Mode of expert distribution recorder.",
+      "type": "string"
+    },
+    "experts_shared_outer_loras": {
+      "description": "Force shared outer LoRA mode for MoE models. When set, w1/w3 lora_A and w2 lora_B are shared across experts (expert_dim=1). Use --no-experts-shared-outer-loras to force disable. By default this is auto-detected from adapter weights.",
+      "type": "boolean"
+    },
+    "export_metrics_to_file": {
+      "description": "Export performance metrics for each request to local file (e.g. for forwarding to external systems).",
+      "type": "boolean",
+      "default": false
+    },
+    "export_metrics_to_file_dir": {
+      "description": "Directory path for writing performance metrics files (required when --export-metrics-to-file is enabled).",
+      "type": "string"
+    },
+    "extra_metric_labels": {
+      "description": "The custom labels for metrics. e.g. '{\"label1\": \"value1\", \"label2\": \"value2\"}'",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "fastapi_root_path": {
+      "description": "App is behind a path based routing proxy.",
+      "type": "string",
+      "default": ""
+    },
+    "file_storage_path": {
+      "description": "The path of the file storage in backend.",
+      "type": "string",
+      "default": "sglang_storage"
+    },
+    "flashinfer_mla_disable_ragged": {
+      "description": "Not using ragged prefill wrapper when running flashinfer mla",
+      "type": "boolean",
+      "default": false
+    },
+    "flashinfer_mxfp4_moe_precision": {
+      "description": "Choose the computation precision of flashinfer mxfp4 moe",
+      "type": "string",
+      "enum": [
+        "bf16",
+        "default"
+      ],
+      "default": "default"
+    },
+    "forward_hooks": {
+      "description": "JSON-formatted forward hook specifications to attach to the model.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "fp4_gemm_runner_backend": {
+      "description": "Choose the runner backend for NVFP4 GEMM operations. Options: 'auto' (default; selects flashinfer_cudnn on SM120, flashinfer_cutlass otherwise), 'cutlass' (SGLang CUTLASS kernel), 'flashinfer_cutlass' (FlashInfer CUTLASS backend), 'flashinfer_cudnn' (FlashInfer cuDNN backend, optimal on CUDA 13+ with cuDNN 9.15+), 'flashinfer_trtllm' (FlashInfer TensorRT-LLM backend, requires different weight preparation with shuffling).",
+      "type": "string",
+      "enum": [
+        "auto",
+        "cutlass",
+        "flashinfer_cudnn",
+        "flashinfer_cutlass",
+        "flashinfer_trtllm"
+      ],
+      "default": "auto"
+    },
+    "fp8_gemm_runner_backend": {
+      "description": "Choose the runner backend for Blockwise FP8 GEMM operations. Options: 'auto' (default, auto-selects based on hardware), 'deep_gemm' (JIT-compiled; enabled by default on NVIDIA Hopper (SM90) and Blackwell (SM100) when DeepGEMM is installed), 'flashinfer_trtllm' (optimal for Blackwell and low-latency), 'flashinfer_cutlass' (FlashInfer CUTLASS groupwise FP8 GEMM), 'flashinfer_deepgemm' (Hopper SM90 only; uses swapAB optimization for small M dimensions in decoding), 'cutlass' (optimal for Hopper/Blackwell GPUs and high-throughput), 'triton' (fallback, widely compatible), 'aiter' (ROCm only).",
+      "type": "string",
+      "enum": [
+        "aiter",
+        "auto",
+        "cutlass",
+        "deep_gemm",
+        "flashinfer_cutlass",
+        "flashinfer_deepgemm",
+        "flashinfer_trtllm",
+        "triton"
+      ],
+      "default": "auto"
+    },
+    "gc_warning_threshold_secs": {
+      "description": "The threshold for long GC warning. If a GC takes longer than this, a warning will be logged. Set to 0 to disable.",
+      "type": "number",
+      "default": 0.0
+    },
+    "gpu_id_step": {
+      "description": "The delta between consecutive GPU IDs that are used. For example, setting it to 2 will use GPU 0,2,4,...",
+      "type": "integer",
+      "default": 1
+    },
+    "grammar_backend": {
+      "description": "Choose the backend for grammar-guided decoding.",
+      "type": "string",
+      "enum": [
+        "llguidance",
+        "none",
+        "outlines",
+        "xgrammar"
+      ]
+    },
+    "grpc_mode": {
+      "description": "If set, use gRPC server instead of HTTP server.",
+      "type": "boolean",
+      "default": false
+    },
+    "hf_chat_template_name": {
+      "description": "When the HuggingFace tokenizer has multiple chat templates (e.g., 'default', 'tool_use', 'rag'), specify which named template to use. If not set, the first available template is used.",
+      "type": "string"
+    },
+    "hicache_io_backend": {
+      "description": "The IO backend for KV cache transfer between CPU and GPU",
+      "type": "string",
+      "enum": [
+        "direct",
+        "kernel",
+        "kernel_ascend"
+      ],
+      "default": "kernel"
+    },
+    "hicache_mem_layout": {
+      "description": "The layout of host memory pool for hierarchical cache.",
+      "type": "string",
+      "enum": [
+        "layer_first",
+        "page_first",
+        "page_first_direct",
+        "page_first_kv_split",
+        "page_head"
+      ],
+      "default": "layer_first"
+    },
+    "hicache_ratio": {
+      "description": "The ratio of the size of host KV cache memory pool to the size of device pool.",
+      "type": "number",
+      "default": 2.0
+    },
+    "hicache_size": {
+      "description": "The size of host KV cache memory pool in gigabytes, which will override the hicache_ratio if set.",
+      "type": "integer",
+      "default": 0
+    },
+    "hicache_storage_backend": {
+      "description": "The storage backend for hierarchical KV cache. Built-in backends: file, mooncake, hf3fs, nixl, aibrix. For dynamic backend, use --hicache-storage-backend-extra-config to specify: backend_name (custom name), module_path (Python module path), class_name (backend class name).",
+      "type": "string",
+      "enum": [
+        "aibrix",
+        "dynamic",
+        "eic",
+        "file",
+        "hf3fs",
+        "mooncake",
+        "nixl"
+      ]
+    },
+    "hicache_storage_backend_extra_config": {
+      "description": "A dictionary in JSON string format, or a string starting with a leading '@' and a config file in JSON/YAML/TOML format, containing extra configuration for the storage backend.",
+      "type": "string"
+    },
+    "hicache_storage_prefetch_policy": {
+      "description": "Control when prefetching from the storage backend should stop.",
+      "type": "string",
+      "enum": [
+        "best_effort",
+        "timeout",
+        "wait_complete"
+      ],
+      "default": "best_effort"
+    },
+    "hicache_write_policy": {
+      "description": "The write policy of hierarchical cache.",
+      "type": "string",
+      "enum": [
+        "write_back",
+        "write_through",
+        "write_through_selective"
+      ],
+      "default": "write_through"
+    },
+    "hisparse_config": {
+      "description": "A dictionary in JSON string format for hierarchical sparse attention configuration. Example: '{\"top_k\": 2048, \"device_buffer_size\": 4096}'",
+      "type": "string"
+    },
+    "incremental_streaming_output": {
+      "description": "[Deprecated] Use --incremental-streaming-output instead.",
+      "type": "boolean",
+      "default": false
+    },
+    "init_expert_location": {
+      "description": "Initial location of EP experts.",
+      "type": "string",
+      "default": "trivial"
+    },
+    "is_embedding": {
+      "description": "Whether to use a CausalLM as an embedding model.",
+      "type": "boolean",
+      "default": false
+    },
+    "json_model_override_args": {
+      "description": "A dictionary in JSON string format used to override default model configurations.",
+      "type": "string",
+      "default": "{}"
+    },
+    "keep_mm_feature_on_device": {
+      "description": "Keep multimodal feature tensors on device after processing to save D2H copy.",
+      "type": "boolean",
+      "default": false
+    },
+    "kt_cpuinfer": {
+      "description": "[ktransformers parameter] The number of CPUInfer threads.",
+      "type": "integer"
+    },
+    "kt_max_deferred_experts_per_token": {
+      "description": "[ktransformers parameter] Maximum number of experts deferred to CPU per token. All MoE layers except the final one use this value; the final layer always uses 0.",
+      "type": "integer"
+    },
+    "kt_method": {
+      "description": "[ktransformers parameter] Quantization formats for CPU execution.",
+      "type": "string"
+    },
+    "kt_num_gpu_experts": {
+      "description": "[ktransformers parameter] The number of GPU experts.",
+      "type": "integer"
+    },
+    "kt_threadpool_count": {
+      "description": "[ktransformers parameter] One-to-one with the number of NUMA nodes (one thread pool per NUMA).",
+      "type": "integer"
+    },
+    "kt_weight_path": {
+      "description": "[ktransformers parameter] The path of the quantized expert weights for amx kernel. A local folder.",
+      "type": "string"
+    },
+    "kv_cache_dtype": {
+      "description": "Data type for kv cache storage. \"auto\" will use model data type. \"bf16\" or \"bfloat16\" for BF16 KV cache. \"fp8_e5m2\" and \"fp8_e4m3\" are supported for CUDA 11.8+. \"fp4_e2m1\" (only mxfp4) is supported for CUDA 12.8+ and PyTorch 2.8.0+",
+      "type": "string",
+      "enum": [
+        "auto",
+        "bf16",
+        "bfloat16",
+        "fp4_e2m1",
+        "fp8_e4m3",
+        "fp8_e5m2"
+      ],
+      "default": "auto"
+    },
+    "kv_events_config": {
+      "description": "Config in json format for NVIDIA dynamo KV event publishing. Publishing will be enabled if this flag is used.",
+      "type": "string"
+    },
+    "language_only": {
+      "description": "For VLM, load weights for the language model only.",
+      "type": "boolean",
+      "default": false
+    },
+    "limit_mm_data_per_request": {
+      "description": "Limit the number of multimodal inputs per request. e.g. '{\"image\": 1, \"video\": 1, \"audio\": 1}'",
+      "type": "string"
+    },
+    "linear_attn_backend": {
+      "description": "The default kernel backend for linear attention (GDN/KDA). Can be overridden per-mode by --linear-attn-decode-backend and --linear-attn-prefill-backend.",
+      "type": "string",
+      "enum": [
+        "cutedsl",
+        "flashinfer",
+        "triton"
+      ],
+      "default": "triton"
+    },
+    "linear_attn_decode_backend": {
+      "description": "Override the kernel backend for linear attention decode. If not set, uses --linear-attn-backend.",
+      "type": "string",
+      "enum": [
+        "cutedsl",
+        "flashinfer",
+        "triton"
+      ]
+    },
+    "linear_attn_prefill_backend": {
+      "description": "Override the kernel backend for linear attention prefill/extend. If not set, uses --linear-attn-backend.",
+      "type": "string",
+      "enum": [
+        "cutedsl",
+        "flashinfer",
+        "triton"
+      ]
+    },
+    "load_balance_method": {
+      "description": "The load balancing strategy for data parallelism.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "follow_bootstrap_room",
+        "round_robin",
+        "total_requests",
+        "total_tokens"
+      ],
+      "default": "auto"
+    },
+    "load_format": {
+      "description": "The format of the model weights to load. \"auto\" will try to load the weights in the safetensors format and fall back to the pytorch bin format if safetensors format is not available. \"pt\" will load the weights in the pytorch bin format. \"safetensors\" will load the weights in the safetensors format. \"npcache\" will load the weights in pytorch format and store a numpy cache to speed up the loading. \"dummy\" will initialize the weights with random values, which is mainly for profiling.\"gguf\" will load the weights in the gguf format. \"bitsandbytes\" will load the weights using bitsandbytes quantization.\"layered\" loads weights layer by layer so that one can quantize a layer before loading another to make the peak memory envelope smaller.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "bitsandbytes",
+        "dummy",
+        "fastsafetensors",
+        "flash_rl",
+        "gguf",
+        "layered",
+        "mistral",
+        "npcache",
+        "private",
+        "pt",
+        "remote",
+        "remote_instance",
+        "runai_streamer",
+        "safetensors",
+        "sharded_state"
+      ],
+      "default": "auto"
+    },
+    "log_requests": {
+      "description": "Log metadata, inputs, outputs of all requests. The verbosity is decided by --log-requests-level",
+      "type": "boolean",
+      "default": false
+    },
+    "log_requests_format": {
+      "description": "Format for request logging: 'text' (human-readable) or 'json' (structured)",
+      "type": "string",
+      "enum": [
+        "json",
+        "text"
+      ],
+      "default": "text"
+    },
+    "log_requests_level": {
+      "description": "0: Log metadata (no sampling parameters). 1: Log metadata and sampling parameters. 2: Log metadata, sampling parameters and partial input/output. 3: Log every input/output.",
+      "type": "string",
+      "enum": [
+        "0",
+        "1",
+        "2",
+        "3"
+      ],
+      "default": 2
+    },
+    "lora_backend": {
+      "description": "Choose the kernel backend for multi-LoRA serving.",
+      "type": "string",
+      "enum": [
+        "ascend",
+        "csgmv",
+        "torch_native",
+        "triton"
+      ],
+      "default": "csgmv"
+    },
+    "lora_eviction_policy": {
+      "description": "LoRA adapter eviction policy when memory pool is full. 'lru': Least Recently Used (default, better cache efficiency). 'fifo': First-In-First-Out.",
+      "type": "string",
+      "enum": [
+        "fifo",
+        "lru"
+      ],
+      "default": "lru"
+    },
+    "mamba_backend": {
+      "description": "Choose the kernel backend for Mamba SSM operations. Default is 'triton'. Options: 'triton' (default), 'flashinfer' (requires FlashInfer with Mamba support).",
+      "type": "string",
+      "enum": [
+        "flashinfer",
+        "triton"
+      ],
+      "default": "triton"
+    },
+    "mamba_full_memory_ratio": {
+      "description": "The ratio of mamba state memory to full kv cache memory.",
+      "type": "number",
+      "default": 0.9
+    },
+    "mamba_scheduler_strategy": {
+      "description": "The strategy to use for mamba radix cache.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "extra_buffer",
+        "no_buffer"
+      ],
+      "default": "auto"
+    },
+    "mamba_ssm_dtype": {
+      "description": "The data type of the SSM states in mamba cache. If not set, will be read from model config (mamba_ssm_dtype).",
+      "type": "string",
+      "enum": [
+        "bfloat16",
+        "float16",
+        "float32"
+      ]
+    },
+    "mamba_track_interval": {
+      "description": "The interval to track the mamba state during decode.",
+      "type": "integer",
+      "default": 256
+    },
+    "max_loaded_loras": {
+      "description": "If specified, it limits the maximum number of LoRA adapters loaded in CPU memory at a time. The value must be greater than or equal to `--max-loras-per-batch`.",
+      "type": "integer"
+    },
+    "max_lora_chunk_size": {
+      "description": "Maximum chunk size for the ChunkedSGMV LoRA backend. Only used when --lora-backend is 'csgmv'. Choosing a larger value might improve performance.",
+      "type": "string",
+      "enum": [
+        "128",
+        "16",
+        "32",
+        "64"
+      ],
+      "default": 16
+    },
+    "max_lora_rank": {
+      "description": "The maximum rank of LoRA adapters. If not specified, it will be automatically inferred from the adapters provided in --lora-paths.",
+      "type": "integer"
+    },
+    "max_loras_per_batch": {
+      "description": "Maximum number of adapters for a running batch, include base-only request.",
+      "type": "integer",
+      "default": 8
+    },
+    "max_mamba_cache_size": {
+      "description": "The maximum size of the mamba cache.",
+      "type": "integer"
+    },
+    "max_prefill_tokens": {
+      "description": "The maximum number of tokens in a prefill batch. The real bound will be the maximum of this value and the model's maximum context length. Supports standard SI suffixes (k, M, G, T) and IEC suffixes (Ki, Mi, Gi, Ti). Suffixes are case-sensitive. Decimals are allowed for SI suffixes only. Examples: '1k' -> 1000 '1M' -> 1000000 '25.6k' -> 25600 '1Ki' -> 1024 '1Mi' -> 1048576",
+      "type": "integer",
+      "default": 16384
+    },
+    "max_queued_requests": {
+      "description": "The maximum number of queued requests. This option is ignored when using disaggregation-mode.",
+      "type": "integer"
+    },
+    "max_running_requests": {
+      "description": "The maximum number of running requests.",
+      "type": "integer"
+    },
+    "max_total_tokens": {
+      "description": "The maximum number of tokens in the memory pool. If not specified, it will be automatically calculated based on the memory usage fraction. This option is typically used for development and debugging purposes. Supports standard SI suffixes (k, M, G, T) and IEC suffixes (Ki, Mi, Gi, Ti). Suffixes are case-sensitive. Decimals are allowed for SI suffixes only. Examples: '1k' -> 1000 '1M' -> 1000000 '25.6k' -> 25600 '1Ki' -> 1024 '1Mi' -> 1048576",
+      "type": "integer"
+    },
+    "mem_fraction_static": {
+      "description": "The fraction of the memory used for static allocation (model weights and KV cache memory pool). Use a smaller value if you see out-of-memory errors.",
+      "type": "number"
+    },
+    "mm_attention_backend": {
+      "description": "Set multimodal attention backend.",
+      "type": "string",
+      "enum": [
+        "aiter_attn",
+        "ascend_attn",
+        "fa3",
+        "fa4",
+        "flashinfer_cudnn",
+        "sdpa",
+        "triton_attn"
+      ]
+    },
+    "mm_enable_dp_encoder": {
+      "description": "Enabling data parallelism for mm encoder. The dp size will be set to the tp size automatically.",
+      "type": "boolean",
+      "default": false
+    },
+    "mm_process_config": {
+      "description": "Multimodal preprocessing config, a json config contains keys: `image`, `video`, `audio`",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "model_checksum": {
+      "description": "Model file integrity verification. If provided without value, uses model-path as HF repo ID. Otherwise, provide checksums JSON file path or HuggingFace repo ID.",
+      "type": "string"
+    },
+    "model_impl": {
+      "description": "Which implementation of the model to use. * \"auto\" will try to use the SGLang implementation if it exists and fall back to the Transformers implementation if no SGLang implementation is available. * \"sglang\" will use the SGLang model implementation. * \"transformers\" will use the Transformers model * \"mindspore\" will use the MindSpore model implementation.",
+      "type": "string",
+      "default": "auto"
+    },
+    "model_loader_extra_config": {
+      "description": "Extra config for model loader. This will be passed to the model loader corresponding to the chosen load_format.",
+      "type": "string",
+      "default": "{}"
+    },
+    "modelexpress_config": {
+      "description": "JSON config for ModelExpress P2P weight loading. Keys: \"url\" (required, gRPC host:port), \"model_name\" (optional, defaults to --model-path), \"source\" (optional bool, true for seed mode). Example: '{\"url\": \"localhost:8001\", \"model_name\": \"my-model\", \"source\": true}'",
+      "type": "string"
+    },
+    "modelopt_checkpoint_restore_path": {
+      "description": "Path to restore a previously saved ModelOpt quantized checkpoint. If provided, the quantization process will be skipped and the model will be loaded from this checkpoint.",
+      "type": "string"
+    },
+    "modelopt_checkpoint_save_path": {
+      "description": "Path to save the ModelOpt quantized checkpoint after quantization. This allows reusing the quantized model in future runs.",
+      "type": "string"
+    },
+    "modelopt_export_path": {
+      "description": "Path to export the quantized model in HuggingFace format after ModelOpt quantization. The exported model can then be used directly with SGLang for inference. If not provided, the model will not be exported.",
+      "type": "string"
+    },
+    "modelopt_quant": {
+      "description": "The ModelOpt quantization configuration. Supported values: 'fp8', 'int4_awq', 'w4a8_awq', 'nvfp4', 'nvfp4_awq'. This requires the NVIDIA Model Optimizer library to be installed: pip install nvidia-modelopt",
+      "type": "string"
+    },
+    "moe_a2a_backend": {
+      "description": "Choose the backend for MoE A2A.",
+      "type": "string",
+      "enum": [
+        "ascend_fuseep",
+        "deepep",
+        "flashinfer",
+        "mooncake",
+        "mori",
+        "nixl",
+        "none"
+      ],
+      "default": "none"
+    },
+    "moe_dense_tp_size": {
+      "description": "TP size for MoE dense MLP layers. This flag is useful when, with large TP size, there are errors caused by weights in MLP layers having dimension smaller than the min dimension GEMM supports.",
+      "type": "integer"
+    },
+    "moe_dp_size": {
+      "description": "The moe data parallelism size.",
+      "type": "integer",
+      "default": 1
+    },
+    "moe_runner_backend": {
+      "description": "Choose the runner backend for MoE.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "cutlass",
+        "deep_gemm",
+        "flashinfer_cutedsl",
+        "flashinfer_cutlass",
+        "flashinfer_mxfp4",
+        "flashinfer_trtllm",
+        "flashinfer_trtllm_routed",
+        "triton",
+        "triton_kernel"
+      ],
+      "default": "auto"
+    },
+    "mooncake_ib_device": {
+      "description": "The InfiniBand devices for Mooncake Backend transfer, accepts multiple comma-separated devices (e.g., --mooncake-ib-device mlx5_0,mlx5_1). Default is None, which triggers automatic device detection when Mooncake Backend is enabled.",
+      "type": "string"
+    },
+    "multi_item_scoring_delimiter": {
+      "description": "Delimiter token ID for multi-item scoring. Used to combine Query and Items into a single sequence: Query<delimiter>Item1<delimiter>Item2<delimiter>... This enables efficient batch processing of multiple items against a single query.",
+      "type": "integer"
+    },
+    "nccl_port": {
+      "description": "The port for NCCL distributed environment setup. Defaults to a random port.",
+      "type": "integer"
+    },
+    "nsa_decode_backend": {
+      "description": "NSA decode backend. If not specified, auto-detects based on hardware and kv_cache_dtype.",
+      "type": "string",
+      "enum": [
+        "aiter",
+        "fa3",
+        "flashmla_auto",
+        "flashmla_kv",
+        "flashmla_sparse",
+        "tilelang",
+        "trtllm"
+      ]
+    },
+    "nsa_prefill_backend": {
+      "description": "NSA prefill backend. If not specified, auto-detects based on hardware and kv_cache_dtype.",
+      "type": "string",
+      "enum": [
+        "aiter",
+        "fa3",
+        "flashmla_auto",
+        "flashmla_kv",
+        "flashmla_sparse",
+        "tilelang",
+        "trtllm"
+      ]
+    },
+    "nsa_prefill_cp_mode": {
+      "description": "Token splitting mode for the prefill phase of DeepSeek v3.2 under context parallelism. Optional values: 'round-robin-split'(default), 'in-seq-split' 'round-robin-split' distributes tokens across ranks based on token_idx %% cp_size. It supports multi-batch prefill, fused MoE, and FP8 KV cache.",
+      "type": "string",
+      "enum": [
+        "in-seq-split",
+        "round-robin-split"
+      ],
+      "default": "round-robin-split"
+    },
+    "num_continuous_decode_steps": {
+      "description": "Run multiple continuous decoding steps to reduce scheduling overhead. This can potentially increase throughput but may also increase time-to-first-token latency. The default value is 1, meaning only run one decoding step at a time.",
+      "type": "integer",
+      "default": 1
+    },
+    "num_reserved_decode_tokens": {
+      "description": "Number of decode tokens that will have memory reserved when adding new request to the running batch.",
+      "type": "integer",
+      "default": 512
+    },
+    "offload_group_size": {
+      "description": "Number of layers per group in offloading.",
+      "type": "integer",
+      "default": -1
+    },
+    "offload_mode": {
+      "description": "Mode of offloading.",
+      "type": "string",
+      "default": "cpu"
+    },
+    "offload_num_in_group": {
+      "description": "Number of layers to be offloaded within a group.",
+      "type": "integer",
+      "default": 1
+    },
+    "offload_prefetch_step": {
+      "description": "Steps to prefetch in offloading.",
+      "type": "integer",
+      "default": 1
+    },
+    "otlp_traces_endpoint": {
+      "description": "Config opentelemetry collector endpoint if --enable-trace is set. format: <ip>:<port>",
+      "type": "string",
+      "default": "localhost:4317"
+    },
+    "page_size": {
+      "description": "The number of tokens in a page.",
+      "type": "integer"
+    },
+    "pdmux_config_path": {
+      "description": "The path of the PD-Multiplexing config file.",
+      "type": "string"
+    },
+    "piecewise_cuda_graph_compiler": {
+      "description": "Set the compiler for piecewise cuda graph. Choices are: eager, inductor.",
+      "type": "string",
+      "enum": [
+        "eager",
+        "inductor"
+      ],
+      "default": "eager"
+    },
+    "piecewise_cuda_graph_max_tokens": {
+      "description": "Set the maximum tokens when using piecewise cuda graph.",
+      "type": "integer"
+    },
+    "pp_async_batch_depth": {
+      "description": "The async batch depth of pipeline parallelism.",
+      "type": "integer",
+      "default": 0
+    },
+    "pp_max_micro_batch_size": {
+      "description": "The maximum micro batch size in pipeline parallelism.",
+      "type": "integer"
+    },
+    "pp_size": {
+      "description": "The pipeline parallelism size.",
+      "type": "integer",
+      "default": 1
+    },
+    "pre_warm_nccl": {
+      "description": "Pre-warm NCCL/RCCL communicators during startup to reduce P99 TTFT cold-start latency. Default: enabled for AMD/HIP (RCCL), disabled for NVIDIA/CUDA (NCCL).",
+      "type": "boolean",
+      "default": false
+    },
+    "preferred_sampling_params": {
+      "description": "json-formatted sampling settings that will be returned in /get_model_info",
+      "type": "string"
+    },
+    "prefill_attention_backend": {
+      "description": "Choose the kernels for prefill attention layers (have priority over --attention-backend).",
+      "type": "string",
+      "enum": [
+        "aiter",
+        "ascend",
+        "cutlass_mla",
+        "dual_chunk_flash_attn",
+        "fa3",
+        "fa4",
+        "flashinfer",
+        "flashmla",
+        "flex_attention",
+        "intel_amx",
+        "intel_xpu",
+        "nsa",
+        "torch_native",
+        "triton",
+        "trtllm_mha",
+        "trtllm_mla",
+        "wave"
+      ]
+    },
+    "prefill_cp_mode": {
+      "description": "Token splitting mode for the prefill phase under context parallelism. Optional values: 'in-seq-split' (default)",
+      "type": "string",
+      "enum": [
+        "in-seq-split"
+      ],
+      "default": "in-seq-split"
+    },
+    "prefill_delayer_max_delay_passes": {
+      "description": "Maximum forward passes to delay prefill.",
+      "type": "integer",
+      "default": 30
+    },
+    "prefill_delayer_token_usage_low_watermark": {
+      "description": "Token usage low watermark for prefill delayer.",
+      "type": "number"
+    },
+    "prefill_max_requests": {
+      "description": "The maximum number of requests in a prefill batch. If not specified, there is no limit.",
+      "type": "integer"
+    },
+    "priority_scheduling_preemption_threshold": {
+      "description": "Minimum difference in priorities for an incoming request to have to preempt running request(s).",
+      "type": "integer",
+      "default": 10
+    },
+    "quantization": {
+      "description": "The quantization method.",
+      "type": "string",
+      "enum": [
+        "auto-round",
+        "awq",
+        "awq_marlin",
+        "bitsandbytes",
+        "compressed-tensors",
+        "fp8",
+        "gguf",
+        "gptq",
+        "gptq_marlin",
+        "marlin",
+        "modelopt",
+        "modelopt_fp4",
+        "modelopt_fp8",
+        "modelopt_mixed",
+        "modelslim",
+        "moe_wna16",
+        "mxfp4",
+        "mxfp8",
+        "petit_nvfp4",
+        "qoq",
+        "quark_int4fp8_moe",
+        "w4afp8",
+        "w8a8_fp8",
+        "w8a8_int8"
+      ]
+    },
+    "quantization_param_path": {
+      "description": "Path to the JSON file containing the KV cache scaling factors. This should generally be supplied, when KV cache dtype is FP8. Otherwise, KV cache scaling factors default to 1.0, which may cause accuracy issues.",
+      "type": "string"
+    },
+    "quantize_and_serve": {
+      "description": "Quantize the model with ModelOpt and immediately serve it without exporting. This is useful for development and prototyping. For production, it's recommended to use separate quantization and deployment steps.",
+      "type": "boolean",
+      "default": false
+    },
+    "radix_eviction_policy": {
+      "description": "The eviction policy of radix trees. 'lru' stands for Least Recently Used, 'lfu' stands for Least Frequently Used, and 'slru' stands for Segmented Least Recently Used.",
+      "type": "string",
+      "enum": [
+        "lfu",
+        "lru",
+        "slru"
+      ],
+      "default": "lru"
+    },
+    "random_seed": {
+      "description": "The random seed.",
+      "type": "integer"
+    },
+    "reasoning_parser": {
+      "description": "Specify the parser for reasoning models, supported parsers are: ['deepseek-r1', 'deepseek-v3', 'glm45', 'gpt-oss', 'kimi', 'kimi_k2', 'mimo', 'qwen3', 'qwen3-thinking', 'minimax', 'minimax-append-think', 'step3', 'step3p5', 'mistral', 'nemotron_3', 'interns1'].",
+      "type": "string",
+      "enum": [
+        "deepseek-r1",
+        "deepseek-v3",
+        "glm45",
+        "gpt-oss",
+        "interns1",
+        "kimi",
+        "kimi_k2",
+        "mimo",
+        "minimax",
+        "minimax-append-think",
+        "mistral",
+        "nemotron_3",
+        "qwen3",
+        "qwen3-thinking",
+        "step3",
+        "step3p5"
+      ]
+    },
+    "remote_instance_weight_loader_backend": {
+      "description": "The backend for loading weights from remote instance. Can be 'transfer_engine', 'nccl', or 'modelexpress'. Default is 'nccl'.",
+      "type": "string",
+      "enum": [
+        "modelexpress",
+        "nccl",
+        "transfer_engine"
+      ],
+      "default": "nccl"
+    },
+    "remote_instance_weight_loader_seed_instance_ip": {
+      "description": "The ip of the seed instance for loading weights from remote instance.",
+      "type": "string"
+    },
+    "remote_instance_weight_loader_seed_instance_service_port": {
+      "description": "The service port of the seed instance for loading weights from remote instance.",
+      "type": "integer"
+    },
+    "remote_instance_weight_loader_send_weights_group_ports": {
+      "description": "The communication group ports for loading weights from remote instance.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "remote_instance_weight_loader_start_seed_via_transfer_engine": {
+      "description": "Start seed server via transfer engine backend for remote instance weight loader.",
+      "type": "boolean",
+      "default": false
+    },
+    "revision": {
+      "description": "The specific model version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.",
+      "type": "string"
+    },
+    "rl_on_policy_target": {
+      "description": "The training system that SGLang needs to match for true on-policy.",
+      "type": "string",
+      "enum": [
+        "fsdp"
+      ]
+    },
+    "rl_quant_profile": {
+      "description": "Path to the FlashRL quantization profile. Required when using --load-format flash_rl.",
+      "type": "string"
+    },
+    "sampling_backend": {
+      "description": "Choose the kernels for sampling layers.",
+      "type": "string",
+      "enum": [
+        "ascend",
+        "flashinfer",
+        "pytorch"
+      ]
+    },
+    "sampling_defaults": {
+      "description": "Where to get default sampling parameters. 'openai' uses SGLang/OpenAI defaults (temperature=1.0, top_p=1.0, etc.). 'model' uses the model's generation_config.json to get the recommended sampling parameters if available. Default is 'model'.",
+      "type": "string",
+      "enum": [
+        "model",
+        "openai"
+      ],
+      "default": "model"
+    },
+    "schedule_conservativeness": {
+      "description": "How conservative the schedule policy is. A larger value means more conservative scheduling. Use a larger value if you see requests being retracted frequently.",
+      "type": "number",
+      "default": 1.0
+    },
+    "schedule_low_priority_values_first": {
+      "description": "If specified with --enable-priority-scheduling, the scheduler will schedule requests with lower priority integer values first.",
+      "type": "boolean",
+      "default": false
+    },
+    "schedule_policy": {
+      "description": "The scheduling policy of the requests.",
+      "type": "string",
+      "enum": [
+        "dfs-weight",
+        "fcfs",
+        "lof",
+        "lpm",
+        "priority",
+        "random",
+        "routing-key"
+      ],
+      "default": "fcfs"
+    },
+    "scheduler_recv_interval": {
+      "description": "The interval to poll requests in scheduler. Can be set to >1 to reduce the overhead of this.",
+      "type": "integer",
+      "default": 1
+    },
+    "served_model_name": {
+      "description": "Override the model name returned by the v1/models endpoint in OpenAI API server.",
+      "type": "string"
+    },
+    "skip_server_warmup": {
+      "description": "If set, skip warmup.",
+      "type": "boolean",
+      "default": false
+    },
+    "sleep_on_idle": {
+      "description": "Reduce CPU usage when sglang is idle.",
+      "type": "boolean",
+      "default": false
+    },
+    "sm_group_num": {
+      "description": "Number of sm partition groups.",
+      "type": "integer",
+      "default": 8
+    },
+    "soft_watchdog_timeout": {
+      "description": "Set soft watchdog timeout in seconds. If a forward batch takes longer than this, the server will dump information for debugging.",
+      "type": "number"
+    },
+    "speculative_accept_threshold_acc": {
+      "description": "The accept probability of a draft token is raised from its target probability p to min(1, p / threshold_acc).",
+      "type": "number",
+      "default": 1.0
+    },
+    "speculative_accept_threshold_single": {
+      "description": "Accept a draft token if its probability in the target model is greater than this threshold.",
+      "type": "number",
+      "default": 1.0
+    },
+    "speculative_algorithm": {
+      "description": "Speculative algorithm.",
+      "type": "string",
+      "enum": [
+        "EAGLE",
+        "EAGLE3",
+        "NEXTN",
+        "NGRAM",
+        "STANDALONE"
+      ]
+    },
+    "speculative_attention_mode": {
+      "description": "Attention backend for speculative decoding operations (both target verify and draft extend). Can be one of 'prefill' (default) or 'decode'.",
+      "type": "string",
+      "enum": [
+        "decode",
+        "prefill"
+      ],
+      "default": "prefill"
+    },
+    "speculative_draft_attention_backend": {
+      "description": "Attention backend for speculative decoding drafting.",
+      "type": "string"
+    },
+    "speculative_draft_load_format": {
+      "description": "The format of the draft model weights to load. If not specified, will use the same format as --load-format. Use 'dummy' to initialize draft model weights with random values for profiling.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "bitsandbytes",
+        "dummy",
+        "fastsafetensors",
+        "flash_rl",
+        "gguf",
+        "layered",
+        "mistral",
+        "npcache",
+        "private",
+        "pt",
+        "remote",
+        "remote_instance",
+        "runai_streamer",
+        "safetensors",
+        "sharded_state"
+      ]
+    },
+    "speculative_draft_model_path": {
+      "description": "The path of the draft model weights. This can be a local folder or a Hugging Face repo ID.",
+      "type": "string"
+    },
+    "speculative_draft_model_quantization": {
+      "description": "The quantization method for speculative model.",
+      "type": "string",
+      "enum": [
+        "auto-round",
+        "awq",
+        "awq_marlin",
+        "bitsandbytes",
+        "compressed-tensors",
+        "fp8",
+        "gguf",
+        "gptq",
+        "gptq_marlin",
+        "marlin",
+        "modelopt",
+        "modelopt_fp4",
+        "modelopt_fp8",
+        "modelopt_mixed",
+        "modelslim",
+        "moe_wna16",
+        "mxfp4",
+        "mxfp8",
+        "petit_nvfp4",
+        "qoq",
+        "quark_int4fp8_moe",
+        "unquant",
+        "w4afp8",
+        "w8a8_fp8",
+        "w8a8_int8"
+      ]
+    },
+    "speculative_draft_model_revision": {
+      "description": "The specific draft model version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.",
+      "type": "string"
+    },
+    "speculative_eagle_topk": {
+      "description": "The number of tokens sampled from the draft model in eagle2 each step.",
+      "type": "integer"
+    },
+    "speculative_moe_a2a_backend": {
+      "description": "Choose the backend for MoE A2A in speculative decoding",
+      "type": "string",
+      "enum": [
+        "ascend_fuseep",
+        "deepep",
+        "flashinfer",
+        "mooncake",
+        "mori",
+        "nixl",
+        "none"
+      ]
+    },
+    "speculative_moe_runner_backend": {
+      "description": "Choose the runner backend for MoE in speculative decoding.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "cutlass",
+        "deep_gemm",
+        "flashinfer_cutedsl",
+        "flashinfer_cutlass",
+        "flashinfer_mxfp4",
+        "flashinfer_trtllm",
+        "flashinfer_trtllm_routed",
+        "triton",
+        "triton_kernel"
+      ]
+    },
+    "speculative_ngram_capacity": {
+      "description": "The cache capacity for ngram speculative decoding.",
+      "type": "integer",
+      "default": 10000000
+    },
+    "speculative_ngram_match_type": {
+      "description": "The match type for cache tree.",
+      "type": "string",
+      "enum": [
+        "BFS",
+        "PROB"
+      ],
+      "default": "BFS"
+    },
+    "speculative_ngram_max_bfs_breadth": {
+      "description": "The maximum breadth for BFS (Breadth-First Search) in ngram speculative decoding.",
+      "type": "integer",
+      "default": 10
+    },
+    "speculative_ngram_max_trie_depth": {
+      "description": "The max trie depth for ngram speculative decoding.",
+      "type": "integer",
+      "default": 18
+    },
+    "speculative_ngram_min_bfs_breadth": {
+      "description": "The minimum breadth for BFS (Breadth-First Search) in ngram speculative decoding.",
+      "type": "integer",
+      "default": 1
+    },
+    "speculative_num_draft_tokens": {
+      "description": "The number of tokens sampled from the draft model in Speculative Decoding.",
+      "type": "integer"
+    },
+    "speculative_num_steps": {
+      "description": "The number of steps sampled from draft model in Speculative Decoding.",
+      "type": "integer"
+    },
+    "speculative_token_map": {
+      "description": "The path of the draft model's small vocab table.",
+      "type": "string"
+    },
+    "ssl_ca_certs": {
+      "description": "The CA certificates file.",
+      "type": "string"
+    },
+    "ssl_certfile": {
+      "description": "The file path to the SSL certificate file.",
+      "type": "string"
+    },
+    "ssl_keyfile": {
+      "description": "The file path to the SSL key file.",
+      "type": "string"
+    },
+    "ssl_keyfile_password": {
+      "description": "The password to decrypt the SSL keyfile.",
+      "type": "string"
+    },
+    "stream_interval": {
+      "description": "The interval (or buffer size) for streaming in terms of the token length. A smaller value makes streaming smoother, while a larger value makes the throughput higher",
+      "type": "integer",
+      "default": 1
+    },
+    "stream_response_default_include_usage": {
+      "description": "Include usage in every streaming response (even when stream_options is not specified).",
+      "type": "boolean",
+      "default": false
+    },
+    "swa_full_tokens_ratio": {
+      "description": "The ratio of SWA layer KV tokens / full layer KV tokens, regardless of the number of swa:full layers. It should be between 0 and 1. E.g. 0.5 means if each swa layer has 50 tokens, then each full layer has 100 tokens.",
+      "type": "number",
+      "default": 0.8
+    },
+    "tbo_token_distribution_threshold": {
+      "description": "The threshold of token distribution between two batches in micro-batch-overlap, determines whether to two-batch-overlap or two-chunk-overlap. Set to 0 denote disable two-chunk-overlap.",
+      "type": "number",
+      "default": 0.48
+    },
+    "tokenizer_metrics_custom_labels_header": {
+      "description": "Specify the HTTP header for passing custom labels for tokenizer metrics.",
+      "type": "string",
+      "default": "x-custom-labels"
+    },
+    "tokenizer_mode": {
+      "description": "Tokenizer mode. 'auto' will use the fast tokenizer if available, and 'slow' will always use the slow tokenizer.",
+      "type": "string",
+      "enum": [
+        "auto",
+        "slow"
+      ],
+      "default": "auto"
+    },
+    "tokenizer_worker_num": {
+      "description": "The worker num of the tokenizer manager.",
+      "type": "integer",
+      "default": 1
+    },
+    "tool_call_parser": {
+      "description": "Specify the parser for handling tool-call interactions. Options include: ['deepseekv3', 'deepseekv31', 'deepseekv32', 'glm', 'glm45', 'glm47', 'gpt-oss', 'kimi_k2', 'lfm2', 'llama3', 'mimo', 'mistral', 'pythonic', 'qwen', 'qwen25', 'qwen3_coder', 'step3', 'step3p5', 'minimax-m2', 'trinity', 'interns1', 'hermes', 'gigachat3'].",
+      "type": "string",
+      "enum": [
+        "deepseekv3",
+        "deepseekv31",
+        "deepseekv32",
+        "gigachat3",
+        "glm",
+        "glm45",
+        "glm47",
+        "gpt-oss",
+        "hermes",
+        "interns1",
+        "kimi_k2",
+        "lfm2",
+        "llama3",
+        "mimo",
+        "minimax-m2",
+        "mistral",
+        "pythonic",
+        "qwen",
+        "qwen25",
+        "qwen3_coder",
+        "step3",
+        "step3p5",
+        "trinity"
+      ]
+    },
+    "tool_server": {
+      "description": "Either 'demo' or a comma-separated list of tool server urls to use for the model. If not specified, no tool server will be used.",
+      "type": "string"
+    },
+    "torch_compile_max_bs": {
+      "description": "Set the maximum batch size when using torch compile.",
+      "type": "integer",
+      "default": 32
+    },
+    "torchao_config": {
+      "description": "Optimize the model with torchao. Experimental feature. Current choices are: int8dq, int8wo, int4wo-<group_size>, fp8wo, fp8dq-per_tensor, fp8dq-per_row",
+      "type": "string",
+      "default": ""
+    },
+    "tp_size": {
+      "description": "The tensor parallelism size.",
+      "type": "integer",
+      "default": 1
+    },
+    "triton_attention_num_kv_splits": {
+      "description": "The number of KV splits in flash decoding Triton kernel. Larger value is better in longer context scenarios. The default value is 8.",
+      "type": "integer",
+      "default": 8
+    },
+    "triton_attention_reduce_in_fp32": {
+      "description": "Cast the intermediate attention results to fp32 to avoid possible crashes related to fp16.This only affects Triton attention kernels.",
+      "type": "boolean",
+      "default": false
+    },
+    "triton_attention_split_tile_size": {
+      "description": "The size of split KV tile in flash decoding Triton kernel. Used for deterministic inference.",
+      "type": "integer"
+    },
+    "trust_remote_code": {
+      "description": "Whether or not to allow for custom models defined on the Hub in their own modeling files.",
+      "type": "boolean",
+      "default": false
+    },
+    "use_ray": {
+      "description": "Use Ray actors for scheduler process management.",
+      "type": "boolean",
+      "default": false
+    },
+    "warmups": {
+      "description": "Specify custom warmup functions (csv) to run before server starts eg. --warmups=warmup_name1,warmup_name2 will run the functions `warmup_name1` and `warmup_name2` specified in warmup.py before the server starts listening for requests",
+      "type": "string"
+    },
+    "watchdog_timeout": {
+      "description": "Set watchdog timeout in seconds. If a forward batch takes longer than this, the server will crash to prevent hanging.",
+      "type": "number",
+      "default": 300
+    },
+    "weight_loader_disable_mmap": {
+      "description": "Disable mmap while loading weight using safetensors.",
+      "type": "boolean",
+      "default": false
+    },
+    "weight_version": {
+      "description": "Version identifier for the model weights. Defaults to 'default' if not specified.",
+      "type": "string",
+      "default": "default"
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml
+++ b/internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml
@@ -1,0 +1,156 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .EndpointName }}
+  namespace: {{ .Namespace }}
+  labels:
+    engine: {{ .EngineName }}
+    engine_version: {{ .EngineVersion }}
+    routing_logic: {{ .RoutingLogic }}
+    app: inference
+spec:
+  replicas: {{ .Replicas }}
+  progressDeadlineSeconds: 1200
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      cluster: {{ .ClusterName }}
+      workspace: {{ .Workspace }}
+      endpoint: {{ .EndpointName }}
+      app: inference
+  template:
+    metadata:
+      labels:
+        engine: {{ .EngineName }}
+        engine_version: {{ .EngineVersion }}
+        cluster: {{ .ClusterName }}
+        workspace: {{ .Workspace }}
+        endpoint: {{ .EndpointName }}
+        routing_logic: {{ .RoutingLogic }}
+        app: inference
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: endpoint
+                      operator: In
+                      values:
+                        - {{ .EndpointName }}
+                topologyKey: "kubernetes.io/hostname"
+      {{- if .NodeSelector }}
+      nodeSelector:
+        {{- range $key, $value := .NodeSelector }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      {{- if .ImagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .ImagePullSecret }}
+      {{- end }}
+
+      {{- if .Volumes }}
+      volumes:
+{{ .Volumes | toYaml | indent 6 }}
+      {{- end }}
+      initContainers:
+        - name: model-downloader
+          image: {{ .ImagePrefix }}/neutree/neutree-runtime:{{ .NeutreeVersion }}
+          command:
+            - bash
+            - -c
+          args:
+            - >-
+              python3 -m neutree.downloader
+              --name="{{ .ModelArgs.name }}"
+              --registry_type="{{ .ModelArgs.registry_type }}"
+              --registry_path="{{ .ModelArgs.registry_path }}"
+              --path="{{ .ModelArgs.path }}"
+              --version="{{ .ModelArgs.version }}"
+              --file="{{ .ModelArgs.file }}"
+              --task="{{ .ModelArgs.task }}"
+          env:
+           {{ range $key, $value := .Env }}
+           - name: {{ $key }}
+             value: "{{ $value }}"
+           {{ end }}
+          {{- if .VolumeMounts }}
+          volumeMounts:
+{{ .VolumeMounts | toYaml | indent 10 }}
+          {{- end }}
+
+      containers:
+        - name: {{ .EngineName }}
+          image: {{ .ImagePrefix }}/{{ .ImageRepo }}:{{ .ImageTag }}
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          - --host
+          - "0.0.0.0"
+          - --port
+          - "8000"
+          - --model-path
+          - {{ .ModelArgs.path }}
+          - --served-model-name
+          - {{ .ModelArgs.serve_name }}
+          {{- if eq .ModelArgs.task "text-embedding" }}
+          - --is-embedding
+          {{- end }}
+          {{/* SGLang argparse only registers kebab-case long options
+               (e.g. --tp-size); convert schema underscore keys at render
+               time so the same dict drives the CLI here and the Python
+               kwargs on the SSH/Ray path. */}}
+          {{- if .EngineArgs }}
+          {{- range $key, $value := .EngineArgs }}
+          - --{{ $key | replace "_" "-" }}
+      {{- if ne (printf "%v" $value) "true"}}
+          - "{{ $value }}"
+      {{- end }}
+          {{- end }}
+          {{- end }}
+          resources:
+            limits:
+              {{- range $key, $value := .Resources }}
+              {{ $key }}: {{ $value }}
+              {{- end }}
+            requests:
+              {{- range $key, $value := .Resources }}
+              {{ $key }}: {{ $value }}
+              {{- end }}
+          env:
+           {{ range $key, $value := .Env }}
+           - name: {{ $key }}
+             value: "{{ $value }}"
+           {{ end }}
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          {{- if .VolumeMounts }}
+          volumeMounts:
+{{ .VolumeMounts | toYaml | indent 10 }}
+          {{- end }}

--- a/internal/engine/template.go
+++ b/internal/engine/template.go
@@ -15,6 +15,9 @@ var vllmV0_17_1DeployTemplate string
 //go:embed llama-cpp/v0.3.7/templates/kubernetes/default.yaml
 var llamaCppDefaultDeployTemplate string
 
+//go:embed sglang/v0.5.10/templates/kubernetes/default.yaml
+var sglangV0_5_10DeployTemplate string
+
 // GetVLLMV0_11_2DeployTemplate returns the default deployment template for vLLM V0.11.2 engine
 func GetVLLMV0_11_2DeployTemplate() string {
 	return base64.StdEncoding.EncodeToString([]byte(vllmV0_11_2DeployTemplate))
@@ -30,11 +33,17 @@ func GetLlamaCppDefaultDeployTemplate() string {
 	return base64.StdEncoding.EncodeToString([]byte(llamaCppDefaultDeployTemplate))
 }
 
+// GetSGLangV0_5_10DeployTemplate returns the default deployment template for SGLang V0.5.10 engine
+func GetSGLangV0_5_10DeployTemplate() string {
+	return base64.StdEncoding.EncodeToString([]byte(sglangV0_5_10DeployTemplate))
+}
+
 // DeployTemplates contains all available deployment templates
 var DeployTemplates = map[string]func() string{
 	"vllm-v0.11.2":     GetVLLMV0_11_2DeployTemplate,
 	"vllm-v0.17.1":     GetVLLMV0_17_1DeployTemplate,
 	"llama-cpp-v0.3.7": GetLlamaCppDefaultDeployTemplate,
+	"sglang-v0.5.10":   GetSGLangV0_5_10DeployTemplate,
 }
 
 // GetDeployTemplate returns the deployment template for a specific engine

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -104,11 +104,18 @@ func (k *kubernetesOrchestrator) setEngineDefaultArgs(data *DeploymentManifestVa
 	}
 }
 
-// setVLLMTensorParallelDefault auto-sets tensor-parallel-size = GPU count for vLLM
-// when GPU > 1 and is a whole number. Must be called after user engine_args are merged,
-// because users may provide the key in either hyphen or underscore format.
-func setVLLMTensorParallelDefault(data *DeploymentManifestVariables, endpoint *v1.Endpoint, engine *v1.Engine) {
-	if engine.Metadata.Name != v1.EngineNameVLLM || endpoint.Spec.Resources == nil {
+// setEngineTensorParallelDefault auto-sets the engine's tensor-parallel-size
+// arg = GPU count when GPU > 1 and is a whole number. Must be called after
+// user engine_args are merged, because users may provide the key in either
+// hyphen or underscore format. The K8s template applies sprig
+// `replace "_" "-"` at render time so both forms map to the same CLI flag.
+func setEngineTensorParallelDefault(data *DeploymentManifestVariables, endpoint *v1.Endpoint, engine *v1.Engine) {
+	if endpoint.Spec.Resources == nil {
+		return
+	}
+
+	tpKey := engineTPArgKey(engine.Metadata.Name)
+	if tpKey == "" {
 		return
 	}
 
@@ -117,11 +124,12 @@ func setVLLMTensorParallelDefault(data *DeploymentManifestVariables, endpoint *v
 		return
 	}
 
-	_, hasDash := data.EngineArgs["tensor-parallel-size"]
-	_, hasUnderscore := data.EngineArgs["tensor_parallel_size"]
+	dashKey := strings.ReplaceAll(tpKey, "_", "-")
+	_, hasDash := data.EngineArgs[dashKey]
+	_, hasUnderscore := data.EngineArgs[tpKey]
 
 	if !hasDash && !hasUnderscore {
-		data.EngineArgs["tensor_parallel_size"] = int(gpuCount)
+		data.EngineArgs[tpKey] = int(gpuCount)
 	}
 }
 
@@ -137,9 +145,10 @@ func (k *kubernetesOrchestrator) setEngineArgs(data *DeploymentManifestVariables
 		}
 	}
 
-	// Auto-set vLLM tensor-parallel-size after user args are merged,
-	// so we can detect user-provided values in either key format.
-	setVLLMTensorParallelDefault(data, endpoint, engine)
+	// Auto-set tensor-parallel-size after user args are merged, so we can
+	// detect user-provided values in either key format. Applies to engines
+	// that expose a TP arg (vLLM / SGLang).
+	setEngineTensorParallelDefault(data, endpoint, engine)
 
 	// Prepare engine arg values for YAML double-quoted template rendering.
 	// Handles native maps, unescaped JSON strings, and pre-escaped strings.

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -1521,6 +1521,114 @@ func TestKubernetesOrchestrator_setEngineArgs(t *testing.T) {
 			},
 			expectedArgs: map[string]interface{}{},
 		},
+		{
+			name: "sglang engine with GPU > 1 should auto-set tp_size",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Resources: &v1.ResourceSpec{
+						GPU: pointer.String("4"),
+					},
+				},
+			},
+			expectedArgs: map[string]interface{}{
+				"tp_size": 4,
+			},
+		},
+		{
+			name: "sglang engine with GPU <= 1 should not set tp_size",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Resources: &v1.ResourceSpec{
+						GPU: pointer.String("1"),
+					},
+				},
+			},
+			expectedArgs: map[string]interface{}{},
+		},
+		{
+			name: "sglang engine fractional GPU should not set tp_size",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Resources: &v1.ResourceSpec{
+						GPU: pointer.String("2.5"),
+					},
+				},
+			},
+			expectedArgs: map[string]interface{}{},
+		},
+		{
+			name: "sglang engine user-provided kebab tp-size prevents default",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Resources: &v1.ResourceSpec{
+						GPU: pointer.String("4"),
+					},
+					Variables: map[string]interface{}{
+						"engine_args": map[string]interface{}{
+							"tp-size": "2",
+						},
+					},
+				},
+			},
+			expectedArgs: map[string]interface{}{
+				"tp-size": "2",
+			},
+		},
+		{
+			name: "sglang engine user-provided underscore key prevents default",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Resources: &v1.ResourceSpec{
+						GPU: pointer.String("4"),
+					},
+					Variables: map[string]interface{}{
+						"engine_args": map[string]interface{}{
+							"tp_size": "1",
+						},
+					},
+				},
+			},
+			expectedArgs: map[string]interface{}{
+				"tp_size": "1",
+			},
+		},
+		{
+			name: "sglang engine with nil resources should not set tp_size",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{},
+			},
+			expectedArgs: map[string]interface{}{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -594,7 +594,7 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 
 	maps.Copy(app.Args, endpoint.Spec.Variables)
 
-	setVLLMDefaultTensorParallelSize(endpoint, &app, rayResource.NumGPUs)
+	setDefaultTensorParallelSize(endpoint, &app, rayResource.NumGPUs)
 
 	setEngineSpecialEnv(endpoint, deployedCluster, applicationEnv)
 
@@ -646,10 +646,18 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 	return app, nil
 }
 
-// setVLLMDefaultTensorParallelSize auto-sets tensor_parallel_size = GPU count in engine_args
-// for vLLM engine when GPU > 1 and is a whole number. Skips if user already configured it.
-func setVLLMDefaultTensorParallelSize(endpoint *v1.Endpoint, app *dashboard.RayServeApplication, numGPUs float64) {
-	if endpoint.Spec.Engine == nil || endpoint.Spec.Engine.Engine != v1.EngineNameVLLM {
+// setDefaultTensorParallelSize auto-sets the tensor-parallel field in
+// engine_args to GPU count when GPU > 1 and is a whole number. Skips if the
+// engine doesn't take a TP arg or if the user already configured it (in
+// either underscore or kebab form — users sometimes copy CLI flag names
+// verbatim).
+func setDefaultTensorParallelSize(endpoint *v1.Endpoint, app *dashboard.RayServeApplication, numGPUs float64) {
+	if endpoint.Spec.Engine == nil {
+		return
+	}
+
+	tpKey := engineTPArgKey(endpoint.Spec.Engine.Engine)
+	if tpKey == "" {
 		return
 	}
 
@@ -662,10 +670,17 @@ func setVLLMDefaultTensorParallelSize(endpoint *v1.Endpoint, app *dashboard.RayS
 		engineArgs = make(map[string]interface{})
 	}
 
-	if _, exists := engineArgs["tensor_parallel_size"]; !exists {
-		engineArgs["tensor_parallel_size"] = int(numGPUs)
-		app.Args["engine_args"] = engineArgs
+	if _, hasUnderscore := engineArgs[tpKey]; hasUnderscore {
+		return
 	}
+
+	dashKey := strings.ReplaceAll(tpKey, "_", "-")
+	if _, hasDash := engineArgs[dashKey]; hasDash {
+		return
+	}
+
+	engineArgs[tpKey] = int(numGPUs)
+	app.Args["engine_args"] = engineArgs
 }
 
 // buildEngineContainerConfigs constructs two runtime_env.container configs for

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -1854,7 +1854,7 @@ func TestEndpointToApplication_ContainerConfig(t *testing.T) {
 	}
 }
 
-func TestEndpointToApplication_VLLMTensorParallelSize(t *testing.T) {
+func TestEndpointToApplication_TensorParallelSize(t *testing.T) {
 	nvidiaGPU := string(v1.AcceleratorTypeNVIDIAGPU)
 
 	modelRegistry := &v1.ModelRegistry{
@@ -1864,7 +1864,7 @@ func TestEndpointToApplication_VLLMTensorParallelSize(t *testing.T) {
 	}
 	deployedCluster := &v1.Cluster{}
 
-	makeEndpoint := func(gpu string, variables map[string]interface{}) *v1.Endpoint {
+	makeEndpoint := func(engineName, engineVersion, gpu string, variables map[string]interface{}) *v1.Endpoint {
 		ep := &v1.Endpoint{
 			Metadata: &v1.Metadata{
 				Workspace: "test",
@@ -1872,8 +1872,8 @@ func TestEndpointToApplication_VLLMTensorParallelSize(t *testing.T) {
 			},
 			Spec: &v1.EndpointSpec{
 				Engine: &v1.EndpointEngineSpec{
-					Engine:  "vllm",
-					Version: "v0.11.2",
+					Engine:  engineName,
+					Version: engineVersion,
 				},
 				Resources: &v1.ResourceSpec{
 					GPU: &gpu,
@@ -1893,43 +1893,144 @@ func TestEndpointToApplication_VLLMTensorParallelSize(t *testing.T) {
 
 	tests := []struct {
 		name                    string
+		engineName              string
+		engineVersion           string
+		tpKey                   string
 		gpu                     string
 		variables               map[string]interface{}
 		expectedTensorParallel  interface{}
 		expectEngineArgsPresent bool
 	}{
+		// vLLM cases
 		{
-			name:                    "GPU=4 should auto-set tensor_parallel_size=4",
+			name:                    "vllm GPU=4 should auto-set tensor_parallel_size=4",
+			engineName:              v1.EngineNameVLLM,
+			engineVersion:           "v0.11.2",
+			tpKey:                   "tensor_parallel_size",
 			gpu:                     "4",
 			variables:               nil,
 			expectedTensorParallel:  4,
 			expectEngineArgsPresent: true,
 		},
 		{
-			name:                    "GPU=2 should auto-set tensor_parallel_size=2",
+			name:                    "vllm GPU=2 should auto-set tensor_parallel_size=2",
+			engineName:              v1.EngineNameVLLM,
+			engineVersion:           "v0.11.2",
+			tpKey:                   "tensor_parallel_size",
 			gpu:                     "2",
 			variables:               nil,
 			expectedTensorParallel:  2,
 			expectEngineArgsPresent: true,
 		},
 		{
-			name:                    "GPU=1 should not set tensor_parallel_size",
+			name:                    "vllm GPU=1 should not set tensor_parallel_size",
+			engineName:              v1.EngineNameVLLM,
+			engineVersion:           "v0.11.2",
+			tpKey:                   "tensor_parallel_size",
 			gpu:                     "1",
 			variables:               nil,
 			expectEngineArgsPresent: false,
 		},
 		{
-			name:                    "fractional GPU should not set tensor_parallel_size",
+			name:                    "vllm fractional GPU should not set tensor_parallel_size",
+			engineName:              v1.EngineNameVLLM,
+			engineVersion:           "v0.11.2",
+			tpKey:                   "tensor_parallel_size",
 			gpu:                     "2.5",
 			variables:               nil,
 			expectEngineArgsPresent: false,
 		},
 		{
-			name: "user-provided tensor_parallel_size should not be overridden",
-			gpu:  "4",
+			name:          "vllm user-provided tensor_parallel_size should not be overridden",
+			engineName:    v1.EngineNameVLLM,
+			engineVersion: "v0.11.2",
+			tpKey:         "tensor_parallel_size",
+			gpu:           "4",
 			variables: map[string]interface{}{
 				"engine_args": map[string]interface{}{
 					"tensor_parallel_size": 2,
+				},
+			},
+			expectedTensorParallel:  2,
+			expectEngineArgsPresent: true,
+		},
+		// SGLang cases — ServerArgs dataclass field is `tp_size` (not vLLM's
+		// `tensor_parallel_size`), see engineTPArgKey in ray_orchestrator.go.
+		{
+			name:                    "sglang GPU=4 should auto-set tp_size=4",
+			engineName:              v1.EngineNameSGLang,
+			engineVersion:           "v0.5.10",
+			tpKey:                   "tp_size",
+			gpu:                     "4",
+			variables:               nil,
+			expectedTensorParallel:  4,
+			expectEngineArgsPresent: true,
+		},
+		{
+			name:                    "sglang GPU=2 should auto-set tp_size=2",
+			engineName:              v1.EngineNameSGLang,
+			engineVersion:           "v0.5.10",
+			tpKey:                   "tp_size",
+			gpu:                     "2",
+			variables:               nil,
+			expectedTensorParallel:  2,
+			expectEngineArgsPresent: true,
+		},
+		{
+			name:                    "sglang GPU=1 should not set tp_size",
+			engineName:              v1.EngineNameSGLang,
+			engineVersion:           "v0.5.10",
+			tpKey:                   "tp_size",
+			gpu:                     "1",
+			variables:               nil,
+			expectEngineArgsPresent: false,
+		},
+		{
+			name:                    "sglang fractional GPU should not set tp_size",
+			engineName:              v1.EngineNameSGLang,
+			engineVersion:           "v0.5.10",
+			tpKey:                   "tp_size",
+			gpu:                     "2.5",
+			variables:               nil,
+			expectEngineArgsPresent: false,
+		},
+		{
+			name:          "sglang user-provided tp_size should not be overridden",
+			engineName:    v1.EngineNameSGLang,
+			engineVersion: "v0.5.10",
+			tpKey:         "tp_size",
+			gpu:           "4",
+			variables: map[string]interface{}{
+				"engine_args": map[string]interface{}{
+					"tp_size": 2,
+				},
+			},
+			expectedTensorParallel:  2,
+			expectEngineArgsPresent: true,
+		},
+		{
+			name:          "vllm user-provided kebab tensor-parallel-size should not be overridden",
+			engineName:    v1.EngineNameVLLM,
+			engineVersion: "v0.11.2",
+			tpKey:         "tensor-parallel-size",
+			gpu:           "4",
+			variables: map[string]interface{}{
+				"engine_args": map[string]interface{}{
+					"tensor-parallel-size": 2,
+				},
+			},
+			expectedTensorParallel:  2,
+			expectEngineArgsPresent: true,
+		},
+		{
+			name:          "sglang user-provided kebab tp-size should not be overridden",
+			engineName:    v1.EngineNameSGLang,
+			engineVersion: "v0.5.10",
+			tpKey:         "tp-size",
+			gpu:           "4",
+			variables: map[string]interface{}{
+				"engine_args": map[string]interface{}{
+					"tp-size": 2,
 				},
 			},
 			expectedTensorParallel:  2,
@@ -1943,17 +2044,18 @@ func TestEndpointToApplication_VLLMTensorParallelSize(t *testing.T) {
 			mgr.EXPECT().GetConverter(nvidiaGPU).
 				Return(plugin.NewGPUConverter(), true)
 
-			app, err := EndpointToApplication(makeEndpoint(tt.gpu, tt.variables), deployedCluster, modelRegistry, nil, nil, mgr)
+			app, err := EndpointToApplication(makeEndpoint(tt.engineName, tt.engineVersion, tt.gpu, tt.variables),
+				deployedCluster, modelRegistry, nil, nil, mgr)
 			assert.NoError(t, err)
 
 			engineArgs, hasEngineArgs := app.Args["engine_args"].(map[string]interface{})
 			if tt.expectEngineArgsPresent {
 				assert.True(t, hasEngineArgs, "engine_args should be present")
-				assert.Equal(t, tt.expectedTensorParallel, engineArgs["tensor_parallel_size"])
+				assert.Equal(t, tt.expectedTensorParallel, engineArgs[tt.tpKey])
 			} else {
 				if hasEngineArgs {
-					_, hasTensorParallel := engineArgs["tensor_parallel_size"]
-					assert.False(t, hasTensorParallel, "tensor_parallel_size should not be set")
+					_, hasTensorParallel := engineArgs[tt.tpKey]
+					assert.False(t, hasTensorParallel, "%s should not be set", tt.tpKey)
 				}
 			}
 		})

--- a/internal/orchestrator/util.go
+++ b/internal/orchestrator/util.go
@@ -17,6 +17,23 @@ import (
 
 const acceleratorTypeCPU = "cpu"
 
+// engineTPArgKey returns the underscore-form engine_args key the engine
+// uses for tensor parallel size. vLLM uses `tensor_parallel_size`; SGLang's
+// ServerArgs dataclass field is `tp_size`. Returns "" when the engine
+// doesn't take a TP arg (e.g. llama-cpp single-process). Shared by both the
+// Ray (SSH cluster) and Kubernetes orchestrators so the auto-TP rule is
+// defined exactly once.
+func engineTPArgKey(engineName string) string {
+	switch engineName {
+	case v1.EngineNameVLLM:
+		return "tensor_parallel_size"
+	case v1.EngineNameSGLang:
+		return "tp_size"
+	default:
+		return ""
+	}
+}
+
 func getEndpointDeployCluster(s storage.Storage, endpoint *v1.Endpoint) (*v1.Cluster, error) { //nolint:unparam
 	clusterFilter := []storage.Filter{
 		{

--- a/observability/grafana/dashboards/sglang_grafana_dashboard.json
+++ b/observability/grafana/dashboards/sglang_grafana_dashboard.json
@@ -1,0 +1,1104 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 8,
+  "links": [],
+  "panels": [
+    {
+      "id": 9999,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "html",
+        "content": "<style>\n/* ============================================================\n   Grafana Custom Theme\n   ============================================================ */\n\n/* ---------- Dark Mode ---------- */\nbody[class*=\"theme-dark\"],\nbody:not([class*=\"theme-light\"]) {\n  --ui-bg: hsl(217.5, 9.09%, 17.25%);\n  --ui-card: hsl(210, 9.09%, 12.94%);\n  --ui-border: hsl(0, 0%, 18.46%);\n  --ui-input: hsl(214.29, 5.04%, 27.25%);\n  --ui-primary: hsl(226.73, 58.43%, 65.1%);\n  --ui-fg: hsl(334, 34%, 98%);\n  --ui-muted-fg: hsl(0, 0%, 60.77%);\n  --ui-destructive: hsl(358.16, 68.78%, 53.53%);\n  --ui-radius: 0.5rem;\n}\n\n/* ---------- Light Mode ---------- */\nbody[class*=\"theme-light\"] {\n  --ui-bg: hsl(0, 0%, 97.69%);\n  --ui-card: hsl(0, 0%, 100%);\n  --ui-border: hsl(0, 0%, 80.78%);\n  --ui-input: hsl(0, 0%, 80.78%);\n  --ui-primary: hsl(211.29, 100%, 50%);\n  --ui-fg: hsl(334, 55%, 1%);\n  --ui-muted-fg: hsl(206.04, 0%, 50.77%);\n  --ui-destructive: hsl(3.19, 100%, 59.41%);\n  --ui-radius: 0.5rem;\n}\n\n/* ---------- Global Background ---------- */\nbody,\n.main-view,\n[class*=\"page-wrapper\"]>div>div:first-child {\n  background-color: var(--ui-bg) !important;\n}\n\n/* ---------- Panel Container ---------- */\nsection[class*=\"panel-container\"] {\n  background-color: var(--ui-card) !important;\n  border: 1px solid var(--ui-border) !important;\n  border-radius: var(--ui-radius) !important;\n}\n\n/* ---------- Panel Title ---------- */\n[class*=\"panel-title\"] {\n  color: var(--ui-muted-fg) !important;\n  font-size: 13px !important;\n  font-weight: 500 !important;\n}\n\n/* ---------- Padding ---------- */\n[data-testid=\"data-testid dashboard controls\"] {\n  padding: 0 0 8px 0 !important;\n}\n\n[class*=\"-canvas-wrapper-old\"] [class*=\"-body\"] {\n  padding: 0 !important;\n  margin-top: -32px !important;\n}\n\n/* ---------- Dashboard Variable Controls ---------- */\n[class*=\"submenu-controls\"],\n[class*=\"SubMenu\"] {\n  background-color: var(--ui-bg) !important;\n  border-bottom: 1px solid var(--ui-border) !important;\n  z-index: 10 !important;\n  position: relative !important;\n  padding: 8px 8px 8px 16px !important;\n}\n\n/* Variable Container */\n[data-testid=\"data-testid template variable\"] {\n  display: flex !important;\n  align-items: center !important;\n}\n\n/* Variable Label */\n[data-testid=\"data-testid template variable\"]>label {\n  background-color: var(--ui-input) !important;\n  color: var(--ui-fg) !important;\n  border: 1px solid var(--ui-border) !important;\n  border-right: none !important;\n  border-radius: var(--ui-radius) 0 0 var(--ui-radius) !important;\n  font-size: 13px !important;\n  padding: 5px 12px !important;\n  line-height: 1.4 !important;\n  white-space: nowrap !important;\n}\n\n/* Variable Dropdown - Outer Wrapper */\n[data-testid=\"data-testid template variable\"] [class*=\"-input-wrapper\"] {\n  background-color: var(--ui-card) !important;\n  border: 1px solid var(--ui-border) !important;\n  border-left: none !important;\n  border-radius: 0 var(--ui-radius) var(--ui-radius) 0 !important;\n}\n\n/* Variable Dropdown - Inner Container */\n[data-testid=\"data-testid template variable\"] [class*=\"-input-wrapper\"]>div:not([class*=\"input-suffix\"]):not([class*=\"a11yText\"]) {\n  background-color: var(--ui-card) !important;\n  border: none !important;\n  border-radius: 0 var(--ui-radius) var(--ui-radius) 0 !important;\n}\n\n/* Variable Value Container */\n[data-testid=\"data-testid template variable\"] [class*=\"select-value-container\"] {\n  background-color: transparent !important;\n}\n\n/* Variable Selected Value */\ndiv[class*=\"singleValue\"],\ndiv[class*=\"grafana-select-value-container\"] {\n  color: var(--ui-fg) !important;\n  font-size: 13px !important;\n}\n\n/* Variable Dropdown Arrow */\ndiv[class*=\"input-suffix\"] {\n  color: var(--ui-muted-fg) !important;\n}\n\ndiv[class*=\"input-suffix\"] svg {\n  fill: var(--ui-muted-fg) !important;\n}\n\n/* Variable Dropdown Menu (expanded) */\ndiv[class*=\"menu\"],\n[class*=\"options-group\"] {\n  z-index: 1050 !important;\n  background-color: var(--ui-card) !important;\n  border: 1px solid var(--ui-border) !important;\n  border-radius: var(--ui-radius) !important;\n  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3) !important;\n}\n\n/* Dropdown Options */\ndiv[class*=\"option\"] {\n  color: var(--ui-fg) !important;\n  font-size: 13px !important;\n}\n\ndiv[class*=\"option\"]:hover,\ndiv[class*=\"option\"][class*=\"focused\"] {\n  background-color: var(--ui-input) !important;\n}\n\ndiv[class*=\"option\"][class*=\"selected\"] {\n  background-color: var(--ui-primary) !important;\n  color: #fff !important;\n}\n\n/* ---------- Time Picker / Toolbar Buttons ---------- */\nbutton[class*=\"toolbar-button\"],\nbutton[data-testid=\"data-testid TimePicker Open Button\"],\n.button-group button {\n  background-color: var(--ui-card) !important;\n  color: var(--ui-fg) !important;\n  border: 1px solid var(--ui-border) !important;\n  border-radius: var(--ui-radius) !important;\n}\n\n/* Button Group Connectors */\n.button-group {\n  gap: 0 !important;\n}\n\n.button-group button:first-child {\n  border-radius: var(--ui-radius) 0 0 var(--ui-radius) !important;\n  border-right: none !important;\n}\n\n.button-group button:last-child {\n  border-radius: 0 var(--ui-radius) var(--ui-radius) 0 !important;\n}\n\n/* ---------- Refresh Picker ---------- */\n[class*=\"refresh-picker\"] button,\n[class*=\"RefreshPicker\"] button {\n  background-color: var(--ui-card) !important;\n  color: var(--ui-fg) !important;\n  border: 1px solid var(--ui-border) !important;\n}\n\n/* ---------- Top Navigation ---------- */\n[class*=\"navbar\"],\nheader[class*=\"page-toolbar\"] {\n  background-color: var(--ui-card) !important;\n  border-bottom: 1px solid var(--ui-border) !important;\n}\n\n/* ---------- Inputs / Selects ---------- */\ninput:not([type=\"checkbox\"]):not([type=\"radio\"]),\nselect,\n[class*=\"gf-form-input\"] {\n  border-color: var(--ui-border) !important;\n  border-radius: var(--ui-radius) !important;\n  color: var(--ui-fg) !important;\n}\n\n/* ---------- Tables ---------- */\ntable tbody tr:nth-child(odd) {\n  background-color: color-mix(in srgb, var(--ui-input) 15%, transparent) !important;\n}\n\ntable tbody tr:hover {\n  background-color: color-mix(in srgb, var(--ui-primary) 8%, transparent) !important;\n}\n\ntable th {\n  color: var(--ui-muted-fg) !important;\n  border-bottom: 1px solid var(--ui-border) !important;\n}\n\n/* ---------- Links ---------- */\na:not([class*=\"btn\"]):not([class*=\"variable\"]) {\n  color: var(--ui-primary) !important;\n}\n\n/* ---------- Row Title ---------- */\n.dashboard-row .dashboard-row__title {\n  color: var(--ui-fg) !important;\n}\n\n/* ---------- Tooltip ---------- */\n[class*=\"tooltip\"]:not([class*=\"panel\"]) {\n  background-color: var(--ui-card) !important;\n  border: 1px solid var(--ui-border) !important;\n  border-radius: var(--ui-radius) !important;\n  color: var(--ui-fg) !important;\n}\n\n/* ---------- Alert ---------- */\n[class*=\"alert-error\"],\n[class*=\"alerting\"] {\n  border-color: var(--ui-destructive) !important;\n}\n\n/* ---------- Scrollbar ---------- */\n::-webkit-scrollbar {\n  width: 6px;\n  height: 6px;\n}\n\n::-webkit-scrollbar-track {\n  background: transparent;\n}\n\n::-webkit-scrollbar-thumb {\n  background: var(--ui-input);\n  border-radius: 3px;\n}\n\n::-webkit-scrollbar-thumb:hover {\n  background: var(--ui-muted-fg);\n}\n\n/* Hide the injected theme panel itself */\ndiv[data-griditem-key=\"grid-item-9999\"] {\n  visibility: hidden !important;\n}\n</style>",
+        "code": {
+          "language": "html",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        }
+      },
+      "transparent": true
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(rate(sglang_e2e_request_latency_seconds_sum{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]) /  rate(sglang_e2e_request_latency_seconds_count{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))\r\n",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Avg",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        }
+      ],
+      "title": "End-to-End Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 17,
+      "maxDataPoints": 30,
+      "options": {
+        "calculate": false,
+        "calculation": {
+          "yBuckets": {
+            "scale": {
+              "type": "linear"
+            }
+          }
+        },
+        "cellGap": 1,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "secs"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum(increase(sglang_e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])) by (le)\r\n",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "End-to-End Request Latency(s) Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg(rate(sglang_time_to_first_token_seconds_sum{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]) /  rate(sglang_time_to_first_token_seconds_count{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))\r\n",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Avg",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        }
+      ],
+      "title": "Time-To-First-Token Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 19,
+      "maxDataPoints": 30,
+      "options": {
+        "calculate": false,
+        "calculation": {
+          "xBuckets": {
+            "value": ""
+          },
+          "yBuckets": {
+            "mode": "size",
+            "scale": {
+              "type": "linear"
+            },
+            "value": ""
+          }
+        },
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(le) (increase(sglang_time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Time-To-First-Token Seconds Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sglang_num_running_reqs{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Num Running Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "editorMode": "code",
+          "expr": "sglang_gen_throughput{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Token Generation Throughput (Tokens / S)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sglang_cache_hit_rate{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": true,
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ddyfngn31dg5cf"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sglang_num_queue_reqs{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Number Queued Requests",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "edx8memhpd9tsa"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "name": "Application",
+        "label": "Application",
+        "type": "query",
+        "hide": 0,
+        "refresh": 2,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(application)",
+        "query": {
+          "query": "label_values(application)",
+          "refId": "Var-App"
+        },
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "regex": "",
+        "sort": 0
+      },
+      {
+        "name": "Deployment",
+        "label": "Deployment",
+        "type": "query",
+        "hide": 0,
+        "refresh": 2,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(deployment)",
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "Var-Dep"
+        },
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "regex": "",
+        "sort": 0
+      },
+      {
+        "name": "Replica",
+        "label": "Replica",
+        "type": "query",
+        "hide": 0,
+        "refresh": 2,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(replica)",
+        "query": {
+          "query": "label_values(replica)",
+          "refId": "Var-Rep"
+        },
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "regex": "",
+        "sort": 0
+      },
+      {
+        "name": "Cluster",
+        "label": "Cluster",
+        "type": "query",
+        "hide": 0,
+        "refresh": 2,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(neutree_cluster)",
+        "query": {
+          "query": "label_values(neutree_cluster)",
+          "refId": "Var-Clu"
+        },
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "regex": "",
+        "sort": 0
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "SGLang Dashboard",
+  "uid": "sglang",
+  "version": 11
+}

--- a/observability/vmagent/prometheus.yml
+++ b/observability/vmagent/prometheus.yml
@@ -27,3 +27,13 @@ scrape_configs:
       regex: 'ray_vllm[:_](.+)'
       target_label: __name__
       replacement: 'vllm:$1'
+  # Strip Ray's auto-prepended ray_ from SGLang metrics so dashboard panels
+  # query the names SGLang upstream uses natively (e.g.
+  # sglang_e2e_request_latency_seconds_bucket). Symmetric to the vLLM rule
+  # above but with sglang_ output (not sglang:) — SGLang upstream uses an
+  # underscore separator throughout, including in their reference Grafana
+  # dashboard, so preserving that lets us reuse upstream queries verbatim.
+    - source_labels: [__name__]
+      regex: 'ray_sglang[:_](.+)'
+      target_label: __name__
+      replacement: 'sglang_$1'

--- a/scripts/dashboard/configs/sglang_convert.json
+++ b/scripts/dashboard/configs/sglang_convert.json
@@ -1,0 +1,66 @@
+{
+  "name": "SGLang to Neutree",
+  "description": "Convert open-source SGLang Dashboard to Neutree-integrated version",
+  "source_file": "sglang-upstream/grafana.json",
+  "output_file": "output/sglang_grafana_dashboard.json",
+  "uid": "sglang",
+  "keep_datasource_variable": true,
+
+  "filter_rules": [
+    {
+      "name": "drop_existing_model_name_filter",
+      "description": "Strip the upstream {model_name=~\"$model_name\"} filter so we can replace it with Neutree multi-dimensional filters in the next rule",
+      "pattern": "\\{model_name=~\"\\$model_name\"\\}",
+      "replacement": "",
+      "is_regex": true
+    },
+    {
+      "name": "inject_neutree_filters",
+      "description": "Append Neutree multi-tenant filters to every sglang_<name>(_<word>)* metric reference. Matches both unfiltered and filter-stripped forms; the look-ahead guards against double-injection on metrics that are already followed by an opening brace.",
+      "pattern": "(sglang_[a-zA-Z0-9_]+)(?!\\{)",
+      "replacement": "\\1{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+      "is_regex": true
+    }
+  ],
+
+  "custom_rules": [],
+
+  "variables": [
+    {
+      "name": "Application",
+      "label": "Application",
+      "query": "label_values(application)",
+      "multi": true,
+      "include_all": true,
+      "all_value": ".*",
+      "variable_type": "query"
+    },
+    {
+      "name": "Deployment",
+      "label": "Deployment",
+      "query": "label_values(deployment)",
+      "multi": true,
+      "include_all": true,
+      "all_value": ".*",
+      "variable_type": "query"
+    },
+    {
+      "name": "Replica",
+      "label": "Replica",
+      "query": "label_values(replica)",
+      "multi": true,
+      "include_all": true,
+      "all_value": ".*",
+      "variable_type": "query"
+    },
+    {
+      "name": "Cluster",
+      "label": "Cluster",
+      "query": "label_values(neutree_cluster)",
+      "multi": true,
+      "include_all": true,
+      "all_value": ".*",
+      "variable_type": "query"
+    }
+  ]
+}

--- a/scripts/dashboard/convert_sglang_dashboard.py
+++ b/scripts/dashboard/convert_sglang_dashboard.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+SGLang Grafana Dashboard Conversion Shortcut Script
+
+This is a convenience wrapper script that uses the generic converter with
+the sglang_convert.json configuration file to convert SGLang Dashboard.
+
+Usage with generic converter: python dashboard_converter.py configs/sglang_convert.json
+Usage with this shortcut script: python convert_sglang_dashboard.py
+"""
+
+import sys, os
+from pathlib import Path
+
+# Import generic converter
+from dashboard_converter import load_config_from_file, DashboardConverter
+
+
+def main():
+    """
+    Main function - uses predefined SGLang conversion configuration
+    """
+    config_file = 'configs/sglang_convert.json'
+
+    try:
+        print(f"📋 Using configuration file: {config_file}")
+        print("💡 Hint: To customize conversion rules, edit the config file or create a new one\n")
+        print(os.getcwd())
+        config = load_config_from_file(str(config_file))
+        converter = DashboardConverter(config)
+        success = converter.convert()
+
+        if success:
+            print("\n🎉 SGLang Dashboard conversion successful!")
+
+        sys.exit(0 if success else 1)
+
+    except Exception as e:
+        print(f"❌ Conversion failed: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/dashboard/sync-grafana-dashboards.sh
+++ b/scripts/dashboard/sync-grafana-dashboards.sh
@@ -3,6 +3,11 @@ set -e
 
 mkdir -p output # ensure output directory exists
 python3 ./convert_vllm_dashboard.py
+# Upstream SGLang ships a single grafana JSON; rename to the canonical filename
+# the converter expects, then run it through the same config-driven pipeline as
+# vLLM so the dashboard picks up Neutree multi-tenant filter variables.
+mv -f sglang-upstream/sglang-dashboard.json sglang-upstream/grafana.json
+python3 ./convert_sglang_dashboard.py
 python3 ./convert_ray_to_neutree.py ray-upstream/data_grafana_dashboard.json output/data_grafana_dashboard.json
 python3 ./convert_ray_to_neutree.py ray-upstream/default_grafana_dashboard.json output/default_grafana_dashboard.json
 python3 ./convert_ray_to_neutree.py ray-upstream/serve_deployment_grafana_dashboard.json output/serve_deployment_grafana_dashboard.json

--- a/scripts/dashboard/vendir.yml
+++ b/scripts/dashboard/vendir.yml
@@ -15,3 +15,12 @@ directories:
       url: https://github.com/vllm-project/vllm.git
       ref: v0.8.5
     newRootPath: examples/online_serving/prometheus_grafana
+- path: sglang-upstream
+  contents:
+  - path: .
+    git:
+      url: https://github.com/sgl-project/sglang.git
+      ref: v0.5.10
+    newRootPath: examples/monitoring/grafana/dashboards/json
+    includePaths:
+    - sglang-dashboard.json

--- a/tests/e2e/endpoint_k8s_config_test.go
+++ b/tests/e2e/endpoint_k8s_config_test.go
@@ -500,4 +500,79 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 			Expect(code).To(Equal(200), "inference failed: %s", body)
 		})
 	})
+
+	// --- SGLang All Schema Types ---
+	//
+	// Mirrors the vLLM "All Schema Types Engine Args" block above: deploy with
+	// a multi-type engine_args YAML, assert each value reaches the engine as
+	// a container CLI flag (kebab-case via the K8s template's `_` → `-`
+	// conversion), then exercise inference end-to-end.
+
+	Describe("SGLang All Schema Types Engine Args", Ordered, Label("config", "schema", "sglang"), func() {
+		var schemaEpName string
+
+		BeforeAll(func() {
+			schemaEpName = "e2e-ep-k8s-sglang-schema-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if schemaEpName != "" {
+				deleteEndpoint(schemaEpName)
+			}
+		})
+
+		It("should deploy SGLang with all schema data types", Label("C2649562"), func() {
+			yamlPath := applyEndpoint(schemaEpName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")),
+				withEngineArgs(allSchemaTypesEngineArgsSGLang()))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(schemaEpName)
+
+			ep := getEndpoint(schemaEpName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+		})
+
+		It("should have all engine_args as container CLI flags", func() {
+			ctx := context.Background()
+			d, err := k8sH.GetDeployment(ctx, namespace, schemaEpName)
+			Expect(err).NotTo(HaveOccurred(), "should find endpoint deployment %s", schemaEpName)
+
+			found := false
+
+			for _, c := range d.Spec.Template.Spec.Containers {
+				if c.Name != v1.EngineNameSGLang {
+					continue
+				}
+
+				allArgs := append(c.Command, c.Args...)
+				argsStr := strings.Join(allArgs, " ")
+
+				// SGLang's K8s template converts underscore engine_args keys to
+				// kebab-case CLI flags (sprig replace "_" "-"); assert kebab.
+				Expect(argsStr).To(ContainSubstring("--tp-size"), "integer")
+				Expect(argsStr).To(ContainSubstring("--mem-fraction-static"), "number/float")
+				Expect(argsStr).To(ContainSubstring("--disable-cuda-graph"), "boolean")
+				Expect(argsStr).To(ContainSubstring("--dtype"), "string enum")
+				Expect(argsStr).To(ContainSubstring("--chunked-prefill-size"), "integer")
+				Expect(argsStr).To(ContainSubstring("--served-model-name"), "string")
+				Expect(argsStr).To(ContainSubstring("--attention-backend"), "string enum")
+				Expect(argsStr).To(ContainSubstring("--cuda-graph-max-bs"), "integer")
+				Expect(argsStr).To(ContainSubstring("--preferred-sampling-params"), "object/JSON")
+				Expect(argsStr).To(ContainSubstring("--json-model-override-args"), "object/JSON")
+				found = true
+
+				break
+			}
+
+			Expect(found).To(BeTrue(), "should find sglang container in schema endpoint deployment")
+		})
+
+		It("should serve inference with all-types config", func() {
+			ep := getEndpoint(schemaEpName)
+			code, body, err := inferChat(ep.Status.ServiceURL, "Hello SGLang schema types")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(200), "inference failed: %s", body)
+		})
+	})
 })

--- a/tests/e2e/endpoint_k8s_inference_test.go
+++ b/tests/e2e/endpoint_k8s_inference_test.go
@@ -156,7 +156,7 @@ var _ = Describe("K8s Endpoint", Ordered, Label("endpoint", "k8s"), func() {
 		})
 
 		It("should deploy with tp=2 (gpu=2) and reach Running", Label("C2613759"), func() {
-			tpArgs := append(engineArgs(), EngineArg{Key: "tensor_parallel_size", Value: "2"})
+			tpArgs := append(engineArgs(profileEngineName()), EngineArg{Key: "tensor_parallel_size", Value: "2"})
 			yamlPath := applyEndpoint(epName, clusterName,
 				withGPU("2"), withEngineArgs(tpArgs))
 			defer os.Remove(yamlPath)
@@ -255,4 +255,168 @@ var _ = Describe("K8s Endpoint", Ordered, Label("endpoint", "k8s"), func() {
 
 	// --- Status & Delete (K8s-specific) ---
 
+	// --- SGLang cases ---
+	//
+	// Co-located with the vLLM/default-engine inference cases above so they
+	// share one cluster + model registry. Filter via
+	// --ginkgo.label-filter='endpoint && k8s && sglang' to run only these.
+
+	Describe("SGLang Chat Completion", Ordered, Label("inference", "chat", "sglang"), func() {
+		var epName string
+
+		BeforeAll(func() {
+			epName = "e2e-sglang-chat-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if epName != "" {
+				deleteEndpoint(epName)
+			}
+		})
+
+		It("should deploy SGLang endpoint and serve chat completion", Label("C2649559"), func() {
+			yamlPath := applyEndpoint(epName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+			Expect(ep.Status.ServiceURL).NotTo(BeEmpty())
+
+			code, body, err := inferChat(ep.Status.ServiceURL, "Hello")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(http.StatusOK), "chat completion failed: %s", body)
+			Expect(body).To(ContainSubstring("choices"))
+		})
+	})
+
+	Describe("SGLang Embedding", Ordered, Label("inference", "embedding", "sglang"), func() {
+		var epName string
+
+		BeforeAll(func() {
+			if profileEmbeddingModelName() == "" {
+				Skip("embedding_model.name not configured in profile, skipping")
+			}
+			epName = "e2e-sglang-embed-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if epName != "" {
+				deleteEndpoint(epName)
+			}
+		})
+
+		It("should deploy SGLang embedding endpoint and serve /v1/embeddings", Label("C2649560"), func() {
+			yamlPath := applyEndpoint(epName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")),
+				withModel(profileEmbeddingModelName(), profileEmbeddingModelVersion()),
+				withTask("text-embedding"))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			code, body, err := inferEmbedding(ep.Status.ServiceURL, profileEmbeddingModelName(), "Hello world")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(http.StatusOK), "embedding inference failed: %s", body)
+
+			var resp map[string]any
+			Expect(json.Unmarshal([]byte(body), &resp)).To(Succeed())
+			Expect(resp).To(HaveKey("data"))
+		})
+	})
+
+	// SGLang multi-type engine_args forwarding lives in
+	// endpoint_k8s_config_test.go alongside vLLM's "All Schema Types Engine
+	// Args" — same K8s container-CLI verification style.
+
+	Describe("SGLang Tensor Parallel TP=2", Ordered, Label("inference", "tp2", "sglang"), func() {
+		var epName string
+
+		BeforeAll(func() {
+			epName = "e2e-sglang-tp2-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if epName != "" {
+				deleteEndpoint(epName)
+			}
+		})
+
+		It("should deploy SGLang with tp_size=2 (gpu=2) and reach Running", Label("C2649563"), func() {
+			tpArgs := []EngineArg{{Key: "tp_size", Value: "2"}}
+			yamlPath := applyEndpoint(epName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")),
+				withGPU("2"), withEngineArgs(tpArgs))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+			Expect(ep.Status.ServiceURL).NotTo(BeEmpty())
+
+			By("Verifying tp_size=2 in Ray Serve config")
+			c := getClusterFullJSON(clusterName)
+			rayH := NewRayHelper(c.Status.DashboardURL)
+
+			appName := profileWorkspace() + "_" + epName
+			appConfig, err := rayH.GetApplicationConfig(appName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(appConfig).NotTo(BeNil(), "application %s should exist", appName)
+
+			engineArgs, ok := appConfig.Args["engine_args"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "engine_args should exist")
+
+			tp, ok := engineArgs["tp_size"]
+			Expect(ok).To(BeTrue(), "tp_size should exist in engine_args")
+			Expect(tp).To(BeNumerically("==", 2),
+				"tp_size should be 2 (user-specified value)")
+		})
+	})
+
+	Describe("SGLang Auto Tensor Parallel", Ordered, Label("inference", "auto-tp", "sglang"), func() {
+		var epName string
+
+		BeforeAll(func() {
+			epName = "e2e-sglang-autotp-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if epName != "" {
+				deleteEndpoint(epName)
+			}
+		})
+
+		It("should auto-set tp_size to GPU count when not specified", Label("C2649564"), func() {
+			yamlPath := applyEndpoint(epName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")),
+				withGPU("2"))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+
+			By("Verifying tp_size auto-set to GPU count (2) in Ray Serve config")
+			c := getClusterFullJSON(clusterName)
+			rayH := NewRayHelper(c.Status.DashboardURL)
+
+			appName := profileWorkspace() + "_" + epName
+			appConfig, err := rayH.GetApplicationConfig(appName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(appConfig).NotTo(BeNil(), "application %s should exist", appName)
+
+			engineArgs, ok := appConfig.Args["engine_args"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "engine_args should exist")
+
+			tp, ok := engineArgs["tp_size"]
+			Expect(ok).To(BeTrue(), "tp_size should be auto-set in engine_args")
+			Expect(tp).To(BeNumerically("==", 2),
+				"tp_size should be auto-set to GPU count (2)")
+		})
+	})
 })

--- a/tests/e2e/endpoint_ssh_config_test.go
+++ b/tests/e2e/endpoint_ssh_config_test.go
@@ -220,7 +220,7 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 		})
 
 		It("should deploy with serving-only engine_arg ignored", Label("C2644063"), func() {
-			servingArgs := append(engineArgs(), EngineArg{Key: "response_role", Value: "assistant"})
+			servingArgs := append(engineArgs(profileEngineName()), EngineArg{Key: "response_role", Value: "assistant"})
 
 			yamlPath := applyEndpoint(servingEpName, clusterName,
 				withEngineArgs(servingArgs))
@@ -282,6 +282,89 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 		It("should serve inference with all-types config", func() {
 			ep := getEndpoint(schemaEpName)
 			code, body, err := inferChat(ep.Status.ServiceURL, "Hello with all schema types")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(200), "inference failed: %s", body)
+		})
+	})
+
+	// --- SGLang All Schema Types ---
+	//
+	// Mirrors the vLLM "All Schema Types Engine Args" block above: deploy with
+	// a multi-type engine_args YAML, assert each value reaches the engine via
+	// Ray Serve's app config (SSH always goes through Ray Serve), then exercise
+	// inference end-to-end.
+
+	Describe("SGLang All Schema Types Engine Args", Ordered, Label("schema", "sglang"), func() {
+		var schemaEpName string
+
+		BeforeAll(func() {
+			schemaEpName = "e2e-ep-ssh-sglang-schema-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if schemaEpName != "" {
+				deleteEndpoint(schemaEpName)
+			}
+		})
+
+		It("should deploy SGLang with all schema data types in engine_args", Label("C2649562"), func() {
+			yamlPath := applyEndpoint(schemaEpName, clusterName,
+				withEngine(v1.EngineNameSGLang, profileEngineVersionFor(v1.EngineNameSGLang)),
+				withEngineArgs(allSchemaTypesEngineArgsSGLang()))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(schemaEpName)
+
+			ep := getEndpoint(schemaEpName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+		})
+
+		It("should have engine_args reflected in Ray Serve config", func() {
+			appName := profileWorkspace() + "_" + schemaEpName
+			apps, err := rayH.GetServeApplications()
+			Expect(err).NotTo(HaveOccurred())
+
+			appStatus, ok := apps.Applications[appName]
+			Expect(ok).To(BeTrue(), "application %s should exist", appName)
+			Expect(appStatus.DeployedAppConfig).NotTo(BeNil())
+			Expect(appStatus.DeployedAppConfig.Args).NotTo(BeNil())
+
+			engineArgs, ok := appStatus.DeployedAppConfig.Args["engine_args"]
+			Expect(ok).To(BeTrue(), "args should have engine_args")
+
+			eaMap, isMap := engineArgs.(map[string]interface{})
+			Expect(isMap).To(BeTrue(), "engine_args should be a map")
+
+			// Verify every key/value from allSchemaTypesEngineArgsSGLang
+			// reaches Ray Serve intact, covering int / float / bool / string /
+			// string-enum / object-as-JSON-string types.
+			Expect(eaMap).To(HaveKey("tp_size"))
+			Expect(eaMap["tp_size"]).To(BeNumerically("==", 1), "integer")
+
+			Expect(eaMap).To(HaveKey("mem_fraction_static"))
+			Expect(eaMap["mem_fraction_static"]).To(BeNumerically("~", 0.85, 1e-9), "number/float")
+
+			Expect(eaMap).To(HaveKeyWithValue("disable_cuda_graph", true), "boolean")
+			Expect(eaMap).To(HaveKeyWithValue("dtype", "auto"), "string enum")
+
+			Expect(eaMap).To(HaveKey("chunked_prefill_size"))
+			Expect(eaMap["chunked_prefill_size"]).To(BeNumerically("==", 8192), "integer")
+
+			Expect(eaMap).To(HaveKeyWithValue("served_model_name", "neu-sglang-test"), "string")
+			Expect(eaMap).To(HaveKeyWithValue("attention_backend", "torch_native"), "string enum")
+
+			Expect(eaMap).To(HaveKey("cuda_graph_max_bs"))
+			Expect(eaMap["cuda_graph_max_bs"]).To(BeNumerically("==", 4), "integer")
+
+			Expect(eaMap).To(HaveKeyWithValue("preferred_sampling_params",
+				`{"temperature": 0.7, "top_p": 0.9}`), "object/JSON string")
+			Expect(eaMap).To(HaveKeyWithValue("json_model_override_args",
+				`{"max_position_embeddings": 32768}`), "object/JSON string")
+		})
+
+		It("should serve inference with all-types config", func() {
+			ep := getEndpoint(schemaEpName)
+			code, body, err := inferChat(ep.Status.ServiceURL, "Hello SGLang with all schema types")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(code).To(Equal(200), "inference failed: %s", body)
 		})

--- a/tests/e2e/endpoint_ssh_inference_test.go
+++ b/tests/e2e/endpoint_ssh_inference_test.go
@@ -159,7 +159,7 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 
 		// C2642267 step 2-3: multi-GPU TP deploy + inference
 		It("should deploy with tp=2 (gpu=2) and reach Running", Label("C2613759", "C2642248", "C2642267"), func() {
-			tpArgs := append(engineArgs(), EngineArg{Key: "tensor_parallel_size", Value: "2"})
+			tpArgs := append(engineArgs(profileEngineName()), EngineArg{Key: "tensor_parallel_size", Value: "2"})
 			yamlPath := applyEndpoint(epName, clusterName,
 				withGPU("2"), withEngineArgs(tpArgs))
 			defer os.Remove(yamlPath)
@@ -320,4 +320,168 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 		})
 	})
 
+	// --- SGLang cases ---
+	//
+	// Co-located with the vLLM/default-engine inference cases above so they
+	// share one cluster + model registry. Filter via
+	// --ginkgo.label-filter='endpoint && ssh && sglang' to run only these.
+
+	Describe("SGLang Chat Completion", Ordered, Label("inference", "chat", "sglang"), func() {
+		var epName string
+
+		BeforeAll(func() {
+			epName = "e2e-sglang-ssh-chat-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if epName != "" {
+				deleteEndpoint(epName)
+			}
+		})
+
+		It("should deploy SGLang endpoint and serve chat completion", Label("C2649559"), func() {
+			yamlPath := applyEndpoint(epName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+			Expect(ep.Status.ServiceURL).NotTo(BeEmpty())
+
+			code, body, err := inferChat(ep.Status.ServiceURL, "Hello")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(http.StatusOK), "chat completion failed: %s", body)
+			Expect(body).To(ContainSubstring("choices"))
+		})
+	})
+
+	Describe("SGLang Embedding", Ordered, Label("inference", "embedding", "sglang"), func() {
+		var epName string
+
+		BeforeAll(func() {
+			if profileEmbeddingModelName() == "" {
+				Skip("embedding_model.name not configured in profile, skipping")
+			}
+			epName = "e2e-sglang-ssh-embed-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if epName != "" {
+				deleteEndpoint(epName)
+			}
+		})
+
+		It("should deploy SGLang embedding endpoint and serve /v1/embeddings", Label("C2649560"), func() {
+			yamlPath := applyEndpoint(epName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")),
+				withModel(profileEmbeddingModelName(), profileEmbeddingModelVersion()),
+				withTask("text-embedding"))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			code, body, err := inferEmbedding(ep.Status.ServiceURL, profileEmbeddingModelName(), "Hello world")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(http.StatusOK), "embedding inference failed: %s", body)
+
+			var resp map[string]any
+			Expect(json.Unmarshal([]byte(body), &resp)).To(Succeed())
+			Expect(resp).To(HaveKey("data"))
+		})
+	})
+
+	// SGLang multi-type engine_args forwarding lives in
+	// endpoint_ssh_config_test.go alongside vLLM's "All Schema Types Engine
+	// Args" — same Ray-Serve-app-config verification style.
+
+	Describe("SGLang Tensor Parallel TP=2", Ordered, Label("inference", "tp2", "sglang"), func() {
+		var epName string
+
+		BeforeAll(func() {
+			epName = "e2e-sglang-ssh-tp2-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if epName != "" {
+				deleteEndpoint(epName)
+			}
+		})
+
+		It("should deploy SGLang with tp_size=2 (gpu=2) and reach Running", Label("C2649563"), func() {
+			tpArgs := []EngineArg{{Key: "tp_size", Value: "2"}}
+			yamlPath := applyEndpoint(epName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")),
+				withGPU("2"), withEngineArgs(tpArgs))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+			Expect(ep.Status.ServiceURL).NotTo(BeEmpty())
+
+			By("Verifying tp_size=2 in Ray Serve config")
+			cluster := getClusterFullJSON(clusterName)
+			rayH := NewRayHelper(cluster.Status.DashboardURL)
+
+			appName := profileWorkspace() + "_" + epName
+			appConfig, err := rayH.GetApplicationConfig(appName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(appConfig).NotTo(BeNil(), "application %s should exist", appName)
+
+			engineArgs, ok := appConfig.Args["engine_args"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "engine_args should exist")
+
+			tp, ok := engineArgs["tp_size"]
+			Expect(ok).To(BeTrue(), "tp_size should exist in engine_args")
+			Expect(tp).To(BeNumerically("==", 2),
+				"tp_size should be 2 (user-specified value)")
+		})
+	})
+
+	Describe("SGLang Auto Tensor Parallel", Ordered, Label("inference", "auto-tp", "sglang"), func() {
+		var epName string
+
+		BeforeAll(func() {
+			epName = "e2e-sglang-ssh-autotp-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			if epName != "" {
+				deleteEndpoint(epName)
+			}
+		})
+
+		It("should auto-set tp_size to GPU count when not specified", Label("C2649564"), func() {
+			yamlPath := applyEndpoint(epName, clusterName,
+				withEngine("sglang", profileEngineVersionFor("sglang")),
+				withGPU("2"))
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+
+			By("Verifying tp_size auto-set to GPU count (2) in Ray Serve config")
+			cluster := getClusterFullJSON(clusterName)
+			rayH := NewRayHelper(cluster.Status.DashboardURL)
+
+			appName := profileWorkspace() + "_" + epName
+			appConfig, err := rayH.GetApplicationConfig(appName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(appConfig).NotTo(BeNil(), "application %s should exist", appName)
+
+			engineArgs, ok := appConfig.Args["engine_args"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "engine_args should exist")
+
+			tp, ok := engineArgs["tp_size"]
+			Expect(ok).To(BeTrue(), "tp_size should be auto-set in engine_args")
+			Expect(tp).To(BeNumerically("==", 2),
+				"tp_size should be auto-set to GPU count (2)")
+		})
+	})
 })

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1180,10 +1180,14 @@ func teardownCluster(clusterName string) {
 
 // --- Endpoint helpers ---
 
-// engineArgs parses profile engine_args ("k=v,k2=v2,...") into a structured slice
-// for direct injection into the endpoint template via {{range}}.
-func engineArgs() []EngineArg {
-	raw := profileEngineArgs()
+// engineArgs parses the named engine's profile engine_args
+// ("k=v,k2=v2,...") into a structured slice for direct injection into the
+// endpoint template via {{range}}.
+func engineArgs(engineName string) []EngineArg {
+	raw := profileEngineArgsFor(engineName)
+	if raw == "" {
+		return nil
+	}
 
 	var args []EngineArg
 
@@ -1280,12 +1284,18 @@ func renderEndpoint(name, cluster string, opts ...EndpointOption) (string, *endp
 		model:         profileModelName(),
 		modelVersion:  profileModelVersion(),
 		task:          profileModelTask(),
-		engineArgs:    engineArgs(),
-		gpu:           "1",
-		forceUpdate:   true,
+		// engineArgs intentionally left nil here. Resolved AFTER opts run
+		// so withEngine can change engineName first and the per-engine
+		// profile lookup picks the right engine's args.
+		gpu:         "1",
+		forceUpdate: true,
 	}
 	for _, fn := range opts {
 		fn(o)
+	}
+
+	if len(o.engineArgs) == 0 {
+		o.engineArgs = engineArgs(o.engineName)
 	}
 
 	if o.accType == "" || o.accProduct == "" {
@@ -1341,6 +1351,28 @@ func allSchemaTypesEngineArgs() []EngineArg {
 		{Key: "enforce_eager", Value: "true"},
 		{Key: "seed", Value: "42"},
 		{Key: "override_generation_config", Value: `'{"temperature": 0.8}'`},
+	}
+}
+
+// allSchemaTypesEngineArgsSGLang returns an engine_args slice for the SGLang
+// engine covering int / float / bool / string / string-enum / object /
+// nested-object. Keys use ServerArgs dataclass field names (underscore form);
+// the K8s template applies sprig replace "_" "-" so the CLI side sees kebab.
+// Array types are intentionally absent — SGLang's only array-shaped CLI flag
+// is `--cuda-graph-bs` (nargs="+"), which the single-token K8s template can't
+// render.
+func allSchemaTypesEngineArgsSGLang() []EngineArg {
+	return []EngineArg{
+		{Key: "tp_size", Value: "1"},
+		{Key: "mem_fraction_static", Value: "0.85"},
+		{Key: "disable_cuda_graph", Value: "true"},
+		{Key: "dtype", Value: "auto"},
+		{Key: "chunked_prefill_size", Value: "8192"},
+		{Key: "served_model_name", Value: "neu-sglang-test"},
+		{Key: "attention_backend", Value: "torch_native"},
+		{Key: "cuda_graph_max_bs", Value: "4"},
+		{Key: "preferred_sampling_params", Value: `'{"temperature": 0.7, "top_p": 0.9}'`},
+		{Key: "json_model_override_args", Value: `'{"max_position_embeddings": 32768}'`},
 	}
 }
 
@@ -1441,6 +1473,7 @@ func inferChat(serviceURL, prompt string) (int, string, error) {
 	})
 }
 
+//nolint:unparam // input is a fixture-style literal across callers by design;
 func inferEmbedding(serviceURL, model, input string) (int, string, error) {
 	return doInferenceRequest(serviceURL, "/v1/embeddings", map[string]any{
 		"model": model,
@@ -1448,6 +1481,7 @@ func inferEmbedding(serviceURL, model, input string) (int, string, error) {
 	})
 }
 
+//nolint:unparam // query is a fixture-style literal across callers by design;
 func inferRerank(serviceURL, model, query string, documents []string) (int, string, error) {
 	return doInferenceRequest(serviceURL, "/v1/rerank", map[string]any{
 		"model":     model,

--- a/tests/e2e/profile.go
+++ b/tests/e2e/profile.go
@@ -9,7 +9,24 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const defaultModelVersion = "latest"
+const (
+	defaultModelVersion = "latest"
+	// defaultEngineName is the engine looked up by helpers that don't take an
+	// explicit engine name (renderEndpoint default, profileEngineVersion, etc.).
+	// Tests that target a different engine pass it via withEngine(name, version).
+	defaultEngineName = "vllm"
+)
+
+// EngineProfile carries per-engine configuration loaded from the test profile
+// under engines.<name>.
+type EngineProfile struct {
+	Version    string `yaml:"version"`
+	OldVersion string `yaml:"old_version"`
+	// EngineArgs is a comma-separated `k=v` list that engineArgsYAML expands
+	// into a YAML snippet under spec.variables.engine_args. Empty (or missing)
+	// means rely on the engine's built-in defaults.
+	EngineArgs string `yaml:"engine_args"`
+}
 
 // Profile represents the test-infra standard profile format (snake_case).
 type Profile struct {
@@ -56,11 +73,13 @@ type Profile struct {
 		OldVersion string `yaml:"old_version"`
 	} `yaml:"cluster"`
 
-	Engine struct {
-		Name       string `yaml:"name"`
-		Version    string `yaml:"version"`
-		OldVersion string `yaml:"old_version"`
-	} `yaml:"engine"`
+	// Engines holds per-engine configuration keyed by engine name (e.g. "vllm",
+	// "sglang", "llama-cpp"). The default engine for tests that don't pass an
+	// explicit withEngine option is "vllm" (see defaultEngineName below). Each
+	// entry carries its own version, optional old_version (for multi-version
+	// isolation tests), and engine_args, so adding a new engine is one yaml
+	// block — no Go struct change required.
+	Engines map[string]EngineProfile `yaml:"engines"`
 
 	Model struct {
 		Name    string `yaml:"name"`
@@ -80,8 +99,7 @@ type Profile struct {
 	} `yaml:"rerank_model"`
 
 	Endpoint struct {
-		EngineArgs string `yaml:"engine_args"`
-		Timeout    string `yaml:"timeout"`
+		Timeout string `yaml:"timeout"`
 	} `yaml:"endpoint"`
 
 	MockUpstreamHost string `yaml:"mock_upstream_host"`
@@ -265,28 +283,44 @@ func profileClusterVersion() string {
 	return "v1.0.1"
 }
 
-func profileEngineName() string {
-	if profile.Engine.Name != "" {
-		return profile.Engine.Name
-	}
+// profileEngineName returns the implicit-default engine name. With the
+// per-engine profile shape (engines.<name>) the selector concept is gone;
+// tests that target a specific engine pass it via withEngine(name, ...).
+func profileEngineName() string { return defaultEngineName }
 
-	return "vllm"
-}
+// profileEngineVersion returns the version for the default engine. Tests that
+// target a different engine should call profileEngineVersionFor(name) or pass
+// the version explicitly via withEngine(name, version).
+func profileEngineVersion() string { return profileEngineVersionFor(defaultEngineName) }
 
-func profileEngineVersion() string {
-	if profile.Engine.Version != "" {
-		return profile.Engine.Version
-	}
-
-	return "v0.11.2"
-}
-
+// profileEngineOldVersion returns the old-version for the default engine,
+// used by the multi-version isolation test on vLLM.
 func profileEngineOldVersion() string {
-	if profile.Engine.OldVersion != "" {
-		return profile.Engine.OldVersion
+	v := profile.Engines[defaultEngineName].OldVersion
+	if v != "" {
+		return v
 	}
 
 	return "v0.8.5"
+}
+
+// profileEngineVersionFor returns the configured version for the named engine,
+// falling back to a per-engine baked-in default when the profile entry is empty.
+func profileEngineVersionFor(name string) string {
+	if v := profile.Engines[name].Version; v != "" {
+		return v
+	}
+
+	switch name {
+	case "vllm":
+		return "v0.11.2"
+	case "sglang":
+		return "v0.5.10"
+	case "llama-cpp":
+		return "v0.3.7"
+	}
+
+	return ""
 }
 
 func profileModelName() string { return profile.Model.Name }
@@ -307,12 +341,21 @@ func profileModelTask() string {
 	return "text-generation"
 }
 
-func profileEngineArgs() string {
-	if profile.Endpoint.EngineArgs != "" {
-		return profile.Endpoint.EngineArgs
+// profileEngineArgsFor returns the comma-separated engine_args string
+// configured for the named engine. Falls back to vLLM's permissive defaults
+// for the default engine (so existing vLLM tests keep working without a
+// profile change) and to empty for other engines (let the engine apply its
+// own built-in defaults).
+func profileEngineArgsFor(name string) string {
+	if v := profile.Engines[name].EngineArgs; v != "" {
+		return v
 	}
 
-	return "dtype=half,gpu_memory_utilization=0.85"
+	if name == defaultEngineName {
+		return "dtype=half,gpu_memory_utilization=0.85"
+	}
+
+	return ""
 }
 
 func profileEndpointTimeout() string {

--- a/tests/e2e/profile.yaml.example
+++ b/tests/e2e/profile.yaml.example
@@ -38,11 +38,22 @@ cluster:
   # old_version: for upgrade tests — the version to create before upgrading to cluster.version
   old_version: ""
 
-engine:
-  name: vllm
-  version: v0.11.2
-  # old_version: for multi-version isolation tests only
-  old_version: v0.8.5
+# Per-engine configuration. Default engine for tests that don't pass an
+# explicit withEngine() option is "vllm". Tests that target a specific engine
+# (e.g. SGLang K8s suite uses withEngine("sglang", "v0.5.10")) pull from the
+# corresponding entry below. Empty / missing entries fall back to baked-in
+# defaults inside profile.go.
+engines:
+  vllm:
+    version: v0.11.2
+    old_version: v0.8.5            # multi-version isolation test (vLLM only)
+    engine_args: "dtype=half,gpu_memory_utilization=0.85"
+  sglang:
+    version: v0.5.10
+    engine_args: ""                # empty → SGLang uses its built-in defaults
+  llama-cpp:
+    version: v0.3.7
+    engine_args: ""
 
 model:
   name: test-model
@@ -62,7 +73,7 @@ rerank_model:
 
 endpoint:
   # accelerator_type and accelerator_product are auto-detected from cluster status
-  engine_args: "dtype=half,gpu_memory_utilization=0.85"
+  # engine_args has moved into engines.<name>.engine_args (see top of file).
   timeout: "10m"
 
 mock_upstream_host: host.docker.internal


### PR DESCRIPTION
## Issues

NEU-429 — Support SGLang inference engine (v1.1.0).

## Changes

### Control plane
- `api/v1/engine_types.go`: add `EngineNameSGLang`
- `internal/engine/builtin.go`: register SGLang `v0.5.10` with `nvidia_gpu` image and supported tasks `[text-generation, text-embedding]`. SGLang's `/v1/rerank` doesn't match the Cohere/Jina shape Neutree clients expect (bare list with `score`, top_n<=0 rejected), so users are steered to vLLM for rerank. The `amd_gpu` image is buildable via Makefile but intentionally not registered until an AMD test cluster is available
- `internal/engine/sglang/v0.5.10/schema.json`: 27 ServerArgs fields, kebab-case keys matching `sglang.launch_server` CLI verbatim
- `internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml`: mirrors vLLM v0.11.2 layout; `--is-embedding` gated on `text-embedding` model task
- `schema.go` / `template.go`: embed + `Get*` + `EngineSchemas` / `DeployTemplates` registration
- `internal/orchestrator/kubernetes_orchestrator_resource.go` + `ray_orchestrator.go`: auto-set tensor-parallel-size = GPU count (when GPU > 1, whole) for engines that expose a TP arg. vLLM uses `tensor_parallel_size`, SGLang uses `tp_size`; both kebab and underscore user inputs are detected. K8s and Ray paths share the same logic via per-side `engineTPArgKey*` helpers
- Tests: `builtin_test.go` (locks SGLang nvidia_gpu image tag scheme; rejects `amd_gpu`; rejects `text-rerank` in supported tasks), `schema_test.go` (spot-checks every type bucket: int / float / bool / string / enum / array / object / nested), parameterized TP unit tests over `(engineName, tpKey)` covering vLLM + SGLang for GPU>1 / GPU<=1 / fractional / kebab-override / underscore-override / nil-resources

### Data plane + image build
- `cluster-image-builder/serve/sglang/v0_5_10/app.py`: Ray Serve Backend + Controller mirroring vLLM v0.11.2 / llama_cpp v0.3.7 (streaming/non-streaming split, `_FakeRawRequest` stub, lazy serving handlers, `__del__` shutdown)
- `cluster-image-builder/Dockerfile.engine-sglang`: single Dockerfile (NVIDIA + ROCm by `ENGINE_BASE_IMAGE` ARG); COPY-only downloader (no `pip install` of `downloader/requirements.txt` to avoid downgrading huggingface_hub past what SGLang's transformers 5.x needs)
- `cluster-image-builder/Makefile`: `ENGINE_SGLANG_*` vars + four targets (`docker-{build,push}-engine-sglang{,-rocm}`) + manifest variants. Tag scheme preserves upstream tag verbatim:
  - NVIDIA: `neutree/engine-sglang:v0.5.10-ray<rayver>`
  - ROCm: `neutree/engine-sglang:v0.5.10-rocm720-mi30x-ray<rayver>`
- `.github/workflows/release-engine-image.yaml`: add `sglang` to engine choice + plumb `ENGINE_SGLANG_VERSION` (NVIDIA build only via workflow; ROCm via manual `make` for v1.1.0)

### E2E
- `tests/e2e/endpoint_{k8s,ssh}_inference_test.go`: SGLang inference cases under `Label("inference", "...", "sglang")` — chat completion, embedding, tensor parallel TP=2, auto-tp. Single `Ordered` Describe per outer suite shares one cluster + one model registry to avoid GPU contention
  - C2649559 — chat completion happy path
  - C2649560 — `/v1/embeddings` single + batch
  - C2649563 — explicit `tp_size=2` end-to-end
  - C2649564 — auto-tp: `gpu=2` with no user `tp_size`, orchestrator infers `tp_size=2`
- `tests/e2e/endpoint_{k8s,ssh}_config_test.go`: SGLang multi-type engine_args forwarding (C2649562). K8s lane verifies via container CLI flags; SSH lane verifies via Ray Serve app config (mirrors vLLM "All Schema Types Engine Args" structure)
- `tests/e2e/helpers.go`: `allSchemaTypesEngineArgsYAMLSGLang()` covers int / float / bool / string / enum / object types (no array — SGLang's `--cuda-graph-bs` is `nargs="+"` which the single-token K8s template can't render). The endpoint render helper builds the entire `variables:` block in Go and omits it when `engine_args` is empty (so YAML stays canonical instead of rendering `engine_args:` null); single-line `key: value` snippets without a leading newline are auto-prefixed
- E2E profile uses a per-engine `engines: map[string]EngineProfile` block keyed by engine name; default engine remains `vllm`. Engine-specific tests pull `engines.<name>.{version,engine_args}`. Eliminates cross-engine arg leakage and gives each engine its own `version`/`engine_args`/`old_version` slot for multi-version tests
- Both suites use `withEngine("sglang", profileEngineVersionFor("sglang"))` so the verifier can pin a patch-suffixed image (e.g. `v0.5.10-neutree8`) via profile without touching test code

### Metrics bridge
- `cluster-image-builder/serve/_metrics/sglang_ray_bridge.py`: `PromToRayBridge` constructs the same `CollectorRegistry` + `MultiProcessCollector` SGLang's `launch_server` uses for `/metrics` (reads `PROMETHEUS_MULTIPROC_DIR` populated by `Engine.__init__`), polls every 5s and re-emits each sample through `ray.util.metrics`. Counters use delta diff against the previous tick. Histogram bucket / sum / count samples are forwarded as gauges with the `le` label preserved on bucket samples — `histogram_quantile()` reconstructs the histogram on the consumer side without per-observation replay (mirrors the strategy in [ray-project/ray#63123](https://github.com/ray-project/ray/pull/63123), the upstream Ray Serve LLM SGLang adapter). Replica-context tags (`deployment` / `replica` / `application`) are injected at metric-create time so the SGLang dashboard can multi-tenant filter the same way vLLM does
- Backend: defaults `enable_metrics=True` (gates SGLang's `set_prometheus_multiproc_dir`); starts bridge as asyncio task right after `Engine()` returns; cancels in `__del__` before `engine.shutdown()`
- `observability/vmagent/prometheus.yml`: relabel `ray_sglang[:_]<name>` → `sglang_<name>` (underscore separator, matching SGLang upstream metric naming)

### Grafana dashboard
- `scripts/dashboard/vendir.yml`: pin SGLang upstream `examples/monitoring/grafana/dashboards/json/sglang-dashboard.json` at v0.5.10
- `scripts/dashboard/configs/sglang_convert.json`: strip upstream `{model_name=~"$model_name"}` clause + inject Neutree four-axis filter (`application` / `deployment` / `replica` / `neutree_cluster`) on every `sglang_<name>` reference
- `scripts/dashboard/convert_sglang_dashboard.py` + `sync-grafana-dashboards.sh`: pipeline driver
- `observability/grafana/dashboards/sglang_grafana_dashboard.json`: 8 panels preserved, uid normalised to `sglang`, theme panel auto-injected
- `.gitignore`: `scripts/dashboard/sglang-upstream`

## Test

### Local

- [x] `go vet ./...` (changed packages clean)
- [x] `go test ./internal/engine/...` (builtin registration + schema spot-check + SGLang task whitelist all green)
- [x] `go test ./internal/orchestrator/... -run "TensorParallel|setEngineArgs"` (vLLM + SGLang TP cases all pass)
- [x] `go test ./internal/... ./api/... ./pkg/...` (no regression)
- [x] `go build ./tests/e2e/...` (e2e test files compile)
- [x] `python3 -m py_compile cluster-image-builder/serve/sglang/v0_5_10/app.py`
- [x] `python3 -m py_compile cluster-image-builder/serve/_metrics/sglang_ray_bridge.py`
- [x] `make --just-print` for `docker-build-engine-sglang{,-rocm}`: dry-run renders expected base image + tag scheme; existing vLLM target byte-identical
- [x] yaml syntax: `release-engine-image.yaml`, `vendir.yml`, `vmagent/prometheus.yml`
- [x] dashboard converter pipeline executed; output validates: 8 panels preserved, 4-axis Neutree filter injected, no leftover `model_name=~"$model_name"`, theme panel id 9999 auto-injected

### CI

- [x] GitHub Actions `pr-check`
- [x] codecov/patch
- [x] release-engine-image dispatch (NVIDIA + `engine_patch_suffix=8`): produces `docker.io/neutree/engine-sglang:v0.5.10-neutree8-ray2.53.0` (used for SSH cluster validation; copied to `192.168.22.100/neutree-test/` (patch-version registry))

### Cluster validation

**SSH/Ray static cluster lane (passed, image `v0.5.10-neutree8`, 7 specs in 14m12s):**
- [x] C2649562 SGLang All Schema Types Engine Args → deploy + Ray Serve config check (every key/value reaches engine intact across int / float / bool / string / enum / object) + serve inference green
- [x] C2649559 chat completion → HTTP 200 + `choices` non-empty
- [x] C2649560 embedding `/v1/embeddings` → HTTP 200 with `data` array
- [x] C2649563 SGLang Tensor Parallel TP=2 (gpu=2, user-set `tp_size: 2`) → endpoint Running + Ray Serve config has `tp_size=2`
- [x] C2649564 SGLang Auto Tensor Parallel (gpu=2, no user `tp_size`) → orchestrator auto-sets `tp_size=2` in Ray Serve config + endpoint Running

**K8s lane — `--ginkgo.label-filter='endpoint && k8s && sglang'` (deferred to verifier):**
- [ ] C2649562 SGLang All Schema Types Engine Args → deploy + container CLI flags (`--tp-size`, `--mem-fraction-static`, `--disable-cuda-graph`, `--dtype`, `--chunked-prefill-size`, `--served-model-name`, `--attention-backend`, `--cuda-graph-max-bs`, `--preferred-sampling-params`, `--json-model-override-args`) + serve inference
- [ ] C2649559 chat completion (K8s)
- [ ] C2649560 embedding single + batch (K8s)
- [ ] C2649563 explicit `tp_size=2` (K8s)
- [ ] C2649564 auto-tp (K8s)

**Observability smoke (either lane, deferred):**
- [x] Verify SGLang dashboard panels render with the four Neutree variables auto-bound from endpoint context (live SGLang traffic populates the panels)
- [x] Verify `/metrics` from any Ray Serve replica exposes `ray_sglang_*` series; vmagent rewrite produces `sglang_*` in VictoriaMetrics