### PR TITLE
refactor: split release-engine-image workflow per engine

### DIFF
--- a/.github/workflows/release-engine-image-llama-cpp.yaml
+++ b/.github/workflows/release-engine-image-llama-cpp.yaml
@@ -1,0 +1,81 @@
+name: release-engine-image-llama-cpp
+
+# llama-cpp-python is CPU-only on the Neutree side, so this workflow has no
+# accelerator input. Add an accelerator dimension here only when llama-cpp
+# starts shipping accelerator-specific upstream variants.
+on:
+  workflow_dispatch:
+    inputs:
+      engine_version:
+        description: "llama-cpp-python version (e.g. v0.3.7)"
+        required: true
+        type: string
+      ray_version:
+        description: "the ray version branch/tag to build from"
+        required: false
+        type: string
+        default: "ray-2.53.0-neutree"
+      ray_short_version:
+        description: "ray short version for image tag (e.g: ray2.53.0)"
+        required: false
+        type: string
+        default: "ray2.53.0"
+      engine_patch_suffix:
+        description: "optional alphanumeric patch identifier appended to the output tag (e.g. '1' produces <engine_version>-neutree1-<ray_short_version>); allowed chars [a-zA-Z0-9._-]; empty keeps the upstream tag"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build-amd64-image:
+    runs-on: ["serve-builder","X64"]
+    name: build amd64 llama-cpp engine image
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate engine_patch_suffix
+        if: ${{ github.event.inputs.engine_patch_suffix != '' }}
+        run: |
+          printf '%s\n' "${{ github.event.inputs.engine_patch_suffix }}" | grep -qE '^[a-zA-Z0-9._-]+$' \
+            || { echo "engine_patch_suffix must match [a-zA-Z0-9._-]+"; exit 1; }
+      - name: Login docker
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.SERVE_IMAGE_REPO }}
+          username: ${{ secrets.SERVE_IMAGE_PUSH_USERNAME }}
+          password: ${{ secrets.SERVE_IMAGE_PUSH_TOKEN }}
+      - name: build and push engine image
+        run: |
+          cd cluster-image-builder
+          make docker-build-engine-llama-cpp docker-push-engine-llama-cpp
+        env:
+          IMAGE_PROJECT: ${{ secrets.RELEASE_SERVE_IMAGE_PROJECT }}
+          IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
+          ARCH: amd64
+          ENGINE_LLAMA_CPP_VERSION: ${{ github.event.inputs.engine_version }}
+          RAY_VERSION: ${{ github.event.inputs.ray_version }}
+          RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
+          ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}
+  push-manifests:
+    runs-on: ["serve-builder","X64"]
+    name: merge and push llama-cpp manifests
+    needs:
+      - build-amd64-image
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login docker
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.SERVE_IMAGE_REPO }}
+          username: ${{ secrets.SERVE_IMAGE_PUSH_USERNAME }}
+          password: ${{ secrets.SERVE_IMAGE_PUSH_TOKEN }}
+      - name: push manifests
+        run: |
+          cd cluster-image-builder
+          make docker-push-manifest-engine-llama-cpp
+        env:
+          IMAGE_PROJECT: ${{ secrets.RELEASE_SERVE_IMAGE_PROJECT }}
+          IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
+          ALL_ARCH: amd64
+          ENGINE_LLAMA_CPP_VERSION: ${{ github.event.inputs.engine_version }}
+          RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
+          ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}

--- a/.github/workflows/release-engine-image-llama-cpp.yaml
+++ b/.github/workflows/release-engine-image-llama-cpp.yaml
@@ -21,7 +21,7 @@ on:
         type: string
         default: "ray2.53.0"
       engine_patch_suffix:
-        description: "optional alphanumeric patch identifier appended to the output tag (e.g. '1' produces <engine_version>-neutree1-<ray_short_version>); allowed chars [a-zA-Z0-9._-]; empty keeps the upstream tag"
+        description: "optional patch identifier appended to the output tag, allowed chars [a-zA-Z0-9._-] (e.g. '1' produces <engine_version>-neutree1-<ray_short_version>); empty keeps the upstream tag"
         required: false
         type: string
         default: ""

