### PR TITLE
fix: suppress transient Deploying flicker on sibling endpoints (SSH/Ray)

### DIFF
--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -341,11 +341,20 @@ func allDeploymentsHealthy(deployments map[string]dashboard.Deployment) bool {
 // mapDeployingPhase resolves the endpoint phase when Ray Serve reports the
 // application as DEPLOYING or NOT_STARTED. Returns Failed when any deployment
 // is UNHEALTHY; returns Running when the previous Neutree phase was Running,
-// the proxy is healthy, and every deployment is HEALTHY — the false-positive
-// window opened by Ray's PUT /api/serve/applications/ when it unconditionally
-// writes DEPLOYING to every application in the request even if their configs
-// are unchanged (see ray-project/ray#25381, #42974, #44226). Otherwise
-// returns Deploying.
+// the proxy is healthy, every deployment is HEALTHY, and the upstream app
+// status is DEPLOYING — the false-positive window opened by Ray's PUT
+// /api/serve/applications/ when it unconditionally writes DEPLOYING to every
+// application in the request even if their configs are unchanged (see
+// ray-project/ray#25381, #42974, #44226). NOT_STARTED is excluded from
+// suppression: Ray returns it when the application is not present in its
+// state, which never matches the false-positive window. Otherwise returns
+// Deploying.
+//
+// The suppression is a snapshot heuristic — it accepts the case where
+// Neutree misses an in-progress UPDATING window between polls (poll cadence
+// > deployment-update duration). In that case the deployments observed are
+// already HEALTHY and traffic is being served; reporting Running matches
+// the actual serving state.
 func mapDeployingPhase(endpoint *v1.Endpoint, status dashboard.RayServeApplicationStatus, proxyReady bool) v1.EndpointPhase {
 	for _, deployment := range status.Deployments {
 		if deployment.Status == dashboard.DeploymentStatusUnhealthy {
@@ -353,7 +362,8 @@ func mapDeployingPhase(endpoint *v1.Endpoint, status dashboard.RayServeApplicati
 		}
 	}
 
-	if proxyReady &&
+	if status.Status == "DEPLOYING" &&
+		proxyReady &&
 		endpoint.Status != nil &&
 		endpoint.Status.Phase == v1.EndpointPhaseRUNNING &&
 		len(status.Deployments) > 0 &&

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -338,6 +338,32 @@ func allDeploymentsHealthy(deployments map[string]dashboard.Deployment) bool {
 	return true
 }
 
+// mapDeployingPhase resolves the endpoint phase when Ray Serve reports the
+// application as DEPLOYING or NOT_STARTED. Returns Failed when any deployment
+// is UNHEALTHY; returns Running when the previous Neutree phase was Running,
+// the proxy is healthy, and every deployment is HEALTHY — the false-positive
+// window opened by Ray's PUT /api/serve/applications/ when it unconditionally
+// writes DEPLOYING to every application in the request even if their configs
+// are unchanged (see ray-project/ray#25381, #42974, #44226). Otherwise
+// returns Deploying.
+func mapDeployingPhase(endpoint *v1.Endpoint, status dashboard.RayServeApplicationStatus, proxyReady bool) v1.EndpointPhase {
+	for _, deployment := range status.Deployments {
+		if deployment.Status == dashboard.DeploymentStatusUnhealthy {
+			return v1.EndpointPhaseFAILED
+		}
+	}
+
+	if proxyReady &&
+		endpoint.Status != nil &&
+		endpoint.Status.Phase == v1.EndpointPhaseRUNNING &&
+		len(status.Deployments) > 0 &&
+		allDeploymentsHealthy(status.Deployments) {
+		return v1.EndpointPhaseRUNNING
+	}
+
+	return v1.EndpointPhaseDEPLOYING
+}
+
 // GetEndpointStatus retrieves the status of a specific endpoint from Ray Serve.
 func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.EndpointStatus, error) {
 	// Placeholder implementation: Get all apps and check if ours exists.
@@ -412,32 +438,7 @@ func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.Endpoint
 
 	switch status.Status {
 	case "DEPLOYING", "NOT_STARTED":
-		phase = v1.EndpointPhaseDEPLOYING
-
-		for _, deployment := range status.Deployments {
-			if deployment.Status == dashboard.DeploymentStatusUnhealthy {
-				phase = v1.EndpointPhaseFAILED
-				break
-			}
-		}
-
-		// Suppress the transient DEPLOYING reported by Ray Serve when this
-		// endpoint's replicas are not actually being touched. PUT
-		// /api/serve/applications/ unconditionally writes app status to
-		// DEPLOYING for every app in the request (Ray application_state.py
-		// _set_target_state), then the next reconcile tick derives the real
-		// status from deployment statuses (_determine_app_status). For a
-		// neighbor endpoint whose config did not change, deployments stay
-		// HEALTHY throughout the window and the visible flicker is purely
-		// state-machine noise. See ray-project/ray#25381, #42974, #44226.
-		if phase == v1.EndpointPhaseDEPLOYING &&
-			proxyReady &&
-			endpoint.Status != nil &&
-			endpoint.Status.Phase == v1.EndpointPhaseRUNNING &&
-			len(status.Deployments) > 0 &&
-			allDeploymentsHealthy(status.Deployments) {
-			phase = v1.EndpointPhaseRUNNING
-		}
+		phase = mapDeployingPhase(endpoint, status, proxyReady)
 	case "DEPLOY_FAILED", "UNHEALTHY":
 		phase = v1.EndpointPhaseFAILED
 	case "RUNNING":

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -324,6 +324,20 @@ func (o *RayOrchestrator) deleteEndpoint(ctx *OrchestratorContext) error {
 	return nil
 }
 
+// allDeploymentsHealthy returns true when every entry in the deployment map
+// reports HEALTHY. An empty map returns true; callers should guard with
+// len(deployments) > 0 when "no deployments registered" should not count as
+// healthy.
+func allDeploymentsHealthy(deployments map[string]dashboard.Deployment) bool {
+	for _, dep := range deployments {
+		if dep.Status != dashboard.DeploymentStatusHealthy {
+			return false
+		}
+	}
+
+	return true
+}
+
 // GetEndpointStatus retrieves the status of a specific endpoint from Ray Serve.
 func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.EndpointStatus, error) {
 	// Placeholder implementation: Get all apps and check if ours exists.
@@ -405,6 +419,24 @@ func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.Endpoint
 				phase = v1.EndpointPhaseFAILED
 				break
 			}
+		}
+
+		// Suppress the transient DEPLOYING reported by Ray Serve when this
+		// endpoint's replicas are not actually being touched. PUT
+		// /api/serve/applications/ unconditionally writes app status to
+		// DEPLOYING for every app in the request (Ray application_state.py
+		// _set_target_state), then the next reconcile tick derives the real
+		// status from deployment statuses (_determine_app_status). For a
+		// neighbor endpoint whose config did not change, deployments stay
+		// HEALTHY throughout the window and the visible flicker is purely
+		// state-machine noise. See ray-project/ray#25381, #42974, #44226.
+		if phase == v1.EndpointPhaseDEPLOYING &&
+			proxyReady &&
+			endpoint.Status != nil &&
+			endpoint.Status.Phase == v1.EndpointPhaseRUNNING &&
+			len(status.Deployments) > 0 &&
+			allDeploymentsHealthy(status.Deployments) {
+			phase = v1.EndpointPhaseRUNNING
 		}
 	case "DEPLOY_FAILED", "UNHEALTHY":
 		phase = v1.EndpointPhaseFAILED

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2639,6 +2639,211 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectErrorMsg: "Deployment BACKEND: backend deployment is error",
 			expectError:    false,
 		},
+		// NEU-422: suppress transient DEPLOYING when previously Running and replicas remain Healthy.
+		// Ray Serve PUT /api/serve/applications/ briefly flips status to DEPLOYING for every
+		// application in the request — including unchanged ones — even though their deployments
+		// are not actually restarted. See ray-project/ray#25381, #42974, #44226.
+		{
+			name: "NEU-422 suppress transient DEPLOYING when previously Running and all deployments Healthy",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {Name: "BACKEND", Status: dashboard.DeploymentStatusHealthy},
+								"WORKER":  {Name: "WORKER", Status: dashboard.DeploymentStatusHealthy},
+							},
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusHealthy},
+					},
+				}, nil)
+			},
+			expectedPhase: v1.EndpointPhaseRUNNING,
+			expectError:   false,
+		},
+		{
+			name: "NEU-422 do not suppress when this endpoint is actually rolling out (a deployment is UPDATING)",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {Name: "BACKEND", Status: dashboard.DeploymentStatusHealthy},
+								"WORKER":  {Name: "WORKER", Status: "UPDATING"},
+							},
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusHealthy},
+					},
+				}, nil)
+			},
+			expectedPhase: v1.EndpointPhaseDEPLOYING,
+			expectError:   false,
+		},
+		{
+			name: "NEU-422 do not suppress when previous status is nil (initial deploy)",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				// Status nil — endpoint has never reported a phase.
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {Name: "BACKEND", Status: dashboard.DeploymentStatusHealthy},
+							},
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusHealthy},
+					},
+				}, nil)
+			},
+			expectedPhase: v1.EndpointPhaseDEPLOYING,
+			expectError:   false,
+		},
+		{
+			name: "NEU-422 do not suppress when previous status is Failed (recovering from failure)",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseFAILED}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {Name: "BACKEND", Status: dashboard.DeploymentStatusHealthy},
+							},
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusHealthy},
+					},
+				}, nil)
+			},
+			expectedPhase: v1.EndpointPhaseDEPLOYING,
+			expectError:   false,
+		},
+		{
+			name: "NEU-422 UNHEALTHY deployment still maps to Failed even if previously Running (failure precedence preserved)",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {Name: "BACKEND", Status: dashboard.DeploymentStatusUnhealthy, Message: "OOM killed"},
+							},
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusHealthy},
+					},
+				}, nil)
+			},
+			expectedPhase:  v1.EndpointPhaseFAILED,
+			expectErrorMsg: "Deployment BACKEND: OOM killed",
+			expectError:    false,
+		},
+		{
+			name: "NEU-422 do not suppress when proxy is unhealthy (HTTP entry not serving)",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {Name: "BACKEND", Status: dashboard.DeploymentStatusHealthy},
+							},
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusUnhealthy},
+					},
+				}, nil)
+			},
+			expectedPhase: v1.EndpointPhaseDEPLOYING,
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2812,6 +2812,70 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:    false,
 		},
 		{
+			name: "NEU-422 do not suppress when Deployments map is empty (no replicas registered)",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments:       map[string]dashboard.Deployment{},
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusHealthy},
+					},
+				}, nil)
+			},
+			expectedPhase: v1.EndpointPhaseDEPLOYING,
+			expectError:   false,
+		},
+		{
+			name: "NEU-422 do not suppress NOT_STARTED (Ray app not present in state)",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "NOT_STARTED",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {Name: "BACKEND", Status: dashboard.DeploymentStatusHealthy},
+							},
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusHealthy},
+					},
+				}, nil)
+			},
+			expectedPhase: v1.EndpointPhaseDEPLOYING,
+			expectError:   false,
+		},
+		{
 			name: "NEU-422 do not suppress when proxy is unhealthy (HTTP entry not serving)",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2639,12 +2639,12 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectErrorMsg: "Deployment BACKEND: backend deployment is error",
 			expectError:    false,
 		},
