### PR TITLE
fix: surface failed actor logs on SSH cluster after init crash

### DIFF
--- a/internal/ray/dashboard/actors.go
+++ b/internal/ray/dashboard/actors.go
@@ -1,0 +1,87 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// ActorFilter is a single (key, predicate, value) tuple sent to Ray's
+// state API as repeated filter_keys / filter_predicates / filter_values
+// query parameters.
+//
+// Predicate must be "=" or "!="; only "=" is pushed down to GCS for the
+// supported keys (actor_id / state / job_id). All other filters fall
+// back to client-side do_filter inside the dashboard process.
+type ActorFilter struct {
+	Key       string
+	Predicate string
+	Value     string
+}
+
+// ActorsResponse is the full envelope returned by GET /api/v0/actors,
+// after Ray's rest_response + do_reply wraps the inner ListApiResponse.
+type ActorsResponse struct {
+	Result bool               `json:"result"`
+	Msg    string             `json:"msg"`
+	Data   ActorsResponseData `json:"data"`
+}
+
+type ActorsResponseData struct {
+	Result ActorsListResult `json:"result"`
+}
+
+type ActorsListResult struct {
+	Total              int     `json:"total"`
+	NumAfterTruncation int     `json:"num_after_truncation"`
+	NumFiltered        int     `json:"num_filtered"`
+	Result             []Actor `json:"result"`
+}
+
+// Actor mirrors Ray's ActorState schema (snake_case via
+// preserving_proto_field_name=True). DeathCause only populates when
+// detail=true is sent in the request.
+type Actor struct {
+	ActorID    string                 `json:"actor_id"`
+	ClassName  string                 `json:"class_name"`
+	State      string                 `json:"state"`
+	Name       string                 `json:"name"`
+	NodeID     string                 `json:"node_id"`
+	PID        int                    `json:"pid"`
+	DeathCause map[string]interface{} `json:"death_cause,omitempty"`
+}
+
+// ListActors queries GET /api/v0/actors with the given filters.
+//
+// detail=true asks Ray to populate detail-only fields such as DeathCause.
+// limit > 0 caps the response; pass 0 to use Ray's default (100).
+func (c *Client) ListActors(filters []ActorFilter, detail bool, limit int) (*ActorsResponse, error) {
+	q := url.Values{}
+	for _, f := range filters {
+		q.Add("filter_keys", f.Key)
+		q.Add("filter_predicates", f.Predicate)
+		q.Add("filter_values", f.Value)
+	}
+
+	if detail {
+		q.Set("detail", "true")
+	}
+
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+
+	path := "/api/v0/actors"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	var resp ActorsResponse
+	if err := c.doRequest(http.MethodGet, path, nil, &resp); err != nil {
+		return nil, errors.Wrap(err, "failed to list actors")
+	}
+
+	return &resp, nil
+}

--- a/internal/ray/dashboard/actors.go
+++ b/internal/ray/dashboard/actors.go
@@ -40,9 +40,16 @@ type ActorsListResult struct {
 	Result             []Actor `json:"result"`
 }
 
-// Actor mirrors Ray's ActorState schema (snake_case via
-// preserving_proto_field_name=True). DeathCause only populates when
-// detail=true is sent in the request.
+// Actor mirrors fields exposed by Ray's state API for actors. Field names
+// follow the snake_case used by Ray (preserving_proto_field_name=True).
+//
+// StartTime / EndTime come from the underlying GCS ActorTableData protobuf
+// (start_time / end_time, unix ms) — they pass through the JSON even though
+// they are not listed in the public ActorState docstring. They are required
+// to identify the most recently created actor for a Serve deployment after
+// Ray Serve has removed the failed replica from /api/serve/applications/.
+//
+// DeathCause only populates when detail=true is sent in the request.
 type Actor struct {
 	ActorID    string                 `json:"actor_id"`
 	ClassName  string                 `json:"class_name"`
@@ -50,6 +57,8 @@ type Actor struct {
 	Name       string                 `json:"name"`
 	NodeID     string                 `json:"node_id"`
 	PID        int                    `json:"pid"`
+	StartTime  int64                  `json:"start_time"`
+	EndTime    int64                  `json:"end_time"`
 	DeathCause map[string]interface{} `json:"death_cause,omitempty"`
 }
 

--- a/internal/ray/dashboard/actors_test.go
+++ b/internal/ray/dashboard/actors_test.go
@@ -1,0 +1,123 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_ListActors_BuildsFilterQueryParams(t *testing.T) {
+	var capturedQuery map[string][]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v0/actors", r.URL.Path)
+		capturedQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"result":true,"msg":"","data":{"result":{"total":0,"num_after_truncation":0,"num_filtered":0,"result":[]}}}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{dashboardURL: srv.URL, client: &http.Client{}}
+
+	resp, err := c.ListActors([]ActorFilter{
+		{Key: "class_name", Predicate: "=", Value: "ServeReplica:default_test:deploy"},
+		{Key: "state", Predicate: "=", Value: "DEAD"},
+	}, true, 100)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, []string{"class_name", "state"}, capturedQuery["filter_keys"])
+	assert.Equal(t, []string{"=", "="}, capturedQuery["filter_predicates"])
+	assert.Equal(t, []string{"ServeReplica:default_test:deploy", "DEAD"}, capturedQuery["filter_values"])
+	assert.Equal(t, []string{"true"}, capturedQuery["detail"])
+	assert.Equal(t, []string{"100"}, capturedQuery["limit"])
+}
+
+func TestClient_ListActors_ParsesResponse(t *testing.T) {
+	body := `{
+		"result": true,
+		"msg": "",
+		"data": {
+			"result": {
+				"total": 2,
+				"num_after_truncation": 2,
+				"num_filtered": 1,
+				"result": [
+					{
+						"actor_id": "abc123",
+						"class_name": "ServeReplica:default_test:deploy",
+						"state": "DEAD",
+						"name": "SERVE_REPLICA::default_test#deploy#xyz789",
+						"node_id": "node-1",
+						"pid": 1234,
+						"death_cause": {"actor_died_error_context": {"error_message": "init failed"}}
+					}
+				]
+			}
+		}
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := &Client{dashboardURL: srv.URL, client: &http.Client{}}
+
+	resp, err := c.ListActors(nil, true, 100)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Result)
+	assert.Equal(t, 2, resp.Data.Result.Total)
+	assert.Equal(t, 1, resp.Data.Result.NumFiltered)
+	require.Len(t, resp.Data.Result.Result, 1)
+
+	a := resp.Data.Result.Result[0]
+	assert.Equal(t, "abc123", a.ActorID)
+	assert.Equal(t, "ServeReplica:default_test:deploy", a.ClassName)
+	assert.Equal(t, "DEAD", a.State)
+	assert.Equal(t, "SERVE_REPLICA::default_test#deploy#xyz789", a.Name)
+	assert.Equal(t, "node-1", a.NodeID)
+	assert.Equal(t, 1234, a.PID)
+	require.NotNil(t, a.DeathCause)
+}
+
+func TestClient_ListActors_OmitsDetailWhenFalse(t *testing.T) {
+	var capturedQuery map[string][]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.Query()
+		_, _ = w.Write([]byte(`{"data":{"result":{"result":[]}}}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{dashboardURL: srv.URL, client: &http.Client{}}
+
+	_, err := c.ListActors(nil, false, 0)
+
+	require.NoError(t, err)
+	_, hasDetail := capturedQuery["detail"]
+	assert.False(t, hasDetail, "detail should not appear in query when false")
+	_, hasLimit := capturedQuery["limit"]
+	assert.False(t, hasLimit, "limit should not appear in query when 0")
+}
+
+func TestClient_ListActors_NonOKStatusReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`server boom`))
+	}))
+	defer srv.Close()
+
+	c := &Client{dashboardURL: srv.URL, client: &http.Client{}}
+
+	resp, err := c.ListActors(nil, false, 0)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}

