### PR TITLE
fix: handle PEP 604 unions and hydrate custom-config fields in coerce_args

### DIFF
--- a/cluster-image-builder/serve/_utils/coerce.py
+++ b/cluster-image-builder/serve/_utils/coerce.py
@@ -5,8 +5,12 @@ import functools
 import json
 import logging
 import re
+import types
 import typing
 from typing import Any, Dict, Union
+
+from pydantic import BaseModel, TypeAdapter
+from pydantic import ValidationError as PydanticValidationError
 
 logger = logging.getLogger("ray.serve")
 
@@ -105,18 +109,29 @@ def _get_field_annotations(model_class: type) -> Dict[str, Any]:
     return {}
 
 
+def _unwrap_optional(annotation: Any) -> Any:
+    """Strip Optional[X] / X | None — handles both typing.Union and PEP 604 types.UnionType."""
+    if typing.get_origin(annotation) in (Union, types.UnionType):
+        non_none = [a for a in typing.get_args(annotation) if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return annotation
+
+
 def _wants_dict_or_list(annotation: Any) -> bool:
     """Return True if the annotation expects a dict or list type."""
-    origin = getattr(annotation, '__origin__', None)
+    target = _unwrap_optional(annotation)
+    origin = typing.get_origin(target)
+    return origin in (dict, list) or target in (dict, list)
 
-    # Unwrap Optional[X] (Union[X, None]) → X
-    if origin is Union:
-        type_args = [a for a in annotation.__args__ if a is not type(None)]
-        if len(type_args) == 1:
-            annotation = type_args[0]
-            origin = getattr(annotation, '__origin__', None)
 
-    return origin in (dict, list) or annotation in (dict, list)
+def _is_dataclass_like(tp: Any) -> bool:
+    """True if *tp* is a class hydratable from JSON (Pydantic model or dataclass)."""
+    if not isinstance(tp, type):
+        return False
+    if issubclass(tp, BaseModel):
+        return True
+    return dataclasses.is_dataclass(tp)
 
 
 def coerce_args(args: Dict[str, Any], model_class: type) -> None:
@@ -129,8 +144,8 @@ def coerce_args(args: Dict[str, Any], model_class: type) -> None:
     values through as-is.
 
     This function inspects each field's type annotation and converts JSON strings
-    only for fields that expect dict or list types, leaving all other values
-    untouched.
+    for dict/list fields and for custom dataclass/Pydantic-model fields (via
+    TypeAdapter), leaving all other values untouched.
 
     Supports both Pydantic models/dataclasses and standard Python dataclasses.
 
@@ -146,14 +161,26 @@ def coerce_args(args: Dict[str, Any], model_class: type) -> None:
     for field_name, annotation in annotations.items():
         if field_name not in args or not isinstance(args[field_name], str):
             continue
+        raw = args[field_name]
 
         if _wants_dict_or_list(annotation):
             try:
-                parsed = json.loads(args[field_name])
+                parsed = json.loads(raw)
             except (json.JSONDecodeError, TypeError):
                 continue
             if isinstance(parsed, (dict, list)):
                 args[field_name] = parsed
+            continue
+
+        target = _unwrap_optional(annotation)
+        if _is_dataclass_like(target):
+            try:
+                args[field_name] = TypeAdapter(target).validate_json(raw)
+            except PydanticValidationError as e:
+                logger.warning(
+                    "coerce_args: TypeAdapter failed for field %r (target=%s): %s",
+                    field_name, target.__name__, e,
+                )
 
 
 def filter_engine_args(args: Dict[str, Any], engine_args_class: type) -> None:

--- a/cluster-image-builder/serve/_utils/coerce.py
+++ b/cluster-image-builder/serve/_utils/coerce.py
@@ -181,6 +181,17 @@ def coerce_args(args: Dict[str, Any], model_class: type) -> None:
                     "coerce_args: TypeAdapter failed for field %r (target=%s): %s",
                     field_name, target.__name__, e,
                 )