-		// NEU-422: suppress transient DEPLOYING when previously Running and replicas remain Healthy.
+		// Suppress transient DEPLOYING when previously Running and replicas remain Healthy.
 		// Ray Serve PUT /api/serve/applications/ briefly flips status to DEPLOYING for every
 		// application in the request — including unchanged ones — even though their deployments
 		// are not actually restarted. See ray-project/ray#25381, #42974, #44226.
 		{
-			name: "NEU-422 suppress transient DEPLOYING when previously Running and all deployments Healthy",
+			name: "suppress transient DEPLOYING when previously Running and all deployments Healthy",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
@@ -2678,7 +2678,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name: "NEU-422 do not suppress when this endpoint is actually rolling out (a deployment is UPDATING)",
+			name: "do not suppress when this endpoint is actually rolling out (a deployment is UPDATING)",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
@@ -2712,7 +2712,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name: "NEU-422 do not suppress when previous status is nil (initial deploy)",
+			name: "do not suppress when previous status is nil (initial deploy)",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				// Status nil — endpoint has never reported a phase.
@@ -2745,7 +2745,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name: "NEU-422 do not suppress when previous status is Failed (recovering from failure)",
+			name: "do not suppress when previous status is Failed (recovering from failure)",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseFAILED}
@@ -2778,7 +2778,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name: "NEU-422 UNHEALTHY deployment still maps to Failed even if previously Running (failure precedence preserved)",
+			name: "UNHEALTHY deployment still maps to Failed even if previously Running (failure precedence preserved)",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
@@ -2812,7 +2812,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name: "NEU-422 do not suppress when Deployments map is empty (no replicas registered)",
+			name: "do not suppress when Deployments map is empty (no replicas registered)",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
@@ -2843,7 +2843,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name: "NEU-422 do not suppress NOT_STARTED (Ray app not present in state)",
+			name: "do not suppress NOT_STARTED (Ray app not present in state)",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
@@ -2876,7 +2876,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name: "NEU-422 do not suppress when proxy is unhealthy (HTTP entry not serving)",
+			name: "do not suppress when proxy is unhealthy (HTTP entry not serving)",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				ep.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}

