### PR TITLE
fix: fall back to dataclass fields when get_type_hints fails on vLLM v0.20.0

### DIFF
--- a/cluster-image-builder/serve/_utils/coerce.py
+++ b/cluster-image-builder/serve/_utils/coerce.py
@@ -4,10 +4,65 @@ import dataclasses
 import functools
 import json
 import logging
+import re
 import typing
 from typing import Any, Dict, Union
 
 logger = logging.getLogger("ray.serve")
+
+# CPython NameError message format: "name 'X' is not defined".
+# Format has been stable since at least 3.5 and is shared by PyPy.
+_NAMEERROR_NAME_RE = re.compile(r"name '([^']+)' is not defined")
+
+# Bound on the iterative recovery loop. Real engine arg classes leak at most
+# a handful of TYPE_CHECKING-only aliases; 64 is an order of magnitude past
+# anything realistic and still finite.
+_RECOVERY_MAX_ITERS = 64
+
+
+def _recover_type_hints(model_class: type) -> Dict[str, Any]:
+    """Resolve a dataclass's field annotations even when ``typing.get_type_hints``
+    raises ``NameError`` due to TYPE_CHECKING-only aliases that lack a runtime
+    ``= Any`` fallback (e.g. vLLM v0.20.0 ``OnlineQuantizationConfigArgs``).
+
+    Strategy: keep retrying ``get_type_hints`` with ``localns`` populated by the
+    names ``NameError`` reports as missing, each bound to ``Any``. Bounded loop;
+    if a non-NameError exception interrupts, or the regex fails to extract a
+    name, fall back to ``dataclasses.fields()`` which preserves the keyset
+    (filter_engine_args still works) but loses real type objects (coerce_args
+    degrades to pass-through).
+    """
+    extras: Dict[str, Any] = {}
+    last_err: BaseException | None = None
+    for _ in range(_RECOVERY_MAX_ITERS):
+        try:
+            return typing.get_type_hints(model_class, localns=extras)
+        except NameError as exc:
+            last_err = exc
+            match = _NAMEERROR_NAME_RE.search(str(exc))
+            if match is None:
+                break
+            missing = match.group(1)
+            if missing in extras:
+                # Same name keeps failing — defensive break to avoid spinning
+                # if get_type_hints surfaces a NameError it can't recover from
+                # even with the alias supplied.
+                break
+            extras[missing] = Any
+        except Exception as exc:
+            last_err = exc
+            break
+
+    logger.warning(
+        "_get_field_annotations: typing.get_type_hints(%r) recovery failed (%s); "
+        "falling back to __dataclass_fields__ (coerce_args will degrade)",
+        model_class,
+        last_err,
+    )
+    try:
+        return {f.name: f.type for f in dataclasses.fields(model_class)}
+    except Exception:
+        return {}
 
 
 @functools.lru_cache(maxsize=None)
@@ -16,7 +71,7 @@ def _get_field_annotations(model_class: type) -> Dict[str, Any]:
 
     Cached per-class: ``coerce_args`` and ``filter_engine_args`` both call this
     once per replica startup, so caching avoids redundant introspection work and