+            except Exception as e:
+                # TypeAdapter(target) schema generation can raise PydanticUserError /
+                # NameError on pathological dataclasses (unresolved forward refs in
+                # nested fields, etc.). coerce_args must never crash replica startup
+                # — the original string is preserved and vLLM will surface a clearer
+                # error downstream if the value is genuinely unusable.
+                logger.warning(
+                    "coerce_args: TypeAdapter construction or unexpected error for "
+                    "field %r (target=%s): %s",
+                    field_name, getattr(target, "__name__", target), e,
+                )
 
 
 def filter_engine_args(args: Dict[str, Any], engine_args_class: type) -> None:

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -2,7 +2,7 @@
 
 import logging
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
 import pytest
@@ -33,6 +33,42 @@ class SampleStdDataclass:
     name: str = ""
     config: Optional[Dict[str, Any]] = None
     items: Optional[List[str]] = None
+    count: int = 0
+
+
+# --- Fixtures for PEP 604 / dataclass-hydration coverage (NEU-425) ---
+
+
+@dataclass
+class FakeAttentionConfig:
+    backend: str = ""
+
+
+class FakePydanticConfig(BaseModel):
+    x: int = 0
+
+
+@dataclass
+class FakeInner:
+    v: int = 0
+
+
+@dataclass
+class FakeOuter:
+    inner: FakeInner = field(default_factory=FakeInner)
+
+
+@dataclass
+class FakeEngineV017:
+    """Minimal stub mirroring vLLM v0.17.1+ EngineArgs annotation shapes."""
+    speculative_config: dict[str, Any] | None = None       # PEP 604 dict
+    allowed_media_domains: list[str] | None = None          # PEP 604 list
+    bare_dict: dict[str, str] = field(default_factory=dict) # PEP 604 bare
+    attn_required: FakeAttentionConfig = field(default_factory=FakeAttentionConfig)
+    attn_optional: FakeAttentionConfig | None = None        # PEP 604 + custom
+    cfg_optional: FakePydanticConfig | None = None
+    outer: FakeOuter = field(default_factory=FakeOuter)
+    name: str = ""
     count: int = 0
 
 
@@ -127,6 +163,73 @@ class TestCoerceArgs:
         coerce_args(args, SampleStdDataclass)
         assert args["count"] == "42"
 
+
+# ---------------------------------------------------------------------------
+# PEP 604 + dataclass-hydration tests (NEU-425)
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceArgsPEP604:
+    def test_pep604_optional_dict_coerced(self):
+        args = {"speculative_config": '{"method":"mtp","num":2}'}
+        coerce_args(args, FakeEngineV017)
+        assert args["speculative_config"] == {"method": "mtp", "num": 2}
+
+    def test_pep604_optional_list_coerced(self):
+        args = {"allowed_media_domains": '["a.com","b.com"]'}
+        coerce_args(args, FakeEngineV017)
+        assert args["allowed_media_domains"] == ["a.com", "b.com"]
+
+    def test_pep604_bare_dict_coerced(self):
+        args = {"bare_dict": '{"k":"v"}'}
+        coerce_args(args, FakeEngineV017)
+        assert args["bare_dict"] == {"k": "v"}
+
+
+class TestCoerceArgsDataclassHydration:
+    def test_dataclass_field_hydrated_to_instance(self):
+        args = {"attn_required": '{"backend":"FLASH"}'}
+        coerce_args(args, FakeEngineV017)
+        assert isinstance(args["attn_required"], FakeAttentionConfig)
+        assert args["attn_required"].backend == "FLASH"
+
+    def test_pep604_optional_dataclass_hydrated(self):
+        args = {"attn_optional": '{"backend":"FLASH_ATTN"}'}
+        coerce_args(args, FakeEngineV017)
+        assert isinstance(args["attn_optional"], FakeAttentionConfig)
+        assert args["attn_optional"].backend == "FLASH_ATTN"
+
+    def test_pydantic_model_hydrated(self):
+        args = {"cfg_optional": '{"x":42}'}
+        coerce_args(args, FakeEngineV017)
+        assert isinstance(args["cfg_optional"], FakePydanticConfig)
+        assert args["cfg_optional"].x == 42
+
+    def test_nested_dataclass_hydrated_recursively(self):
+        args = {"outer": '{"inner":{"v":42}}'}
+        coerce_args(args, FakeEngineV017)
+        assert isinstance(args["outer"], FakeOuter)
+        assert isinstance(args["outer"].inner, FakeInner)
+        assert args["outer"].inner.v == 42
+
+    def test_validation_error_keeps_string_and_warns(self, caplog):
+        # backend expects str, give a list — Pydantic should reject
+        args = {"attn_required": '{"backend": [1, 2, 3]}'}
+        with caplog.at_level(logging.WARNING, logger="ray.serve"):
+            coerce_args(args, FakeEngineV017)
+        assert args["attn_required"] == '{"backend": [1, 2, 3]}'
+        assert "TypeAdapter" in caplog.text
+
+    def test_invalid_json_for_dataclass_keeps_string(self):
+        args = {"attn_required": "not valid json"}
+        coerce_args(args, FakeEngineV017)
+        assert args["attn_required"] == "not valid json"
+
+    def test_native_instance_passthrough(self):
+        existing = FakeAttentionConfig(backend="ALREADY_SET")
+        args = {"attn_required": existing}
+        coerce_args(args, FakeEngineV017)
+        assert args["attn_required"] is existing
 
 
 # ---------------------------------------------------------------------------

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -231,6 +231,38 @@ class TestCoerceArgsDataclassHydration:
         coerce_args(args, FakeEngineV017)
         assert args["attn_required"] is existing
 