--- a/tests/e2e/endpoint_ssh_inference_test.go
+++ b/tests/e2e/endpoint_ssh_inference_test.go
@@ -145,7 +145,7 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 		})
 	})
 
-	// --- Sibling Endpoint Update Isolation (NEU-422) ---
+	// --- Sibling Endpoint Update Isolation ---
 	//
 	// Ray Serve PUT /api/serve/applications/ unconditionally writes
 	// ApplicationStatus to DEPLOYING for every application in the request,
@@ -154,7 +154,10 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 	// Deploying → Running flicker on sibling endpoints whenever any single
 	// endpoint in the same cluster is updated. See ray-project/ray#25381,
 	// #42974, #44226.
-	Describe("Sibling Endpoint Update Isolation", Ordered, Label("inference", "isolation", "NEU-422"), func() {
+	//
+	// Lives under the inference-test file purely to reuse the SSH cluster
+	// fixture; the case itself is a status-reporting assertion.
+	Describe("Sibling Endpoint Update Isolation", Ordered, Label("status", "isolation"), func() {
 		var epNameA, epNameB string
 
 		BeforeAll(func() {
@@ -186,11 +189,11 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 			By("Updating endpoint A (re-apply with extra env to force a Ray Serve PUT)")
 			// withEnv injects a new key into the endpoint spec → the controller
 			// detects a config diff and re-issues PUT /api/serve/applications/
-			// against Ray. The PUT is what triggers Ray's transient DEPLOYING
-			// write on every application in the request (NEU-422 trigger);
-			// the env key itself is a marker, the value is irrelevant.
+			// against Ray. The PUT is what triggers the transient DEPLOYING
+			// write on every application in the request; the env key itself is
+			// a marker, the value is irrelevant.
 			yamlAUpdate := applyEndpoint(epNameA, clusterName,
-				withEnv(map[string]string{"NEU_422_E2E_MARKER": "1"}))
+				withEnv(map[string]string{"E2E_ISOLATION_MARKER": "1"}))
 			defer os.Remove(yamlAUpdate)
 
 			By("Polling endpoint B every second for 90s — phase must stay Running")
@@ -202,7 +205,7 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 				return getEndpoint(epNameB).Status.Phase
 			}, 90*time.Second, 1*time.Second).
 				Should(BeEquivalentTo("Running"),
-					"endpoint B phase flickered while endpoint A was being updated (NEU-422 regression)")
+					"endpoint B phase flickered while endpoint A was being updated")
 
 			By("Waiting for endpoint A rollout to settle")
 			waitEndpointRunning(epNameA)

--- a/tests/e2e/endpoint_ssh_inference_test.go
+++ b/tests/e2e/endpoint_ssh_inference_test.go
@@ -184,11 +184,20 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 			lastTransitionBefore := epBBefore.Status.LastTransitionTime
 
 			By("Updating endpoint A (re-apply with extra env to force a Ray Serve PUT)")
+			// withEnv injects a new key into the endpoint spec → the controller
+			// detects a config diff and re-issues PUT /api/serve/applications/
+			// against Ray. The PUT is what triggers Ray's transient DEPLOYING
+			// write on every application in the request (NEU-422 trigger);
+			// the env key itself is a marker, the value is irrelevant.
 			yamlAUpdate := applyEndpoint(epNameA, clusterName,
 				withEnv(map[string]string{"NEU_422_E2E_MARKER": "1"}))
 			defer os.Remove(yamlAUpdate)
 
 			By("Polling endpoint B every second for 90s — phase must stay Running")
+			// Sampling-based assertion: catches any flicker the controller
+			// reconciles slower than 1s. The definitive guard is the
+			// LastTransitionTime equality check below — it catches any phase
+			// write by the controller regardless of poll cadence.
 			Consistently(func() v1.EndpointPhase {
 				return getEndpoint(epNameB).Status.Phase
 			}, 90*time.Second, 1*time.Second).
@@ -205,7 +214,14 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 				Should(BeEquivalentTo("Running"),
 					"endpoint B phase flickered after endpoint A finished rollout")
 
-			By("Verifying endpoint B LastTransitionTime did not change")
+			By("Verifying endpoint B LastTransitionTime did not change (definitive guard)")
+			// LastTransitionTime is bumped only when the controller detects an
+			// actual status change (shouldUpdateStatus → updateStatus). If
+			// endpoint B's phase ever flipped — even momentarily between two
+			// reconciles the sampling above couldn't catch — the controller
+			// would have written the change and bumped LastTransitionTime.
+			// Equality with the pre-update baseline therefore strictly proves
+			// no phase write happened for endpoint B during A's update.
 			epBAfter := getEndpoint(epNameB)
 			Expect(epBAfter.Status.LastTransitionTime).To(Equal(lastTransitionBefore),
 				"endpoint B LastTransitionTime changed (controller wrote an intermediate phase) — before=%q after=%q",

--- a/tests/e2e/endpoint_ssh_inference_test.go
+++ b/tests/e2e/endpoint_ssh_inference_test.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
 var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
@@ -139,6 +142,74 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 			codeB, bodyB, err := inferChat(epB.Status.ServiceURL, "Hello after delete")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(codeB).To(Equal(http.StatusOK), "inference on ep-B after deleting ep-A failed: %s", bodyB)
+		})
+	})
+
+	// --- Sibling Endpoint Update Isolation (NEU-422) ---
+	//
+	// Ray Serve PUT /api/serve/applications/ unconditionally writes
+	// ApplicationStatus to DEPLOYING for every application in the request,
+	// even those whose configs are unchanged. Without the suppression in
+	// GetEndpointStatus this leaks to Neutree as a transient Running →
+	// Deploying → Running flicker on sibling endpoints whenever any single
+	// endpoint in the same cluster is updated. See ray-project/ray#25381,
+	// #42974, #44226.
+	Describe("Sibling Endpoint Update Isolation", Ordered, Label("inference", "isolation", "NEU-422"), func() {
+		var epNameA, epNameB string
+
+		BeforeAll(func() {
+			epNameA = "e2e-ep-ssh-isoA-" + Cfg.RunID
+			epNameB = "e2e-ep-ssh-isoB-" + Cfg.RunID
+		})
+
+		AfterAll(func() {
+			deleteEndpoint(epNameA)
+			deleteEndpoint(epNameB)
+		})
+
+		It("should keep sibling endpoint Running when one endpoint is updated", Label("C2650084"), func() {
+			By("Deploying endpoint A and waiting for Running")
+			yamlA := applyEndpoint(epNameA, clusterName)
+			defer os.Remove(yamlA)
+			waitEndpointRunning(epNameA)
+
+			By("Deploying endpoint B and waiting for Running")
+			yamlB := applyEndpoint(epNameB, clusterName)
+			defer os.Remove(yamlB)
+			waitEndpointRunning(epNameB)
+
+			By("Recording endpoint B baseline before updating endpoint A")
+			epBBefore := getEndpoint(epNameB)
+			Expect(epBBefore.Status.Phase).To(BeEquivalentTo("Running"))
+			lastTransitionBefore := epBBefore.Status.LastTransitionTime
+
+			By("Updating endpoint A (re-apply with extra env to force a Ray Serve PUT)")
+			yamlAUpdate := applyEndpoint(epNameA, clusterName,
+				withEnv(map[string]string{"NEU_422_E2E_MARKER": "1"}))
+			defer os.Remove(yamlAUpdate)
+
+			By("Polling endpoint B every second for 90s — phase must stay Running")
+			Consistently(func() v1.EndpointPhase {
+				return getEndpoint(epNameB).Status.Phase
+			}, 90*time.Second, 1*time.Second).
+				Should(BeEquivalentTo("Running"),
+					"endpoint B phase flickered while endpoint A was being updated (NEU-422 regression)")
+
+			By("Waiting for endpoint A rollout to settle")
+			waitEndpointRunning(epNameA)
+
+			By("Sampling endpoint B for an additional 10s after A settled")
+			Consistently(func() v1.EndpointPhase {
+				return getEndpoint(epNameB).Status.Phase
+			}, 10*time.Second, 1*time.Second).
+				Should(BeEquivalentTo("Running"),
+					"endpoint B phase flickered after endpoint A finished rollout")
+
+			By("Verifying endpoint B LastTransitionTime did not change")
+			epBAfter := getEndpoint(epNameB)
+			Expect(epBAfter.Status.LastTransitionTime).To(Equal(lastTransitionBefore),
+				"endpoint B LastTransitionTime changed (controller wrote an intermediate phase) — before=%q after=%q",
+				lastTransitionBefore, epBAfter.Status.LastTransitionTime)
 		})
 	})
 