-    keeps the fallback warning at most once per (class, replica). Returned dict
+    keeps the recovery warning at most once per (class, replica). Returned dict
     is treated as read-only by callers.
     """
     # Pydantic model / pydantic dataclass
@@ -28,14 +83,14 @@ def _get_field_annotations(model_class: type) -> Dict[str, Any]:
     if dataclasses.is_dataclass(model_class):
         try:
             return typing.get_type_hints(model_class)
+        except NameError:
+            # ``get_type_hints`` is all-or-nothing: one bad field invalidates
+            # the whole result. Try to recover by feeding ``Any`` as a stub
+            # for each missing name reported by NameError, then re-running.
+            # When this succeeds, every other field returns a real type
+            # object so coerce_args keeps full JSON-string coercion.
+            return _recover_type_hints(model_class)
         except Exception as exc:
-            # get_type_hints() is all-or-nothing: if any field annotation
-            # references a name missing at runtime (e.g. vLLM v0.20.0
-            # AsyncEngineArgs missing a TYPE_CHECKING fallback alias), the
-            # whole result is lost. Fall back to __dataclass_fields__ which
-            # holds the raw declared types without re-evaluating annotations.
-            # filter_engine_args only needs the keyset; coerce_args degrades
-            # to a pass-through for fields whose annotation is a raw string.
             logger.warning(
                 "_get_field_annotations: typing.get_type_hints(%r) failed (%s); "
                 "falling back to __dataclass_fields__",

--- a/cluster-image-builder/serve/_utils/coerce.py
+++ b/cluster-image-builder/serve/_utils/coerce.py
@@ -1,6 +1,7 @@
 """Shared utilities for Neutree Ray Serve applications."""
 
 import dataclasses
+import functools
 import json
 import logging
 import typing
@@ -9,8 +10,15 @@ from typing import Any, Dict, Union
 logger = logging.getLogger("ray.serve")
 
 
+@functools.lru_cache(maxsize=None)
 def _get_field_annotations(model_class: type) -> Dict[str, Any]:
-    """Extract field name → annotation mapping from Pydantic models or standard dataclasses."""
+    """Extract field name → annotation mapping from Pydantic models or standard dataclasses.
+
+    Cached per-class: ``coerce_args`` and ``filter_engine_args`` both call this
+    once per replica startup, so caching avoids redundant introspection work and
+    keeps the fallback warning at most once per (class, replica). Returned dict
+    is treated as read-only by callers.
+    """
     # Pydantic model / pydantic dataclass
     pydantic_fields = getattr(model_class, '__pydantic_fields__', None)
     if pydantic_fields is not None:
@@ -34,7 +42,10 @@ def _get_field_annotations(model_class: type) -> Dict[str, Any]:
                 model_class,
                 exc,
             )
-            return {f.name: f.type for f in dataclasses.fields(model_class)}
+            try:
+                return {f.name: f.type for f in dataclasses.fields(model_class)}
+            except Exception:
+                return {}
 
     return {}
 

--- a/cluster-image-builder/serve/_utils/coerce.py
+++ b/cluster-image-builder/serve/_utils/coerce.py
@@ -20,8 +20,21 @@ def _get_field_annotations(model_class: type) -> Dict[str, Any]:
     if dataclasses.is_dataclass(model_class):
         try:
             return typing.get_type_hints(model_class)
-        except Exception:
-            return {}
+        except Exception as exc:
+            # get_type_hints() is all-or-nothing: if any field annotation
+            # references a name missing at runtime (e.g. vLLM v0.20.0
+            # AsyncEngineArgs missing a TYPE_CHECKING fallback alias), the
+            # whole result is lost. Fall back to __dataclass_fields__ which
+            # holds the raw declared types without re-evaluating annotations.
+            # filter_engine_args only needs the keyset; coerce_args degrades
+            # to a pass-through for fields whose annotation is a raw string.
+            logger.warning(
+                "_get_field_annotations: typing.get_type_hints(%r) failed (%s); "
+                "falling back to __dataclass_fields__",
+                model_class,
+                exc,
+            )
+            return {f.name: f.type for f in dataclasses.fields(model_class)}
 
     return {}
 

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -1,13 +1,16 @@
 """Tests for serve._utils.coerce_args and filter_engine_args."""
 
 import logging
+import typing
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
+import pytest
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from serve._utils import coerce_args, filter_engine_args
+from serve._utils.coerce import _get_field_annotations
 
 
 class SampleModel(BaseModel):
@@ -138,6 +141,20 @@ class _FakeEngineArgs:
     reasoning_parser: Optional[str] = None
 
 
+@dataclass
+class _BrokenTypeHintsArgs:
+    """Mirrors vLLM v0.20.0 AsyncEngineArgs: one field annotation is a string
+    forward-ref to a name that does not exist at runtime, so
+    ``typing.get_type_hints()`` raises ``NameError``. ``get_type_hints`` is
+    all-or-nothing — one bad field invalidates the whole result.
+    """
+
+    model: str = ""
+    max_model_len: int = 0
+    # Forward-ref string referencing an undefined symbol — eval at runtime fails.
+    quantization_config: "_NonExistentRuntimeAlias | None" = None  # type: ignore[name-defined]
+
+
 # ---------------------------------------------------------------------------
 # Tests for filter_engine_args
 # ---------------------------------------------------------------------------
@@ -175,3 +192,50 @@ class TestFilterEngineArgs:
             filter_engine_args(args, dict)
         assert args == {"anything": "goes"}
         assert "could not introspect" in caplog.text
+
+    def test_filter_works_when_get_type_hints_raises(self, caplog):
+        """Regression for NEU-433: when ``typing.get_type_hints`` raises
+        (e.g., vLLM v0.20.0 AsyncEngineArgs missing a TYPE_CHECKING alias),
+        ``filter_engine_args`` must still strip unknown keys via the
+        ``__dataclass_fields__`` fallback, not silently no-op.
+        """
+        # Sanity: the fixture really triggers the failure mode we care about.
+        with pytest.raises(NameError):
+            typing.get_type_hints(_BrokenTypeHintsArgs)
+
+        args = {"model": "llama", "max_model_len": 4096, "bogus": 42}
+        with caplog.at_level(logging.WARNING, logger="ray.serve"):
+            filter_engine_args(args, _BrokenTypeHintsArgs)
+        assert args == {"model": "llama", "max_model_len": 4096}
+        # Safety net must still fire — not the "could not introspect" bail-out.
+        assert "could not introspect" not in caplog.text
+        assert "1 unknown engine parameter(s) ignored" in caplog.text
+        assert "bogus" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Tests for _get_field_annotations fallback (NEU-433)
+# ---------------------------------------------------------------------------
+
+
+class TestGetFieldAnnotationsFallback:
+    def test_returns_field_names_when_get_type_hints_raises(self):
+        """When ``typing.get_type_hints`` raises on a dataclass, fall back
+        to ``dataclasses.fields()`` so the field-name keyset is preserved.
+        """
+        with pytest.raises(NameError):
+            typing.get_type_hints(_BrokenTypeHintsArgs)
+
+        result = _get_field_annotations(_BrokenTypeHintsArgs)
+        assert set(result.keys()) == {"model", "max_model_len", "quantization_config"}
+
+    def test_coerce_args_degrades_silently_under_fallback(self):
+        """Under the fallback path ``f.type`` is a raw string rather than a
+        real type object, so dict/list coercion silently degrades to a
+        pass-through. Acceptable trade-off documented in NEU-433: better
+        than the prior behaviour where the entire safety net no-opped.
+        """
+        args = {"quantization_config": '{"key": "value"}'}
+        coerce_args(args, _BrokenTypeHintsArgs)
+        # No exception, no coercion — value passes through untouched.
+        assert args["quantization_config"] == '{"key": "value"}'

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -2,7 +2,7 @@
 
 import logging
 import typing
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
 import pytest

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -159,11 +159,10 @@ class _BrokenTypeHintsArgs:
 class _AllStringAnnotationsArgs:
     """Closer simulation of the production vLLM v0.20.0 case: every annotation
     is stored as a string (as ``from __future__ import annotations`` would
-    produce module-wide), and one references an undefined name so
-    ``get_type_hints`` raises. Under the fallback path every ``f.type`` is a
-    raw string, which means ``coerce_args`` cannot coerce *any* dict/list
-    field — the safety-net is restored but JSON-string coercion degrades
-    across the board.
+    produce module-wide), and one references an undefined name so a naive
+    ``typing.get_type_hints()`` call raises. The Option B recovery path injects
+    ``Any`` for the missing name and re-runs, so callers see real type objects
+    for every annotation and ``coerce_args`` keeps full JSON-string coercion.
     """
 
     name: "str" = ""
@@ -233,17 +232,18 @@ class TestFilterEngineArgs:
 
 
 # ---------------------------------------------------------------------------
-# Tests for _get_field_annotations fallback (NEU-433)
+# Tests for _get_field_annotations recovery (NEU-433, Option B)
 # ---------------------------------------------------------------------------
 
 
-class TestGetFieldAnnotationsFallback:
-    def test_returns_field_names_when_get_type_hints_raises(self, caplog):
-        """When ``typing.get_type_hints`` raises on a dataclass, fall back
-        to ``dataclasses.fields()`` so the field-name keyset is preserved.
-        Also asserts the diagnostic warning fires — that warning is the
-        operator's primary signal to investigate the engine image.
+class TestGetFieldAnnotationsRecovery:
+    def test_recovers_real_type_objects_via_localns_injection(self, caplog):
+        """When ``typing.get_type_hints`` raises ``NameError`` on a
+        TYPE_CHECKING-only alias, the recovery loop injects ``Any`` for the
+        missing name and re-runs. Healthy fields keep their real type objects
+        so downstream consumers (``coerce_args``) keep full functionality.
         """