+    def test_typeadapter_constructor_raise_keeps_string(self, monkeypatch, caplog):
+        """If TypeAdapter(target) schema generation itself raises (e.g.
+        PydanticUserError on an unresolved forward-ref in a nested field,
+        NameError, etc.), coerce_args must keep the original string and not
+        crash replica startup."""
+        from serve._utils import coerce
+
+        class _BoomError(Exception):
+            pass
+
+        def fake_typeadapter(target):
+            raise _BoomError("schema generation blew up")
+
+        monkeypatch.setattr(coerce, "TypeAdapter", fake_typeadapter)
+        args = {"attn_required": '{"backend":"FLASH"}'}
+        with caplog.at_level(logging.WARNING, logger="ray.serve"):
+            coerce_args(args, FakeEngineV017)
+        assert args["attn_required"] == '{"backend":"FLASH"}'
+        assert "TypeAdapter construction or unexpected error" in caplog.text
+
+    def test_string_annotation_passthrough(self):
+        """Under NEU-433 last-resort recovery, _get_field_annotations returns
+        raw annotation strings from dataclasses.fields() instead of resolved
+        type objects. _is_dataclass_like / _wants_dict_or_list must short-
+        circuit on str — annotation is not a type, no hydration attempted,
+        original string preserved."""
+        from serve._utils.coerce import _is_dataclass_like, _wants_dict_or_list
+
+        # Both predicates safely return False on raw annotation strings.
+        assert _is_dataclass_like("FakeAttentionConfig") is False
+        assert _wants_dict_or_list("dict[str, Any] | None") is False
+
 
 # ---------------------------------------------------------------------------
 # Fixture for filter_engine_args tests


### PR DESCRIPTION
## Issues

NEU-425: on the SSH/Ray path, vLLM v0.17.1+ engines crash at replica startup when users pass `speculative_config` (and similar fields) as JSON strings:

```
AttributeError: 'str' object has no attribute 'update'
  at vllm/engine/arg_utils.py:1508 in create_speculative_config
```

Ray Serve retries 3 times and the endpoint never reaches Running.

### Root cause

vLLM v0.17.1+ rewrote several `EngineArgs` fields from `Optional[Dict[...]]` (typing.Union at runtime) to PEP 604 syntax `dict[...] | None` (types.UnionType at runtime). `coerce_args._wants_dict_or_list` only inspected `origin is typing.Union`, which silently misses PEP 604 unions — Optional unwrap was skipped and the JSON string was passed through to `AsyncEngineArgs(**args)`, where vLLM crashed on the first `.update(...)` call inside `create_speculative_config`.

### Scope

PEP 604 affects every dict/list field vLLM has rewritten to the new syntax:

- **v0.17.1 (7 fields):** `speculative_config`, `allowed_media_domains`, `cudagraph_capture_sizes`, `mm_processor_kwargs`, `default_mm_loras`, `collect_detailed_traces`, `logits_processors`
- **v0.19.1 (+1):** `lora_target_modules`

A second class of fields was also broken on this path — custom-config dataclasses like `AttentionConfig`, `CompilationConfig`, `KVTransferConfig`, `ReasoningConfig` accept a dict argument via their `__post_init__`, but coerce_args returned `False` on these annotations (not dict/list at runtime), so the JSON string reached vLLM where it crashed similarly.

The K8s CLI path is unaffected — vLLM argparse runs `optional_type(json.loads)` per field. SSH/Ray bypasses argparse and depends entirely on `coerce_args`.

### Why now (vs. PR #377)

PR #377 (NEU-433) fixed a different failure on the same file — `typing.get_type_hints()` raising `NameError` for vLLM v0.20.0's `OnlineQuantizationConfigArgs` forward-ref. Both fixes are needed and coexist: this PR rebases on top of #377 and the v0.20.0 NameError recovery + `lru_cache` are preserved verbatim.

## Changes

`cluster-image-builder/serve/_utils/coerce.py`

- New `_unwrap_optional(annotation)` helper that strips `Optional[X]` / `X | None` via `typing.get_origin` / `typing.get_args`, recognising both `typing.Union` and `types.UnionType`. Replaces the legacy `origin is Union` check that only saw the former.
- `_wants_dict_or_list` now routes through `_unwrap_optional` and uses `typing.get_origin`, so PEP 604 `dict[...]`, `list[...]`, `dict[...] | None`, and `list[...] | None` all coerce correctly.
- New `_is_dataclass_like(tp)` predicate plus a new branch in `coerce_args`: when the annotation unwraps to a dataclass or Pydantic model, the JSON string is hydrated via `pydantic.TypeAdapter(target).validate_json(raw)` — mirrors vLLM CLI's `parse_dataclass` behaviour. Pydantic v2 is already a vLLM v0.17.1+ dependency, no new requirement is introduced.
- `pydantic.ValidationError` is caught and logged so a malformed user payload keeps the original string (vLLM will raise downstream, same as today) instead of crashing inside `coerce_args` itself.

The v0.20.0 `NameError` recovery loop (`_recover_type_hints`, `_NAMEERROR_NAME_RE`, `_RECOVERY_MAX_ITERS`, `@functools.lru_cache` on `_get_field_annotations`) is preserved exactly as #377 introduced it.

## Test

Unit tests added in `cluster-image-builder/serve/_utils/test_coerce.py`:

- `TestCoerceArgsPEP604` (3 cases) — `dict[str, Any] | None`, `list[str] | None`, and bare `dict[str, str]` all coerce from JSON strings.
- `TestCoerceArgsDataclassHydration` (7 cases) — required dataclass field, PEP 604 optional dataclass, Pydantic model, nested dataclass recursion, `ValidationError` fallback (string preserved + warning logged), invalid-JSON fallback, and native-instance passthrough.

```
$ cd cluster-image-builder && PYTHONPATH=. python3 -m pytest serve/_utils/test_coerce.py -v
========================= 36 passed in 0.10s ==========================
```

E2E deferred to post-merge verification (per user direction). TestRail cases are pre-created and ready for the verifier:

- **C2649429** — SSH cluster + vLLM v0.19.1 + `speculative_config` (PEP 604 dict, string form) — P0 bug repro
- **C2649430** — SSH cluster + vLLM v0.19.1 + `attention_config` (custom dataclass, string form) — P1 bug repro
- **C2649431** — SSH cluster + vLLM v0.19.1 + B-class custom-config field (no dict-branch `__post_init__`) — P1 hydration via TypeAdapter

Verifier: pull the next nightly that includes this fix, deploy a vLLM v0.19.1 endpoint on an SSH cluster, set `speculative_config` to a JSON string (e.g. `'{"method":"mtp","num_speculative_tokens":2}'`), and confirm the endpoint reaches Running within ~2min and `/v1/chat/completions` returns 200. Run the three TestRail cases above for full coverage.