--- a/.github/workflows/release-engine-image-sglang.yaml
+++ b/.github/workflows/release-engine-image-sglang.yaml
@@ -1,0 +1,109 @@
+name: release-engine-image-sglang
+
+on:
+  workflow_dispatch:
+    inputs:
+      accelerator:
+        description: "accelerator type"
+        required: true
+        type: choice
+        options:
+          - nvidia
+          - rocm
+      engine_version:
+        description: "SGLang engine version (e.g. v0.5.10)"
+        required: true
+        type: string
+      base_image_tag_override:
+        description: "optional override for the upstream SGLang base image tag (default: <engine_version> for nvidia, <engine_version>-rocm720-mi30x for rocm); use to point at MI355x or other ROCm variants"
+        required: false
+        type: string
+        default: ""
+      ray_version:
+        description: "the ray version branch/tag to build from"
+        required: false
+        type: string
+        default: "ray-2.53.0-neutree"
+      ray_short_version:
+        description: "ray short version for image tag (e.g: ray2.53.0)"
+        required: false
+        type: string
+        default: "ray2.53.0"
+      engine_patch_suffix:
+        description: "optional alphanumeric patch identifier appended to the output tag (e.g. '1' produces <tag>-neutree1-<ray_short_version>); allowed chars [a-zA-Z0-9._-]; empty keeps the upstream tag"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build-amd64-image:
+    runs-on: ["serve-builder","X64"]
+    name: build amd64 sglang engine image
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate engine_patch_suffix
+        if: ${{ github.event.inputs.engine_patch_suffix != '' }}
+        run: |
+          printf '%s\n' "${{ github.event.inputs.engine_patch_suffix }}" | grep -qE '^[a-zA-Z0-9._-]+$' \
+            || { echo "engine_patch_suffix must match [a-zA-Z0-9._-]+"; exit 1; }
+      - name: Login docker
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.SERVE_IMAGE_REPO }}
+          username: ${{ secrets.SERVE_IMAGE_PUSH_USERNAME }}
+          password: ${{ secrets.SERVE_IMAGE_PUSH_TOKEN }}
+      - name: Resolve make target suffix
+        id: target
+        run: |
+          if [ "${{ github.event.inputs.accelerator }}" = "rocm" ]; then
+            echo "suffix=-rocm" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: build and push engine image
+        run: |
+          cd cluster-image-builder
+          make docker-build-engine-sglang${{ steps.target.outputs.suffix }} docker-push-engine-sglang${{ steps.target.outputs.suffix }}
+        env:
+          IMAGE_PROJECT: ${{ secrets.RELEASE_SERVE_IMAGE_PROJECT }}
+          IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
+          ARCH: amd64
+          ENGINE_SGLANG_VERSION: ${{ github.event.inputs.engine_version }}
+          ENGINE_SGLANG_BASE_IMAGE_TAG: ${{ github.event.inputs.base_image_tag_override || github.event.inputs.engine_version }}
+          ENGINE_SGLANG_ROCM_TAG: ${{ github.event.inputs.base_image_tag_override || format('{0}-rocm720-mi30x', github.event.inputs.engine_version) }}
+          RAY_VERSION: ${{ github.event.inputs.ray_version }}
+          RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
+          ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}
+  push-manifests:
+    runs-on: ["serve-builder","X64"]
+    name: merge and push sglang manifests
+    needs:
+      - build-amd64-image
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login docker
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.SERVE_IMAGE_REPO }}
+          username: ${{ secrets.SERVE_IMAGE_PUSH_USERNAME }}
+          password: ${{ secrets.SERVE_IMAGE_PUSH_TOKEN }}
+      - name: Resolve manifest target suffix
+        id: target
+        run: |
+          if [ "${{ github.event.inputs.accelerator }}" = "rocm" ]; then
+            echo "suffix=-rocm" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: push manifests
+        run: |
+          cd cluster-image-builder
+          make docker-push-manifest-engine-sglang${{ steps.target.outputs.suffix }}
+        env:
+          IMAGE_PROJECT: ${{ secrets.RELEASE_SERVE_IMAGE_PROJECT }}
+          IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
+          ALL_ARCH: amd64
+          ENGINE_SGLANG_VERSION: ${{ github.event.inputs.engine_version }}
+          ENGINE_SGLANG_ROCM_TAG: ${{ github.event.inputs.base_image_tag_override || format('{0}-rocm720-mi30x', github.event.inputs.engine_version) }}
+          RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
+          ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}

--- a/.github/workflows/release-engine-image-sglang.yaml
+++ b/.github/workflows/release-engine-image-sglang.yaml
@@ -104,6 +104,7 @@ jobs:
           IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
           ALL_ARCH: amd64
           ENGINE_SGLANG_VERSION: ${{ github.event.inputs.engine_version }}
+          ENGINE_SGLANG_BASE_IMAGE_TAG: ${{ github.event.inputs.base_image_tag_override || github.event.inputs.engine_version }}
           ENGINE_SGLANG_ROCM_TAG: ${{ github.event.inputs.base_image_tag_override || format('{0}-rocm720-mi30x', github.event.inputs.engine_version) }}
           RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
           ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}