+        # Sanity: the fixture really triggers the failure mode we care about.
         with pytest.raises(NameError):
             typing.get_type_hints(_BrokenTypeHintsArgs)
         _get_field_annotations.cache_clear()
@@ -252,25 +252,17 @@ class TestGetFieldAnnotationsFallback:
             result = _get_field_annotations(_BrokenTypeHintsArgs)
 
         assert set(result.keys()) == {"model", "max_model_len", "quantization_config"}
-        assert "falling back to __dataclass_fields__" in caplog.text
+        # Healthy fields recover real type objects, not raw strings.
+        assert result["model"] is str
+        assert result["max_model_len"] is int
+        # Recovery succeeded → no fallback warning emitted.
+        assert "falling back to __dataclass_fields__" not in caplog.text
 
-    def test_coerce_args_degrades_silently_under_fallback(self):
-        """Under the fallback path ``f.type`` is a raw string rather than a
-        real type object, so dict/list coercion silently degrades to a
-        pass-through. Acceptable trade-off documented in NEU-433: better
-        than the prior behaviour where the entire safety net no-opped.
-        """
-        _get_field_annotations.cache_clear()
-        args = {"quantization_config": '{"key": "value"}'}
-        coerce_args(args, _BrokenTypeHintsArgs)
-        # No exception, no coercion — value passes through untouched.
-        assert args["quantization_config"] == '{"key": "value"}'
-
-    def test_coerce_args_full_degradation_when_all_annotations_are_strings(self):
-        """Closer to the real production path: every annotation is a string,
-        so even healthy dict/list fields lose their JSON-string coercion when
-        the fallback fires. The safety-net is preserved (next test confirms
-        that for filter_engine_args), but coerce_args is a pass-through.
+    def test_coerce_args_recovers_dict_and_list_coercion(self):
+        """Under Option B every healthy annotation resolves to a real type
+        object, so dict/list JSON-string coercion still works on the
+        SSH/Ray path even when one field's annotation referenced a missing
+        TYPE_CHECKING alias.
         """
         _get_field_annotations.cache_clear()
         args = {
@@ -278,16 +270,13 @@ class TestGetFieldAnnotationsFallback:
             "items": '["a", "b"]',
         }
         coerce_args(args, _AllStringAnnotationsArgs)
-        # Fallback path: f.type is a raw string for every field, so
-        # _wants_dict_or_list returns False for all of them and JSON strings
-        # pass through untouched. This is the documented degradation.
-        assert args["config"] == '{"temperature": 0.5}'
-        assert args["items"] == '["a", "b"]'
+        # Healthy fields decoded — Option B preserves their real types.
+        assert args["config"] == {"temperature": 0.5}
+        assert args["items"] == ["a", "b"]
 
-    def test_filter_engine_args_keyset_intact_when_all_annotations_are_strings(self):
-        """The complementary half of the trade-off: even with every annotation
-        a string, ``filter_engine_args`` still gets the field-name keyset and
-        strips unknown keys. This is what the NEU-433 fix actually buys.
+    def test_filter_engine_args_strips_unknowns_under_recovery(self):
+        """``filter_engine_args`` still gets the full field-name keyset
+        after recovery, so unknown keys are stripped as designed.
         """
         _get_field_annotations.cache_clear()
         args = {
@@ -296,4 +285,36 @@ class TestGetFieldAnnotationsFallback:
             "bogus": 42,
         }
         filter_engine_args(args, _AllStringAnnotationsArgs)
