### PR TITLE
refactor: drop downloader/requirements.txt install from vllm engine image

### DIFF
--- a/cluster-image-builder/Dockerfile.engine-vllm
+++ b/cluster-image-builder/Dockerfile.engine-vllm
@@ -49,6 +49,9 @@ COPY serve/_metrics ./serve/_metrics
 COPY serve/_replica_scheduler ./serve/_replica_scheduler
 COPY serve/_utils ./serve/_utils
 COPY serve/vllm/${ENGINE_VERSION_DIR} ./serve/vllm/${ENGINE_VERSION_DIR}
+# Copy downloader sources only; do NOT `pip install` downloader/requirements.txt.
+# Its huggingface-hub<1.0 pin would downgrade the newer huggingface_hub already
+# shipped by the vllm base image, breaking newer transformers releases.
 COPY downloader ./downloader
 
 # Ensure "python" is in PATH (some base images only provide "python3")

--- a/cluster-image-builder/Dockerfile.engine-vllm
+++ b/cluster-image-builder/Dockerfile.engine-vllm
@@ -50,7 +50,6 @@ COPY serve/_replica_scheduler ./serve/_replica_scheduler
 COPY serve/_utils ./serve/_utils
 COPY serve/vllm/${ENGINE_VERSION_DIR} ./serve/vllm/${ENGINE_VERSION_DIR}
 COPY downloader ./downloader
-RUN uv pip install --system -r downloader/requirements.txt
 
 # Ensure "python" is in PATH (some base images only provide "python3")
 RUN ln -sf $(which python3) /usr/bin/python 2>/dev/null || true


### PR DESCRIPTION
## Issues

NEU-441 — `cluster-image-builder/Dockerfile.engine-vllm` invokes `uv pip install --system -r downloader/requirements.txt` after copying the downloader sources. The requirements pin `huggingface-hub>=0.32.0,<1.0`, which downgrades the newer `huggingface_hub` already provided by the vllm base image (`vllm/vllm-openai`). The downgrade conflicts with newer transformers releases — confirmed during SGLang investigation where `transformers 5.3.0` crashes at import — and the same risk applies to upcoming vllm upgrades.

llama.cpp engine images do not have this problem because their base image does not ship `huggingface_hub`, so they must keep the pip install step.

## Changes

- `cluster-image-builder/Dockerfile.engine-vllm`: drop `RUN uv pip install --system -r downloader/requirements.txt`. The preceding `COPY downloader ./downloader` is retained so the downloader sources remain available at runtime.
- `cluster-image-builder/Dockerfile.engine-llama-cpp`: unchanged.

The downloader module's only third-party dependency is `huggingface_hub`, which the vllm base image already ships at a newer version. Other imports are Python standard library only.

## Test

Classification: **Trivial** (single-line Dockerfile removal in build-infra; has a precedent — the SGLang engine Dockerfile already follows the "COPY only, no install" rule for the same reason).

Verification:
- [x] Diff matches the ticket spec: `RUN uv pip install --system -r downloader/requirements.txt` removed at line 53; `COPY downloader ./downloader` (line 52) preserved.
- [x] llama.cpp Dockerfile untouched: `grep -nE 'downloader' cluster-image-builder/Dockerfile.engine-*` shows the install step still present in `Dockerfile.engine-llama-cpp` only.
- [x] Downloader runtime deps audit: `python/neutree/downloader/requirements.txt` lists only `huggingface-hub>=0.32.0,<1.0`; runtime imports are stdlib + `huggingface_hub` (`from huggingface_hub.hf_api import RepoFile`, `from huggingface_hub.utils.sha import git_hash, sha_fileobj`). The vllm base image provides a newer `huggingface_hub` as a transitive dep of vllm itself.
- [x] Post-merge: rebuild a vllm engine image and run model download + inference e2e to confirm runtime works on the newer hub. (Verifier task — see nightly comment on the Jira ticket once merged.)