--- a/.github/workflows/release-engine-image-sglang.yaml
+++ b/.github/workflows/release-engine-image-sglang.yaml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       base_image_tag_override:
-        description: "optional override for the upstream SGLang base image tag (default: <engine_version> for nvidia, <engine_version>-rocm720-mi30x for rocm); use to point at MI355x or other ROCm variants"
+        description: "optional override for the upstream SGLang base image tag (default: <engine_version> for nvidia, <engine_version>-rocm720-mi30x for rocm); must be a tag of the same upstream version as engine_version because the Neutree serve-layer code is still selected by engine_version via ENGINE_SGLANG_DIR_VERSION (e.g. ROCm variant tags of v0.5.10 are fine, a v0.6.0 tag is not)"
         required: false
         type: string
         default: ""
@@ -30,7 +30,7 @@ on:
         type: string
         default: "ray2.53.0"
       engine_patch_suffix:
-        description: "optional alphanumeric patch identifier appended to the output tag (e.g. '1' produces <tag>-neutree1-<ray_short_version>); allowed chars [a-zA-Z0-9._-]; empty keeps the upstream tag"
+        description: "optional patch identifier appended to the output tag, allowed chars [a-zA-Z0-9._-] (e.g. '1' produces <tag>-neutree1-<ray_short_version>); empty keeps the upstream tag"
         required: false
         type: string
         default: ""

--- a/.github/workflows/release-engine-image-vllm.yaml
+++ b/.github/workflows/release-engine-image-vllm.yaml
@@ -1,25 +1,24 @@
-name: release-engine-image
+name: release-engine-image-vllm
 
-# This workflow only builds NVIDIA-accelerated images. ROCm targets exist in
-# the Makefile (docker-build-engine-vllm-rocm, docker-build-engine-sglang-rocm)
-# and can be invoked manually for ad-hoc builds, but the workflow does not
-# expose them yet — see the follow-up ticket for splitting into per-engine
-# workflows with first-class accelerator + base-image-tag overrides.
 on:
   workflow_dispatch:
     inputs:
-      engine:
-        description: "engine name"
+      accelerator:
+        description: "accelerator type"
         required: true
         type: choice
         options:
-          - vllm
-          - llama-cpp
-          - sglang
+          - nvidia
+          - rocm
       engine_version:
-        description: "engine version (e.g: v0.11.2 for vllm, v0.3.7 for llama-cpp, v0.5.10 for sglang)"
+        description: "vLLM engine version (e.g. v0.11.2)"
         required: true
         type: string
+      base_image_tag_override:
+        description: "optional override for the upstream vLLM base image tag (default: <engine_version>); use to point at non-standard upstream tags such as dev builds without editing the Makefile"
+        required: false
+        type: string
+        default: ""
       ray_version:
         description: "the ray version branch/tag to build from"
         required: false
@@ -39,7 +38,7 @@ on:
 jobs:
   build-amd64-image:
     runs-on: ["serve-builder","X64"]
-    name: build amd64 engine image
+    name: build amd64 vllm engine image
     steps:
       - uses: actions/checkout@v2
       - name: Validate engine_patch_suffix
@@ -53,23 +52,31 @@ jobs:
           registry: ${{ secrets.SERVE_IMAGE_REPO }}
           username: ${{ secrets.SERVE_IMAGE_PUSH_USERNAME }}
           password: ${{ secrets.SERVE_IMAGE_PUSH_TOKEN }}
+      - name: Resolve make target suffix
+        id: target
+        run: |
+          if [ "${{ github.event.inputs.accelerator }}" = "rocm" ]; then
+            echo "suffix=-rocm" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=" >> "$GITHUB_OUTPUT"
+          fi
       - name: build and push engine image
         run: |
           cd cluster-image-builder
-          make docker-build-engine-${{ github.event.inputs.engine }} docker-push-engine-${{ github.event.inputs.engine }}
+          make docker-build-engine-vllm${{ steps.target.outputs.suffix }} docker-push-engine-vllm${{ steps.target.outputs.suffix }}
         env:
           IMAGE_PROJECT: ${{ secrets.RELEASE_SERVE_IMAGE_PROJECT }}
           IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
           ARCH: amd64
           ENGINE_VLLM_VERSION: ${{ github.event.inputs.engine_version }}
-          ENGINE_LLAMA_CPP_VERSION: ${{ github.event.inputs.engine_version }}
-          ENGINE_SGLANG_VERSION: ${{ github.event.inputs.engine_version }}
+          ENGINE_VLLM_BASE_IMAGE_TAG: ${{ github.event.inputs.base_image_tag_override || github.event.inputs.engine_version }}
+          ENGINE_VLLM_ROCM_BASE_IMAGE_TAG: ${{ github.event.inputs.base_image_tag_override || github.event.inputs.engine_version }}
           RAY_VERSION: ${{ github.event.inputs.ray_version }}
           RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
           ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}
   push-manifests:
     runs-on: ["serve-builder","X64"]