--- a/tests/e2e/endpoint_ssh_inference_test.go
+++ b/tests/e2e/endpoint_ssh_inference_test.go
@@ -158,8 +158,8 @@ var _ = Describe("SSH Endpoint", Ordered, Label("endpoint", "ssh"), func() {
 		var epNameA, epNameB string
 
 		BeforeAll(func() {
-			epNameA = "e2e-ep-ssh-isoA-" + Cfg.RunID
-			epNameB = "e2e-ep-ssh-isoB-" + Cfg.RunID
+			epNameA = "e2e-ep-ssh-iso-a-" + Cfg.RunID
+			epNameB = "e2e-ep-ssh-iso-b-" + Cfg.RunID
 		})
 
 		AfterAll(func() {


### PR DESCRIPTION
## Issue

NEU-422 — Defect, priority normal, component api-server.

On static-node (SSH/Ray) clusters with ≥2 inference endpoints, updating one endpoint caused all other endpoints in the same cluster to briefly flicker from `Running` to `Deploying` and back to `Running`. The replicas were never actually touched — the flicker was state-machine noise leaking out of Ray Serve.

## Summary

Ray Serve's `PUT /api/serve/applications/` iterates over every application in the request and calls `apply_app_config()` for each, unconditionally writing `ApplicationStatus.DEPLOYING` via `_set_target_state` (`python/ray/serve/_private/application_state.py:405-406`). The next reconcile tick derives the real status from deployment statuses via `_determine_app_status` (line 770-826) and converges back to `RUNNING`. Neutree's `GetEndpointStatus()` polled the dashboard in this gap and propagated the false-positive `DEPLOYING` to user-visible phase.

Mitigate inside `GetEndpointStatus()`: when the Ray app reports `DEPLOYING` (not `NOT_STARTED`) with every deployment `HEALTHY`, the proxy is healthy, and the endpoint's previously reported Neutree phase is `Running`, treat the `DEPLOYING` as a transient state-machine artifact and keep reporting `Running`. Real updates of this endpoint flow through `UPDATING` / `UPSCALING` / `DOWNSCALING` deployment statuses so the suppression does not hide actual rollouts; initial deploys and recovery-from-Failed do not match (previous phase ≠ `Running`); `NOT_STARTED` (app not in Ray state) is excluded from suppression.

Related upstream: ray-project/ray#25381, #42974, #44226.

## Changes

- `internal/orchestrator/ray_orchestrator.go`
  - New helper `allDeploymentsHealthy(deployments map[string]dashboard.Deployment) bool`
  - New helper `mapDeployingPhase(endpoint, status, proxyReady) v1.EndpointPhase` extracted from `GetEndpointStatus()` (also keeps gocyclo budget). Suppression block guarded by `(status.Status == "DEPLOYING" && proxyReady && endpoint.Status.Phase == Running && len(deployments) > 0 && allDeploymentsHealthy(deployments))`.
- `internal/orchestrator/ray_orchestrator_test.go`
  - 8 new table cases in `TestRayOrchestrator_GetEndpointStatus` covering: main suppression, real-update (deployment `UPDATING`), initial deploy (`endpoint.Status == nil`), recovery from `Failed`, `UNHEALTHY` → `Failed` precedence, proxy unhealthy, empty `Deployments` map, and `NOT_STARTED` no-suppression.
- `tests/e2e/endpoint_ssh_inference_test.go`
  - New `Describe` block `"Sibling Endpoint Update Isolation"` (Ginkgo labels `status`, `isolation`; TestRail case `C2650084` in `Endpoint / Status Management`): deploys two endpoints on the same SSH cluster, updates one, asserts the sibling phase stays `Running` for 90s (`Consistently`) plus 10s after rollout settles, with `LastTransitionTime` unchanged.

## Test Plan

- [x] **Unit tests (`go test -race ./internal/orchestrator/...`)** — PASS. All 8 new cases observed RED → GREEN for the main suppression case; full table (26 cases) passes with race detector.
- [x] **E2E** — label `endpoint && ssh && (isolation || multi-version)` run against `10.255.1.54:3000` after hot-deploy of `fix-NEU-422`:
  - Initial run (commit b2df54bf): 3 Passed (multi-version isolation regression: C2642251, C2642252, plus serve-inference) / 1 Failed — failure was an e2e test bug (uppercase endpoint name violated Neutree resource name format).
  - Re-run after fix (commit 3c2d2871, lowercase names): isolation case scoped re-run → **PASS** (1 of 1, 546.4s). Endpoint B held `Running` for the full 90s polling window during A's update, plus 10s after settle; `LastTransitionTime` unchanged.
- [x] **`go vet ./...` / `golangci-lint`** — clean on changed files (gocyclo of `GetEndpointStatus` kept within budget by extracting `mapDeployingPhase`).
- [ ] **DB integration (`make db-test`)** — not affected (no schema/migration changes).

## Risk & Rollback

- No schema change, no API/CRD change, no DB migration.
- Single-package logic patch; rollback is `git revert` of `internal/orchestrator/ray_orchestrator.go` changes.
- The triple-condition guard (`status.Status == "DEPLOYING" && prev = Running && proxy ready && all deployments HEALTHY`) is exclusive: real updates and failures cannot match (deployment statuses transition through `UPDATING` / `UNHEALTHY` per Ray's `_determine_app_status`).
- Suppression is a snapshot heuristic; it accepts the case where Neutree misses an in-progress `UPDATING` window between polls. In that case the observed state (HEALTHY replicas + healthy proxy) matches the reported phase (Running) — the endpoint is actually serving traffic correctly. Next reconcile tick converges Ray back to `RUNNING` and falls through to the normal code path.