+        # filter only strips unknowns; it doesn't coerce — values stay as-is.
         assert args == {"name": "model-x", "config": '{"temperature": 0.5}'}
+
+    def test_falls_back_to_fields_when_recovery_cannot_extract_name(
+        self, monkeypatch, caplog
+    ):
+        """If the NameError message format is unrecognisable (theoretical
+        future Python change, or another exception type altogether) the
+        function still degrades gracefully: ``dataclasses.fields()`` is
+        called so ``filter_engine_args`` keeps the keyset, while
+        ``coerce_args`` falls back to a pass-through. This pins the last-
+        resort safety behaviour against future Python releases.
+        """
+        _get_field_annotations.cache_clear()
+
+        original = typing.get_type_hints
+
+        def fake_get_type_hints(*args, **kwargs):
+            # Raise NameError with a non-standard message so the regex misses.
+            raise NameError("unrecognised wording about a missing name")
+
+        monkeypatch.setattr(typing, "get_type_hints", fake_get_type_hints)
+
+        with caplog.at_level(logging.WARNING, logger="ray.serve"):
+            result = _get_field_annotations(_BrokenTypeHintsArgs)
+
+        # Keyset preserved through dataclasses.fields() last-resort fallback.
+        assert set(result.keys()) == {"model", "max_model_len", "quantization_config"}
+        # Recovery failed warning emitted so operators know coerce degraded.
+        assert "falling back to __dataclass_fields__" in caplog.text
+
+        # Restore for any subsequent tests.
+        monkeypatch.setattr(typing, "get_type_hints", original)

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -155,6 +155,23 @@ class _BrokenTypeHintsArgs:
     quantization_config: "_NonExistentRuntimeAlias | None" = None  # type: ignore[name-defined]
 
 