-    name: merge and push manifests
+    name: merge and push vllm manifests
     needs:
       - build-amd64-image
     steps:
@@ -80,16 +87,22 @@ jobs:
           registry: ${{ secrets.SERVE_IMAGE_REPO }}
           username: ${{ secrets.SERVE_IMAGE_PUSH_USERNAME }}
           password: ${{ secrets.SERVE_IMAGE_PUSH_TOKEN }}
+      - name: Resolve manifest target suffix
+        id: target
+        run: |
+          if [ "${{ github.event.inputs.accelerator }}" = "rocm" ]; then
+            echo "suffix=-rocm" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=" >> "$GITHUB_OUTPUT"
+          fi
       - name: push manifests
         run: |
           cd cluster-image-builder
-          make docker-push-manifest-engine-${{ github.event.inputs.engine }}
+          make docker-push-manifest-engine-vllm${{ steps.target.outputs.suffix }}
         env:
           IMAGE_PROJECT: ${{ secrets.RELEASE_SERVE_IMAGE_PROJECT }}
           IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
           ALL_ARCH: amd64
           ENGINE_VLLM_VERSION: ${{ github.event.inputs.engine_version }}
-          ENGINE_LLAMA_CPP_VERSION: ${{ github.event.inputs.engine_version }}
-          ENGINE_SGLANG_VERSION: ${{ github.event.inputs.engine_version }}
           RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
           ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}

--- a/.github/workflows/release-engine-image-vllm.yaml
+++ b/.github/workflows/release-engine-image-vllm.yaml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       base_image_tag_override:
-        description: "optional override for the upstream vLLM base image tag (default: <engine_version>); use to point at non-standard upstream tags such as dev builds without editing the Makefile"
+        description: "optional override for the upstream vLLM base image tag (default: <engine_version>); must be a tag of the same upstream version as engine_version because the Neutree serve-layer code is still selected by engine_version via ENGINE_VLLM_DIR_VERSION (e.g. dev/preview tags of v0.11.2 are fine, a v0.12.0 tag is not)"
         required: false
         type: string
         default: ""
@@ -30,7 +30,7 @@ on:
         type: string
         default: "ray2.53.0"
       engine_patch_suffix:
-        description: "optional alphanumeric patch identifier appended to the output tag (e.g. '1' produces <engine_version>-neutree1-<ray_short_version>); allowed chars [a-zA-Z0-9._-]; empty keeps the upstream tag"
+        description: "optional patch identifier appended to the output tag, allowed chars [a-zA-Z0-9._-] (e.g. '1' produces <engine_version>-neutree1-<ray_short_version>); empty keeps the upstream tag"
         required: false
         type: string
         default: ""

--- a/.github/workflows/release-engine-image-vllm.yaml
+++ b/.github/workflows/release-engine-image-vllm.yaml
@@ -104,5 +104,7 @@ jobs:
           IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
           ALL_ARCH: amd64
           ENGINE_VLLM_VERSION: ${{ github.event.inputs.engine_version }}
+          ENGINE_VLLM_BASE_IMAGE_TAG: ${{ github.event.inputs.base_image_tag_override || github.event.inputs.engine_version }}
+          ENGINE_VLLM_ROCM_BASE_IMAGE_TAG: ${{ github.event.inputs.base_image_tag_override || github.event.inputs.engine_version }}
           RAY_SHORT_VERSION: ${{ github.event.inputs.ray_short_version }}
           ENGINE_PATCH_SUFFIX: ${{ github.event.inputs.engine_patch_suffix }}

--- a/cluster-image-builder/Makefile
+++ b/cluster-image-builder/Makefile
@@ -73,12 +73,12 @@ docker-build-amd-gpu: prepare ## Build the AMD GPU cluster image
 .PHONY: docker-build-engine-vllm
 docker-build-engine-vllm: prepare ## Build the vLLM engine image (NVIDIA)
 	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_BASE_IMAGE_REPO):$(ENGINE_VLLM_BASE_IMAGE_TAG) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
-		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
+		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-build-engine-vllm-rocm
 docker-build-engine-vllm-rocm: prepare ## Build the vLLM engine image (ROCm)
 	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_ROCM_BASE_IMAGE_REPO):$(ENGINE_VLLM_ROCM_BASE_IMAGE_TAG) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
-		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
+		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_ROCM_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-build-engine-llama-cpp
 docker-build-engine-llama-cpp: prepare ## Build the llama-cpp-python engine image