--- a/internal/ray/dashboard/client.go
+++ b/internal/ray/dashboard/client.go
@@ -19,6 +19,9 @@ type DashboardService interface {
 	// Serve related methods
 	GetServeApplications() (*RayServeApplicationsResponse, error)
 	UpdateServeApplications(appsReq RayServeApplicationsRequest) error
+
+	// State API: actor listing with filters
+	ListActors(filters []ActorFilter, detail bool, limit int) (*ActorsResponse, error)
 }
 
 type Client struct {

--- a/internal/ray/dashboard/mocks/mock_dashboard_service.go
+++ b/internal/ray/dashboard/mocks/mock_dashboard_service.go
@@ -191,6 +191,66 @@ func (_c *MockDashboardService_GetServeApplications_Call) RunAndReturn(run func(
 	return _c
 }
 
+// ListActors provides a mock function with given fields: filters, detail, limit
+func (_m *MockDashboardService) ListActors(filters []dashboard.ActorFilter, detail bool, limit int) (*dashboard.ActorsResponse, error) {
+	ret := _m.Called(filters, detail, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListActors")
+	}
+
+	var r0 *dashboard.ActorsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]dashboard.ActorFilter, bool, int) (*dashboard.ActorsResponse, error)); ok {
+		return rf(filters, detail, limit)
+	}
+	if rf, ok := ret.Get(0).(func([]dashboard.ActorFilter, bool, int) *dashboard.ActorsResponse); ok {
+		r0 = rf(filters, detail, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dashboard.ActorsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func([]dashboard.ActorFilter, bool, int) error); ok {
+		r1 = rf(filters, detail, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockDashboardService_ListActors_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListActors'
+type MockDashboardService_ListActors_Call struct {
+	*mock.Call
+}
+
+// ListActors is a helper method to define mock.On call
+//   - filters []dashboard.ActorFilter
+//   - detail bool
+//   - limit int
+func (_e *MockDashboardService_Expecter) ListActors(filters interface{}, detail interface{}, limit interface{}) *MockDashboardService_ListActors_Call {
+	return &MockDashboardService_ListActors_Call{Call: _e.mock.On("ListActors", filters, detail, limit)}
+}
+
+func (_c *MockDashboardService_ListActors_Call) Run(run func(filters []dashboard.ActorFilter, detail bool, limit int)) *MockDashboardService_ListActors_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]dashboard.ActorFilter), args[1].(bool), args[2].(int))
+	})
+	return _c
+}
+
+func (_c *MockDashboardService_ListActors_Call) Return(_a0 *dashboard.ActorsResponse, _a1 error) *MockDashboardService_ListActors_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockDashboardService_ListActors_Call) RunAndReturn(run func([]dashboard.ActorFilter, bool, int) (*dashboard.ActorsResponse, error)) *MockDashboardService_ListActors_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListNodes provides a mock function with no fields
 func (_m *MockDashboardService) ListNodes() ([]v1.NodeSummary, error) {
 	ret := _m.Called()

--- a/internal/ray/dashboard/serve_replica.go
+++ b/internal/ray/dashboard/serve_replica.go
@@ -1,0 +1,137 @@
+package dashboard
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ExtractReplicaShortID parses a Ray Serve actor name of the form
+// "SERVE_REPLICA::<app>#<deployment>#<short_id>" and returns short_id.
+// Returns "" when the name does not have at least one '#' separator or
+// ends with one.
+func ExtractReplicaShortID(actorName string) string {
+	idx := strings.LastIndex(actorName, "#")
+	if idx < 0 || idx+1 >= len(actorName) {
+		return ""
+	}
+
+	return actorName[idx+1:]
+}
+
+// ReplicaShortIDFromActor returns the short_id parsed from actor.Name,
+// falling back to actor.ActorID when the name does not match the Ray
+// Serve naming convention.
+func ReplicaShortIDFromActor(a *Actor) string {
+	if id := ExtractReplicaShortID(a.Name); id != "" {
+		return id
+	}
+
+	return a.ActorID
+}
+
+// ListFailedActorsForDeployment fetches DEAD actors that belong to the
+// given Ray Serve <app>:<deployment> via the dashboard state API.
+//
+// limit=100 is intentional: the goal is to surface the most recent few
+// failures, not the full history. A deployment that has flapped more
+// than 100 times within Ray's actor-table retention window will trim
+// the oldest records, which is acceptable.
+func ListFailedActorsForDeployment(svc DashboardService, appName, deploymentName string) ([]Actor, error) {
+	className := fmt.Sprintf("ServeReplica:%s:%s", appName, deploymentName)
+	resp, err := svc.ListActors([]ActorFilter{
+		{Key: "class_name", Predicate: "=", Value: className},
+		{Key: "state", Predicate: "=", Value: "DEAD"},
+	}, true, 100)
+
+	if err != nil {
+		return nil, fmt.Errorf("list actors %s: %w", className, err)
+	}
+
+	return resp.Data.Result.Result, nil
+}
+
+// FindFailedActorForDeployment returns the most recently started DEAD
+// actor for the deployment, or nil if none exist. "Most recent" is
+// decided by the actor's start_time (unix ms from GCS ActorTableData);
+// ties fall back to actor_id lexicographic order so the result is
+// deterministic.
+func FindFailedActorForDeployment(svc DashboardService, appName, deploymentName string) (*Actor, error) {
+	actors, err := ListFailedActorsForDeployment(svc, appName, deploymentName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(actors) == 0 {
+		return nil, nil
+	}
+
+	pick := 0
+
+	for i := 1; i < len(actors); i++ {
+		switch {
+		case actors[i].StartTime > actors[pick].StartTime:
+			pick = i
+		case actors[i].StartTime == actors[pick].StartTime && actors[i].ActorID > actors[pick].ActorID:
+			pick = i
+		}
+	}
+
+	a := actors[pick]
+
+	return &a, nil
+}
+
+// FindFailedActorByReplicaID returns the DEAD actor whose name encodes
+// the requested replica_id, or nil if no DEAD actor matches.
+//
+// Match priority:
+//  1. ExtractReplicaShortID(actor.Name) == replicaID — the canonical
+//     Ray Serve naming `SERVE_REPLICA::<app>#<deployment>#<short_id>`.
+//  2. actor.ActorID == replicaID — covers the degenerate case where a
+//     synthesized replica_id used actor_id (ReplicaShortIDFromActor
+//     falls back to actor_id when actor.Name does not match the
+//     convention). Without this, the synthesize → click → fetch
+//     round-trip would be unresolvable for unconventionally named
+//     actors.
+func FindFailedActorByReplicaID(svc DashboardService, appName, deploymentName, replicaID string) (*Actor, error) {
+	actors, err := ListFailedActorsForDeployment(svc, appName, deploymentName)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range actors {
+		if ExtractReplicaShortID(actors[i].Name) == replicaID || actors[i].ActorID == replicaID {
+			return &actors[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// LookupFailedActorAcrossDeployments scans the given deployment names
+// for a DEAD actor whose name encodes the requested replica_id.
+// Returns the first match, or (nil, nil) when no DEAD actor matches in
+// any deployment.
+//
+// Names are sorted before iteration so the search order is
+// deterministic across calls — Go map iteration order is randomized,
+// which would otherwise make the result depend on map seed when an
+// app has multiple deployments (e.g. P/D, prefill+decode).
+func LookupFailedActorAcrossDeployments(svc DashboardService, appName string, deploymentNames []string, replicaID string) (*Actor, error) {
+	sorted := append([]string(nil), deploymentNames...)
+	sort.Strings(sorted)
+
+	for _, deploymentName := range sorted {
+		actor, err := FindFailedActorByReplicaID(svc, appName, deploymentName, replicaID)
+		if err != nil {
+			return nil, err
+		}
+
+		if actor != nil {
+			return actor, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/ray/dashboard/serve_replica_test.go
+++ b/internal/ray/dashboard/serve_replica_test.go
@@ -1,0 +1,226 @@
+package dashboard_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neutree-ai/neutree/internal/ray/dashboard"
+	dashboardmocks "github.com/neutree-ai/neutree/internal/ray/dashboard/mocks"
+)
+
+func TestExtractReplicaShortID(t *testing.T) {
+	tests := []struct {
+		name     string
+		actor    string
+		expected string
+	}{
+		{"well-formed serve replica name", "SERVE_REPLICA::default_test#deploy-1#abc123", "abc123"},
+		{"name with no hash", "weird-name", ""},
+		{"name ending with hash returns empty", "SERVE_REPLICA::a#b#", ""},
+		{"empty name", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, dashboard.ExtractReplicaShortID(tt.actor))
+		})
+	}
+}
+
+func TestReplicaShortIDFromActor(t *testing.T) {
+	tests := []struct {
+		name     string
+		actor    dashboard.Actor
+		expected string
+	}{
+		{
+			name:     "well-formed name returns short_id",
+			actor:    dashboard.Actor{ActorID: "actor-aa", Name: "SERVE_REPLICA::default_test#deploy-1#shortxyz"},
+			expected: "shortxyz",
+		},
+		{
+			name:     "non-conventional name falls back to actor_id",
+			actor:    dashboard.Actor{ActorID: "actor-bb", Name: "weird-name"},
+			expected: "actor-bb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, dashboard.ReplicaShortIDFromActor(&tt.actor))
+		})
+	}
+}
+
+func TestListFailedActorsForDeployment_BuildsExpectedFilters(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+
+	svc.EXPECT().
+		ListActors(mock.MatchedBy(func(filters []dashboard.ActorFilter) bool {
+			hasClass, hasState := false, false
+			for _, f := range filters {
+				if f.Key == "class_name" && f.Predicate == "=" && f.Value == "ServeReplica:default_app:deploy-1" {
+					hasClass = true
+				}
+				if f.Key == "state" && f.Predicate == "=" && f.Value == "DEAD" {
+					hasState = true
+				}
+			}
+			return hasClass && hasState
+		}), true, 100).
+		Return(&dashboard.ActorsResponse{
+			Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: []dashboard.Actor{{ActorID: "x"}}}},
+		}, nil).
+		Once()
+
+	actors, err := dashboard.ListFailedActorsForDeployment(svc, "default_app", "deploy-1")
+
+	require.NoError(t, err)
+	require.Len(t, actors, 1)
+	assert.Equal(t, "x", actors[0].ActorID)
+}
+
+func TestListFailedActorsForDeployment_PropagatesError(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+	svc.EXPECT().ListActors(mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("boom")).Once()
+
+	_, err := dashboard.ListFailedActorsForDeployment(svc, "app", "dep")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ServeReplica:app:dep")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestFindFailedActorForDeployment_PicksMostRecentByStartTime(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+
+	// Highest actor_id intentionally on oldest start_time so a regression
+	// to actor_id ordering would flip the assertion.
+	svc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: []dashboard.Actor{
+			{ActorID: "actor-zzz", Name: "SERVE_REPLICA::a#d#oldshort", StartTime: 1000},
+			{ActorID: "actor-mmm", Name: "SERVE_REPLICA::a#d#midshort", StartTime: 2000},
+			{ActorID: "actor-aaa", Name: "SERVE_REPLICA::a#d#newshort", StartTime: 3000},
+		}}},
+	}, nil).Once()
+
+	got, err := dashboard.FindFailedActorForDeployment(svc, "a", "d")
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "actor-aaa", got.ActorID)
+}
+
+func TestFindFailedActorForDeployment_StartTimeTieBrokenByActorID(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+
+	svc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: []dashboard.Actor{
+			{ActorID: "actor-aaa", Name: "SERVE_REPLICA::a#d#aa", StartTime: 5000},
+			{ActorID: "actor-zzz", Name: "SERVE_REPLICA::a#d#zz", StartTime: 5000},
+		}}},
+	}, nil).Once()
+
+	got, err := dashboard.FindFailedActorForDeployment(svc, "a", "d")
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "actor-zzz", got.ActorID)
+}
+
+func TestFindFailedActorForDeployment_NoActorsReturnsNil(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+	svc.EXPECT().ListActors(mock.Anything, mock.Anything, mock.Anything).Return(&dashboard.ActorsResponse{}, nil).Once()
+
+	got, err := dashboard.FindFailedActorForDeployment(svc, "a", "d")
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestFindFailedActorByReplicaID_MatchesShortID(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+	svc.EXPECT().ListActors(mock.Anything, mock.Anything, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: []dashboard.Actor{
+			{ActorID: "actor-1", Name: "SERVE_REPLICA::a#d#wanted"},
+			{ActorID: "actor-2", Name: "SERVE_REPLICA::a#d#other"},
+		}}},
+	}, nil).Once()
+
+	got, err := dashboard.FindFailedActorByReplicaID(svc, "a", "d", "wanted")
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "actor-1", got.ActorID)
+}
+
+func TestFindFailedActorByReplicaID_FallsBackToActorID(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+	svc.EXPECT().ListActors(mock.Anything, mock.Anything, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: []dashboard.Actor{
+			{ActorID: "weird-id", Name: "non-conventional-name"},
+		}}},
+	}, nil).Once()
+
+	got, err := dashboard.FindFailedActorByReplicaID(svc, "a", "d", "weird-id")
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "weird-id", got.ActorID)
+}
+
+func TestFindFailedActorByReplicaID_NoMatchReturnsNil(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+	svc.EXPECT().ListActors(mock.Anything, mock.Anything, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: []dashboard.Actor{
+			{ActorID: "x", Name: "SERVE_REPLICA::a#d#other"},
+		}}},
+	}, nil).Once()
+
+	got, err := dashboard.FindFailedActorByReplicaID(svc, "a", "d", "missing")
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestLookupFailedActorAcrossDeployments_DeterministicOrder(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+
+	// Both deployments have a matching actor. Sorted iteration must visit
+	// "alpha" before "beta", so the alpha actor wins.
+	svc.EXPECT().
+		ListActors(mock.MatchedBy(func(filters []dashboard.ActorFilter) bool {
+			for _, f := range filters {
+				if f.Key == "class_name" && f.Value == "ServeReplica:app:alpha" {
+					return true
+				}
+			}
+			return false
+		}), mock.Anything, mock.Anything).
+		Return(&dashboard.ActorsResponse{
+			Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: []dashboard.Actor{
+				{ActorID: "alpha-actor", Name: "SERVE_REPLICA::app#alpha#wanted"},
+			}}},
+		}, nil).
+		Once()
+
+	got, err := dashboard.LookupFailedActorAcrossDeployments(svc, "app", []string{"beta", "alpha"}, "wanted")
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "alpha-actor", got.ActorID)
+}
+
+func TestLookupFailedActorAcrossDeployments_NoMatchReturnsNil(t *testing.T) {
+	svc := dashboardmocks.NewMockDashboardService(t)
+	svc.EXPECT().ListActors(mock.Anything, mock.Anything, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: nil}},
+	}, nil).Twice()
+
+	got, err := dashboard.LookupFailedActorAcrossDeployments(svc, "app", []string{"d1", "d2"}, "missing")
+
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}