+@dataclass
+class _AllStringAnnotationsArgs:
+    """Closer simulation of the production vLLM v0.20.0 case: every annotation
+    is stored as a string (as ``from __future__ import annotations`` would
+    produce module-wide), and one references an undefined name so
+    ``get_type_hints`` raises. Under the fallback path every ``f.type`` is a
+    raw string, which means ``coerce_args`` cannot coerce *any* dict/list
+    field — the safety-net is restored but JSON-string coercion degrades
+    across the board.
+    """
+
+    name: "str" = ""
+    config: "Optional[Dict[str, Any]]" = None
+    items: "Optional[List[str]]" = None
+    quantization_config: "_NonExistentRuntimeAlias | None" = None  # type: ignore[name-defined]
+
+
 # ---------------------------------------------------------------------------
 # Tests for filter_engine_args
 # ---------------------------------------------------------------------------
@@ -202,6 +219,8 @@ class TestFilterEngineArgs:
         # Sanity: the fixture really triggers the failure mode we care about.
         with pytest.raises(NameError):
             typing.get_type_hints(_BrokenTypeHintsArgs)
+        # Cache is shared across tests; force a fresh evaluation here.
+        _get_field_annotations.cache_clear()
 
         args = {"model": "llama", "max_model_len": 4096, "bogus": 42}
         with caplog.at_level(logging.WARNING, logger="ray.serve"):
@@ -219,15 +238,21 @@ class TestFilterEngineArgs:
 
 
 class TestGetFieldAnnotationsFallback:
-    def test_returns_field_names_when_get_type_hints_raises(self):
+    def test_returns_field_names_when_get_type_hints_raises(self, caplog):
         """When ``typing.get_type_hints`` raises on a dataclass, fall back
         to ``dataclasses.fields()`` so the field-name keyset is preserved.
+        Also asserts the diagnostic warning fires — that warning is the
+        operator's primary signal to investigate the engine image.
         """
         with pytest.raises(NameError):
             typing.get_type_hints(_BrokenTypeHintsArgs)