@@ -88,7 +88,7 @@ docker-build-engine-llama-cpp: prepare ## Build the llama-cpp-python engine imag
 .PHONY: docker-build-engine-sglang
 docker-build-engine-sglang: prepare ## Build the SGLang engine image (NVIDIA)
 	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_SGLANG_BASE_IMAGE_REPO):$(ENGINE_SGLANG_BASE_IMAGE_TAG) --build-arg ENGINE_VERSION_DIR=$(ENGINE_SGLANG_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
-		-f Dockerfile.engine-sglang -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
+		-f Dockerfile.engine-sglang -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-build-engine-sglang-rocm
 docker-build-engine-sglang-rocm: prepare ## Build the SGLang engine image (AMD ROCm, MI300x)
@@ -109,11 +109,11 @@ docker-push-amd-gpu: ## Push the AMD GPU image
 
 .PHONY: docker-push-engine-vllm
 docker-push-engine-vllm: ## Push the vLLM engine image (NVIDIA)
-	docker push $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
+	docker push $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
 
 .PHONY: docker-push-engine-vllm-rocm
 docker-push-engine-vllm-rocm: ## Push the vLLM engine image (ROCm)
-	docker push $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
+	docker push $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_ROCM_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
 
 .PHONY: docker-push-engine-llama-cpp
 docker-push-engine-llama-cpp: ## Push the llama-cpp-python engine image
@@ -121,7 +121,7 @@ docker-push-engine-llama-cpp: ## Push the llama-cpp-python engine image
 
 .PHONY: docker-push-engine-sglang
 docker-push-engine-sglang: ## Push the SGLang engine image (NVIDIA)
-	docker push $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
+	docker push $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)
 
 .PHONY: docker-push-engine-sglang-rocm
 docker-push-engine-sglang-rocm: ## Push the SGLang engine image (AMD ROCm, MI300x)
@@ -129,11 +129,11 @@ docker-push-engine-sglang-rocm: ## Push the SGLang engine image (AMD ROCm, MI300
 
 .PHONY: docker-push-manifest-engine-vllm
 docker-push-manifest-engine-vllm: ## Push the vLLM engine manifest image
-	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
+	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm:$(ENGINE_VLLM_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
 
 .PHONY: docker-push-manifest-engine-vllm-rocm
 docker-push-manifest-engine-vllm-rocm: ## Push the vLLM engine manifest image (ROCm)
-	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
+	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_ROCM_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm-rocm:$(ENGINE_VLLM_ROCM_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
 
 .PHONY: docker-push-manifest-engine-llama-cpp
 docker-push-manifest-engine-llama-cpp: ## Push the llama-cpp engine manifest image
@@ -141,7 +141,7 @@ docker-push-manifest-engine-llama-cpp: ## Push the llama-cpp engine manifest ima
 
 .PHONY: docker-push-manifest-engine-sglang
 docker-push-manifest-engine-sglang: ## Push the SGLang engine manifest image (NVIDIA)
-	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
+	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-sglang:$(ENGINE_SGLANG_BASE_IMAGE_TAG)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
 
 .PHONY: docker-push-manifest-engine-sglang-rocm
 docker-push-manifest-engine-sglang-rocm: ## Push the SGLang engine manifest image (AMD ROCm)

--- a/cluster-image-builder/Makefile
+++ b/cluster-image-builder/Makefile
@@ -20,15 +20,25 @@ ENGINE_VLLM_BASE_IMAGE_REPO ?= vllm/vllm-openai
 ENGINE_VLLM_ROCM_BASE_IMAGE_REPO ?= vllm/vllm-openai-rocm
 ENGINE_VLLM_VERSION ?= v0.11.2
 ENGINE_VLLM_DIR_VERSION ?= $(shell echo $(ENGINE_VLLM_VERSION) | sed 's/-.*//' | tr '.' '_')
+# Optional override of the upstream vLLM base image tag (defaults to
+# ENGINE_VLLM_VERSION). Use to point at non-standard upstream tags (e.g. dev
+# builds) without editing the Makefile; release workflows expose this via the
+# `base_image_tag_override` input.
+ENGINE_VLLM_BASE_IMAGE_TAG ?= $(ENGINE_VLLM_VERSION)
+ENGINE_VLLM_ROCM_BASE_IMAGE_TAG ?= $(ENGINE_VLLM_VERSION)
 ENGINE_LLAMA_CPP_VERSION ?= v0.3.7
 ENGINE_LLAMA_CPP_DIR_VERSION ?= $(shell echo $(ENGINE_LLAMA_CPP_VERSION) | sed 's/-.*//' | tr '.' '_')
 # SGLang base image. ENGINE_SGLANG_VERSION is the upstream tag prefix used as
 # the *Neutree* image tag prefix (per design doc 4.x): for NVIDIA pull
-# lmsysorg/sglang:<ENGINE_SGLANG_VERSION>; for ROCm pull
-# lmsysorg/sglang:<ENGINE_SGLANG_ROCM_TAG> (preserves the rocm720-mi30x suffix
-# in the resulting Neutree image tag, e.g. v0.5.10-rocm720-mi30x-ray2.53.0).
+# lmsysorg/sglang:<ENGINE_SGLANG_BASE_IMAGE_TAG> (defaults to
+# ENGINE_SGLANG_VERSION); for ROCm pull lmsysorg/sglang:<ENGINE_SGLANG_ROCM_TAG>
+# (preserves the rocm720-mi30x suffix in the resulting Neutree image tag, e.g.
+# v0.5.10-rocm720-mi30x-ray2.53.0). Both base-image tags are overridable so
+# release workflows can point at MI355x or other variants without editing the
+# Makefile.
 ENGINE_SGLANG_BASE_IMAGE_REPO ?= lmsysorg/sglang
 ENGINE_SGLANG_VERSION ?= v0.5.10
+ENGINE_SGLANG_BASE_IMAGE_TAG ?= $(ENGINE_SGLANG_VERSION)
 ENGINE_SGLANG_ROCM_TAG ?= $(ENGINE_SGLANG_VERSION)-rocm720-mi30x
 ENGINE_SGLANG_DIR_VERSION ?= $(shell echo $(ENGINE_SGLANG_VERSION) | sed 's/-.*//' | tr '.' '_')
 RAY_SHORT_VERSION ?= ray2.53.0
@@ -62,12 +72,12 @@ docker-build-amd-gpu: prepare ## Build the AMD GPU cluster image
 
 .PHONY: docker-build-engine-vllm
 docker-build-engine-vllm: prepare ## Build the vLLM engine image (NVIDIA)
-	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_BASE_IMAGE_REPO):$(ENGINE_VLLM_VERSION) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
+	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_BASE_IMAGE_REPO):$(ENGINE_VLLM_BASE_IMAGE_TAG) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
 		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-build-engine-vllm-rocm
 docker-build-engine-vllm-rocm: prepare ## Build the vLLM engine image (ROCm)