--- a/internal/routes/logs/endpoint_logs.go
+++ b/internal/routes/logs/endpoint_logs.go
@@ -59,27 +59,19 @@ type LogInfo struct {
 
 // RayApplicationsResponse represents Ray Dashboard API response structure.
 //
-// TODO(NEU-423 follow-up): consolidate Ray API handling under
-// `internal/ray/dashboard/`. The migration scope includes:
+// TODO: Ray dashboard API types and calls belong in `internal/ray/dashboard/`,
+// not in the routes layer. The following items here violate that and should
+// move:
+//   - Types: RayApplicationsResponse, RayApplication, RayDeployment, RayReplica
+//   - Inline `httpClient.Get("/api/serve/applications/")` in getRayLogSources
+//     and streamRayLogs (should go through `dashboard.Client.doRequest`)
+//   - Ray-domain helpers (Ray Serve naming + DEAD-actor ranking, no
+//     routes-layer concerns): extractReplicaShortID, replicaShortIDFromActor,
+//     listFailedActorsForDeployment, findFailedActorForDeployment,
+//     findFailedActorByReplicaID, lookupFailedActorAcrossDeployments
 //
-//  1. The four legacy types here (RayApplicationsResponse, RayApplication,
-//     RayDeployment, RayReplica) plus the inline `httpClient.Get` call for
-//     `/api/serve/applications/` in `getRayLogSources` / `streamRayLogs` —
-//     these predate the rule that "Ray dashboard API types and calls live
-//     in `internal/ray/dashboard/`".
-//  2. The Ray-domain helpers added by this PR — `extractReplicaShortID`,
-//     `replicaShortIDFromActor`, `listFailedActorsForDeployment`,
-//     `findFailedActorForDeployment`, `findFailedActorByReplicaID`,
-//     `lookupFailedActorAcrossDeployments` — which encode Ray Serve naming
-//     conventions and DEAD-actor ranking. They belong next to
-//     `internal/ray/dashboard/actors.go`, not in the routes layer.
-//
-// `buildFailedReplicaInfo` stays here because it constructs neutree's API
-// response shape (`ReplicaInfo`), not Ray-domain output.
-//
-// Out of scope for the NEU-423 bug fix to keep the change minimal; tracked
-// in memory `improvement-ray-dashboard-consolidation.md` for the next PR
-// that touches this file or `internal/ray/dashboard/`.
+// buildFailedReplicaInfo stays in this file: it constructs the public API
+// response shape (ReplicaInfo), which is a routes-layer concern.
 type RayApplicationsResponse struct {
 	Applications map[string]RayApplication `json:"applications"`
 }
@@ -509,10 +501,10 @@ func findFailedActorByReplicaID(svc dashboard.DashboardService, appName, deploym
 // the requested replica_id. Returns the first match, or (nil, nil) when
 // no DEAD actor matches in any deployment.
 //
-// Deployment names are sorted before iteration so multi-deployment apps
-// (e.g. P/D, prefill+decode) get a deterministic search order. This
-// matters less today (one deployment per endpoint) but pre-empts
-// nondeterministic behavior the moment that assumption breaks.
+// Deployment names are sorted before iteration so the search order is
+// deterministic across calls — Go map iteration order is randomized,
+// which would otherwise make the result depend on map seed when an app
+// has multiple deployments (e.g. P/D, prefill+decode).
 func lookupFailedActorAcrossDeployments(
 	svc dashboard.DashboardService,
 	appName string,

--- a/internal/routes/logs/endpoint_logs.go
+++ b/internal/routes/logs/endpoint_logs.go
@@ -415,9 +415,10 @@ func listFailedActorsForDeployment(svc dashboard.DashboardService, appName, depl
 	return resp.Data.Result.Result, nil
 }
 
-// findFailedActorForDeployment returns the DEAD actor with the highest
-// actor_id (lexicographic order, which approximates the most recent
-// allocation by Ray's GCS), or nil if none exist.
+// findFailedActorForDeployment returns the most recently started DEAD actor
+// for the deployment, or nil if none exist. "Most recent" is decided by
+// the actor's start_time (unix ms from GCS ActorTableData); ties fall back
+// to actor_id lexicographic order so the result is still deterministic.
 func findFailedActorForDeployment(svc dashboard.DashboardService, appName, deploymentName string) (*dashboard.Actor, error) {
 	actors, err := listFailedActorsForDeployment(svc, appName, deploymentName)
 	if err != nil {
@@ -429,8 +430,12 @@ func findFailedActorForDeployment(svc dashboard.DashboardService, appName, deplo
 	}
 
 	pick := 0
+
 	for i := 1; i < len(actors); i++ {
-		if actors[i].ActorID > actors[pick].ActorID {
+		switch {
+		case actors[i].StartTime > actors[pick].StartTime:
+			pick = i
+		case actors[i].StartTime == actors[pick].StartTime && actors[i].ActorID > actors[pick].ActorID:
 			pick = i
 		}
 	}

--- a/internal/routes/logs/endpoint_logs.go
+++ b/internal/routes/logs/endpoint_logs.go
@@ -6,9 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -60,18 +58,12 @@ type LogInfo struct {
 // RayApplicationsResponse represents Ray Dashboard API response structure.
 //
 // TODO: Ray dashboard API types and calls belong in `internal/ray/dashboard/`,
-// not in the routes layer. The following items here violate that and should
-// move:
-//   - Types: RayApplicationsResponse, RayApplication, RayDeployment, RayReplica
-//   - Inline `httpClient.Get("/api/serve/applications/")` in getRayLogSources
-//     and streamRayLogs (should go through `dashboard.Client.doRequest`)
-//   - Ray-domain helpers (Ray Serve naming + DEAD-actor ranking, no
-//     routes-layer concerns): extractReplicaShortID, replicaShortIDFromActor,
-//     listFailedActorsForDeployment, findFailedActorForDeployment,
-//     findFailedActorByReplicaID, lookupFailedActorAcrossDeployments
-//
-// buildFailedReplicaInfo stays in this file: it constructs the public API
-// response shape (ReplicaInfo), which is a routes-layer concern.
+// not in the routes layer. These types (RayApplicationsResponse,
+// RayApplication, RayDeployment, RayReplica) and the inline
+// `httpClient.Get("/api/serve/applications/")` calls in getRayLogSources
+// and streamRayLogs should be replaced with a typed
+// `dashboard.GetServeApplicationsForLogs` (or equivalent) so callers go
+// through `dashboard.Client.doRequest` instead of hand-rolled HTTP.
 type RayApplicationsResponse struct {
 	Applications map[string]RayApplication `json:"applications"`
 }
@@ -377,11 +369,11 @@ func getRayLogSources(cluster *v1.Cluster, httpClient util.HTTPClient, workspace
 			// still return whatever live deployments exist with empty replicas.
 			// streamRayLogs takes the opposite stance and propagates the error,
 			// because a failing log stream cannot return partial output.
-			failed, err := findFailedActorForDeployment(dashboard.NewDashboardService(dashboardURL), appName, deploymentName)
+			failed, err := dashboard.FindFailedActorForDeployment(dashboard.NewDashboardService(dashboardURL), appName, deploymentName)
 			if err != nil {
 				klog.Warningf("failed to look up DEAD actors for %s/%s: %v", appName, deploymentName, err)
 			} else if failed != nil {
-				replicas = append(replicas, buildFailedReplicaInfo(workspace, endpointName, replicaShortIDFromActor(failed)))
+				replicas = append(replicas, buildFailedReplicaInfo(workspace, endpointName, dashboard.ReplicaShortIDFromActor(failed)))
 			}
 		}
 
@@ -392,144 +384,6 @@ func getRayLogSources(cluster *v1.Cluster, httpClient util.HTTPClient, workspace
 	}
 
 	return response, nil
-}
-
-// extractReplicaShortID parses a Ray Serve actor name of the form
-// "SERVE_REPLICA::<app>#<deployment>#<short_id>" and returns short_id.
-// Returns "" if the name does not have at least one '#' separator or
-// ends with one.
-func extractReplicaShortID(actorName string) string {
-	idx := strings.LastIndex(actorName, "#")
-	if idx < 0 || idx+1 >= len(actorName) {
-		return ""
-	}
-
-	return actorName[idx+1:]
-}
-
-// replicaShortIDFromActor returns the short_id parsed from actor.Name,
-// falling back to actor_id when the name does not match the Ray Serve
-// convention.
-func replicaShortIDFromActor(a *dashboard.Actor) string {
-	if id := extractReplicaShortID(a.Name); id != "" {
-		return id
-	}
-
-	return a.ActorID
-}
-
-// listFailedActorsForDeployment fetches DEAD actors that belong to the
-// given Ray Serve <app>:<deployment> from the dashboard state API.
-//
-// limit=100 is intentional: the goal is to give the user the most recent
-// few failures, not the full history. A deployment that has flapped more
-// than 100 times within Ray's actor-table retention window will trim the
-// oldest records, which is acceptable.
-func listFailedActorsForDeployment(svc dashboard.DashboardService, appName, deploymentName string) ([]dashboard.Actor, error) {
-	className := fmt.Sprintf("ServeReplica:%s:%s", appName, deploymentName)
-	resp, err := svc.ListActors([]dashboard.ActorFilter{
-		{Key: "class_name", Predicate: "=", Value: className},
-		{Key: "state", Predicate: "=", Value: "DEAD"},
-	}, true, 100)
-
-	if err != nil {
-		return nil, fmt.Errorf("list actors %s: %w", className, err)
-	}
-
-	return resp.Data.Result.Result, nil
-}
-
-// findFailedActorForDeployment returns the most recently started DEAD actor
-// for the deployment, or nil if none exist. "Most recent" is decided by
-// the actor's start_time (unix ms from GCS ActorTableData); ties fall back
-// to actor_id lexicographic order so the result is still deterministic.
-func findFailedActorForDeployment(svc dashboard.DashboardService, appName, deploymentName string) (*dashboard.Actor, error) {
-	actors, err := listFailedActorsForDeployment(svc, appName, deploymentName)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(actors) == 0 {
-		return nil, nil
-	}
-
-	pick := 0
-
-	for i := 1; i < len(actors); i++ {
-		switch {
-		case actors[i].StartTime > actors[pick].StartTime:
-			pick = i
-		case actors[i].StartTime == actors[pick].StartTime && actors[i].ActorID > actors[pick].ActorID:
-			pick = i
-		}
-	}
-
-	a := actors[pick]
-
-	return &a, nil
-}
-
-// findFailedActorByReplicaID returns the DEAD actor whose name encodes
-// the requested replica_id, or nil if no DEAD actor matches.
-//
-// Match priority:
-//  1. extractReplicaShortID(actor.Name) == replicaID — the canonical
-//     Ray Serve naming `SERVE_REPLICA::<app>#<deployment>#<short_id>`.
-//  2. actor.ActorID == replicaID — covers the degenerate case where
-//     getRayLogSources synthesized a ReplicaInfo using actor_id as
-//     the replica_id (replicaShortIDFromActor falls back to actor_id
-//     when actor.Name does not match the Ray naming convention). This
-//     keeps the synthesize → click → fetch round-trip resolvable even
-//     when Ray returns an unconventionally named actor.
-func findFailedActorByReplicaID(svc dashboard.DashboardService, appName, deploymentName, replicaID string) (*dashboard.Actor, error) {
-	actors, err := listFailedActorsForDeployment(svc, appName, deploymentName)
-	if err != nil {
-		return nil, err
-	}
-
-	for i := range actors {
-		if extractReplicaShortID(actors[i].Name) == replicaID || actors[i].ActorID == replicaID {
-			return &actors[i], nil
-		}
-	}
-
-	return nil, nil
-}
-
-// lookupFailedActorAcrossDeployments scans every deployment in the live
-// Ray Serve applications response for a DEAD actor whose name encodes
-// the requested replica_id. Returns the first match, or (nil, nil) when
-// no DEAD actor matches in any deployment.
-//
-// Deployment names are sorted before iteration so the search order is
-// deterministic across calls — Go map iteration order is randomized,
-// which would otherwise make the result depend on map seed when an app
-// has multiple deployments (e.g. P/D, prefill+decode).
-func lookupFailedActorAcrossDeployments(
-	svc dashboard.DashboardService,
-	appName string,
-	deployments map[string]RayDeployment,
-	replicaID string,
-) (*dashboard.Actor, error) {
-	names := make([]string, 0, len(deployments))
-	for n := range deployments {
-		names = append(names, n)
-	}
-
-	sort.Strings(names)
-
-	for _, deploymentName := range names {
-		actor, err := findFailedActorByReplicaID(svc, appName, deploymentName, replicaID)
-		if err != nil {
-			return nil, err
-		}
-
-		if actor != nil {
-			return actor, nil
-		}
-	}
-
-	return nil, nil
 }
 
 // buildFailedReplicaInfo synthesizes a ReplicaInfo for a DEAD actor
@@ -676,7 +530,14 @@ func streamRayLogs(c *gin.Context, cluster *v1.Cluster, httpClient util.HTTPClie
 			return fmt.Errorf("unsupported log type: %s", logType)
 		}
 	} else {
-		failedActor, err := lookupFailedActorAcrossDeployments(dashboard.NewDashboardService(dashboardURL), appName, app.Deployments, replicaID)
+		deploymentNames := make([]string, 0, len(app.Deployments))
+		for n := range app.Deployments {
+			deploymentNames = append(deploymentNames, n)
+		}
+
+		failedActor, err := dashboard.LookupFailedActorAcrossDeployments(
+			dashboard.NewDashboardService(dashboardURL), appName, deploymentNames, replicaID,
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/routes/logs/endpoint_logs.go
+++ b/internal/routes/logs/endpoint_logs.go
@@ -465,6 +465,16 @@ func findFailedActorForDeployment(svc dashboard.DashboardService, appName, deplo
 
 // findFailedActorByReplicaID returns the DEAD actor whose name encodes
 // the requested replica_id, or nil if no DEAD actor matches.
+//
+// Match priority:
+//  1. extractReplicaShortID(actor.Name) == replicaID — the canonical
+//     Ray Serve naming `SERVE_REPLICA::<app>#<deployment>#<short_id>`.
+//  2. actor.ActorID == replicaID — covers the degenerate case where
+//     getRayLogSources synthesized a ReplicaInfo using actor_id as
+//     the replica_id (replicaShortIDFromActor falls back to actor_id
+//     when actor.Name does not match the Ray naming convention). This
+//     keeps the synthesize → click → fetch round-trip resolvable even
+//     when Ray returns an unconventionally named actor.
 func findFailedActorByReplicaID(svc dashboard.DashboardService, appName, deploymentName, replicaID string) (*dashboard.Actor, error) {
 	actors, err := listFailedActorsForDeployment(svc, appName, deploymentName)
 	if err != nil {
@@ -472,7 +482,7 @@ func findFailedActorByReplicaID(svc dashboard.DashboardService, appName, deploym
 	}
 
 	for i := range actors {
-		if extractReplicaShortID(actors[i].Name) == replicaID {
+		if extractReplicaShortID(actors[i].Name) == replicaID || actors[i].ActorID == replicaID {
 			return &actors[i], nil
 		}
 	}

--- a/internal/routes/logs/endpoint_logs.go
+++ b/internal/routes/logs/endpoint_logs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -56,7 +57,15 @@ type LogInfo struct {
 	DownloadURL string `json:"download_url"`
 }
 
-// RayApplicationsResponse represents Ray Dashboard API response structure
+// RayApplicationsResponse represents Ray Dashboard API response structure.
+//
+// TODO(NEU-423 follow-up): these RayApplicationsResponse / RayApplication /
+// RayDeployment / RayReplica types and the inline httpClient.Get for
+// /api/serve/applications/ predate the rule that "Ray dashboard API types
+// and calls live in internal/ray/dashboard/". The new failed-actor lookup
+// follows the rule (see internal/ray/dashboard/actors.go); migrating these
+// older types is out of scope for the bug fix and tracked separately to
+// keep the change minimal.
 type RayApplicationsResponse struct {
 	Applications map[string]RayApplication `json:"applications"`
 }
@@ -358,6 +367,10 @@ func getRayLogSources(cluster *v1.Cluster, httpClient util.HTTPClient, workspace
 		}
 
 		if len(replicas) == 0 {
+			// State-API fallback failure is non-fatal here: log-sources should
+			// still return whatever live deployments exist with empty replicas.
+			// streamRayLogs takes the opposite stance and propagates the error,
+			// because a failing log stream cannot return partial output.
 			failed, err := findFailedActorForDeployment(dashboard.NewDashboardService(dashboardURL), appName, deploymentName)
 			if err != nil {
 				klog.Warningf("failed to look up DEAD actors for %s/%s: %v", appName, deploymentName, err)
@@ -401,6 +414,11 @@ func replicaShortIDFromActor(a *dashboard.Actor) string {
 
 // listFailedActorsForDeployment fetches DEAD actors that belong to the
 // given Ray Serve <app>:<deployment> from the dashboard state API.
+//
+// limit=100 is intentional: the goal is to give the user the most recent
+// few failures, not the full history. A deployment that has flapped more
+// than 100 times within Ray's actor-table retention window will trim the
+// oldest records, which is acceptable.
 func listFailedActorsForDeployment(svc dashboard.DashboardService, appName, deploymentName string) ([]dashboard.Actor, error) {
 	className := fmt.Sprintf("ServeReplica:%s:%s", appName, deploymentName)
 	resp, err := svc.ListActors([]dashboard.ActorFilter{
@@ -466,13 +484,25 @@ func findFailedActorByReplicaID(svc dashboard.DashboardService, appName, deploym
 // Ray Serve applications response for a DEAD actor whose name encodes
 // the requested replica_id. Returns the first match, or (nil, nil) when
 // no DEAD actor matches in any deployment.
+//
+// Deployment names are sorted before iteration so multi-deployment apps
+// (e.g. P/D, prefill+decode) get a deterministic search order. This
+// matters less today (one deployment per endpoint) but pre-empts
+// nondeterministic behavior the moment that assumption breaks.
 func lookupFailedActorAcrossDeployments(
 	svc dashboard.DashboardService,
 	appName string,
 	deployments map[string]RayDeployment,
 	replicaID string,
 ) (*dashboard.Actor, error) {
-	for deploymentName := range deployments {
+	names := make([]string, 0, len(deployments))
+	for n := range deployments {
+		names = append(names, n)
+	}
+
+	sort.Strings(names)
+
+	for _, deploymentName := range names {
 		actor, err := findFailedActorByReplicaID(svc, appName, deploymentName, replicaID)
 		if err != nil {
 			return nil, err

--- a/internal/routes/logs/endpoint_logs.go
+++ b/internal/routes/logs/endpoint_logs.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/ray/dashboard"
 	"github.com/neutree-ai/neutree/internal/util"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
@@ -35,9 +37,15 @@ type DeploymentInfo struct {
 	Replicas []ReplicaInfo `json:"replicas"`
 }
 
-// ReplicaInfo represents replica information
+// ReplicaInfo represents replica information.
+//
+// Failed marks a synthesized replica recovered from the Ray state API
+// after Ray Serve removed the actor from the live applications response;
+// only stderr / stdout log types are available in that case (no
+// log_file_path means the application log file cannot be addressed).
 type ReplicaInfo struct {
 	ReplicaID string    `json:"replica_id"`
+	Failed    bool      `json:"failed,omitempty"`
 	Logs      []LogInfo `json:"logs"`
 }
 
@@ -349,6 +357,15 @@ func getRayLogSources(cluster *v1.Cluster, httpClient util.HTTPClient, workspace
 			})
 		}
 
+		if len(replicas) == 0 {
+			failed, err := findFailedActorForDeployment(dashboard.NewDashboardService(dashboardURL), appName, deploymentName)
+			if err != nil {
+				klog.Warningf("failed to look up DEAD actors for %s/%s: %v", appName, deploymentName, err)
+			} else if failed != nil {
+				replicas = append(replicas, buildFailedReplicaInfo(workspace, endpointName, replicaShortIDFromActor(failed)))
+			}
+		}
+
 		response.Deployments = append(response.Deployments, DeploymentInfo{
 			Name:     deploymentName,
 			Replicas: replicas,
@@ -356,6 +373,132 @@ func getRayLogSources(cluster *v1.Cluster, httpClient util.HTTPClient, workspace
 	}
 
 	return response, nil
+}
+
+// extractReplicaShortID parses a Ray Serve actor name of the form
+// "SERVE_REPLICA::<app>#<deployment>#<short_id>" and returns short_id.
+// Returns "" if the name does not have at least one '#' separator or
+// ends with one.
+func extractReplicaShortID(actorName string) string {
+	idx := strings.LastIndex(actorName, "#")
+	if idx < 0 || idx+1 >= len(actorName) {
+		return ""
+	}
+
+	return actorName[idx+1:]
+}
+
+// replicaShortIDFromActor returns the short_id parsed from actor.Name,
+// falling back to actor_id when the name does not match the Ray Serve
+// convention.
+func replicaShortIDFromActor(a *dashboard.Actor) string {
+	if id := extractReplicaShortID(a.Name); id != "" {
+		return id
+	}
+
+	return a.ActorID
+}
+
+// listFailedActorsForDeployment fetches DEAD actors that belong to the
+// given Ray Serve <app>:<deployment> from the dashboard state API.
+func listFailedActorsForDeployment(svc dashboard.DashboardService, appName, deploymentName string) ([]dashboard.Actor, error) {
+	className := fmt.Sprintf("ServeReplica:%s:%s", appName, deploymentName)
+	resp, err := svc.ListActors([]dashboard.ActorFilter{
+		{Key: "class_name", Predicate: "=", Value: className},
+		{Key: "state", Predicate: "=", Value: "DEAD"},
+	}, true, 100)
+
+	if err != nil {
+		return nil, fmt.Errorf("list actors %s: %w", className, err)
+	}
+
+	return resp.Data.Result.Result, nil
+}
+
+// findFailedActorForDeployment returns the DEAD actor with the highest
+// actor_id (lexicographic order, which approximates the most recent
+// allocation by Ray's GCS), or nil if none exist.
+func findFailedActorForDeployment(svc dashboard.DashboardService, appName, deploymentName string) (*dashboard.Actor, error) {
+	actors, err := listFailedActorsForDeployment(svc, appName, deploymentName)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(actors) == 0 {
+		return nil, nil
+	}
+
+	pick := 0
+	for i := 1; i < len(actors); i++ {
+		if actors[i].ActorID > actors[pick].ActorID {
+			pick = i
+		}
+	}
+
+	a := actors[pick]
+
+	return &a, nil
+}
+
+// findFailedActorByReplicaID returns the DEAD actor whose name encodes
+// the requested replica_id, or nil if no DEAD actor matches.
+func findFailedActorByReplicaID(svc dashboard.DashboardService, appName, deploymentName, replicaID string) (*dashboard.Actor, error) {
+	actors, err := listFailedActorsForDeployment(svc, appName, deploymentName)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range actors {
+		if extractReplicaShortID(actors[i].Name) == replicaID {
+			return &actors[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// lookupFailedActorAcrossDeployments scans every deployment in the live
+// Ray Serve applications response for a DEAD actor whose name encodes
+// the requested replica_id. Returns the first match, or (nil, nil) when
+// no DEAD actor matches in any deployment.
+func lookupFailedActorAcrossDeployments(
+	svc dashboard.DashboardService,
+	appName string,
+	deployments map[string]RayDeployment,
+	replicaID string,
+) (*dashboard.Actor, error) {
+	for deploymentName := range deployments {
+		actor, err := findFailedActorByReplicaID(svc, appName, deploymentName, replicaID)
+		if err != nil {
+			return nil, err
+		}
+
+		if actor != nil {
+			return actor, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// buildFailedReplicaInfo synthesizes a ReplicaInfo for a DEAD actor
+// recovered from the state API. Only stderr / stdout log types are
+// exposed because the application log file path is not retained in
+// the actor table once Ray Serve has removed the replica.
+func buildFailedReplicaInfo(workspace, endpointName, replicaID string) ReplicaInfo {
+	mkLog := func(t string) LogInfo {
+		return LogInfo{
+			Type:        t,
+			URL:         fmt.Sprintf("/api/v1/endpoints/%s/%s/logs/%s/%s", workspace, endpointName, replicaID, t),
+			DownloadURL: fmt.Sprintf("/api/v1/endpoints/%s/%s/logs/%s/%s?download=true", workspace, endpointName, replicaID, t),
+		}
+	}
+
+	return ReplicaInfo{
+		ReplicaID: replicaID,
+		Failed:    true,
+		Logs:      []LogInfo{mkLog("stderr"), mkLog("stdout")},
+	}
 }
 
 // getK8sLogSources gets log sources from Kubernetes cluster
@@ -456,31 +599,53 @@ func streamRayLogs(c *gin.Context, cluster *v1.Cluster, httpClient util.HTTPClie
 		}
 	}
 
-	if replica == nil {
-		return fmt.Errorf("replica %s not found", replicaID)
-	}
-
-	// Build log URL based on log type
+	// Build log URL based on log type. When the replica is not in the
+	// live applications response (Ray Serve removed the failed actor),
+	// fall back to the state API to recover the actor_id.
 	var logURL string
 
-	switch logType {
-	case "application":
-		// Remove leading slash from log file path if present
-		logFilePath := replica.LogFilePath
-		if len(logFilePath) > 0 && logFilePath[0] == '/' {
-			logFilePath = logFilePath[1:]
+	if replica != nil {
+		switch logType {
+		case "application":
+			// Remove leading slash from log file path if present
+			logFilePath := replica.LogFilePath
+			if len(logFilePath) > 0 && logFilePath[0] == '/' {
+				logFilePath = logFilePath[1:]
+			}
+
+			logURL = fmt.Sprintf("%s/api/v0/logs/file?node_id=%s&filename=%s&lines=%d&format=text",
+				dashboardURL, replica.NodeID, logFilePath, lines)
+		case "stderr":
+			logURL = fmt.Sprintf("%s/api/v0/logs/file?actor_id=%s&suffix=err&lines=%d&format=text",
+				dashboardURL, replica.ActorID, lines)
+		case "stdout":
+			logURL = fmt.Sprintf("%s/api/v0/logs/file?actor_id=%s&suffix=out&lines=%d&format=text",
+				dashboardURL, replica.ActorID, lines)
+		default:
+			return fmt.Errorf("unsupported log type: %s", logType)
+		}
+	} else {
+		failedActor, err := lookupFailedActorAcrossDeployments(dashboard.NewDashboardService(dashboardURL), appName, app.Deployments, replicaID)
+		if err != nil {
+			return err
 		}
 
-		logURL = fmt.Sprintf("%s/api/v0/logs/file?node_id=%s&filename=%s&lines=%d&format=text",
-			dashboardURL, replica.NodeID, logFilePath, lines)
-	case "stderr":
-		logURL = fmt.Sprintf("%s/api/v0/logs/file?actor_id=%s&suffix=err&lines=%d&format=text",
-			dashboardURL, replica.ActorID, lines)
-	case "stdout":
-		logURL = fmt.Sprintf("%s/api/v0/logs/file?actor_id=%s&suffix=out&lines=%d&format=text",
-			dashboardURL, replica.ActorID, lines)
-	default:
-		return fmt.Errorf("unsupported log type: %s", logType)
+		if failedActor == nil {
+			return fmt.Errorf("replica %s not found", replicaID)
+		}
+
+		switch logType {
+		case "stderr":
+			logURL = fmt.Sprintf("%s/api/v0/logs/file?actor_id=%s&suffix=err&lines=%d&format=text",
+				dashboardURL, failedActor.ActorID, lines)
+		case "stdout":
+			logURL = fmt.Sprintf("%s/api/v0/logs/file?actor_id=%s&suffix=out&lines=%d&format=text",
+				dashboardURL, failedActor.ActorID, lines)
+		case "application":
+			return fmt.Errorf("application log is unavailable for failed replica %s; use stderr or stdout", replicaID)
+		default:
+			return fmt.Errorf("unsupported log type: %s", logType)
+		}
 	}
 
 	// Fetch logs

--- a/internal/routes/logs/endpoint_logs.go
+++ b/internal/routes/logs/endpoint_logs.go
@@ -59,13 +59,27 @@ type LogInfo struct {
 
 // RayApplicationsResponse represents Ray Dashboard API response structure.
 //
-// TODO(NEU-423 follow-up): these RayApplicationsResponse / RayApplication /
-// RayDeployment / RayReplica types and the inline httpClient.Get for
-// /api/serve/applications/ predate the rule that "Ray dashboard API types
-// and calls live in internal/ray/dashboard/". The new failed-actor lookup
-// follows the rule (see internal/ray/dashboard/actors.go); migrating these
-// older types is out of scope for the bug fix and tracked separately to
-// keep the change minimal.
+// TODO(NEU-423 follow-up): consolidate Ray API handling under
+// `internal/ray/dashboard/`. The migration scope includes:
+//
+//  1. The four legacy types here (RayApplicationsResponse, RayApplication,
+//     RayDeployment, RayReplica) plus the inline `httpClient.Get` call for
+//     `/api/serve/applications/` in `getRayLogSources` / `streamRayLogs` —
+//     these predate the rule that "Ray dashboard API types and calls live
+//     in `internal/ray/dashboard/`".
+//  2. The Ray-domain helpers added by this PR — `extractReplicaShortID`,
+//     `replicaShortIDFromActor`, `listFailedActorsForDeployment`,
+//     `findFailedActorForDeployment`, `findFailedActorByReplicaID`,
+//     `lookupFailedActorAcrossDeployments` — which encode Ray Serve naming
+//     conventions and DEAD-actor ranking. They belong next to
+//     `internal/ray/dashboard/actors.go`, not in the routes layer.
+//
+// `buildFailedReplicaInfo` stays here because it constructs neutree's API
+// response shape (`ReplicaInfo`), not Ray-domain output.
+//
+// Out of scope for the NEU-423 bug fix to keep the change minimal; tracked
+// in memory `improvement-ray-dashboard-consolidation.md` for the next PR
+// that touches this file or `internal/ray/dashboard/`.
 type RayApplicationsResponse struct {
 	Applications map[string]RayApplication `json:"applications"`
 }

--- a/internal/routes/logs/endpoint_logs_test.go
+++ b/internal/routes/logs/endpoint_logs_test.go
@@ -1160,42 +1160,15 @@ func TestHandleGetLogs_K8sCluster_Success(t *testing.T) {
 	mockStorage.AssertExpectations(t)
 }
 
-// ===== Failed-actor fallback (NEU-423) =====
-
-func TestExtractReplicaShortID(t *testing.T) {
-	tests := []struct {
-		name     string
-		actor    string
-		expected string
-	}{
-		{
-			name:     "well-formed serve replica name",
-			actor:    "SERVE_REPLICA::default_test#deploy-1#abc123",
-			expected: "abc123",
-		},
-		{
-			name:     "name with no hash",
-			actor:    "weird-name",
-			expected: "",
-		},
-		{
-			name:     "name ending with hash returns empty",
-			actor:    "SERVE_REPLICA::a#b#",
-			expected: "",
-		},
-		{
-			name:     "empty name",
-			actor:    "",
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, extractReplicaShortID(tt.actor))
-		})
-	}
-}
+// ===== Failed-actor fallback integration tests =====
+//
+// Pure helper tests for the dashboard package functions
+// (ExtractReplicaShortID, ReplicaShortIDFromActor, FindFailedActor*,
+// LookupFailedActorAcrossDeployments) live in
+// internal/ray/dashboard/serve_replica_test.go. The tests here verify
+// the routes-layer integration: getRayLogSources synthesizing a
+// failed=true ReplicaInfo, streamRayLogs resolving a recovered
+// actor_id, and the error path users see when no DEAD actor matches.
 
 func TestGetRayLogSources_FailedActor_FallbackToDashboardActors(t *testing.T) {
 	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
@@ -1282,92 +1255,6 @@ func TestGetRayLogSources_FailedActor_FallbackToDashboardActors(t *testing.T) {
 	}
 	assert.True(t, logTypes["stderr"], "failed replica should expose stderr log")
 	assert.True(t, logTypes["stdout"], "failed replica should expose stdout log")
-}
-
-func TestGetRayLogSources_FailedActor_PicksMostRecentByStartTime(t *testing.T) {
-	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
-	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
-
-	originalFactory := dashboard.NewDashboardService
-	defer func() { dashboard.NewDashboardService = originalFactory }()
-	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
-		return mockDashboardSvc
-	}
-
-	cluster := &v1.Cluster{
-		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
-		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
-	}
-
-	appsResponse := `{"applications":{"default_ep":{"deployments":{"d":{"replicas":[]}}}}}`
-	mockHTTPClient.On("Get", mock.Anything).Return(&http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader(appsResponse)),
-		Header:     make(http.Header),
-	}, nil).Once()
-
-	// start_time comes from the GCS ActorTableData protobuf (unix ms).
-	// The mock here intentionally puts the highest actor_id on the
-	// oldest start_time to prove start_time wins over actor_id ordering.
-	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
-		Data: dashboard.ActorsResponseData{
-			Result: dashboard.ActorsListResult{
-				Result: []dashboard.Actor{
-					{ActorID: "actor-zzz", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#oldshort", StartTime: 1000},
-					{ActorID: "actor-mmm", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#midshort", StartTime: 2000},
-					{ActorID: "actor-aaa", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#newshort", StartTime: 3000},
-				},
-			},
-		},
-	}, nil).Once()
-
-	resp, err := getRayLogSources(cluster, mockHTTPClient, "default", "ep")
-
-	require.NoError(t, err)
-	require.Len(t, resp.Deployments, 1)
-	require.Len(t, resp.Deployments[0].Replicas, 1)
-	assert.Equal(t, "newshort", resp.Deployments[0].Replicas[0].ReplicaID,
-		"should pick the actor with highest start_time, even when its actor_id is lexicographically lowest")
-}
-
-func TestGetRayLogSources_FailedActor_StartTimeTieBrokenByActorID(t *testing.T) {
-	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
-	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
-
-	originalFactory := dashboard.NewDashboardService
-	defer func() { dashboard.NewDashboardService = originalFactory }()
-	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
-		return mockDashboardSvc
-	}
-
-	cluster := &v1.Cluster{
-		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
-		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
-	}
-
-	mockHTTPClient.On("Get", mock.Anything).Return(&http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader(`{"applications":{"default_ep":{"deployments":{"d":{"replicas":[]}}}}}`)),
-		Header:     make(http.Header),
-	}, nil).Once()
-
-	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
-		Data: dashboard.ActorsResponseData{
-			Result: dashboard.ActorsListResult{
-				Result: []dashboard.Actor{
-					{ActorID: "actor-aaa", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#aaa-short", StartTime: 5000},
-					{ActorID: "actor-zzz", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#zzz-short", StartTime: 5000},
-				},
-			},
-		},
-	}, nil).Once()
-
-	resp, err := getRayLogSources(cluster, mockHTTPClient, "default", "ep")
-
-	require.NoError(t, err)
-	require.Len(t, resp.Deployments[0].Replicas, 1)
-	assert.Equal(t, "zzz-short", resp.Deployments[0].Replicas[0].ReplicaID,
-		"with equal start_time, fall back to higher actor_id for deterministic output")
 }
 
 func TestGetRayLogSources_FailedActor_NoDeadActors_ReturnsEmptyReplicas(t *testing.T) {

--- a/internal/routes/logs/endpoint_logs_test.go
+++ b/internal/routes/logs/endpoint_logs_test.go
@@ -1491,5 +1491,6 @@ func TestStreamRayLogs_FailedActor_NotFoundReturnsError(t *testing.T) {
 	err := streamRayLogs(c, cluster, mockHTTPClient, "default", "ep", "missing-replica", "stderr", 500)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "replica missing-replica not found",
+		"error must name the missing replica so the user can correlate it with their request")
 }

--- a/internal/routes/logs/endpoint_logs_test.go
+++ b/internal/routes/logs/endpoint_logs_test.go
@@ -12,9 +12,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/ray/dashboard"
+	dashboardmocks "github.com/neutree-ai/neutree/internal/ray/dashboard/mocks"
 	"github.com/neutree-ai/neutree/internal/util"
 	utilmocks "github.com/neutree-ai/neutree/internal/util/mocks"
 	"github.com/neutree-ai/neutree/pkg/storage/mocks"
@@ -1155,4 +1158,295 @@ func TestHandleGetLogs_K8sCluster_Success(t *testing.T) {
 	assert.Equal(t, logContent, w.Body.String())
 
 	mockStorage.AssertExpectations(t)
+}
+
+// ===== Failed-actor fallback (NEU-423) =====
+
+func TestExtractReplicaShortID(t *testing.T) {
+	tests := []struct {
+		name     string
+		actor    string
+		expected string
+	}{
+		{
+			name:     "well-formed serve replica name",
+			actor:    "SERVE_REPLICA::default_test#deploy-1#abc123",
+			expected: "abc123",
+		},
+		{
+			name:     "name with no hash",
+			actor:    "weird-name",
+			expected: "",
+		},
+		{
+			name:     "name ending with hash returns empty",
+			actor:    "SERVE_REPLICA::a#b#",
+			expected: "",
+		},
+		{
+			name:     "empty name",
+			actor:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractReplicaShortID(tt.actor))
+		})
+	}
+}
+
+func TestGetRayLogSources_FailedActor_FallbackToDashboardActors(t *testing.T) {
+	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
+	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
+
+	originalFactory := dashboard.NewDashboardService
+	defer func() { dashboard.NewDashboardService = originalFactory }()
+	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
+		return mockDashboardSvc
+	}
+
+	cluster := &v1.Cluster{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
+		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
+	}
+
+	// Serve API returns a deployment with NO live replicas (actor crashed and was removed).
+	appsResponse := `{
+		"applications": {
+			"default_test-endpoint": {
+				"name": "default_test-endpoint",
+				"deployments": {
+					"deploy-1": {
+						"replicas": []
+					}
+				}
+			}
+		}
+	}`
+	mockHTTPClient.On("Get", mock.MatchedBy(func(url string) bool {
+		return strings.Contains(url, "/api/serve/applications/")
+	})).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(appsResponse)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	// Dashboard /api/v0/actors returns one DEAD actor that belongs to deploy-1.
+	mockDashboardSvc.EXPECT().
+		ListActors(mock.MatchedBy(func(filters []dashboard.ActorFilter) bool {
+			hasClass, hasState := false, false
+			for _, f := range filters {
+				if f.Key == "class_name" && f.Value == "ServeReplica:default_test-endpoint:deploy-1" && f.Predicate == "=" {
+					hasClass = true
+				}
+				if f.Key == "state" && f.Value == "DEAD" && f.Predicate == "=" {
+					hasState = true
+				}
+			}
+			return hasClass && hasState
+		}), true, mock.Anything).
+		Return(&dashboard.ActorsResponse{
+			Data: dashboard.ActorsResponseData{
+				Result: dashboard.ActorsListResult{
+					Total: 1,
+					Result: []dashboard.Actor{
+						{
+							ActorID:   "actor-aaa",
+							ClassName: "ServeReplica:default_test-endpoint:deploy-1",
+							State:     "DEAD",
+							Name:      "SERVE_REPLICA::default_test-endpoint#deploy-1#shortxyz",
+							NodeID:    "node-1",
+						},
+					},
+				},
+			},
+		}, nil).
+		Once()
+
+	resp, err := getRayLogSources(cluster, mockHTTPClient, "default", "test-endpoint")
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Deployments, 1)
+	dep := resp.Deployments[0]
+	require.Len(t, dep.Replicas, 1, "expected one synthesized failed replica")
+	r := dep.Replicas[0]
+	assert.Equal(t, "shortxyz", r.ReplicaID, "replica_id should be the short_id from actor.Name")
+	assert.True(t, r.Failed, "synthesized replica must be marked Failed=true")
+	require.NotEmpty(t, r.Logs)
+	logTypes := map[string]bool{}
+	for _, l := range r.Logs {
+		logTypes[l.Type] = true
+	}
+	assert.True(t, logTypes["stderr"], "failed replica should expose stderr log")
+	assert.True(t, logTypes["stdout"], "failed replica should expose stdout log")
+}
+
+func TestGetRayLogSources_FailedActor_PicksHighestActorIDByLexOrder(t *testing.T) {
+	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
+	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
+
+	originalFactory := dashboard.NewDashboardService
+	defer func() { dashboard.NewDashboardService = originalFactory }()
+	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
+		return mockDashboardSvc
+	}
+
+	cluster := &v1.Cluster{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
+		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
+	}
+
+	appsResponse := `{"applications":{"default_ep":{"deployments":{"d":{"replicas":[]}}}}}`
+	mockHTTPClient.On("Get", mock.Anything).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(appsResponse)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{
+			Result: dashboard.ActorsListResult{
+				Result: []dashboard.Actor{
+					{ActorID: "actor-aaa", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#oldshort"},
+					{ActorID: "actor-zzz", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#newshort"},
+					{ActorID: "actor-mmm", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#midshort"},
+				},
+			},
+		},
+	}, nil).Once()
+
+	resp, err := getRayLogSources(cluster, mockHTTPClient, "default", "ep")
+
+	require.NoError(t, err)
+	require.Len(t, resp.Deployments, 1)
+	require.Len(t, resp.Deployments[0].Replicas, 1)
+	assert.Equal(t, "newshort", resp.Deployments[0].Replicas[0].ReplicaID,
+		"should pick the actor with highest actor_id (lexicographic) which corresponds to the most recent allocation")
+}
+
+func TestGetRayLogSources_FailedActor_NoDeadActors_ReturnsEmptyReplicas(t *testing.T) {
+	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
+	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
+
+	originalFactory := dashboard.NewDashboardService
+	defer func() { dashboard.NewDashboardService = originalFactory }()
+	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
+		return mockDashboardSvc
+	}
+
+	cluster := &v1.Cluster{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
+		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
+	}
+
+	mockHTTPClient.On("Get", mock.Anything).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"applications":{"default_ep":{"deployments":{"d":{"replicas":[]}}}}}`)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: nil}},
+	}, nil).Once()
+
+	resp, err := getRayLogSources(cluster, mockHTTPClient, "default", "ep")
+
+	require.NoError(t, err)
+	require.Len(t, resp.Deployments, 1)
+	assert.Empty(t, resp.Deployments[0].Replicas, "no DEAD actor and no live replica -> empty replicas, no error")
+}
+
+func TestStreamRayLogs_FailedActor_ResolvesActorIDByReplicaID(t *testing.T) {
+	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
+	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
+
+	originalFactory := dashboard.NewDashboardService
+	defer func() { dashboard.NewDashboardService = originalFactory }()
+	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
+		return mockDashboardSvc
+	}
+
+	cluster := &v1.Cluster{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
+		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
+	}
+
+	// Live serve API has no replicas in the deployment.
+	mockHTTPClient.On("Get", mock.MatchedBy(func(url string) bool {
+		return strings.Contains(url, "/api/serve/applications/")
+	})).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"applications":{"default_ep":{"deployments":{"d":{"replicas":[]}}}}}`)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	// Dashboard returns a DEAD actor whose name encodes the requested replica_id.
+	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{
+			Result: dashboard.ActorsListResult{
+				Result: []dashboard.Actor{
+					{ActorID: "dead-actor-id", State: "DEAD", NodeID: "node-x", Name: "SERVE_REPLICA::default_ep#d#wantedshort"},
+				},
+			},
+		},
+	}, nil).Once()
+
+	// Log fetch URL must use the recovered actor_id.
+	logContent := "Traceback (most recent call last):\n  ...\nFileNotFoundError: model not found\n"
+	mockHTTPClient.On("Get", mock.MatchedBy(func(url string) bool {
+		return strings.Contains(url, "actor_id=dead-actor-id") && strings.Contains(url, "suffix=err")
+	})).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(logContent)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	err := streamRayLogs(c, cluster, mockHTTPClient, "default", "ep", "wantedshort", "stderr", 500)
+
+	require.NoError(t, err)
+	assert.Equal(t, logContent, w.Body.String())
+}
+
+func TestStreamRayLogs_FailedActor_NotFoundReturnsError(t *testing.T) {
+	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
+	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
+
+	originalFactory := dashboard.NewDashboardService
+	defer func() { dashboard.NewDashboardService = originalFactory }()
+	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
+		return mockDashboardSvc
+	}
+
+	cluster := &v1.Cluster{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
+		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
+	}
+
+	mockHTTPClient.On("Get", mock.MatchedBy(func(url string) bool {
+		return strings.Contains(url, "/api/serve/applications/")
+	})).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"applications":{"default_ep":{"deployments":{"d":{"replicas":[]}}}}}`)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{Result: dashboard.ActorsListResult{Result: nil}},
+	}, nil).Once()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	err := streamRayLogs(c, cluster, mockHTTPClient, "default", "ep", "missing-replica", "stderr", 500)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }

--- a/internal/routes/logs/endpoint_logs_test.go
+++ b/internal/routes/logs/endpoint_logs_test.go
@@ -1494,3 +1494,59 @@ func TestStreamRayLogs_FailedActor_NotFoundReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "replica missing-replica not found",
 		"error must name the missing replica so the user can correlate it with their request")
 }
+
+func TestStreamRayLogs_FailedActor_ResolvesByActorIDFallback(t *testing.T) {
+	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
+	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
+
+	originalFactory := dashboard.NewDashboardService
+	defer func() { dashboard.NewDashboardService = originalFactory }()
+	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
+		return mockDashboardSvc
+	}
+
+	cluster := &v1.Cluster{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
+		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
+	}
+
+	mockHTTPClient.On("Get", mock.MatchedBy(func(url string) bool {
+		return strings.Contains(url, "/api/serve/applications/")
+	})).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"applications":{"default_ep":{"deployments":{"d":{"replicas":[]}}}}}`)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	// The DEAD actor has an unconventional Name (no '#' separator), so
+	// extractReplicaShortID returns "" and getRayLogSources would have
+	// synthesized a ReplicaInfo with replica_id=actor_id. The click-back
+	// flow must still resolve via the ActorID fallback path.
+	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{
+			Result: dashboard.ActorsListResult{
+				Result: []dashboard.Actor{
+					{ActorID: "weirdactor-id", State: "DEAD", NodeID: "node-y", Name: "non-conventional-actor-name"},
+				},
+			},
+		},
+	}, nil).Once()
+
+	logContent := "actor stderr content\n"
+	mockHTTPClient.On("Get", mock.MatchedBy(func(url string) bool {
+		return strings.Contains(url, "actor_id=weirdactor-id")
+	})).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(logContent)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	err := streamRayLogs(c, cluster, mockHTTPClient, "default", "ep", "weirdactor-id", "stderr", 500)
+
+	require.NoError(t, err)
+	assert.Equal(t, logContent, w.Body.String())
+}

--- a/internal/routes/logs/endpoint_logs_test.go
+++ b/internal/routes/logs/endpoint_logs_test.go
@@ -1284,7 +1284,7 @@ func TestGetRayLogSources_FailedActor_FallbackToDashboardActors(t *testing.T) {
 	assert.True(t, logTypes["stdout"], "failed replica should expose stdout log")
 }
 
-func TestGetRayLogSources_FailedActor_PicksHighestActorIDByLexOrder(t *testing.T) {
+func TestGetRayLogSources_FailedActor_PicksMostRecentByStartTime(t *testing.T) {
 	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
 	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
 
@@ -1306,13 +1306,16 @@ func TestGetRayLogSources_FailedActor_PicksHighestActorIDByLexOrder(t *testing.T
 		Header:     make(http.Header),
 	}, nil).Once()
 
+	// start_time comes from the GCS ActorTableData protobuf (unix ms).
+	// The mock here intentionally puts the highest actor_id on the
+	// oldest start_time to prove start_time wins over actor_id ordering.
 	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
 		Data: dashboard.ActorsResponseData{
 			Result: dashboard.ActorsListResult{
 				Result: []dashboard.Actor{
-					{ActorID: "actor-aaa", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#oldshort"},
-					{ActorID: "actor-zzz", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#newshort"},
-					{ActorID: "actor-mmm", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#midshort"},
+					{ActorID: "actor-zzz", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#oldshort", StartTime: 1000},
+					{ActorID: "actor-mmm", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#midshort", StartTime: 2000},
+					{ActorID: "actor-aaa", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#newshort", StartTime: 3000},
 				},
 			},
 		},
@@ -1324,7 +1327,47 @@ func TestGetRayLogSources_FailedActor_PicksHighestActorIDByLexOrder(t *testing.T
 	require.Len(t, resp.Deployments, 1)
 	require.Len(t, resp.Deployments[0].Replicas, 1)
 	assert.Equal(t, "newshort", resp.Deployments[0].Replicas[0].ReplicaID,
-		"should pick the actor with highest actor_id (lexicographic) which corresponds to the most recent allocation")
+		"should pick the actor with highest start_time, even when its actor_id is lexicographically lowest")
+}
+
+func TestGetRayLogSources_FailedActor_StartTimeTieBrokenByActorID(t *testing.T) {
+	mockHTTPClient := utilmocks.NewMockHTTPClient(t)
+	mockDashboardSvc := dashboardmocks.NewMockDashboardService(t)
+
+	originalFactory := dashboard.NewDashboardService
+	defer func() { dashboard.NewDashboardService = originalFactory }()
+	dashboard.NewDashboardService = func(_ string) dashboard.DashboardService {
+		return mockDashboardSvc
+	}
+
+	cluster := &v1.Cluster{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "test-cluster"},
+		Status:   &v1.ClusterStatus{DashboardURL: "http://ray-dashboard:8265"},
+	}
+
+	mockHTTPClient.On("Get", mock.Anything).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"applications":{"default_ep":{"deployments":{"d":{"replicas":[]}}}}}`)),
+		Header:     make(http.Header),
+	}, nil).Once()
+
+	mockDashboardSvc.EXPECT().ListActors(mock.Anything, true, mock.Anything).Return(&dashboard.ActorsResponse{
+		Data: dashboard.ActorsResponseData{
+			Result: dashboard.ActorsListResult{
+				Result: []dashboard.Actor{
+					{ActorID: "actor-aaa", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#aaa-short", StartTime: 5000},
+					{ActorID: "actor-zzz", State: "DEAD", Name: "SERVE_REPLICA::default_ep#d#zzz-short", StartTime: 5000},
+				},
+			},
+		},
+	}, nil).Once()
+
+	resp, err := getRayLogSources(cluster, mockHTTPClient, "default", "ep")
+
+	require.NoError(t, err)
+	require.Len(t, resp.Deployments[0].Replicas, 1)
+	assert.Equal(t, "zzz-short", resp.Deployments[0].Replicas[0].ReplicaID,
+		"with equal start_time, fall back to higher actor_id for deterministic output")
 }
 
 func TestGetRayLogSources_FailedActor_NoDeadActors_ReturnsEmptyReplicas(t *testing.T) {

--- a/tests/e2e/endpoint_ssh_failure_logs_test.go
+++ b/tests/e2e/endpoint_ssh_failure_logs_test.go
@@ -23,10 +23,10 @@ var _ = Describe("SSH Endpoint Failure Logs", Ordered, Label("endpoint", "ssh", 
 	var clusterName string
 
 	BeforeAll(func() {
-		if profileModelName() == "" {
-			Skip("Model name not configured in profile, skipping SSH endpoint failure-log tests")
-		}
-
+		// This test passes a non-existent model name via withModel(...),
+		// so it does not depend on profile.model.name being set. Profile
+		// gating is delegated to setupSSHCluster (SSH nodes + image
+		// registry) and SetupModelRegistry (model registry config).
 		clusterName = setupSSHCluster("e2e-ep-ssh-fail-")
 
 		By("Setting up model registry")

--- a/tests/e2e/endpoint_ssh_failure_logs_test.go
+++ b/tests/e2e/endpoint_ssh_failure_logs_test.go
@@ -117,11 +117,8 @@ func neutreeAPIRequest(method, path string) ([]byte, int) {
 	req, err := http.NewRequest(method, url, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	authValue := Cfg.APIKey
-	if !strings.HasPrefix(authValue, "Bearer ") {
-		authValue = "Bearer " + authValue
-	}
-	req.Header.Set("Authorization", authValue)
+	// neutree-api accepts the raw API key; only Kong/inference endpoints expect "Bearer <key>".
+	req.Header.Set("Authorization", Cfg.APIKey)
 
 	client := &http.Client{Timeout: 60 * time.Second}
 	resp, err := client.Do(req)

--- a/tests/e2e/endpoint_ssh_failure_logs_test.go
+++ b/tests/e2e/endpoint_ssh_failure_logs_test.go
@@ -12,12 +12,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// NEU-423 / TestRail C2649684:
-// On an SSH/Ray cluster, when a Serve replica's actor fails to initialize
+// On an SSH/Ray cluster, when a Serve replica's actor fails to initialize,
 // Ray Serve removes it from the live applications response. Verify that
 // /log-sources still surfaces the failed actor (with failed=true) via the
 // state API fallback, and /logs/<replica_id>/stderr streams the actor's
-// stderr containing the Python traceback.
+// stderr.
 var _ = Describe("SSH Endpoint Failure Logs", Ordered, Label("endpoint", "ssh", "logs", "failure", "C2649684"), func() {
 	var clusterName string
 

--- a/tests/e2e/endpoint_ssh_failure_logs_test.go
+++ b/tests/e2e/endpoint_ssh_failure_logs_test.go
@@ -90,17 +90,16 @@ var _ = Describe("SSH Endpoint Failure Logs", Ordered, Label("endpoint", "ssh", 
 		Expect(failedReplicaID).NotTo(BeEmpty())
 
 		// Proof-of-wiring assertion: the stream must carry Ray's per-actor metadata
-		// headers (":job_id:" + ":actor_name:..."), proving we recovered the right
-		// DEAD actor and reached its stderr file via /api/v0/logs/file?actor_id=...
-		// before Ray Serve garbage-collected the live applications response.
+		// headers (":job_id:" + ":actor_name:..."), proving the recovered DEAD
+		// actor's stderr file was reachable via /api/v0/logs/file?actor_id=...
 		//
-		// We deliberately don't assert traceback content: whether the actor's
+		// Traceback content is intentionally not asserted: whether the actor's
 		// stderr contains a Python traceback depends on the failure mode. The
-		// "model not in registry" repro path used here is caught by Ray Serve
-		// at the framework layer, so the actor dies before printing user code.
-		// Failure modes that DO traceback (bad engine_args, OOM, missing CUDA)
-		// would surface them through the same wired path; manual verification
-		// of those scenarios is part of the PR test plan.
+		// "model not in registry" repro used here is caught by Ray Serve at the
+		// framework layer, so the actor dies before any user code runs. Failure
+		// modes that do produce a traceback (bad engine_args, OOM, missing CUDA)
+		// surface it through the same wiring; this assertion validates the
+		// wiring rather than the traceback content.
 		body := getEndpointReplicaLog(epName, failedReplicaID, "stderr", 500)
 		Expect(body).NotTo(BeEmpty(), "stderr body should not be empty for failed replica")
 		Expect(body).To(SatisfyAll(

--- a/tests/e2e/endpoint_ssh_failure_logs_test.go
+++ b/tests/e2e/endpoint_ssh_failure_logs_test.go
@@ -1,0 +1,152 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// NEU-423 / TestRail C2649684:
+// On an SSH/Ray cluster, when a Serve replica's actor fails to initialize
+// Ray Serve removes it from the live applications response. Verify that
+// /log-sources still surfaces the failed actor (with failed=true) via the
+// state API fallback, and /logs/<replica_id>/stderr streams the actor's
+// stderr containing the Python traceback.
+var _ = Describe("SSH Endpoint Failure Logs", Ordered, Label("endpoint", "ssh", "logs", "failure", "C2649684"), func() {
+	var clusterName string
+
+	BeforeAll(func() {
+		if profileModelName() == "" {
+			Skip("Model name not configured in profile, skipping SSH endpoint failure-log tests")
+		}
+
+		clusterName = setupSSHCluster("e2e-ep-ssh-fail-")
+
+		By("Setting up model registry")
+		SetupModelRegistry()
+	})
+
+	AfterAll(func() {
+		TeardownModelRegistry()
+		teardownCluster(clusterName)
+	})
+
+	It("should expose failed actor stderr after init crash", func() {
+		epName := "e2e-ep-ssh-faillog-" + Cfg.RunID
+		DeferCleanup(func() { deleteEndpoint(epName) })
+
+		By("Applying endpoint with non-existent model to force init failure")
+		yamlPath := applyEndpoint(epName, clusterName,
+			withModel("non-existent-model-"+Cfg.RunID, "v0.0.0"),
+			withoutForceUpdate(),
+		)
+		defer os.Remove(yamlPath)
+
+		By("Waiting for endpoint to reach Failed phase")
+		waitEndpointFailed(epName)
+
+		By("Calling GET /log-sources and expecting at least one failed replica")
+		var sources logSourcesResponse
+		Eventually(func(g Gomega) {
+			body := getEndpointLogSources(epName)
+			g.Expect(json.Unmarshal(body, &sources)).To(Succeed(), "log-sources body: %s", string(body))
+
+			var foundFailed bool
+			for _, dep := range sources.Deployments {
+				for _, r := range dep.Replicas {
+					if r.Failed && r.ReplicaID != "" {
+						foundFailed = true
+						break
+					}
+				}
+				if foundFailed {
+					break
+				}
+			}
+			g.Expect(foundFailed).To(BeTrue(),
+				"expected at least one Replica with failed=true; raw response: %s", string(body))
+		}, 2*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("Picking the failed replica_id and streaming its stderr")
+		var failedReplicaID string
+		for _, dep := range sources.Deployments {
+			for _, r := range dep.Replicas {
+				if r.Failed {
+					failedReplicaID = r.ReplicaID
+					break
+				}
+			}
+			if failedReplicaID != "" {
+				break
+			}
+		}
+		Expect(failedReplicaID).NotTo(BeEmpty())
+
+		body := getEndpointReplicaLog(epName, failedReplicaID, "stderr", 500)
+		Expect(body).NotTo(BeEmpty(), "stderr body should not be empty for failed replica")
+		Expect(strings.ToLower(body)).To(SatisfyAny(
+			ContainSubstring("traceback"),
+			ContainSubstring("error"),
+		), "stderr should surface a Python traceback / error indicator from the failed actor")
+	})
+})
+
+// ===== test-local helpers (HTTP calls to neutree-api) =====
+
+type logSourcesResponse struct {
+	Deployments []struct {
+		Name     string `json:"name"`
+		Replicas []struct {
+			ReplicaID string `json:"replica_id"`
+			Failed    bool   `json:"failed,omitempty"`
+		} `json:"replicas"`
+	} `json:"deployments"`
+}
+
+func neutreeAPIRequest(method, path string) ([]byte, int) {
+	GinkgoHelper()
+
+	url := strings.TrimRight(Cfg.ServerURL, "/") + path
+	req, err := http.NewRequest(method, url, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	authValue := Cfg.APIKey
+	if !strings.HasPrefix(authValue, "Bearer ") {
+		authValue = "Bearer " + authValue
+	}
+	req.Header.Set("Authorization", authValue)
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	return body, resp.StatusCode
+}
+
+func getEndpointLogSources(epName string) []byte {
+	GinkgoHelper()
+	path := fmt.Sprintf("/api/v1/endpoints/%s/%s/log-sources", profileWorkspace(), epName)
+	body, code := neutreeAPIRequest(http.MethodGet, path)
+	Expect(code).To(Equal(http.StatusOK), "log-sources call failed: %s", string(body))
+	return body
+}
+
+func getEndpointReplicaLog(epName, replicaID, logType string, lines int) string {
+	GinkgoHelper()
+	path := fmt.Sprintf("/api/v1/endpoints/%s/%s/logs/%s/%s?lines=%d",
+		profileWorkspace(), epName, replicaID, logType, lines)
+	body, code := neutreeAPIRequest(http.MethodGet, path)
+	Expect(code).To(Equal(http.StatusOK), "log stream call failed: %s", string(body))
+	return string(body)
+}

--- a/tests/e2e/endpoint_ssh_failure_logs_test.go
+++ b/tests/e2e/endpoint_ssh_failure_logs_test.go
@@ -89,12 +89,25 @@ var _ = Describe("SSH Endpoint Failure Logs", Ordered, Label("endpoint", "ssh", 
 		}
 		Expect(failedReplicaID).NotTo(BeEmpty())
 
+		// Proof-of-wiring assertion: the stream must carry Ray's per-actor metadata
+		// headers (":job_id:" + ":actor_name:..."), proving we recovered the right
+		// DEAD actor and reached its stderr file via /api/v0/logs/file?actor_id=...
+		// before Ray Serve garbage-collected the live applications response.
+		//
+		// We deliberately don't assert traceback content: whether the actor's
+		// stderr contains a Python traceback depends on the failure mode. The
+		// "model not in registry" repro path used here is caught by Ray Serve
+		// at the framework layer, so the actor dies before printing user code.
+		// Failure modes that DO traceback (bad engine_args, OOM, missing CUDA)
+		// would surface them through the same wired path; manual verification
+		// of those scenarios is part of the PR test plan.
 		body := getEndpointReplicaLog(epName, failedReplicaID, "stderr", 500)
 		Expect(body).NotTo(BeEmpty(), "stderr body should not be empty for failed replica")
-		Expect(strings.ToLower(body)).To(SatisfyAny(
-			ContainSubstring("traceback"),
-			ContainSubstring("error"),
-		), "stderr should surface a Python traceback / error indicator from the failed actor")
+		Expect(body).To(SatisfyAll(
+			ContainSubstring(":job_id:"),
+			ContainSubstring(":actor_name:"),
+			ContainSubstring(strings.ToLower(epName)),
+		), "stderr stream should carry Ray actor metadata headers for the failed deployment")
 	})
 })
 

--- a/tests/e2e/endpoint_ssh_failure_logs_test.go
+++ b/tests/e2e/endpoint_ssh_failure_logs_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -110,7 +109,7 @@ var _ = Describe("SSH Endpoint Failure Logs", Ordered, Label("endpoint", "ssh", 
 	})
 })
 
-// ===== test-local helpers (HTTP calls to neutree-api) =====
+// ===== test-local helpers (endpoint-specific URL shapes) =====
 
 type logSourcesResponse struct {
 	Deployments []struct {
@@ -122,31 +121,10 @@ type logSourcesResponse struct {
 	} `json:"deployments"`
 }
 
-func neutreeAPIRequest(method, path string) ([]byte, int) {
-	GinkgoHelper()
-
-	url := strings.TrimRight(Cfg.ServerURL, "/") + path
-	req, err := http.NewRequest(method, url, nil)
-	Expect(err).NotTo(HaveOccurred())
-
-	// neutree-api accepts the raw API key; only Kong/inference endpoints expect "Bearer <key>".
-	req.Header.Set("Authorization", Cfg.APIKey)
-
-	client := &http.Client{Timeout: 60 * time.Second}
-	resp, err := client.Do(req)
-	Expect(err).NotTo(HaveOccurred())
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	Expect(err).NotTo(HaveOccurred())
-
-	return body, resp.StatusCode
-}
-
 func getEndpointLogSources(epName string) []byte {
 	GinkgoHelper()
 	path := fmt.Sprintf("/api/v1/endpoints/%s/%s/log-sources", profileWorkspace(), epName)
-	body, code := neutreeAPIRequest(http.MethodGet, path)
+	body, code := callNeutreeAPI(http.MethodGet, path)
 	Expect(code).To(Equal(http.StatusOK), "log-sources call failed: %s", string(body))
 	return body
 }
@@ -155,7 +133,7 @@ func getEndpointReplicaLog(epName, replicaID, logType string, lines int) string 
 	GinkgoHelper()
 	path := fmt.Sprintf("/api/v1/endpoints/%s/%s/logs/%s/%s?lines=%d",
 		profileWorkspace(), epName, replicaID, logType, lines)
-	body, code := neutreeAPIRequest(http.MethodGet, path)
+	body, code := callNeutreeAPI(http.MethodGet, path)
 	Expect(code).To(Equal(http.StatusOK), "log stream call failed: %s", string(body))
 	return string(body)
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1053,6 +1053,48 @@ func createAPIKey(serverURL, jwt, workspace, name string) string {
 	return apiKey.Status.SkValue
 }
 
+// callNeutreeAPI performs an HTTP request against neutree-api regular
+// endpoints (those served at `Cfg.ServerURL/api/v1/...` other than
+// /api/v1/auth/* and /api/v1/rpc/*).
+//
+// Three auth conventions exist in this file and they are not interchangeable:
+//   - createTestUser / deleteTestUser / createAPIKey: Bearer <jwt>, against
+//     /api/v1/auth/admin/* and /api/v1/rpc/* — admin user JWT middleware.
+//   - doInferenceRequest: Bearer <api_key> against the Kong-routed inference
+//     gateway (serviceURL, NOT Cfg.ServerURL).
+//   - This helper: raw <api_key> (no Bearer prefix) against the regular
+//     /api/v1/... routes. Sending a Bearer-prefixed key here returns
+//     401 invalid_token because the middleware compares against the
+//     stored sk_value verbatim.
+//
+// TODO: unify all of the above (admin JWT, Kong inference, raw API key)
+// into a single api_helper layer. Today the three call patterns share
+// boilerplate (NewRequest + Client{Timeout} + Do + ReadAll) but are
+// duplicated across 6+ functions; a shared low-level httpJSON plus three
+// thin auth wrappers (Admin/Inference/API) would deduplicate the
+// boilerplate without merging the auth conventions, and would give
+// future tests one obvious place to look for "how do I call the API".
+func callNeutreeAPI(method, path string) ([]byte, int) {
+	GinkgoHelper()
+
+	url := strings.TrimRight(Cfg.ServerURL, "/") + path
+	req, err := http.NewRequest(method, url, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	req.Header.Set("Authorization", Cfg.APIKey)
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	return body, resp.StatusCode
+}
+
 // --- Endpoint/inference/accelerator helpers ---
 
 // engineVersionSupportsK8s returns true if the given engine version has K8s deployment templates.


### PR DESCRIPTION
## Issue

NEU-423 — On SSH/Ray static-node clusters, when an inference endpoint's Ray Serve actor fails to initialize (OOM, missing dep, bad model path, etc.), the user cannot view any actor logs through the UI: the log-source selector is empty.

## Summary

Ray Serve removes a failed replica from `/api/serve/applications/` once its actor dies, so the existing `getRayLogSources()` walked an empty `Replicas[]` and returned no log entries, and `streamRayLogs()` reported `replica X not found`. The user lost access to the very stderr/stdout that would explain why the actor died — particularly painful for multi-process inference engines where the controller-level message only carries the main process error.

Recover the failed actor through Ray's state API. `GET /api/v0/actors` filtered by `class_name=ServeReplica:<app>:<deployment>` and `state=DEAD` returns dead actors that Ray Serve has already discarded; the recovered `actor_id` plugs straight into the existing `/api/v0/logs/file?actor_id=...&suffix=err|out` URL since Ray retains per-actor log files for a window after the actor dies.

## Changes

- `internal/ray/dashboard/actors.go` (new) — `Actor`, `ActorFilter`, `ActorsResponse`, `ActorsListResult` types plus `(c *Client) ListActors(filters, detail, limit)`. Mirrors the existing dashboard package pattern (`client.go` ↔ `ClusterMetadataResponse + GetClusterMetadata`, `serve.go` ↔ `RayServeApplicationsResponse + GetServeApplications`).
- `internal/ray/dashboard/serve_replica.go` (new) — Ray Serve replica utilities: `ExtractReplicaShortID`, `ReplicaShortIDFromActor`, `ListFailedActorsForDeployment`, `FindFailedActorForDeployment` (most-recent by `start_time`, tiebreak by `actor_id`), `FindFailedActorByReplicaID` (matches `name` short-id then falls back to `actor_id`), `LookupFailedActorAcrossDeployments` (sorted iteration for deterministic multi-deployment search).
- `internal/ray/dashboard/client.go` — `DashboardService` interface gets `ListActors`; `mockgen` regenerates the mock.
- `internal/ray/dashboard/{actors,serve_replica}_test.go` (new) — 16 unit tests cover filter URL building, response parsing, default omission, non-OK status, ranking by `start_time`, tiebreaker, name vs actor_id matching, deterministic multi-deployment search.
- `internal/routes/logs/endpoint_logs.go`:
  - `ReplicaInfo.Failed` (additive `omitempty` field) marks synthesized replicas so the UI can label them.
  - When `Replicas[]` is empty, `dashboard.FindFailedActorForDeployment` recovers the most recent DEAD actor and `buildFailedReplicaInfo` synthesizes a `ReplicaInfo` with stderr/stdout log URLs. Application log type is intentionally omitted because the `LogFilePath` is not retained for DEAD actors.
  - `streamRayLogs` falls back to `dashboard.LookupFailedActorAcrossDeployments` when `replica_id` is not in the live applications response and reuses the existing actor_id log URL.
- `internal/routes/logs/endpoint_logs_test.go` — 5 integration tests cover the synthesized replica path, empty-result branch, and `streamRayLogs` fallback (success + actor_id-fallback + not-found).
- `tests/e2e/endpoint_ssh_failure_logs_test.go` (new, TestRail C2649684) — Deploys an endpoint pointing at a non-existent model, waits for `Failed` phase, asserts `/log-sources` returns a `failed=true` replica, and confirms the stderr stream carries Ray's per-actor metadata (`:job_id:` + `:actor_name:` + endpoint name) — proving the fallback wiring is correct.
- `tests/e2e/helpers.go` — adds `callNeutreeAPI(method, path)` shared helper for raw-API-key calls against `/api/v1/...`, with documentation of the three-way auth split (Bearer JWT for admin, Bearer API-key for Kong inference, raw API-key for the regular API). The previous `Bearer ` normalization in `helpers.go:1446-1448` only fits the Kong path; sending Bearer-prefixed keys to the regular API returns `401 invalid_token`.

## Test Plan

- [x] E2E (`endpoint && ssh && logs && failure`, TestRail C2649684): **1 Passed | 0 Failed | 225 Skipped in 771s** against the LAN test SSH cluster after a hot CP rebuild + restart.
- [x] DB integration (`make db-test`): not affected — no migrations.
- [x] Unit tests: `go test ./internal/ray/dashboard/... ./internal/routes/logs/...` clean (-race); full-repo `go test` clean apart from the pre-existing CLI build embed prerequisite.
- [x] Lint / vet: `golangci-lint run --fast=false` and `go vet` clean on the changed packages.
- [ ] Manual verification recommended for the verifier on nightly: on an SSH cluster, deliberately break a vLLM endpoint with bad `engine_args` (e.g. `--gpu-memory-utilization=99`) so vLLM crashes mid-init and writes a Python traceback to stderr; expect `/log-sources` to show a `failed=true` replica and `/logs/<replica>/stderr` to stream the traceback. The "model not in registry" path used in the e2e is caught by Ray Serve at the framework layer so the actor's stderr stays empty after Ray's metadata header — that's a Ray behavior, not a regression in this fix; the wiring is the same.

## Risk & Rollback

- Additive only: `ReplicaInfo` gains an `omitempty` `failed` field, `DashboardService` gains a method, no API/CRD/DB schema change.
- Backward compatible with current UI: old clients ignore `failed`; missing field decodes to false.
- Pre-existing `RayApplicationsResponse` / `RayApplication` / `RayDeployment` / `RayReplica` types and the inline `httpClient.Get("/api/serve/applications/")` call in `endpoint_logs.go` still violate the same architectural rule the new code follows. They are flagged with an in-code TODO and tracked separately to keep this PR focused.
- Rollback: revert this branch; behavior reverts to "failed actor logs unavailable" (current main).