### PR TITLE
feat: introduce vllm-omni v0.18.0 engine (Phase 1 SSH cluster mode)

### DIFF
--- a/api/v1/engine_types.go
+++ b/api/v1/engine_types.go
@@ -17,6 +17,7 @@ const (
 	// Engine name constants
 	EngineNameVLLM     = "vllm"
 	EngineNameLlamaCpp = "llama-cpp"
+	EngineNameVLLMOmni = "vllm-omni"
 )
 
 // EngineVersion represents a specific version of an engine with its configuration schema,

--- a/cluster-image-builder/Dockerfile.engine-vllm-omni
+++ b/cluster-image-builder/Dockerfile.engine-vllm-omni
@@ -1,0 +1,68 @@
+ARG RAY_COMMIT
+ARG COMMON_WORKDIR=/app
+ARG RAY_REPO
+ARG ENGINE_BASE_IMAGE=vllm/vllm-omni:v0.18.0
+ARG ENGINE_VERSION_DIR=v0_18_0
+ARG RAY_BUILD_BASE_IMAGE="quay.io/pypa/manylinux2014_x86_64:2024-07-02-9ac04ee"
+
+# --- Ray source fetch ---
+FROM alpine/git:v2.47.2 AS ray_fetch
+ARG RAY_REPO
+ARG RAY_COMMIT
+ARG COMMON_WORKDIR
+WORKDIR ${COMMON_WORKDIR}
+RUN git clone ${RAY_REPO} \
+	    && cd ray \
+	    && git checkout ${RAY_COMMIT}
+
+# --- Ray wheel build ---
+FROM ${RAY_BUILD_BASE_IMAGE} AS build_ray
+ARG COMMON_WORKDIR
+ARG RAY_COMMIT
+ENV BUILDKITE_COMMIT=${RAY_COMMIT}
+ENV TRAVIS_COMMIT=${BUILDKITE_COMMIT}
+ENV BUILD_ONE_PYTHON_ONLY=py312
+ENV RAY_DISABLE_EXTRA_CPP=1
+WORKDIR /ray
+COPY --from=ray_fetch ${COMMON_WORKDIR}/ray /ray
+RUN /ray/python/build-wheel-manylinux2014.sh
+
+# --- Engine image (vllm-omni) ---
+# Base: vllm/vllm-omni:v0.18.0 already includes:
+#   - vllm + vllm-omni Python packages
+#   - System deps for multimodal: espeak-ng, ffmpeg, sox, libsox-fmt-all, jq
+#   - CUDA runtime
+FROM ${ENGINE_BASE_IMAGE}
+
+ENV HOME=/home/ray
+WORKDIR ${HOME}
+
+# Install Ray neutree fork (same version as cluster image)
+RUN --mount=type=bind,from=build_ray,src=/ray,target=/install \
+    cd /install \
+    && whl=$(ls .whl/*.whl) \
+    && uv pip install --system "${whl}[serve,cgraph]"
+
+# Install common serve-layer dependencies
+RUN --mount=type=bind,src=requirements,target=requirements \
+    uv pip install --system -r requirements/common.txt
+
+# Copy Neutree serve layer code (shared + specified engine version only).
+# IMPORTANT: do NOT install downloader/requirements.txt — vllm-omni's base
+# image pins transformers/hf_hub at versions that conflict with the
+# downloader's requirements.txt (parallel to the cluster-image-builder
+# downloader feedback in CLAUDE.md). Copy source only; downloader code
+# inherits the base image's hf_hub/transformers stack.
+ARG ENGINE_VERSION_DIR
+COPY serve/_metrics ./serve/_metrics
+COPY serve/_replica_scheduler ./serve/_replica_scheduler
+COPY serve/_utils ./serve/_utils
+COPY serve/vllm-omni/${ENGINE_VERSION_DIR} ./serve/vllm-omni/${ENGINE_VERSION_DIR}
+COPY downloader ./downloader
+
+# Ensure "python" is in PATH (some base images only provide "python3")
+RUN ln -sf $(which python3) /usr/bin/python 2>/dev/null || true
+
+# Reset ENTRYPOINT from base image so Ray can execute its own commands
+ENTRYPOINT []
+CMD ["/bin/bash"]

--- a/cluster-image-builder/Makefile
+++ b/cluster-image-builder/Makefile
@@ -20,6 +20,9 @@ ENGINE_VLLM_BASE_IMAGE_REPO ?= vllm/vllm-openai
 ENGINE_VLLM_ROCM_BASE_IMAGE_REPO ?= vllm/vllm-openai-rocm
 ENGINE_VLLM_VERSION ?= v0.11.2
 ENGINE_VLLM_DIR_VERSION ?= $(shell echo $(ENGINE_VLLM_VERSION) | sed 's/-.*//' | tr '.' '_')
+ENGINE_VLLM_OMNI_BASE_IMAGE_REPO ?= vllm/vllm-omni
+ENGINE_VLLM_OMNI_VERSION ?= v0.18.0
+ENGINE_VLLM_OMNI_DIR_VERSION ?= $(shell echo $(ENGINE_VLLM_OMNI_VERSION) | sed 's/-.*//' | tr '.' '_')
 ENGINE_LLAMA_CPP_VERSION ?= v0.3.7
 ENGINE_LLAMA_CPP_DIR_VERSION ?= $(shell echo $(ENGINE_LLAMA_CPP_VERSION) | sed 's/-.*//' | tr '.' '_')
 RAY_SHORT_VERSION ?= ray2.53.0
@@ -57,6 +60,11 @@ docker-build-engine-llama-cpp: prepare ## Build the llama-cpp-python engine imag
 	docker build --build-arg LLAMA_CPP_VERSION=$(shell echo $(ENGINE_LLAMA_CPP_VERSION) | sed 's/^v//') --build-arg ENGINE_VERSION_DIR=$(ENGINE_LLAMA_CPP_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
 		-f Dockerfile.engine-llama-cpp -t $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)-$(RAY_SHORT_VERSION) .
 
+.PHONY: docker-build-engine-vllm-omni
+docker-build-engine-vllm-omni: prepare ## Build the vLLM-Omni engine image (NVIDIA, SSH cluster mode)
+	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_OMNI_BASE_IMAGE_REPO):$(ENGINE_VLLM_OMNI_VERSION) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_OMNI_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
+		-f Dockerfile.engine-vllm-omni -t $(NEUTREE_ENGINE_IMAGE)-vllm-omni:$(ENGINE_VLLM_OMNI_VERSION)-$(RAY_SHORT_VERSION) .
+
 .PHONY: docker-push
 docker-push: ## Run docker-push-* targets for all the images
 	$(MAKE) ARCH=$(ARCH) $(addprefix docker-push-,$(ACCELERATORS))