-	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_ROCM_BASE_IMAGE_REPO):$(ENGINE_VLLM_VERSION) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
+	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_VLLM_ROCM_BASE_IMAGE_REPO):$(ENGINE_VLLM_ROCM_BASE_IMAGE_TAG) --build-arg ENGINE_VERSION_DIR=$(ENGINE_VLLM_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
 		-f Dockerfile.engine-vllm -t $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-build-engine-llama-cpp
@@ -77,7 +87,7 @@ docker-build-engine-llama-cpp: prepare ## Build the llama-cpp-python engine imag
 
 .PHONY: docker-build-engine-sglang
 docker-build-engine-sglang: prepare ## Build the SGLang engine image (NVIDIA)
-	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_SGLANG_BASE_IMAGE_REPO):$(ENGINE_SGLANG_VERSION) --build-arg ENGINE_VERSION_DIR=$(ENGINE_SGLANG_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
+	docker build --build-arg ENGINE_BASE_IMAGE=$(ENGINE_SGLANG_BASE_IMAGE_REPO):$(ENGINE_SGLANG_BASE_IMAGE_TAG) --build-arg ENGINE_VERSION_DIR=$(ENGINE_SGLANG_DIR_VERSION) --build-arg RAY_COMMIT=$(RAY_COMMIT) --build-arg RAY_REPO=$(RAY_REPO) \
 		-f Dockerfile.engine-sglang -t $(NEUTREE_ENGINE_IMAGE)-sglang:$(ENGINE_SGLANG_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) .
 
 .PHONY: docker-build-engine-sglang-rocm
@@ -120,6 +130,10 @@ docker-push-engine-sglang-rocm: ## Push the SGLang engine image (AMD ROCm, MI300
 .PHONY: docker-push-manifest-engine-vllm
 docker-push-manifest-engine-vllm: ## Push the vLLM engine manifest image
 	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
+
+.PHONY: docker-push-manifest-engine-vllm-rocm
+docker-push-manifest-engine-vllm-rocm: ## Push the vLLM engine manifest image (ROCm)
+	docker buildx imagetools create -t $(NEUTREE_ENGINE_IMAGE)-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(NEUTREE_ENGINE_IMAGE)\-vllm-rocm:$(ENGINE_VLLM_VERSION)$(ENGINE_PATCH_TAG)-$(RAY_SHORT_VERSION)~g")
 
 .PHONY: docker-push-manifest-engine-llama-cpp
 docker-push-manifest-engine-llama-cpp: ## Push the llama-cpp engine manifest image

--- a/cluster-image-builder/Makefile
+++ b/cluster-image-builder/Makefile
@@ -28,14 +28,19 @@ ENGINE_VLLM_BASE_IMAGE_TAG ?= $(ENGINE_VLLM_VERSION)
 ENGINE_VLLM_ROCM_BASE_IMAGE_TAG ?= $(ENGINE_VLLM_VERSION)
 ENGINE_LLAMA_CPP_VERSION ?= v0.3.7
 ENGINE_LLAMA_CPP_DIR_VERSION ?= $(shell echo $(ENGINE_LLAMA_CPP_VERSION) | sed 's/-.*//' | tr '.' '_')
-# SGLang base image. ENGINE_SGLANG_VERSION is the upstream tag prefix used as
-# the *Neutree* image tag prefix (per design doc 4.x): for NVIDIA pull
-# lmsysorg/sglang:<ENGINE_SGLANG_BASE_IMAGE_TAG> (defaults to
-# ENGINE_SGLANG_VERSION); for ROCm pull lmsysorg/sglang:<ENGINE_SGLANG_ROCM_TAG>
-# (preserves the rocm720-mi30x suffix in the resulting Neutree image tag, e.g.
-# v0.5.10-rocm720-mi30x-ray2.53.0). Both base-image tags are overridable so
-# release workflows can point at MI355x or other variants without editing the
-# Makefile.
+# SGLang base image. ENGINE_SGLANG_VERSION is the default value for both the
+# upstream pull tag and the Neutree output image tag prefix; the actual
+# variables consumed by the recipes are:
+#   - NVIDIA: pull lmsysorg/sglang:<ENGINE_SGLANG_BASE_IMAGE_TAG> and tag the
+#     output engine-sglang:<ENGINE_SGLANG_BASE_IMAGE_TAG>-... (both default to
+#     ENGINE_SGLANG_VERSION).
+#   - ROCm: pull lmsysorg/sglang:<ENGINE_SGLANG_ROCM_TAG> and tag the output
+#     engine-sglang:<ENGINE_SGLANG_ROCM_TAG>-... (defaults to
+#     <ENGINE_SGLANG_VERSION>-rocm720-mi30x), preserving the variant suffix in
+#     the resulting Neutree tag, e.g. v0.5.10-rocm720-mi30x-ray2.53.0.
+# Both base-image tags are overridable so release workflows can point at
+# MI355x or other variants without editing the Makefile; with overrides set,
+# the variant suffix flows through to the Neutree output tag too.
 ENGINE_SGLANG_BASE_IMAGE_REPO ?= lmsysorg/sglang
 ENGINE_SGLANG_VERSION ?= v0.5.10
 ENGINE_SGLANG_BASE_IMAGE_TAG ?= $(ENGINE_SGLANG_VERSION)


### PR DESCRIPTION
## Issues

NEU-438

The monolithic `.github/workflows/release-engine-image.yaml` packs three engines (vllm, llama-cpp, sglang) into one `engine` choice + a single string `engine_version`, while ROCm variants live only as Makefile targets with no workflow entry. SGLang's ROCm side already needs four upstream tag variants (`rocm720-mi30x` / `rocm700-mi30x` / `rocm720-mi35x` / `rocm700-mi35x`) and the only way to build a non-`mi30x` variant today is to edit `cluster-image-builder/Makefile`'s hardcoded `ENGINE_SGLANG_ROCM_TAG`. NEU-429 attempted to fold an `accelerator` dimension into the unified yaml and concluded that one workflow cannot carry the engine x accelerator x base-tag matrix cleanly.

## Changes

- Delete `.github/workflows/release-engine-image.yaml`.
- Add three per-engine workflows whose input shapes match each engine's actual dimensions:
  - `release-engine-image-vllm.yaml`: `accelerator` (nvidia|rocm), `engine_version`, `base_image_tag_override` (optional), ray inputs, `engine_patch_suffix`.
  - `release-engine-image-llama-cpp.yaml`: CPU-only, no accelerator dimension.
  - `release-engine-image-sglang.yaml`: `accelerator` (nvidia|rocm), `engine_version`, `base_image_tag_override` (optional, defaults to `<engine_version>` for nvidia and `<engine_version>-rocm720-mi30x` for rocm), ray inputs, `engine_patch_suffix`.
- `cluster-image-builder/Makefile`:
  - New optional env hooks `ENGINE_VLLM_BASE_IMAGE_TAG`, `ENGINE_VLLM_ROCM_BASE_IMAGE_TAG`, `ENGINE_SGLANG_BASE_IMAGE_TAG`, all defaulting to the corresponding `ENGINE_*_VERSION` so the unset path is byte-identical to before.
  - Wire the new hooks into both the `--build-arg ENGINE_BASE_IMAGE` AND the output Neutree image tag of `docker-build-engine-vllm`, `docker-build-engine-vllm-rocm`, and `docker-build-engine-sglang` (and matching push / manifest targets). When the override is set, the variant suffix flows through to the output tag so multiple ROCm variants (e.g. mi30x and mi35x) can coexist in the registry instead of overwriting one another. This matches the existing `ENGINE_SGLANG_ROCM_TAG` convention.
  - Add the missing `docker-push-manifest-engine-vllm-rocm` target, which the unified workflow never needed because ROCm vLLM had no workflow path.

## Test

Local Makefile dry-runs (`make -n <target>`) against the rewritten Makefile.

Default-path commands (no override) remain byte-identical to pre-change output:

| Target | Resulting `docker build` command |
| --- | --- |
| `docker-build-engine-vllm` | `--build-arg ENGINE_BASE_IMAGE=vllm/vllm-openai:v0.11.2 ... -t .../engine-vllm:v0.11.2-ray2.53.0` |
| `docker-build-engine-vllm-rocm` | `--build-arg ENGINE_BASE_IMAGE=vllm/vllm-openai-rocm:v0.11.2 ... -t .../engine-vllm-rocm:v0.11.2-ray2.53.0` |
| `docker-build-engine-sglang` | `--build-arg ENGINE_BASE_IMAGE=lmsysorg/sglang:v0.5.10 ... -t .../engine-sglang:v0.5.10-ray2.53.0` |
| `docker-build-engine-sglang-rocm` | `--build-arg ENGINE_BASE_IMAGE=lmsysorg/sglang:v0.5.10-rocm720-mi30x ... -t .../engine-sglang:v0.5.10-rocm720-mi30x-ray2.53.0` |
| `docker-build-engine-llama-cpp` | unchanged |

Override-path commands now flow the variant suffix through to the output tag (build / push / manifest all consistent):

| Override env | Resulting base image | Resulting output tag |
| --- | --- | --- |
| `ENGINE_VLLM_BASE_IMAGE_TAG=v0.11.2-dev1` | `vllm/vllm-openai:v0.11.2-dev1` | `engine-vllm:v0.11.2-dev1-ray2.53.0` |
| `ENGINE_VLLM_ROCM_BASE_IMAGE_TAG=v0.11.2-mi355x` | `vllm/vllm-openai-rocm:v0.11.2-mi355x` | `engine-vllm-rocm:v0.11.2-mi355x-ray2.53.0` |
| `ENGINE_SGLANG_BASE_IMAGE_TAG=v0.5.10-rc1` | `lmsysorg/sglang:v0.5.10-rc1` | `engine-sglang:v0.5.10-rc1-ray2.53.0` |
| `ENGINE_SGLANG_ROCM_TAG=v0.5.10-rocm720-mi35x` | `lmsysorg/sglang:v0.5.10-rocm720-mi35x` | `engine-sglang:v0.5.10-rocm720-mi35x-ray2.53.0` |

YAML parses cleanly for all three new workflows.

### Post-merge smoke test

GitHub's `workflow_dispatch` API requires the workflow file to be registered on the default branch first, so the new workflows cannot be dispatched until this PR merges. The full end-to-end smoke must therefore happen post-merge:

```bash
gh workflow run release-engine-image-vllm.yaml      --ref main -f accelerator=nvidia -f engine_version=v0.11.2 -f engine_patch_suffix=neu438
gh workflow run release-engine-image-sglang.yaml    --ref main -f accelerator=nvidia -f engine_version=v0.5.10 -f engine_patch_suffix=neu438
gh workflow run release-engine-image-llama-cpp.yaml --ref main -f engine_version=v0.3.7  -f engine_patch_suffix=neu438
```

Each run is expected to produce `engine-<engine>:<engine_version>-neutreeneu438-ray2.53.0` without overwriting any production tag (the `engine_patch_suffix=neu438` keeps the test images on a separate tag namespace). Acceptance scenarios below will be verified against the resulting build URLs and posted back to the Jira ticket as part of the merge follow-up.

### Acceptance scenarios (gh workflow run)

- [ ] `gh workflow run release-engine-image-sglang.yaml -f accelerator=nvidia -f engine_version=v0.5.10` → produces `engine-sglang:v0.5.10-ray2.53.0`.
- [ ] `gh workflow run release-engine-image-sglang.yaml -f accelerator=rocm -f engine_version=v0.5.10` → produces `engine-sglang:v0.5.10-rocm720-mi30x-ray2.53.0`.
- [ ] `gh workflow run release-engine-image-sglang.yaml -f accelerator=rocm -f engine_version=v0.5.10 -f base_image_tag_override=v0.5.10-rocm720-mi35x` → produces `engine-sglang:v0.5.10-rocm720-mi35x-ray2.53.0`.
- [ ] `gh workflow run release-engine-image-vllm.yaml -f accelerator=rocm -f engine_version=v0.11.2` → produces `engine-vllm-rocm:v0.11.2-ray2.53.0` (this path was unreachable from the old workflow).
- [ ] `gh workflow run release-engine-image-llama-cpp.yaml -f engine_version=v0.3.7` → behavior unchanged from before the split.