+        _get_field_annotations.cache_clear()
 
-        result = _get_field_annotations(_BrokenTypeHintsArgs)
+        with caplog.at_level(logging.WARNING, logger="ray.serve"):
+            result = _get_field_annotations(_BrokenTypeHintsArgs)
+
         assert set(result.keys()) == {"model", "max_model_len", "quantization_config"}
+        assert "falling back to __dataclass_fields__" in caplog.text
 
     def test_coerce_args_degrades_silently_under_fallback(self):
         """Under the fallback path ``f.type`` is a raw string rather than a
@@ -235,7 +260,40 @@ class TestGetFieldAnnotationsFallback:
         pass-through. Acceptable trade-off documented in NEU-433: better
         than the prior behaviour where the entire safety net no-opped.
         """
+        _get_field_annotations.cache_clear()
         args = {"quantization_config": '{"key": "value"}'}
         coerce_args(args, _BrokenTypeHintsArgs)
         # No exception, no coercion — value passes through untouched.
         assert args["quantization_config"] == '{"key": "value"}'
+
+    def test_coerce_args_full_degradation_when_all_annotations_are_strings(self):
+        """Closer to the real production path: every annotation is a string,
+        so even healthy dict/list fields lose their JSON-string coercion when
+        the fallback fires. The safety-net is preserved (next test confirms
+        that for filter_engine_args), but coerce_args is a pass-through.
+        """
+        _get_field_annotations.cache_clear()
+        args = {
+            "config": '{"temperature": 0.5}',
+            "items": '["a", "b"]',
+        }
+        coerce_args(args, _AllStringAnnotationsArgs)
+        # Fallback path: f.type is a raw string for every field, so
+        # _wants_dict_or_list returns False for all of them and JSON strings
+        # pass through untouched. This is the documented degradation.
+        assert args["config"] == '{"temperature": 0.5}'
+        assert args["items"] == '["a", "b"]'
+
+    def test_filter_engine_args_keyset_intact_when_all_annotations_are_strings(self):
+        """The complementary half of the trade-off: even with every annotation
+        a string, ``filter_engine_args`` still gets the field-name keyset and
+        strips unknown keys. This is what the NEU-433 fix actually buys.
+        """
+        _get_field_annotations.cache_clear()
+        args = {
+            "name": "model-x",
+            "config": '{"temperature": 0.5}',
+            "bogus": 42,
+        }
+        filter_engine_args(args, _AllStringAnnotationsArgs)
+        assert args == {"name": "model-x", "config": '{"temperature": 0.5}'}


### PR DESCRIPTION
## Issues

NEU-433: vLLM v0.20.0 (and v0.20.0rc1, including the deepseekv4 variant) triggers a warning at engine startup:

```
filter_engine_args: could not introspect <class 'vllm.engine.arg_utils.AsyncEngineArgs'> — skipping unknown-key filter
```