@@ -80,6 +88,10 @@ docker-push-engine-vllm-rocm: ## Push the vLLM engine image (ROCm)
 .PHONY: docker-push-engine-llama-cpp
 docker-push-engine-llama-cpp: ## Push the llama-cpp-python engine image
 	docker push $(NEUTREE_ENGINE_IMAGE)-llama-cpp:$(ENGINE_LLAMA_CPP_VERSION)-$(RAY_SHORT_VERSION)
+
+.PHONY: docker-push-engine-vllm-omni
+docker-push-engine-vllm-omni: ## Push the vLLM-Omni engine image
+	docker push $(NEUTREE_ENGINE_IMAGE)-vllm-omni:$(ENGINE_VLLM_OMNI_VERSION)-$(RAY_SHORT_VERSION)
 
 .PHONY: docker-push-manifest-engine-vllm
 docker-push-manifest-engine-vllm: ## Push the vLLM engine manifest image

--- a/cluster-image-builder/serve/vllm-omni/v0_18_0/app.py
+++ b/cluster-image-builder/serve/vllm-omni/v0_18_0/app.py
@@ -1,0 +1,71 @@
+"""Ray Serve application for vLLM-Omni v0.18.0.
+
+This is the Phase 1 skeleton. Per the design doc §5.4b, the full
+``AsyncOmni`` integration is driven by the build-test loop:
+
+  build engine image -> ssh push -> deploy endpoint
+    -> tail Ray Serve logs -> fix shape mismatches -> repeat
+
+The skeleton intentionally mirrors ``cluster-image-builder/serve/vllm/v0_17_1/app.py``
+in shape so that diff-based review can spot exactly where vLLM-Omni
+diverges. The known divergence points are marked ``OMNI-TODO`` and
+will be filled in during build-test iteration:
+
+* ``OMNI-TODO[entry-point]``: replace ``vllm.v1.engine.async_llm.AsyncLLM``
+  with ``vllm_omni.entrypoints.AsyncOmni``; the constructor signature
+  is verified against vllm-omni v0.18.0 source.
+* ``OMNI-TODO[serving-class]``: vllm-omni bundles its own OpenAI
+  handler in ``vllm_omni/entrypoints/openai/`` — confirm whether to
+  reuse it or wire the chat completion endpoint manually.
+* ``OMNI-TODO[output-shape]``: ``OmniRequestOutput`` carries
+  text/audio/image latents in separate fields; the streaming response
+  must serialize each modality according to the request's
+  ``modalities`` value. Reference: vllm-omni
+  ``examples/online_serving/qwen2_5_omni/`` upstream.
+* ``OMNI-TODO[error-response]``: verify ``ErrorResponse`` is the
+  nested-shape variant (v0.10.1+) and import path is
+  ``vllm_omni.entrypoints.openai.protocol`` (mirror vLLM v0.17.1
+  changes — see generate-engine-version skill Step 3c).
+
+Phase 1 explicitly excludes:
+
+* multi-stage cross-pod orchestration (use single-host
+  ``worker_backend=multi_process`` only — Phase 3)
+* TTS-only ``/v1/audio/speech``, image generation
+  ``/v1/images/generations``, realtime WebSocket ``/v1/realtime``
+  (Phase 4)
+
+Phase 1 canary: ``Qwen/Qwen2.5-Omni-7B`` — single GPU, audio input
+plus text+audio output via OpenAI-compatible chat completions.
+"""
+
+# OMNI-TODO[entry-point]: import AsyncOmni once skeleton becomes the
+# build-test seed. The Dockerfile's pip stack guarantees vllm_omni is
+# importable; the actual constructor call is iterated in fix commits.
+#
+# Reference upstream:
+#   from vllm_omni.entrypoints import AsyncOmni
+#   from vllm_omni.outputs import OmniRequestOutput
+
+# Skeleton intentionally exports nothing yet so the image builds and
+# the engine-registration path resolves. Iteration commits in this
+# same branch will populate ``builder()`` mirroring the v0.17.1 vLLM
+# app.py.
+
+
+def builder(args: dict):  # pragma: no cover - skeleton
+    """Build the Ray Serve application.
+
+    Args:
+        args: engine arguments forwarded by Neutree Ray orchestrator.
+
+    Raises:
+        NotImplementedError: skeleton only — populated during build-test
+            loop iteration.
+    """
+    raise NotImplementedError(
+        "vllm-omni v0.18.0 Ray Serve app.py is a Phase 1 skeleton; "
+        "the AsyncOmni integration is filled in via the build-test "
+        "loop. See cluster-image-builder/serve/vllm-omni/v0_18_0/app.py "
+        "module docstring for the OMNI-TODO checklist."
+    )

--- a/internal/engine/builtin.go
+++ b/internal/engine/builtin.go
@@ -26,6 +26,11 @@ func GetBuiltinEngines() ([]*v1.Engine, error) {
 		return nil, err
 	}
 
+	vllmOmniV0_18_0EngineSchema, err := GetVLLMOmniV0_18_0EngineSchema()
+	if err != nil {
+		return nil, err
+	}
+
 	engines := []*v1.Engine{
 		{
 			APIVersion: "v1",
@@ -112,6 +117,33 @@ func GetBuiltinEngines() ([]*v1.Engine, error) {
 					},
 				},
 				SupportedTasks: []string{v1.TextGenerationModelTask, v1.TextEmbeddingModelTask, v1.TextRerankModelTask},
+			},
+		},
+		{
+			APIVersion: "v1",
+			Kind:       "Engine",
+			Metadata: &v1.Metadata{
+				Name: v1.EngineNameVLLMOmni,
+			},
+			// Phase 1: SSH cluster mode only. Only the ssh_-prefixed image is
+			// registered and no Kubernetes deploy template is provided. Attempts
+			// to deploy on Kubernetes will fail at image lookup with a clear
+			// "image not found for accelerator" error, naturally guarding
+			// against accidental K8s use until Phase 2 lands the K8s template.
+			Spec: &v1.EngineSpec{
+				Versions: []*v1.EngineVersion{
+					{
+						Version:      "v0.18.0",
+						ValuesSchema: vllmOmniV0_18_0EngineSchema,
+						Images: map[string]*v1.EngineImage{
+							v1.SSHImageKeyPrefix + "nvidia_gpu": {
+								ImageName: "neutree/engine-vllm-omni",
+								Tag:       "v0.18.0-ray2.53.0",
+							},
+						},
+					},
+				},
+				SupportedTasks: []string{v1.TextGenerationModelTask},
 			},
 		},
 	}