`filter_engine_args` (the safety net introduced in #331) silently no-ops, so unknown keys leak through to `AsyncEngineArgs(**args)` and may crash with TypeError.

### Root cause

- vLLM v0.20.0 imports `OnlineQuantizationConfigArgs` only under `TYPE_CHECKING`; the `else` branch sets `Executor / QuantizationMethods / LoadFormats / UsageContext = Any` but forgets `OnlineQuantizationConfigArgs = Any`.
- The field `quantization_config: "dict[str, Any] | OnlineQuantizationConfigArgs | None"` is a forward-reference string.
- `typing.get_type_hints()` re-evaluates the annotation at runtime, hits the missing name, and raises `NameError`.
- `get_type_hints` is all-or-nothing — one failing field invalidates the entire result.
- The prior `except Exception: return {}` then turned `filter_engine_args` into a no-op.

v0.19.1 / v0.17.1 / v0.11.2 / v0.8.5 are unaffected (their TYPE_CHECKING aliases all have `= Any` fallbacks).

### Upstream

[vllm-project/vllm#40847](https://github.com/vllm-project/vllm/pull/40847) fixes the missing alias upstream (one-line `OnlineQuantizationConfigArgs = Any` in the `else:` branch). It is open but not merged at time of writing, and won't ship until the next vLLM release. Our fix is generic — it protects every released vLLM image we already ship (v0.20.0, v0.20.0rc1, deepseekv4 variant) and any future engine that leaks an unresolvable forward reference, regardless of upstream timeline.

## Changes

`cluster-image-builder/serve/_utils/coerce.py`

- `_get_field_annotations`: when `typing.get_type_hints()` raises `NameError`, parse the missing name out of the message, bind it to `Any` in `localns`, and retry. Bounded loop (64 iterations); after a handful of iterations the name set stabilises and `get_type_hints` succeeds. Every healthy field returns a real type object, so `coerce_args` keeps full JSON-string coercion. Only the fields whose annotation actually referenced the missing alias degrade — their type collapses to `Optional[Any]`, which `_wants_dict_or_list` already treats as non-coerceable.
- For the vLLM v0.20.0 case this means one symbol (`OnlineQuantizationConfigArgs`) is stubbed and every other `AsyncEngineArgs` field — including healthy dict/list fields like `chat_template_kwargs`, `mm_processor_kwargs`, `limit_mm_per_prompt`, `additional_config` — keeps full JSON-string decoding on the SSH/Ray path.
- If recovery itself fails (NameError message format unrecognisable, or a non-NameError surfaces) we still fall back to `dataclasses.fields()` so the keyset stays intact for `filter_engine_args` even though `coerce_args` would degrade. A `monkeypatch`-driven test pins this last-resort behaviour against future Python error-message changes.
- `_get_field_annotations` is decorated with `functools.lru_cache(maxsize=None)` so the recovery work and warning fire at most once per (class, replica), even though both `coerce_args` and `filter_engine_args` invoke it independently at startup.

## Test

Unit tests added in `cluster-image-builder/serve/_utils/test_coerce.py`:

- `TestFilterEngineArgs::test_filter_works_when_get_type_hints_raises` — synthetic `_BrokenTypeHintsArgs` dataclass with a forward-ref string annotation pointing at an undefined name (mirroring v0.20.0). Asserts `filter_engine_args` strips unknown keys and the `could not introspect` bail-out is **not** logged.
- `TestGetFieldAnnotationsRecovery::test_recovers_real_type_objects_via_localns_injection` — asserts the recovery loop yields real type objects (`str`, `int`, …) for healthy fields and emits no fallback warning.
- `TestGetFieldAnnotationsRecovery::test_coerce_args_recovers_dict_and_list_coercion` — uses `_AllStringAnnotationsArgs` (all annotations stored as strings, mirroring `from __future__ import annotations`) to assert dict/list JSON-string coercion still works after recovery.
- `TestGetFieldAnnotationsRecovery::test_filter_engine_args_strips_unknowns_under_recovery` — same fixture; confirms the keyset is intact and unknowns are stripped.
- `TestGetFieldAnnotationsRecovery::test_falls_back_to_fields_when_recovery_cannot_extract_name` — `monkeypatch`es `typing.get_type_hints` to raise `NameError` with an unrecognisable message; asserts last-resort `dataclasses.fields()` fallback preserves the keyset and the recovery-failed warning is emitted.

```
$ cd cluster-image-builder && PYTHONPATH=. python3 -m pytest serve/_utils/ -v
========================= 31 passed in 0.10s ==========================
```

E2E skipped per Trivial-track classification: change is isolated to a single Python file in the engine-image runtime, no Go/control-plane impact, fully covered by unit tests including direct regression assertion against the v0.20.0 failure mode and the recovery path that restores `coerce_args`.

Verifier: pull the next nightly that includes this fix, deploy a vLLM v0.20.0 endpoint (any model), and confirm the Ray Serve replica logs no longer contain `filter_engine_args: could not introspect`. Optionally exercise the SSH/Ray path with a JSON-string `chat_template_kwargs` to confirm coercion still works.