--- a/internal/engine/builtin_test.go
+++ b/internal/engine/builtin_test.go
@@ -10,8 +10,8 @@ func TestGetBuiltinEngines(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(engines) != 2 {
-		t.Fatalf("expected 2 built-in engines, got %d", len(engines))
+	if len(engines) != 3 {
+		t.Fatalf("expected 3 built-in engines, got %d", len(engines))
 	}
 
 	engineNames := make(map[string]bool)
@@ -25,6 +25,10 @@ func TestGetBuiltinEngines(t *testing.T) {
 
 	if !engineNames["llama-cpp"] {
 		t.Error("expected llama-cpp engine to be registered")
+	}
+
+	if !engineNames["vllm-omni"] {
+		t.Error("expected vllm-omni engine to be registered")
 	}
 
 	// Verify vllm versions have nvidia_gpu image and deploy template
@@ -44,6 +48,35 @@ func TestGetBuiltinEngines(t *testing.T) {
 				} else if _, ok := k8sTemplates["default"]; !ok {
 					t.Errorf("vllm %s missing default kubernetes deploy template", v.Version)
 				}
+			}
+		}
+	}
+
+	// Phase 1 vllm-omni: SSH cluster mode only.
+	// Verify only the SSH-prefixed image is registered and no Kubernetes deploy
+	// template is present (K8s mode is deferred to Phase 2).
+	for _, e := range engines {
+		if e.Metadata.Name != "vllm-omni" {
+			continue
+		}
+
+		if len(e.Spec.Versions) == 0 {
+			t.Fatalf("vllm-omni has no versions registered")
+		}
+
+		for _, v := range e.Spec.Versions {
+			if v.Version != "v0.18.0" {
+				continue
+			}
+			sshKey := "ssh_nvidia_gpu"
+			if _, ok := v.Images[sshKey]; !ok {
+				t.Errorf("vllm-omni %s missing %s image", v.Version, sshKey)
+			}
+			if _, ok := v.Images["nvidia_gpu"]; ok {
+				t.Errorf("vllm-omni %s should not register K8s nvidia_gpu image in Phase 1 (SSH only)", v.Version)
+			}
+			if len(v.DeployTemplate) != 0 {
+				t.Errorf("vllm-omni %s should not register Kubernetes deploy template in Phase 1, got %v", v.Version, v.DeployTemplate)
 			}
 		}
 	}

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -18,6 +18,9 @@ var vllmV0_17_1EngineSchema []byte
 //go:embed llama-cpp/v0.3.7/schema.json
 var llamaCppV0_3_7EngineSchema []byte
 
+//go:embed vllm-omni/v0.18.0/schema.json
+var vllmOmniV0_18_0EngineSchema []byte
+
 // GetVLLMV0_8_5EngineSchema returns the parsed JSON schema for vLLM V0.8.5 engine
 func GetVLLMV0_8_5EngineSchema() (map[string]interface{}, error) {
 	var schema map[string]interface{}
@@ -57,12 +60,23 @@ func GetLlamaCppDefaultEngineSchema() (map[string]interface{}, error) {
 	return schema, nil
 }
 
+// GetVLLMOmniV0_18_0EngineSchema returns the parsed JSON schema for vLLM-Omni V0.18.0 engine.
+func GetVLLMOmniV0_18_0EngineSchema() (map[string]interface{}, error) {
+	var schema map[string]interface{}
+	if err := json.Unmarshal(vllmOmniV0_18_0EngineSchema, &schema); err != nil {
+		return nil, fmt.Errorf("failed to parse vLLM-Omni V0.18.0 engine schema: %w", err)
+	}
+
+	return schema, nil
+}
+
 // EngineSchemas contains all available engine schemas
 var EngineSchemas = map[string]func() (map[string]interface{}, error){
-	"vllm-v0.8.5":      GetVLLMV0_8_5EngineSchema,
-	"llama-cpp-v0.3.7": GetLlamaCppDefaultEngineSchema,
-	"vllm-v0.11.2":     GetVLLMV0_11_2EngineSchema,
-	"vllm-v0.17.1":     GetVLLMV0_17_1EngineSchema,
+	"vllm-v0.8.5":       GetVLLMV0_8_5EngineSchema,
+	"llama-cpp-v0.3.7":  GetLlamaCppDefaultEngineSchema,
+	"vllm-v0.11.2":      GetVLLMV0_11_2EngineSchema,
+	"vllm-v0.17.1":      GetVLLMV0_17_1EngineSchema,
+	"vllm-omni-v0.18.0": GetVLLMOmniV0_18_0EngineSchema,
 }
 
 // GetEngineSchema returns the schema for a specific engine

--- a/internal/engine/schema_test.go
+++ b/internal/engine/schema_test.go
@@ -43,3 +43,23 @@ func TestGetLlamaCppDefaultEngineSchema(t *testing.T) {
 		t.Fatal("expected schema to be non-nil")
 	}
 }
+
+func TestGetVLLMOmniV0_18_0EngineSchema(t *testing.T) {
+	schema, err := GetVLLMOmniV0_18_0EngineSchema()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema == nil {
+		t.Fatal("expected schema to be non-nil")
+	}
+
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected schema.properties to be an object")
+	}
+	for _, key := range []string{"omni", "output_modalities", "worker_backend", "ray_address", "deploy_config"} {
+		if _, exists := props[key]; !exists {
+			t.Errorf("vllm-omni schema missing required property: %s", key)
+		}
+	}
+}

--- a/internal/engine/vllm-omni/v0.18.0/schema.json
+++ b/internal/engine/vllm-omni/v0.18.0/schema.json
@@ -1,0 +1,986 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "vLLM-Omni v0.18.0 Engine Configuration",
+  "description": "Configuration schema for vLLM-Omni v0.18.0 engine parameters. Inherits vLLM AsyncEngineArgs/FrontendArgs and adds Omni-specific fields. Phase 1 targets SSH cluster mode; K8s mode planned for Phase 2.",
+  "properties": {
+    "omni": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable vllm-omni mode for multi-modal and diffusion models. Required true for vllm-omni engine; UI does not expose this toggle."
+    },
+    "output_modalities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["text", "audio"]
+      },
+      "description": "Control which output channels the model should generate. ['text']: text only. ['audio']: text + audio. ['text', 'audio']: text + audio. If unspecified, the model default applies (typically text + audio for Omni models)."
+    },
+    "worker_backend": {
+      "type": "string",
+      "enum": ["multi_process", "ray"],
+      "default": "multi_process",
+      "description": "Backend used for stage workers. 'multi_process' (default): single-host fork-based; 'ray': cross-node Ray placement-group scheduling. Phase 1 single-host PoC uses multi_process."
+    },
+    "ray_address": {
+      "type": "string",
+      "description": "Address of the Ray cluster to connect to (only meaningful when worker_backend=ray)."
+    },
+    "deploy_config": {
+      "type": "string",
+      "description": "Path to a custom deploy YAML overriding vllm_omni/deploy/<model>.yaml. Leave unset to use the bundled default for the selected model."
+    },
+    "model": {
+      "type": "string",
+      "description": "Name or path of the Hugging Face model to use"
+    },
+    "enable_return_routed_experts": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable returning routed expert info"
+    },
+    "model_weights": {
+      "type": "string",
+      "description": "Path to model weights separate from config"
+    },
+    "served_model_name": {
+      "type": ["string", "array"],
+      "items": {
+        "type": "string"
+      },
+      "description": "The model name(s) used in the API"
+    },
+    "tokenizer": {
+      "type": "string",
+      "description": "Name or path of the Hugging Face tokenizer to use"
+    },
+    "hf_config_path": {
+      "type": "string",
+      "description": "Name or path of the Hugging Face config to use"
+    },
+    "runner": {
+      "type": "string",
+      "enum": ["auto", "draft", "generate", "pooling"],
+      "default": "auto",
+      "description": "The type of model runner to use"
+    },
+    "convert": {
+      "type": "string",
+      "enum": ["auto", "classify", "embed", "none", "reward"],
+      "default": "auto",
+      "description": "Convert the model using adapters"
+    },
+    "skip_tokenizer_init": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip initialization of tokenizer and detokenizer"
+    },
+    "enable_prompt_embeds": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable passing text embeddings via prompt_embeds"
+    },
+    "tokenizer_mode": {
+      "type": "string",
+      "enum": ["auto", "slow", "mistral", "custom"],
+      "default": "auto",
+      "description": "The tokenizer mode to use"
+    },
+    "trust_remote_code": {
+      "type": "boolean",
+      "default": false,
+      "description": "Trust remote code from Hugging Face"
+    },
+    "allowed_local_media_path": {
+      "type": "string",
+      "default": "",
+      "description": "Allowed local media path for security"
+    },
+    "allowed_media_domains": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Allowed media domains for multi-modal inputs"
+    },
+    "download_dir": {
+      "type": "string",
+      "description": "Directory to download and load weights"
+    },
+    "safetensors_load_strategy": {
+      "type": "string",
+      "enum": ["lazy", "eager", "torchao"],
+      "default": "lazy",
+      "description": "Loading strategy for safetensors weights"
+    },
+    "load_format": {
+      "type": "string",
+      "default": "auto",
+      "description": "The format of model weights to load"
+    },
+    "config_format": {
+      "type": "string",
+      "enum": ["auto", "hf", "mistral"],
+      "default": "auto",
+      "description": "The format of the model config to load"
+    },
+    "dtype": {
+      "type": "string",
+      "enum": ["auto", "half", "float16", "bfloat16", "float", "float32"],
+      "default": "auto",
+      "description": "Data type for model weights and activations"
+    },
+    "kv_cache_dtype": {
+      "type": "string",
+      "enum": ["auto", "bfloat16", "fp8", "fp8_ds_mla", "fp8_e4m3", "fp8_e5m2", "fp8_inc"],
+      "default": "auto",
+      "description": "Data type for KV cache storage"
+    },
+    "seed": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Random seed for reproducibility"
+    },
+    "max_model_len": {
+      "type": "integer",
+      "description": "Model context length"
+    },
+    "cudagraph_capture_sizes": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Sizes to capture cudagraph"
+    },
+    "max_cudagraph_capture_size": {
+      "type": "integer",
+      "description": "Maximum cudagraph capture size"
+    },
+    "distributed_executor_backend": {
+      "type": "string",
+      "enum": ["external_launcher", "mp", "ray", "uni"],
+      "description": "Backend for distributed model workers"
+    },
+    "pipeline_parallel_size": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of pipeline parallel groups"
+    },
+    "master_addr": {
+      "type": "string",
+      "default": "127.0.0.1",
+      "description": "Distributed master address"
+    },
+    "master_port": {
+      "type": "integer",
+      "default": 29501,
+      "description": "Distributed master port"
+    },
+    "nnodes": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of nodes for multi-node inference"
+    },
+    "node_rank": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 0,
+      "description": "Distributed node rank"
+    },
+    "tensor_parallel_size": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of tensor parallel groups"
+    },
+    "prefill_context_parallel_size": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of prefill context parallel groups"
+    },
+    "decode_context_parallel_size": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of decode context parallel groups"
+    },
+    "dcp_kv_cache_interleave_size": {
+      "type": "integer",
+      "description": "KV cache interleave size for decode context parallelism"
+    },
+    "cp_kv_cache_interleave_size": {
+      "type": "integer",
+      "description": "KV cache interleave size for context parallelism"
+    },
+    "data_parallel_size": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of data parallel replicas"
+    },
+    "data_parallel_rank": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Data parallel rank of this instance"
+    },
+    "data_parallel_start_rank": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Starting data parallel rank for secondary nodes"
+    },
+    "data_parallel_size_local": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of data parallel replicas on this node"
+    },
+    "data_parallel_address": {
+      "type": "string",
+      "description": "Address of data parallel cluster head-node"
+    },
+    "data_parallel_rpc_port": {
+      "type": "integer",
+      "description": "Port for data parallel RPC communication"
+    },
+    "data_parallel_hybrid_lb": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use hybrid DP load balancing mode"
+    },
+    "data_parallel_external_lb": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use external DP load balancing mode"
+    },
+    "data_parallel_backend": {
+      "type": "string",
+      "enum": ["mp", "ray"],
+      "default": "mp",
+      "description": "Backend for data parallel"
+    },
+    "enable_expert_parallel": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable expert parallelism for MoE models"
+    },
+    "moe_backend": {
+      "type": "string",
+      "description": "Explicit kernel selection for MoE"
+    },
+    "all2all_backend": {
+      "type": "string",
+      "enum": ["allgather_reducescatter", "deepep_high_throughput", "deepep_low_latency", "flashinfer_all2allv", "naive", "pplx", "None"],
+      "description": "All2All backend for MoE expert parallel"
+    },
+    "enable_elastic_ep": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable elastic expert parallelism"
+    },
+    "enable_dbo": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable dual batch overlap"
+    },
+    "ubatch_size": {
+      "type": "integer",
+      "description": "Micro-batch size for dual batch overlap"
+    },
+    "dbo_decode_token_threshold": {
+      "type": "integer",
+      "default": 32,
+      "description": "Token threshold for dual batch overlap decode"
+    },
+    "dbo_prefill_token_threshold": {
+      "type": "integer",
+      "default": 512,
+      "description": "Token threshold for dual batch overlap prefill"
+    },
+    "disable_nccl_for_dp_synchronization": {
+      "type": "boolean",
+      "description": "Force DP sync to use Gloo instead of NCCL"
+    },
+    "eplb_config": {
+      "type": "object",
+      "description": "Expert parallelism load balancing configuration"
+    },
+    "enable_eplb": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable expert parallelism load balancing"
+    },
+    "expert_placement_strategy": {
+      "type": "string",
+      "enum": ["linear", "round_robin"],
+      "default": "linear",
+      "description": "Expert placement strategy for MoE layers"
+    },
+    "max_parallel_loading_workers": {
+      "type": "integer",
+      "description": "Maximum number of parallel loading workers"
+    },
+    "block_size": {
+      "type": "integer",
+      "enum": [1, 8, 16, 32, 64, 128, 256],
+      "description": "Size of a contiguous cache block"
+    },
+    "enable_prefix_caching": {
+      "type": "boolean",
+      "description": "Enable prefix caching"
+    },
+    "prefix_caching_hash_algo": {
+      "type": "string",
+      "enum": ["sha256", "sha256_cbor"],
+      "default": "sha256",
+      "description": "Hash algorithm for prefix caching"
+    },
+    "disable_sliding_window": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable sliding window attention"
+    },
+    "disable_cascade_attn": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable cascade attention for V1"
+    },
+    "swap_space": {
+      "type": "number",
+      "minimum": 0,
+      "default": 4,
+      "description": "CPU swap space size (GiB) per GPU"
+    },
+    "offload_backend": {
+      "type": "string",
+      "default": "auto",
+      "description": "Backend for weight offloading"
+    },
+    "cpu_offload_gb": {
+      "type": "number",
+      "minimum": 0,
+      "default": 0,
+      "description": "The space in GiB to offload to CPU"
+    },
+    "cpu_offload_params": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Parameter names to offload to CPU"
+    },
+    "offload_group_size": {
+      "type": "integer",
+      "description": "Group size for weight offloading"
+    },
+    "offload_num_in_group": {
+      "type": "integer",
+      "description": "Number of layers in each offload group"
+    },
+    "offload_prefetch_step": {
+      "type": "integer",
+      "description": "Prefetch step for weight offloading"
+    },
+    "offload_params": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Parameter names for offloading"
+    },
+    "gpu_memory_utilization": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1.0,
+      "default": 0.9,
+      "description": "The fraction of GPU memory to be used"
+    },
+    "kv_cache_memory_bytes": {
+      "type": "integer",
+      "description": "Size of KV Cache per GPU in bytes"
+    },
+    "max_num_batched_tokens": {
+      "type": "integer",
+      "description": "Maximum number of batched tokens per iteration"
+    },
+    "max_num_partial_prefills": {
+      "type": "integer",
+      "default": 1,
+      "description": "Max concurrent partial prefills for chunked prefill"
+    },
+    "max_long_partial_prefills": {
+      "type": "integer",
+      "default": 1,
+      "description": "Max concurrent long prompts for chunked prefill"
+    },
+    "long_prefill_token_threshold": {
+      "type": "integer",
+      "default": 0,
+      "description": "Token threshold for long prefill"
+    },
+    "max_num_seqs": {
+      "type": "integer",
+      "description": "Maximum number of sequences per iteration"
+    },
+    "max_logprobs": {
+      "type": "integer",
+      "default": 20,
+      "description": "Maximum number of log probabilities to return"
+    },
+    "logprobs_mode": {
+      "type": "string",
+      "enum": ["processed_logits", "processed_logprobs", "raw_logits", "raw_logprobs"],
+      "default": "raw_logprobs",
+      "description": "Indicates the content returned in logprobs"
+    },
+    "disable_log_stats": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable logging statistics"
+    },
+    "aggregate_engine_logging": {
+      "type": "boolean",
+      "default": false,
+      "description": "Log aggregate statistics with data parallel"
+    },
+    "revision": {
+      "type": "string",
+      "description": "The specific model version to use"
+    },
+    "code_revision": {
+      "type": "string",
+      "description": "The specific revision to use for the model code"
+    },
+    "hf_token": {
+      "type": ["string", "boolean"],
+      "description": "Hugging Face token for authentication"
+    },
+    "hf_overrides": {
+      "type": "object",
+      "default": {},
+      "description": "Arguments to be forwarded to HuggingFace config"
+    },
+    "tokenizer_revision": {
+      "type": "string",
+      "description": "Revision of the tokenizer to use"
+    },
+    "quantization": {
+      "type": "string",
+      "description": "Method used to quantize the weights"
+    },
+    "allow_deprecated_quantization": {
+      "type": "boolean",
+      "default": false,
+      "description": "Allow deprecated quantization methods"
+    },
+    "enforce_eager": {
+      "type": "boolean",
+      "default": false,
+      "description": "Always use eager-mode PyTorch"
+    },
+    "disable_custom_all_reduce": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable custom all-reduce kernels"
+    },
+    "language_model_only": {
+      "type": "boolean",
+      "default": false,
+      "description": "Only load language model, skip non-LM components"
+    },
+    "limit_mm_per_prompt": {
+      "type": "object",
+      "default": {},
+      "description": "Maximum number of multi-modal items per prompt"
+    },
+    "enable_mm_embeds": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable passing multimodal embeddings"
+    },
+    "interleave_mm_strings": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable fully interleaved multimodal prompts"
+    },
+    "media_io_kwargs": {
+      "type": "object",
+      "default": {},
+      "description": "Additional args for processing media inputs"
+    },
+    "mm_processor_kwargs": {
+      "type": "object",
+      "description": "Arguments forwarded to multi-modal processor"
+    },
+    "mm_processor_cache_gb": {
+      "type": "number",
+      "default": 4,
+      "description": "Size (GiB) of multi-modal processor cache"
+    },
+    "mm_processor_cache_type": {
+      "type": "string",
+      "enum": ["lru", "shm"],
+      "description": "Type of cache for multi-modal processor"
+    },
+    "mm_shm_cache_max_object_size_mb": {
+      "type": "integer",
+      "default": 128,
+      "description": "Max object size (MiB) in shared memory cache"
+    },
+    "mm_encoder_only": {
+      "type": "boolean",
+      "default": false,
+      "description": "Only use multimodal encoder"
+    },
+    "mm_encoder_tp_mode": {
+      "type": "string",
+      "enum": ["data", "weights"],
+      "description": "Multi-modal encoder tensor parallel mode"
+    },
+    "mm_encoder_attn_backend": {
+      "type": "string",
+      "description": "Multi-modal encoder attention backend"
+    },
+    "io_processor_plugin": {
+      "type": "string",
+      "description": "IOProcessor plugin name to load at startup"
+    },
+    "skip_mm_profiling": {
+      "type": "boolean",
+      "default": false,
+      "description": "Skip multimodal memory profiling"
+    },
+    "video_pruning_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Pruning rate for video via Efficient Video Sampling"
+    },
+    "enable_lora": {
+      "type": "boolean",
+      "description": "Enable handling of LoRA adapters"
+    },
+    "max_loras": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Maximum number of LoRA adapters"
+    },
+    "max_lora_rank": {
+      "type": "integer",
+      "enum": [1, 8, 16, 32, 64, 128, 256, 320, 512],
+      "default": 16,
+      "description": "Maximum LoRA rank"
+    },
+    "default_mm_loras": {
+      "type": "object",
+      "description": "Default LoRA paths for specific modalities"
+    },
+    "fully_sharded_loras": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use fully sharded LoRA layers"
+    },
+    "max_cpu_loras": {
+      "type": "integer",
+      "description": "Maximum number of LoRAs to store in CPU memory"
+    },
+    "lora_dtype": {
+      "type": "string",
+      "default": "auto",
+      "description": "Data type for LoRA"
+    },
+    "enable_tower_connector_lora": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable tower connector LoRA"
+    },
+    "specialize_active_lora": {
+      "type": "boolean",
+      "default": false,
+      "description": "Specialize CUDA graphs for active LoRA"
+    },
+    "ray_workers_use_nsight": {
+      "type": "boolean",
+      "default": false,
+      "description": "Profile Ray workers with nsight"
+    },
+    "num_gpu_blocks_override": {
+      "type": "integer",
+      "description": "Override profiled num_gpu_blocks"
+    },
+    "model_loader_extra_config": {
+      "type": "object",
+      "default": {},
+      "description": "Extra config for model loader"
+    },
+    "ignore_patterns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["original/**/*"],
+      "description": "Patterns to ignore when loading model"
+    },
+    "enable_chunked_prefill": {
+      "type": "boolean",
+      "description": "Enable chunked prefill requests"
+    },
+    "disable_chunked_mm_input": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable partial scheduling of multimodal items"
+    },
+    "disable_hybrid_kv_cache_manager": {
+      "type": "boolean",
+      "description": "Disable hybrid KV cache manager"
+    },
+    "structured_outputs_config": {
+      "type": "object",
+      "description": "Structured outputs configuration"
+    },
+    "reasoning_parser": {
+      "type": "string",
+      "default": "",
+      "description": "Reasoning parser to use"
+    },
+    "reasoning_parser_plugin": {
+      "type": "string",
+      "description": "Path to reasoning parser plugin"
+    },
+    "speculative_config": {
+      "type": "object",
+      "description": "Speculative decoding configuration"
+    },
+    "show_hidden_metrics_for_version": {
+      "type": "string",
+      "description": "Show hidden metrics since specified version"
+    },
+    "otlp_traces_endpoint": {
+      "type": "string",
+      "description": "OpenTelemetry traces target URL"
+    },
+    "collect_detailed_traces": {
+      "type": "string",
+      "description": "Collect detailed traces for specified modules"
+    },
+    "kv_cache_metrics": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable KV cache metrics"
+    },
+    "kv_cache_metrics_sample": {
+      "type": "number",
+      "default": 0.0,
+      "description": "KV cache metrics sampling rate"
+    },
+    "cudagraph_metrics": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable CUDA graph metrics"
+    },
+    "enable_layerwise_nvtx_tracing": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable layer-wise NVTX tracing"
+    },
+    "enable_mfu_metrics": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable MFU metrics"
+    },
+    "enable_logging_iteration_details": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable logging per-iteration details"
+    },
+    "enable_mm_processor_stats": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable multi-modal processor statistics"
+    },
+    "scheduling_policy": {
+      "type": "string",
+      "enum": ["fcfs", "priority"],
+      "default": "fcfs",
+      "description": "The scheduling policy to use"
+    },
+    "scheduler_cls": {
+      "type": "string",
+      "description": "The scheduler class to use"
+    },
+    "pooler_config": {
+      "type": "object",
+      "description": "Pooler config for output pooling behavior"
+    },
+    "compilation_config": {
+      "type": "object",
+      "description": "torch.compile and cudagraph configuration"
+    },
+    "attention_config": {
+      "type": "object",
+      "description": "Attention configuration"
+    },
+    "kernel_config": {
+      "type": "object",
+      "description": "Kernel configuration"
+    },
+    "enable_flashinfer_autotune": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable FlashInfer auto-tuning"
+    },
+    "worker_cls": {
+      "type": "string",
+      "default": "auto",
+      "description": "Full name of the worker class to use"
+    },
+    "worker_extension_cls": {
+      "type": "string",
+      "default": "",
+      "description": "Worker extension class name"
+    },
+    "profiler_config": {
+      "type": "object",
+      "description": "Profiler configuration"
+    },
+    "kv_transfer_config": {
+      "type": "object",
+      "description": "Distributed KV cache transfer config"
+    },
+    "kv_events_config": {
+      "type": "object",
+      "description": "Event publishing configuration"
+    },
+    "ec_transfer_config": {
+      "type": "object",
+      "description": "Distributed EC cache transfer config"
+    },
+    "generation_config": {
+      "type": "string",
+      "default": "auto",
+      "description": "Path to generation config"
+    },
+    "enable_sleep_mode": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable sleep mode for the engine"
+    },
+    "override_generation_config": {
+      "type": "object",
+      "default": {},
+      "description": "Override generation config parameters"
+    },
+    "model_impl": {
+      "type": "string",
+      "enum": ["auto", "terratorch", "transformers", "vllm"],
+      "default": "auto",
+      "description": "Which implementation of the model to use"
+    },
+    "override_attention_dtype": {
+      "type": "string",
+      "description": "Override dtype for attention"
+    },
+    "attention_backend": {
+      "type": "string",
+      "description": "Attention backend to use"
+    },
+    "calculate_kv_scales": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable dynamic calculation of k_scale and v_scale"
+    },
+    "mamba_cache_dtype": {
+      "type": "string",
+      "enum": ["auto", "float32"],
+      "default": "auto",
+      "description": "Data type for Mamba cache"
+    },
+    "mamba_ssm_cache_dtype": {
+      "type": "string",
+      "enum": ["auto", "float32"],
+      "default": "auto",
+      "description": "Data type for Mamba SSM state"
+    },
+    "mamba_block_size": {
+      "type": "integer",
+      "description": "Block size for mamba cache"
+    },
+    "mamba_cache_mode": {
+      "type": "string",
+      "enum": ["auto", "full", "token"],
+      "default": "auto",
+      "description": "Mamba cache mode"
+    },
+    "additional_config": {
+      "type": "object",
+      "default": {},
+      "description": "Additional platform-specific configuration"
+    },
+    "use_tqdm_on_load": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable tqdm progress bar when loading"
+    },
+    "pt_load_map_location": {
+      "type": ["string", "object"],
+      "default": "cpu",
+      "description": "Map location for loading pytorch checkpoint"
+    },
+    "logits_processors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Logits processors class names"
+    },
+    "async_scheduling": {
+      "type": "boolean",
+      "description": "Perform async scheduling"
+    },
+    "stream_interval": {
+      "type": "integer",
+      "default": 1,
+      "description": "Interval for streaming in terms of tokens"
+    },
+    "kv_sharing_fast_prefill": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable KV sharing fast prefill optimization"
+    },
+    "optimization_level": {
+      "type": "integer",
+      "enum": [0, 1, 2, 3],
+      "default": 0,
+      "description": "Optimization level (O0-O3)"
+    },
+    "performance_mode": {
+      "type": "string",
+      "enum": ["balanced", "interactivity", "throughput"],
+      "description": "Simplifies performance tuning"
+    },
+    "kv_offloading_size": {
+      "type": "number",
+      "description": "Size of KV cache offloading buffer (GiB)"
+    },
+    "kv_offloading_backend": {
+      "type": "string",
+      "enum": ["lmcache", "native", "None"],
+      "description": "Backend for KV cache offloading"
+    },
+    "tokens_only": {
+      "type": "boolean",
+      "default": false,
+      "description": "Only enable Tokens In/Out endpoint"
+    },
+    "weight_transfer_config": {
+      "type": "object",
+      "description": "Weight transfer configuration"
+    },
+    "fail_on_environ_validation": {
+      "type": "boolean",
+      "default": false,
+      "description": "Fail on environment variable validation errors"
+    },
+    "enable_log_requests": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable logging of API requests"
+    },
+    "chat_template": {
+      "type": "string",
+      "description": "Chat template file path or inline template"
+    },
+    "chat_template_content_format": {
+      "type": "string",
+      "enum": ["auto", "string", "openai"],
+      "default": "auto",
+      "description": "Chat template content format"
+    },
+    "trust_request_chat_template": {
+      "type": "boolean",
+      "default": false,
+      "description": "Trust chat template from request"
+    },
+    "default_chat_template_kwargs": {
+      "type": "object",
+      "description": "Default kwargs for chat template renderer"
+    },
+    "response_role": {
+      "type": "string",
+      "default": "assistant",
+      "description": "Role name to return for generation"
+    },
+    "return_tokens_as_token_ids": {
+      "type": "boolean",
+      "default": false,
+      "description": "Represent tokens as token_id:{id} strings"
+    },
+    "enable_prompt_tokens_details": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable prompt tokens details in response"
+    },
+    "enable_auto_tool_choice": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable auto tool choice"
+    },
+    "exclude_tools_when_tool_choice_none": {
+      "type": "boolean",
+      "default": false,
+      "description": "Exclude tools when tool_choice is none"
+    },
+    "tool_call_parser": {
+      "type": "string",
+      "description": "Tool call parser to use"
+    },
+    "tool_parser_plugin": {
+      "type": "string",
+      "default": "",
+      "description": "Tool parser plugin path"
+    },
+    "tool_server": {
+      "type": "string",
+      "description": "Tool server host:port pairs"
+    },
+    "enable_server_load_tracking": {
+      "type": "boolean",
+      "default": false,
+      "description": "Track server_load_metrics in app state"
+    },
+    "enable_force_include_usage": {
+      "type": "boolean",
+      "default": false,
+      "description": "Include usage on every request"
+    },
+    "enable_tokenizer_info_endpoint": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable /get_tokenizer_info endpoint"
+    },
+    "enable_log_outputs": {
+      "type": "boolean",
+      "default": false,
+      "description": "Log model outputs"
+    },
+    "enable_log_deltas": {
+      "type": "boolean",
+      "default": true,
+      "description": "Log output deltas when enable_log_outputs is set"
+    },
+    "log_error_stack": {
+      "type": "boolean",
+      "default": false,
+      "description": "Log stack trace of error responses"
+    },
+    "use_gpu_for_pooling_score": {
+      "type": "boolean",
+      "default": false,
+      "description": "Run pooling score MaxSim on GPU"
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -816,7 +816,12 @@ func setEngineSpecialEnv(endpoint *v1.Endpoint, deployedCluster *v1.Cluster, app
 	// Old clusters (<= v1.0.0) use RAY_kill_child_processes_on_worker_exit_with_raylet_subreaper which causes
 	// parent processes to lose child exit codes, breaking vLLM's P2P check. For those clusters, skip the check.
 	// New clusters (> v1.0.0) use RAY_process_group_cleanup_enabled which doesn't have this issue.
-	if endpoint.Spec != nil && endpoint.Spec.Engine != nil && endpoint.Spec.Engine.Engine == v1.EngineNameVLLM {
+	// vllm-omni inherits vLLM's underlying inference engine, so the same P2P
+	// check semantics apply. Both engines need VLLM_SKIP_P2P_CHECK on old
+	// clusters that lose child exit codes.
+	if endpoint.Spec != nil && endpoint.Spec.Engine != nil &&
+		(endpoint.Spec.Engine.Engine == v1.EngineNameVLLM ||
+			endpoint.Spec.Engine.Engine == v1.EngineNameVLLMOmni) {
 		if deployedCluster.Spec != nil && deployedCluster.Spec.Version != "" {
 			isNew, err := semver.LessThan("v1.0.0", deployedCluster.Spec.Version)
 			if err == nil && !isNew {

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2029,6 +2029,40 @@ func TestEndpointToApplication_setEngineSpecialEnv(t *testing.T) {
 			deployedCluster: &v1.Cluster{Spec: &v1.ClusterSpec{Version: "v1.0.1"}},
 			expectedEnvs:    map[string]string{},
 		},
+		{
+			name: "vllm-omni engine on old cluster sets VLLM_SKIP_P2P_CHECK",
+			endpoint: &v1.Endpoint{
+				Metadata: &v1.Metadata{
+					Workspace: "default",
+					Name:      "vllm-omni-endpoint",
+				},
+				Spec: &v1.EndpointSpec{
+					Engine: &v1.EndpointEngineSpec{
+						Engine: "vllm-omni",
+					},
+				},
+			},
+			deployedCluster: &v1.Cluster{Spec: &v1.ClusterSpec{Version: "v1.0.0"}},
+			expectedEnvs: map[string]string{
+				"VLLM_SKIP_P2P_CHECK": "1",
+			},
+		},
+		{
+			name: "vllm-omni engine on new cluster does not set VLLM_SKIP_P2P_CHECK",
+			endpoint: &v1.Endpoint{
+				Metadata: &v1.Metadata{
+					Workspace: "default",
+					Name:      "vllm-omni-endpoint",
+				},
+				Spec: &v1.EndpointSpec{
+					Engine: &v1.EndpointEngineSpec{
+						Engine: "vllm-omni",
+					},
+				},
+			},
+			deployedCluster: &v1.Cluster{Spec: &v1.ClusterSpec{Version: "v1.0.1"}},
+			expectedEnvs:    map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issues

Introduces `vllm-project/vllm-omni` as a new Neutree engine targeting omni-modality models (text + audio + image input/output, e.g. Qwen2.5-Omni). Phase 1 PoC validates the SSH cluster path; Kubernetes mode and extended endpoints follow in later phases.

Design: neutree-dev-docs `feature/vllm-omni-engine-integration-zh.md` (MR !13, **approved**, Revision 1 retargets P1 to SSH cluster mode).

## Changes

This PR establishes the **Phase 1 foundation**. The Ray Serve `app.py` is intentionally a skeleton that the build-test loop iterates on per design doc §5.4b — additional commits within this branch will fill in the AsyncOmni integration once the image is reachable from the test SSH cluster.

**Done** (commits `18c63113` + `e86b2450`):

- `api/v1`: new `EngineNameVLLMOmni` constant.
- `internal/engine`: `vllm-omni-v0.18.0` schema embedded and registered; built-in engine entry registers only the `ssh_`-prefixed image (`neutree/engine-vllm-omni:v0.18.0-ray2.53.0`) with no Kubernetes deploy template, so K8s deploys naturally fail at image lookup until Phase 2.
- `internal/engine/vllm-omni/v0.18.0/schema.json`: vllm-omni schema (vLLM v0.17.1 baseline + omni-specific fields `omni`, `output_modalities`, `worker_backend`, `ray_address`, `deploy_config`).
- `internal/orchestrator/ray_orchestrator.go`: `setEngineSpecialEnv` extended so vllm-omni inherits vLLM's `VLLM_SKIP_P2P_CHECK=1` behavior on old clusters. Backed by table-driven test cases.
- `cluster-image-builder/Dockerfile.engine-vllm-omni`: based on `vllm/vllm-omni:v0.18.0`; multi-stage Ray fork wheel build mirrors `Dockerfile.engine-vllm`. Downloader source is COPYed only — pip install of `downloader/requirements.txt` is intentionally skipped to avoid the hf_hub/transformers downgrade trap documented in CLAUDE.md feedback.
- `cluster-image-builder/Makefile`: `ENGINE_VLLM_OMNI_*` vars, `docker-build-engine-vllm-omni`, `docker-push-engine-vllm-omni` targets. Dry-run verified.
- `cluster-image-builder/serve/vllm-omni/v0_18_0/app.py`: skeleton with explicit `OMNI-TODO` markers covering the four divergence points from vanilla vLLM (entry point, serving class, output shape, error response). Throws `NotImplementedError` so any accidental load surfaces immediately.

**Pending in this branch** (build-test loop):

- [ ] `app.py`: replace skeleton with real `AsyncOmni` integration; serialize `OmniRequestOutput` text/audio/image latents per request `modalities`. Verify Serving class + `ErrorResponse` shape against vllm-omni v0.18.0 source per generate-engine-version skill Steps 3b/3c.
- [ ] e2e test file `tests/e2e/engine_vllm_omni_test.go` with five cases from design doc §6.3 (engine registration, endpoint deploy, audio-in text-out, text+audio output, lifecycle cleanup); Ginkgo Label `vllm-omni`.
- [ ] `.github/workflows/build-engine-image.yaml`: matrix entry for vllm-omni (added once `app.py` reaches a runnable state, to avoid burning registry quota on broken images).

## Test

This PR does not yet pass e2e — the skeleton `app.py` raises `NotImplementedError` on deploy by design. The Step 5 e2e gate applies to the **final state of this branch** before marking ready-for-review (deviation from strict /neutree-dev order; explained below).

**Verified so far:**

- Unit: `go test ./internal/engine/ ./internal/orchestrator/ ./api/v1/` all pass; new tests cover the vllm-omni registration shape and `setEngineSpecialEnv` cases (commit `18c63113`).
- Build infra: `make docker-build-engine-vllm-omni --just-print` emits the expected docker invocation (`vllm/vllm-omni:v0.18.0` base, `v0_18_0` engine dir, tag `neutree/engine-vllm-omni:v0.18.0-ray2.53.0`).
- Scoped `go vet ./internal/engine/ ./internal/orchestrator/ ./api/v1/` clean.

**Manual verification required (verifier checklist for the merged nightly):**

- [ ] Build the engine image off the branch tip (`make docker-build-engine-vllm-omni`) and crane-copy to the test registry.
- [ ] On an SSH cluster with at least one nvidia_gpu node, deploy a Qwen2.5-Omni-7B endpoint via the `vllm-omni` engine.
- [ ] POST `/v1/chat/completions` with audio input and `modalities=["text","audio"]`; expect both text and base64 audio in the response.
- [ ] Confirm the K8s deploy path returns a clear "image not found" error (Phase 1 guard).

## Process notes

- **Deviation from /neutree-dev Step 5 ordering**: this is a Heavy task whose `app.py` requires a build-test loop spanning multiple iterations. Strict "Step 5 e2e green before Step 6 PR creation" doesn't fit — the PR is created in Draft state now to give CI early feedback and to track iteration commits visibly. e2e green becomes the gate before flipping to ready-for-review (Step 9), not before draft creation.
- **Linked design**: GitLab MR !13 in `neutree-dev-docs/feature/vllm-omni-engine-integration-zh.md` — approved, Revision 1 retargeted P1 from K8s to SSH cluster mode.