### PR TITLE
refactor: track current-run lifecycle resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,12 +171,19 @@ test: prepare-build-cli mockgen fmt vet lint ## Run unit test
 	go test -coverprofile coverage.out -covermode=atomic $(shell go list ./... | grep -v 'e2e\|mocks\|db/dbtest')
 
 LABEL_FILTER ?=
-E2E_TIMEOUT ?= 30m
+# Total wall-clock budget for the e2e suite. Ginkgo is the single source of
+# truth — `go test -timeout 0` disables Go test's own deadline so cleanup is
+# never killed by a hard SIGABRT before AfterSuite drains the tracking
+# registry. Default 2h covers the lifecycle suite (~120m measured); shorter
+# subsets can override (e.g. `E2E_TIMEOUT=30m make e2e-test ...`).
+E2E_TIMEOUT ?= 2h
 
 .PHONY: e2e-test
 e2e-test: ## Run E2E tests (requires NEUTREE_SERVER_URL and NEUTREE_API_KEY)
-	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 6h ./tests/e2e/... \
-		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips --ginkgo.timeout=$(E2E_TIMEOUT) $(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")
+	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 0 ./tests/e2e/... \
+		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips \
+		--ginkgo.timeout=$(E2E_TIMEOUT) --ginkgo.grace-period=5m \
+		$(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")
 
 ##@ Database Testing
 

--- a/Makefile
+++ b/Makefile
@@ -209,12 +209,19 @@ test: prepare-build-cli mockgen fmt vet lint ## Run unit test
 	go test -coverprofile coverage.out -covermode=atomic $(shell go list ./... | grep -v 'e2e\|mocks\|db/dbtest')
 
 LABEL_FILTER ?=
-E2E_TIMEOUT ?= 30m
+# Total wall-clock budget for the e2e suite. Ginkgo is the single source of
+# truth — `go test -timeout 0` disables Go test's own deadline so cleanup is
+# never killed by a hard SIGABRT before AfterSuite drains the tracking
+# registry. Default 2h covers the lifecycle suite (~120m measured); shorter
+# subsets can override (e.g. `E2E_TIMEOUT=30m make e2e-test ...`).
+E2E_TIMEOUT ?= 2h
 
 .PHONY: e2e-test
 e2e-test: ## Run E2E tests (requires NEUTREE_SERVER_URL and NEUTREE_API_KEY)
-	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 6h ./tests/e2e/... \
-		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips --ginkgo.timeout=$(E2E_TIMEOUT) $(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")
+	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 0 ./tests/e2e/... \
+		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips \
+		--ginkgo.timeout=$(E2E_TIMEOUT) --ginkgo.grace-period=5m \
+		$(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")
 
 ##@ Gateway Lua Testing
 

--- a/Makefile
+++ b/Makefile
@@ -209,16 +209,15 @@ test: prepare-build-cli mockgen fmt vet lint ## Run unit test
 	go test -coverprofile coverage.out -covermode=atomic $(shell go list ./... | grep -v 'e2e\|mocks\|db/dbtest')
 
 LABEL_FILTER ?=
-# Total wall-clock budget for the e2e suite. Ginkgo is the single source of
-# truth — `go test -timeout 0` disables Go test's own deadline so cleanup is
-# never killed by a hard SIGABRT before AfterSuite drains the tracking
-# registry. Default 2h covers the lifecycle suite (~120m measured); shorter
-# subsets can override (e.g. `E2E_TIMEOUT=30m make e2e-test ...`).
+# Ginkgo owns the suite timeout; this finite outer timeout remains a last-resort
+# kill switch for a wedged test process. Keep E2E_GO_TIMEOUT at least
+# E2E_TIMEOUT plus the 2h cleanup budget; override both for longer suites.
 E2E_TIMEOUT ?= 2h
+E2E_GO_TIMEOUT ?= 6h
 
 .PHONY: e2e-test
 e2e-test: ## Run E2E tests (requires NEUTREE_SERVER_URL and NEUTREE_API_KEY)
-	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 0 ./tests/e2e/... \
+	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout $(E2E_GO_TIMEOUT) ./tests/e2e/... \
 		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips \
 		--ginkgo.timeout=$(E2E_TIMEOUT) --ginkgo.grace-period=5m \
 		$(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")

--- a/Makefile
+++ b/Makefile
@@ -211,9 +211,9 @@ test: prepare-build-cli mockgen fmt vet lint ## Run unit test
 LABEL_FILTER ?=
 # Ginkgo owns the suite timeout; this finite outer timeout remains a last-resort
 # kill switch for a wedged test process. Keep E2E_GO_TIMEOUT at least
-# E2E_TIMEOUT plus the 2h cleanup budget; override both for longer suites.
+# E2E_TIMEOUT plus the 4h cleanup budget; override both for longer suites.
 E2E_TIMEOUT ?= 2h
-E2E_GO_TIMEOUT ?= 6h
+E2E_GO_TIMEOUT ?= 8h
 
 .PHONY: e2e-test
 e2e-test: ## Run E2E tests (requires NEUTREE_SERVER_URL and NEUTREE_API_KEY)

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -1,11 +1,23 @@
 package e2e
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"os/exec"
+	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 )
+
+// cleanupCallTimeout caps each per-resource CLI delete in AfterSuite.
+// Without this, a hung CP would leave AfterSuite blocked indefinitely:
+// `go test -timeout 0` removed the Go runtime backstop, AfterSuite has no
+// Ginkgo NodeTimeout, and grace-period only fires after upstream interrupt.
+const cleanupCallTimeout = 30 * time.Second
 
 // trackedResource records a resource the current e2e session created so the
 // suite-level AfterSuite safety net can force-delete it if a per-Describe
@@ -35,8 +47,12 @@ func trackResource(kind, name, workspace string) {
 	})
 }
 
-// untrackResource removes a resource from the registry. Teardown helpers call
-// this after a successful delete so AfterSuite skips it.
+// untrackResource removes ALL entries matching (kind, name, workspace) from
+// the registry. Removing every duplicate is intentional and paired with the
+// no-dedup-on-write policy in trackResource: writes are append-only for
+// simplicity, removals are exhaustive so a balanced setup/teardown sequence
+// (or a setup that registered twice and an idempotent single teardown)
+// always lands the registry at zero entries for that triple.
 func untrackResource(kind, name, workspace string) {
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
@@ -79,7 +95,8 @@ func cleanupTrackedResources() {
 		len(leftover))
 
 	for _, r := range leftover {
-		result := RunCLI("delete", r.Kind, r.Name,
+		result := runCLIWithTimeout(cleanupCallTimeout,
+			"delete", r.Kind, r.Name,
 			"-w", r.Workspace,
 			"--force", "--ignore-not-found", "--wait=false",
 		)
@@ -89,5 +106,61 @@ func cleanupTrackedResources() {
 			fmt.Fprintf(GinkgoWriter, "  delete %s/%s in %s failed (exit %d): %s\n",
 				r.Kind, r.Name, r.Workspace, result.ExitCode, result.Stderr)
 		}
+	}
+}
+
+// runCLIWithTimeout is a context-bounded sibling of RunCLI used only by
+// AfterSuite cleanup. RunCLI itself uses exec.Command without a context,
+// so a hung CP would block AfterSuite forever in the post-`-timeout 0`
+// world. AfterSuite is the only place this can deadlock the suite (in-spec
+// hangs are bounded by --ginkgo.timeout + grace-period), so the surface is
+// kept narrow here rather than retrofitting RunCLI globally.
+func runCLIWithTimeout(timeout time.Duration, args ...string) CLIResult {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	injected := []string{
+		"--server-url", Cfg.ServerURL,
+		"--api-key", Cfg.APIKey,
+		"--insecure",
+	}
+	fullArgs := make([]string, 0, len(injected)+len(args))
+	fullArgs = append(fullArgs, injected...)
+	fullArgs = append(fullArgs, args...)
+
+	cmd := exec.CommandContext(ctx, cliBinary, fullArgs...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	exitCode := 0
+
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return CLIResult{
+				Stdout:   stdout.String(),
+				Stderr:   strings.TrimSpace(stderr.String()) + " (timed out after " + timeout.String() + ")",
+				ExitCode: 124, // conventional shell timeout exit code
+			}
+		}
+
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				exitCode = status.ExitStatus()
+			} else {
+				exitCode = 1
+			}
+		} else {
+			exitCode = 1
+		}
+	}
+
+	return CLIResult{
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
 	}
 }

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -1,0 +1,93 @@
+package e2e
+
+import (
+	"fmt"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// trackedResource records a resource the current e2e session created so the
+// suite-level AfterSuite safety net can force-delete it if a per-Describe
+// AfterAll was truncated by Ginkgo's grace period.
+type trackedResource struct {
+	Kind      string // "cluster" | "modelregistry" | "imageregistry"
+	Name      string
+	Workspace string
+}
+
+var (
+	trackedMu        sync.Mutex
+	trackedResources []trackedResource
+)
+
+// trackResource registers a resource in the in-process cleanup registry.
+// Setup helpers call this immediately after a successful create so the
+// AfterSuite net can mop up if AfterAll never runs to completion.
+func trackResource(kind, name, workspace string) {
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+
+	trackedResources = append(trackedResources, trackedResource{
+		Kind:      kind,
+		Name:      name,
+		Workspace: workspace,
+	})
+}
+
+// untrackResource removes a resource from the registry. Teardown helpers call
+// this after a successful delete so AfterSuite skips it.
+func untrackResource(kind, name, workspace string) {
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+
+	out := trackedResources[:0]
+	for _, r := range trackedResources {
+		if r.Kind == kind && r.Name == name && r.Workspace == workspace {
+			continue
+		}
+
+		out = append(out, r)
+	}
+
+	trackedResources = out
+}
+
+// cleanupTrackedResources force-deletes every resource still in the registry,
+// asynchronously (--wait=false) so AfterSuite is not blocked on K8s GC.
+// Best-effort: failures are logged to GinkgoWriter without asserting, since
+// AfterSuite failure would surface the suite as failed even when the actual
+// specs passed.
+//
+// This catches two leak sources:
+//   - Per-Describe AfterAll truncated by --ginkgo.grace-period (its own
+//     EnsureDeleted blocks waiting for K8s namespace GC and gets killed
+//     mid-flight).
+//   - AfterAll never runs (panic in BeforeAll, suite-level interruption).
+func cleanupTrackedResources() {
+	trackedMu.Lock()
+	leftover := append([]trackedResource(nil), trackedResources...)
+	trackedResources = nil
+	trackedMu.Unlock()
+
+	if len(leftover) == 0 {
+		return
+	}
+
+	fmt.Fprintf(GinkgoWriter,
+		"AfterSuite: cleaning up %d tracked resource(s) left over from interrupted teardown\n",
+		len(leftover))
+
+	for _, r := range leftover {
+		result := RunCLI("delete", r.Kind, r.Name,
+			"-w", r.Workspace,
+			"--force", "--ignore-not-found", "--wait=false",
+		)
+		if result.ExitCode == 0 {
+			fmt.Fprintf(GinkgoWriter, "  deleted %s/%s in %s\n", r.Kind, r.Name, r.Workspace)
+		} else {
+			fmt.Fprintf(GinkgoWriter, "  delete %s/%s in %s failed (exit %d): %s\n",
+				r.Kind, r.Name, r.Workspace, result.ExitCode, result.Stderr)
+		}
+	}
+}

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -22,6 +22,8 @@ const (
 	// cleanupWaitTimeout gives the controller enough time to finish one
 	// dependency layer before cleanup attempts its parent resources.
 	cleanupWaitTimeout = 5 * time.Minute
+	// cleanupWorkerLimit bounds local CLI processes in one independent wave.
+	cleanupWorkerLimit = 8
 	// cleanupNodeTimeout bounds all dependency layers when AfterSuite runs
 	// after a Ginkgo interruption.
 	// ponytail: fixed 45m cap covers six 5m waves plus delete overhead;
@@ -221,25 +223,39 @@ type cleanupCommandResult struct {
 	result   CLIResult
 }
 
-// runCleanupCommands runs resources from one dependency wave together.
-// ponytail: one CLI process per resource; add a bounded worker pool only if
-// real E2E runs show control-plane pressure from a larger same-kind batch.
+// runCleanupCommands runs resources from one dependency wave with bounded
+// local process and API concurrency.
 func runCleanupCommands(resources []trackedResource, run func(trackedResource) CLIResult) []cleanupCommandResult {
 	results := make([]cleanupCommandResult, len(resources))
+	jobs := make(chan int)
 	var waitGroup sync.WaitGroup
 
-	for index, resource := range resources {
+	workerCount := cleanupWorkerLimit
+	if len(resources) < workerCount {
+		workerCount = len(resources)
+	}
+
+	for worker := 0; worker < workerCount; worker++ {
 		waitGroup.Add(1)
 
-		go func(index int, resource trackedResource) {
+		go func() {
 			defer waitGroup.Done()
 
-			results[index] = cleanupCommandResult{
-				resource: resource,
-				result:   run(resource),
+			for index := range jobs {
+				resource := resources[index]
+				results[index] = cleanupCommandResult{
+					resource: resource,
+					result:   run(resource),
+				}
 			}
-		}(index, resource)
+		}()
 	}
+
+	for index := range resources {
+		jobs <- index
+	}
+
+	close(jobs)
 
 	waitGroup.Wait()
 
@@ -329,7 +345,7 @@ func trackedResourcesFromManifest(path, fallbackWorkspace string) []trackedResou
 		}
 
 		if err != nil {
-			return nil
+			return resources
 		}
 
 		workspace := manifest.Metadata.Workspace

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -24,7 +24,9 @@ const (
 	cleanupWaitTimeout = 5 * time.Minute
 	// cleanupNodeTimeout bounds all dependency layers when AfterSuite runs
 	// after a Ginkgo interruption.
-	cleanupNodeTimeout = 30 * time.Minute
+	// ponytail: fixed 45m cap covers five 5m waves plus delete overhead;
+	// derive it from waves if a future dependency adds another wave.
+	cleanupNodeTimeout = 45 * time.Minute
 )
 
 const (
@@ -162,12 +164,16 @@ func cleanupResourceGroup(ctx context.Context, resources []trackedResource, kind
 
 	deleteSucceeded := true
 
-	for _, resource := range group {
-		result := runCLIWithContext(ctx, cleanupCallTimeout,
+	for _, command := range runCleanupCommands(group, func(resource trackedResource) CLIResult {
+		return runCLIWithContext(ctx, cleanupCallTimeout,
 			"delete", resource.Kind, resource.Name,
 			"-w", resource.Workspace,
 			"--force", "--ignore-not-found", "--wait=false",
 		)
+	}) {
+		resource := command.resource
+		result := command.result
+
 		if result.ExitCode != 0 {
 			deleteSucceeded = false
 
@@ -182,13 +188,17 @@ func cleanupResourceGroup(ctx context.Context, resources []trackedResource, kind
 
 	waitSucceeded := true
 
-	for _, resource := range group {
-		result := runCLIWithContext(ctx, cleanupWaitTimeout,
+	for _, command := range runCleanupCommands(group, func(resource trackedResource) CLIResult {
+		return runCLIWithContext(ctx, cleanupWaitTimeout,
 			"wait", resource.Kind, resource.Name,
 			"-w", resource.Workspace,
 			"--for", "delete",
 			"--timeout", cleanupWaitTimeout.String(),
 		)
+	}) {
+		resource := command.resource
+		result := command.result
+
 		if result.ExitCode == 0 {
 			fmt.Fprintf(GinkgoWriter, "  deleted %s/%s in %s\n",
 				resource.Kind, resource.Name, resource.Workspace)
@@ -201,6 +211,36 @@ func cleanupResourceGroup(ctx context.Context, resources []trackedResource, kind
 	}
 
 	return waitSucceeded
+}
+
+type cleanupCommandResult struct {
+	resource trackedResource
+	result   CLIResult
+}
+
+// runCleanupCommands runs resources from one dependency wave together.
+// ponytail: one CLI process per resource; add a bounded worker pool only if
+// real E2E runs show control-plane pressure from a larger same-kind batch.
+func runCleanupCommands(resources []trackedResource, run func(trackedResource) CLIResult) []cleanupCommandResult {
+	results := make([]cleanupCommandResult, len(resources))
+	var waitGroup sync.WaitGroup
+
+	for index, resource := range resources {
+		waitGroup.Add(1)
+
+		go func(index int, resource trackedResource) {
+			defer waitGroup.Done()
+
+			results[index] = cleanupCommandResult{
+				resource: resource,
+				result:   run(resource),
+			}
+		}(index, resource)
+	}
+
+	waitGroup.Wait()
+
+	return results
 }
 
 func trackedResourcesOfKind(resources []trackedResource, kind string) []trackedResource {

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -26,9 +26,9 @@ const (
 	cleanupWorkerLimit = 8
 	// cleanupNodeTimeout bounds all dependency layers when AfterSuite runs
 	// after a Ginkgo interruption.
-	// ponytail: fixed 2h cap covers six 5m waves in bounded batches plus delete overhead;
+	// ponytail: fixed 4h cap covers six 5m waves in bounded batches plus delete overhead;
 	// derive it from waves if a future dependency adds another wave.
-	cleanupNodeTimeout = 2 * time.Hour
+	cleanupNodeTimeout = 4 * time.Hour
 )
 
 const (

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -6,11 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"sort"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -102,8 +99,7 @@ func trackedResourceCount() int {
 	return len(trackedResources)
 }
 
-// snapshotTrackedResources returns the current registry in dependency-safe
-// delete order without mutating it.
+// snapshotTrackedResources returns the current registry without mutating it.
 func snapshotTrackedResources() []trackedResource {
 	trackedMu.Lock()
 	resources := make([]trackedResource, 0, len(trackedResources))
@@ -113,25 +109,6 @@ func snapshotTrackedResources() []trackedResource {
 	}
 	trackedMu.Unlock()
 
-	sort.Slice(resources, func(i, j int) bool {
-		leftPriority := cleanupPriority(resources[i].Kind)
-		rightPriority := cleanupPriority(resources[j].Kind)
-
-		if leftPriority != rightPriority {
-			return leftPriority < rightPriority
-		}
-
-		if resources[i].Kind != resources[j].Kind {
-			return resources[i].Kind < resources[j].Kind
-		}
-
-		if resources[i].Workspace != resources[j].Workspace {
-			return resources[i].Workspace < resources[j].Workspace
-		}
-
-		return resources[i].Name < resources[j].Name
-	})
-
 	return resources
 }
 
@@ -140,12 +117,6 @@ func clearTrackedResources() {
 	defer trackedMu.Unlock()
 
 	trackedResources = make(map[trackedResource]struct{})
-}
-
-// cleanupTrackedResources uses a background context for unit tests. The suite
-// uses cleanupTrackedResourcesWithContext so its NodeTimeout can stop cleanup.
-func cleanupTrackedResources() {
-	cleanupTrackedResourcesWithContext(context.Background())
 }
 
 // cleanupTrackedResources force-deletes current-process resources in
@@ -304,7 +275,7 @@ func trackedResourcesFromManifest(path, fallbackWorkspace string) []trackedResou
 	}
 
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
-	resources := make(map[trackedResource]struct{})
+	var resources []trackedResource
 
 	for {
 		var manifest manifestResource
@@ -325,28 +296,11 @@ func trackedResourcesFromManifest(path, fallbackWorkspace string) []trackedResou
 
 		resource, ok := newTrackedResource(manifest.Kind, manifest.Metadata.Name, workspace)
 		if ok {
-			resources[resource] = struct{}{}
+			resources = append(resources, resource)
 		}
 	}
 
-	result := make([]trackedResource, 0, len(resources))
-	for resource := range resources {
-		result = append(result, resource)
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		if result[i].Kind != result[j].Kind {
-			return result[i].Kind < result[j].Kind
-		}
-
-		if result[i].Workspace != result[j].Workspace {
-			return result[i].Workspace < result[j].Workspace
-		}
-
-		return result[i].Name < result[j].Name
-	})
-
-	return result
+	return resources
 }
 
 func newTrackedResource(kind, name, workspace string) (trackedResource, bool) {
@@ -368,15 +322,15 @@ func newTrackedResource(kind, name, workspace string) (trackedResource, bool) {
 
 func canonicalTrackedKind(kind string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
-	case "cluster", "clusters":
+	case trackedCluster:
 		return trackedCluster, true
-	case "endpoint", "endpoints":
+	case trackedEndpoint:
 		return trackedEndpoint, true
-	case "externalendpoint", "external-endpoint", "externalendpoints", "external-endpoints":
+	case trackedExternalEndpoint:
 		return trackedExternalEndpoint, true
-	case "imageregistry", "image-registry", "imageregistries", "image-registries":
+	case trackedImageRegistry:
 		return trackedImageRegistry, true
-	case "modelregistry", "model-registry", "modelregistries", "model-registries":
+	case trackedModelRegistry:
 		return trackedModelRegistry, true
 	default:
 		return "", false
@@ -385,19 +339,6 @@ func canonicalTrackedKind(kind string) (string, bool) {
 
 func isCurrentRunResource(name string) bool {
 	return strings.HasPrefix(name, "e2e-") && strings.HasSuffix(name, "-"+Cfg.RunID)
-}
-
-func cleanupPriority(kind string) int {
-	switch kind {
-	case trackedEndpoint, trackedExternalEndpoint:
-		return 0
-	case trackedCluster:
-		return 1
-	case trackedImageRegistry, trackedModelRegistry:
-		return 2
-	default:
-		return 3
-	}
 }
 
 func commandFilePath(args []string) string {
@@ -466,59 +407,16 @@ func directCommandResource(args []string) (trackedResource, bool) {
 	return newTrackedResource(args[1], args[2], commandWorkspace(args))
 }
 
-// runCLIWithTimeout is a context-bounded sibling of RunCLI used by unit tests
-// and single cleanup calls without a Ginkgo node context.
-func runCLIWithTimeout(timeout time.Duration, args ...string) CLIResult {
-	return runCLIWithContext(context.Background(), timeout, args...)
-}
-
 // runCLIWithContext inherits the AfterSuite NodeTimeout and adds a per-command
 // bound so a hung CLI process cannot block the remaining cleanup groups.
 func runCLIWithContext(parent context.Context, timeout time.Duration, args ...string) CLIResult {
 	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 
-	injected := []string{
-		"--server-url", Cfg.ServerURL,
-		"--api-key", Cfg.APIKey,
-		"--insecure",
-	}
-	fullArgs := make([]string, 0, len(injected)+len(args))
-	fullArgs = append(fullArgs, injected...)
-	fullArgs = append(fullArgs, args...)
-
-	cmd := exec.CommandContext(ctx, cliBinary, fullArgs...)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	exitCode := 0
-
-	if err != nil {
-		if ctx.Err() != nil {
-			return CLIResult{
-				Stdout:   stdout.String(),
-				Stderr:   strings.TrimSpace(stderr.String()) + " (cleanup command stopped: " + ctx.Err().Error() + ")",
-				ExitCode: 124,
-			}
-		}
-
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-				exitCode = status.ExitStatus()
-			} else {
-				exitCode = 1
-			}
-		} else {
-			exitCode = 1
-		}
+	result := runCLI(ctx, "", args...)
+	if result.ExitCode == 124 && ctx.Err() != nil {
+		result.Stderr = strings.TrimSpace(result.Stderr) + " (cleanup command stopped: " + ctx.Err().Error() + ")"
 	}
 
-	return CLIResult{
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
-		ExitCode: exitCode,
-	}
+	return result
 }

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -16,8 +16,8 @@ import (
 
 const (
 	// cleanupCallTimeout caps a delete request so a hung API cannot block
-	// AfterSuite indefinitely after `go test -timeout 0` removes Go's runtime
-	// backstop.
+	// AfterSuite indefinitely; the finite Go test timeout remains a final
+	// process-level backstop.
 	cleanupCallTimeout = 30 * time.Second
 	// cleanupWaitTimeout gives the controller enough time to finish one
 	// dependency layer before cleanup attempts its parent resources.
@@ -26,9 +26,9 @@ const (
 	cleanupWorkerLimit = 8
 	// cleanupNodeTimeout bounds all dependency layers when AfterSuite runs
 	// after a Ginkgo interruption.
-	// ponytail: fixed 45m cap covers six 5m waves plus delete overhead;
+	// ponytail: fixed 2h cap covers six 5m waves in bounded batches plus delete overhead;
 	// derive it from waves if a future dependency adds another wave.
-	cleanupNodeTimeout = 45 * time.Minute
+	cleanupNodeTimeout = 2 * time.Hour
 )
 
 const (

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -4,87 +4,157 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	"gopkg.in/yaml.v3"
 )
 
-// cleanupCallTimeout caps each per-resource CLI delete in AfterSuite.
-// Without this, a hung CP would leave AfterSuite blocked indefinitely:
-// `go test -timeout 0` removed the Go runtime backstop, AfterSuite has no
-// Ginkgo NodeTimeout, and grace-period only fires after upstream interrupt.
-const cleanupCallTimeout = 30 * time.Second
+const (
+	// cleanupCallTimeout caps a delete request so a hung API cannot block
+	// AfterSuite indefinitely after `go test -timeout 0` removes Go's runtime
+	// backstop.
+	cleanupCallTimeout = 30 * time.Second
+	// cleanupWaitTimeout gives the controller enough time to finish one
+	// dependency layer before cleanup attempts its parent resources.
+	cleanupWaitTimeout = 5 * time.Minute
+	// cleanupNodeTimeout bounds all dependency layers when AfterSuite runs
+	// after a Ginkgo interruption.
+	cleanupNodeTimeout = 30 * time.Minute
+)
 
-// trackedResource records a resource the current e2e session created so the
-// suite-level AfterSuite safety net can force-delete it if a per-Describe
-// AfterAll was truncated by Ginkgo's grace period.
+const (
+	trackedCluster          = "cluster"
+	trackedEndpoint         = "endpoint"
+	trackedExternalEndpoint = "externalendpoint"
+	trackedImageRegistry    = "imageregistry"
+	trackedModelRegistry    = "modelregistry"
+)
+
+// trackedResource records a lifecycle resource created by the current E2E
+// process. AfterSuite force-deletes entries whose normal cleanup did not
+// complete after a timeout or interruption.
 type trackedResource struct {
-	Kind      string // "cluster" | "modelregistry" | "imageregistry"
+	Kind      string
 	Name      string
 	Workspace string
 }
 
+type manifestResource struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name      string `yaml:"name"`
+		Workspace string `yaml:"workspace"`
+	} `yaml:"metadata"`
+}
+
 var (
 	trackedMu        sync.Mutex
-	trackedResources []trackedResource
+	trackedResources = make(map[trackedResource]struct{})
 )
 
-// trackResource registers a resource in the in-process cleanup registry.
-// Setup helpers call this immediately after a successful create so the
-// AfterSuite net can mop up if AfterAll never runs to completion.
+// trackResource registers a current-process lifecycle resource. It silently
+// ignores unsupported kinds and names that do not belong to the current RunID.
 func trackResource(kind, name, workspace string) {
+	resource, ok := newTrackedResource(kind, name, workspace)
+	if !ok {
+		return
+	}
+
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
 
-	trackedResources = append(trackedResources, trackedResource{
-		Kind:      kind,
+	trackedResources[resource] = struct{}{}
+}
+
+// untrackResource removes an entry after the CLI has confirmed deletion.
+func untrackResource(kind, name, workspace string) {
+	canonicalKind, ok := canonicalTrackedKind(kind)
+	if !ok {
+		return
+	}
+
+	if workspace == "" {
+		workspace = profileWorkspace()
+	}
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+
+	delete(trackedResources, trackedResource{
+		Kind:      canonicalKind,
 		Name:      name,
 		Workspace: workspace,
 	})
 }
 
-// untrackResource removes ALL entries matching (kind, name, workspace) from
-// the registry. Removing every duplicate is intentional and paired with the
-// no-dedup-on-write policy in trackResource: writes are append-only for
-// simplicity, removals are exhaustive so a balanced setup/teardown sequence
-// (or a setup that registered twice and an idempotent single teardown)
-// always lands the registry at zero entries for that triple.
-func untrackResource(kind, name, workspace string) {
+func trackedResourceCount() int {
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
 
-	out := trackedResources[:0]
-	for _, r := range trackedResources {
-		if r.Kind == kind && r.Name == name && r.Workspace == workspace {
-			continue
-		}
-
-		out = append(out, r)
-	}
-
-	trackedResources = out
+	return len(trackedResources)
 }
 
-// cleanupTrackedResources force-deletes every resource still in the registry,
-// asynchronously (--wait=false) so AfterSuite is not blocked on K8s GC.
-// Best-effort: failures are logged to GinkgoWriter without asserting, since
-// AfterSuite failure would surface the suite as failed even when the actual
-// specs passed.
-//
-// This catches two leak sources:
-//   - Per-Describe AfterAll truncated by --ginkgo.grace-period (its own
-//     EnsureDeleted blocks waiting for K8s namespace GC and gets killed
-//     mid-flight).
-//   - AfterAll never runs (panic in BeforeAll, suite-level interruption).
-func cleanupTrackedResources() {
+// snapshotTrackedResources returns the current registry in dependency-safe
+// delete order without mutating it.
+func snapshotTrackedResources() []trackedResource {
 	trackedMu.Lock()
-	leftover := append([]trackedResource(nil), trackedResources...)
-	trackedResources = nil
+	resources := make([]trackedResource, 0, len(trackedResources))
+
+	for resource := range trackedResources {
+		resources = append(resources, resource)
+	}
 	trackedMu.Unlock()
+
+	sort.Slice(resources, func(i, j int) bool {
+		leftPriority := cleanupPriority(resources[i].Kind)
+		rightPriority := cleanupPriority(resources[j].Kind)
+
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+
+		if resources[i].Kind != resources[j].Kind {
+			return resources[i].Kind < resources[j].Kind
+		}
+
+		if resources[i].Workspace != resources[j].Workspace {
+			return resources[i].Workspace < resources[j].Workspace
+		}
+
+		return resources[i].Name < resources[j].Name
+	})
+
+	return resources
+}
+
+func clearTrackedResources() {
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+
+	trackedResources = make(map[trackedResource]struct{})
+}
+
+// cleanupTrackedResources uses a background context for unit tests. The suite
+// uses cleanupTrackedResourcesWithContext so its NodeTimeout can stop cleanup.
+func cleanupTrackedResources() {
+	cleanupTrackedResourcesWithContext(context.Background())
+}
+
+// cleanupTrackedResources force-deletes current-process resources in
+// dependency-safe waves. Parent deletion validators count live children, so
+// each dependency layer must fully disappear before its parents are deleted.
+func cleanupTrackedResourcesWithContext(ctx context.Context) {
+	leftover := snapshotTrackedResources()
+
+	clearTrackedResources()
 
 	if len(leftover) == 0 {
 		return
@@ -94,29 +164,318 @@ func cleanupTrackedResources() {
 		"AfterSuite: cleaning up %d tracked resource(s) left over from interrupted teardown\n",
 		len(leftover))
 
-	for _, r := range leftover {
-		result := runCLIWithTimeout(cleanupCallTimeout,
-			"delete", r.Kind, r.Name,
-			"-w", r.Workspace,
+	// External endpoints have no dependency on the other tracked kinds, so
+	// their failure should not prevent endpoint/cluster cleanup.
+	cleanupResourceGroup(ctx, leftover, trackedExternalEndpoint)
+
+	if !cleanupResourceGroup(ctx, leftover, trackedEndpoint) {
+		return
+	}
+
+	// Model registries only depend on endpoints and may be cleaned while
+	// clusters are still finishing their own deletion.
+	cleanupResourceGroup(ctx, leftover, trackedModelRegistry)
+
+	if !cleanupResourceGroup(ctx, leftover, trackedCluster) {
+		return
+	}
+
+	cleanupResourceGroup(ctx, leftover, trackedImageRegistry)
+}
+
+func cleanupResourceGroup(ctx context.Context, resources []trackedResource, kind string) bool {
+	group := trackedResourcesOfKind(resources, kind)
+	if len(group) == 0 {
+		return true
+	}
+
+	deleteSucceeded := true
+
+	for _, resource := range group {
+		result := runCLIWithContext(ctx, cleanupCallTimeout,
+			"delete", resource.Kind, resource.Name,
+			"-w", resource.Workspace,
 			"--force", "--ignore-not-found", "--wait=false",
 		)
-		if result.ExitCode == 0 {
-			fmt.Fprintf(GinkgoWriter, "  deleted %s/%s in %s\n", r.Kind, r.Name, r.Workspace)
-		} else {
+		if result.ExitCode != 0 {
+			deleteSucceeded = false
+
 			fmt.Fprintf(GinkgoWriter, "  delete %s/%s in %s failed (exit %d): %s\n",
-				r.Kind, r.Name, r.Workspace, result.ExitCode, result.Stderr)
+				resource.Kind, resource.Name, resource.Workspace, result.ExitCode, result.Stderr)
+		}
+	}
+
+	if !deleteSucceeded {
+		return false
+	}
+
+	waitSucceeded := true
+
+	for _, resource := range group {
+		result := runCLIWithContext(ctx, cleanupWaitTimeout,
+			"wait", resource.Kind, resource.Name,
+			"-w", resource.Workspace,
+			"--for", "delete",
+			"--timeout", cleanupWaitTimeout.String(),
+		)
+		if result.ExitCode == 0 {
+			fmt.Fprintf(GinkgoWriter, "  deleted %s/%s in %s\n",
+				resource.Kind, resource.Name, resource.Workspace)
+		} else {
+			waitSucceeded = false
+
+			fmt.Fprintf(GinkgoWriter, "  wait for %s/%s in %s failed (exit %d): %s\n",
+				resource.Kind, resource.Name, resource.Workspace, result.ExitCode, result.Stderr)
+		}
+	}
+
+	return waitSucceeded
+}
+
+func trackedResourcesOfKind(resources []trackedResource, kind string) []trackedResource {
+	var group []trackedResource
+
+	for _, resource := range resources {
+		if resource.Kind == kind {
+			group = append(group, resource)
+		}
+	}
+
+	return group
+}
+
+// trackResourcesForApplyCommand records lifecycle resources from an apply
+// manifest before the command runs. Pre-registration protects resources that
+// are created successfully but whose following wait or test step is interrupted.
+func trackResourcesForApplyCommand(args []string) {
+	if len(args) == 0 || !strings.EqualFold(args[0], "apply") {
+		return
+	}
+
+	manifestPath := commandFilePath(args)
+	if manifestPath == "" {
+		return
+	}
+
+	for _, resource := range trackedResourcesFromManifest(manifestPath, commandWorkspace(args)) {
+		trackResource(resource.Kind, resource.Name, resource.Workspace)
+	}
+}
+
+// reconcileTrackedResourcesAfterCommand updates the registry only after a
+// successful CLI command. Callers pass it no failed command results.
+func reconcileTrackedResourcesAfterCommand(args []string) {
+	if len(args) == 0 {
+		return
+	}
+
+	switch strings.ToLower(args[0]) {
+	case "delete":
+		if commandWaitsAsynchronously(args) {
+			return
+		}
+
+		if manifestPath := commandFilePath(args); manifestPath != "" {
+			for _, resource := range trackedResourcesFromManifest(manifestPath, commandWorkspace(args)) {
+				untrackResource(resource.Kind, resource.Name, resource.Workspace)
+			}
+
+			return
+		}
+
+		if resource, ok := directCommandResource(args); ok {
+			untrackResource(resource.Kind, resource.Name, resource.Workspace)
+		}
+	case "wait":
+		if !waitsForDeletion(args) {
+			return
+		}
+
+		if resource, ok := directCommandResource(args); ok {
+			untrackResource(resource.Kind, resource.Name, resource.Workspace)
 		}
 	}
 }
 
-// runCLIWithTimeout is a context-bounded sibling of RunCLI used only by
-// AfterSuite cleanup. RunCLI itself uses exec.Command without a context,
-// so a hung CP would block AfterSuite forever in the post-`-timeout 0`
-// world. AfterSuite is the only place this can deadlock the suite (in-spec
-// hangs are bounded by --ginkgo.timeout + grace-period), so the surface is
-// kept narrow here rather than retrofitting RunCLI globally.
+func trackedResourcesFromManifest(path, fallbackWorkspace string) []trackedResource {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	resources := make(map[trackedResource]struct{})
+
+	for {
+		var manifest manifestResource
+
+		err := decoder.Decode(&manifest)
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil
+		}
+
+		workspace := manifest.Metadata.Workspace
+		if workspace == "" {
+			workspace = fallbackWorkspace
+		}
+
+		resource, ok := newTrackedResource(manifest.Kind, manifest.Metadata.Name, workspace)
+		if ok {
+			resources[resource] = struct{}{}
+		}
+	}
+
+	result := make([]trackedResource, 0, len(resources))
+	for resource := range resources {
+		result = append(result, resource)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Kind != result[j].Kind {
+			return result[i].Kind < result[j].Kind
+		}
+
+		if result[i].Workspace != result[j].Workspace {
+			return result[i].Workspace < result[j].Workspace
+		}
+
+		return result[i].Name < result[j].Name
+	})
+
+	return result
+}
+
+func newTrackedResource(kind, name, workspace string) (trackedResource, bool) {
+	canonicalKind, ok := canonicalTrackedKind(kind)
+	if !ok || !isCurrentRunResource(name) {
+		return trackedResource{}, false
+	}
+
+	if workspace == "" {
+		workspace = profileWorkspace()
+	}
+
+	return trackedResource{
+		Kind:      canonicalKind,
+		Name:      name,
+		Workspace: workspace,
+	}, true
+}
+
+func canonicalTrackedKind(kind string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "cluster", "clusters":
+		return trackedCluster, true
+	case "endpoint", "endpoints":
+		return trackedEndpoint, true
+	case "externalendpoint", "external-endpoint", "externalendpoints", "external-endpoints":
+		return trackedExternalEndpoint, true
+	case "imageregistry", "image-registry", "imageregistries", "image-registries":
+		return trackedImageRegistry, true
+	case "modelregistry", "model-registry", "modelregistries", "model-registries":
+		return trackedModelRegistry, true
+	default:
+		return "", false
+	}
+}
+
+func isCurrentRunResource(name string) bool {
+	return strings.HasPrefix(name, "e2e-") && strings.HasSuffix(name, "-"+Cfg.RunID)
+}
+
+func cleanupPriority(kind string) int {
+	switch kind {
+	case trackedEndpoint, trackedExternalEndpoint:
+		return 0
+	case trackedCluster:
+		return 1
+	case trackedImageRegistry, trackedModelRegistry:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func commandFilePath(args []string) string {
+	for index, arg := range args {
+		switch {
+		case arg == "-f" || arg == "--file":
+			if index+1 < len(args) {
+				return args[index+1]
+			}
+		case strings.HasPrefix(arg, "--file="):
+			return strings.TrimPrefix(arg, "--file=")
+		}
+	}
+
+	return ""
+}
+
+func commandWorkspace(args []string) string {
+	for index, arg := range args {
+		switch {
+		case arg == "-w" || arg == "--workspace":
+			if index+1 < len(args) {
+				return args[index+1]
+			}
+		case strings.HasPrefix(arg, "--workspace="):
+			return strings.TrimPrefix(arg, "--workspace=")
+		}
+	}
+
+	return profileWorkspace()
+}
+
+func commandWaitsAsynchronously(args []string) bool {
+	for index, arg := range args {
+		if arg == "--wait=false" {
+			return true
+		}
+
+		if arg == "--wait" && index+1 < len(args) && args[index+1] == "false" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func waitsForDeletion(args []string) bool {
+	for index, arg := range args {
+		if arg == "--for=delete" {
+			return true
+		}
+
+		if arg == "--for" && index+1 < len(args) && args[index+1] == "delete" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func directCommandResource(args []string) (trackedResource, bool) {
+	if len(args) < 3 || strings.HasPrefix(args[1], "-") || strings.HasPrefix(args[2], "-") {
+		return trackedResource{}, false
+	}
+
+	return newTrackedResource(args[1], args[2], commandWorkspace(args))
+}
+
+// runCLIWithTimeout is a context-bounded sibling of RunCLI used by unit tests
+// and single cleanup calls without a Ginkgo node context.
 func runCLIWithTimeout(timeout time.Duration, args ...string) CLIResult {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	return runCLIWithContext(context.Background(), timeout, args...)
+}
+
+// runCLIWithContext inherits the AfterSuite NodeTimeout and adds a per-command
+// bound so a hung CLI process cannot block the remaining cleanup groups.
+func runCLIWithContext(parent context.Context, timeout time.Duration, args ...string) CLIResult {
+	ctx, cancel := context.WithTimeout(parent, timeout)
 	defer cancel()
 
 	injected := []string{
@@ -135,15 +494,14 @@ func runCLIWithTimeout(timeout time.Duration, args ...string) CLIResult {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
-
 	exitCode := 0
 
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		if ctx.Err() != nil {
 			return CLIResult{
 				Stdout:   stdout.String(),
-				Stderr:   strings.TrimSpace(stderr.String()) + " (timed out after " + timeout.String() + ")",
-				ExitCode: 124, // conventional shell timeout exit code
+				Stderr:   strings.TrimSpace(stderr.String()) + " (cleanup command stopped: " + ctx.Err().Error() + ")",
+				ExitCode: 124,
 			}
 		}
 

--- a/tests/e2e/cleanup.go
+++ b/tests/e2e/cleanup.go
@@ -24,7 +24,7 @@ const (
 	cleanupWaitTimeout = 5 * time.Minute
 	// cleanupNodeTimeout bounds all dependency layers when AfterSuite runs
 	// after a Ginkgo interruption.
-	// ponytail: fixed 45m cap covers five 5m waves plus delete overhead;
+	// ponytail: fixed 45m cap covers six 5m waves plus delete overhead;
 	// derive it from waves if a future dependency adds another wave.
 	cleanupNodeTimeout = 45 * time.Minute
 )
@@ -35,6 +35,7 @@ const (
 	trackedExternalEndpoint = "externalendpoint"
 	trackedImageRegistry    = "imageregistry"
 	trackedModelRegistry    = "modelregistry"
+	trackedEngine           = "engine"
 )
 
 // trackedResource records a lifecycle resource created by the current E2E
@@ -145,9 +146,10 @@ func cleanupTrackedResourcesWithContext(ctx context.Context) {
 		return
 	}
 
-	// Model registries only depend on endpoints and may be cleaned while
-	// clusters are still finishing their own deletion.
+	// Model registries and engines only depend on endpoints. Their failures are
+	// logged but do not block unrelated cluster/image-registry cleanup.
 	cleanupResourceGroup(ctx, leftover, trackedModelRegistry)
+	cleanupResourceGroup(ctx, leftover, trackedEngine)
 
 	if !cleanupResourceGroup(ctx, leftover, trackedCluster) {
 		return
@@ -163,6 +165,7 @@ func cleanupResourceGroup(ctx context.Context, resources []trackedResource, kind
 	}
 
 	deleteSucceeded := true
+	deletedResources := make([]trackedResource, 0, len(group))
 
 	for _, command := range runCleanupCommands(group, func(resource trackedResource) CLIResult {
 		return runCLIWithContext(ctx, cleanupCallTimeout,
@@ -179,16 +182,16 @@ func cleanupResourceGroup(ctx context.Context, resources []trackedResource, kind
 
 			fmt.Fprintf(GinkgoWriter, "  delete %s/%s in %s failed (exit %d): %s\n",
 				resource.Kind, resource.Name, resource.Workspace, result.ExitCode, result.Stderr)
-		}
-	}
 
-	if !deleteSucceeded {
-		return false
+			continue
+		}
+
+		deletedResources = append(deletedResources, resource)
 	}
 
 	waitSucceeded := true
 
-	for _, command := range runCleanupCommands(group, func(resource trackedResource) CLIResult {
+	for _, command := range runCleanupCommands(deletedResources, func(resource trackedResource) CLIResult {
 		return runCLIWithContext(ctx, cleanupWaitTimeout,
 			"wait", resource.Kind, resource.Name,
 			"-w", resource.Workspace,
@@ -210,7 +213,7 @@ func cleanupResourceGroup(ctx context.Context, resources []trackedResource, kind
 		}
 	}
 
-	return waitSucceeded
+	return deleteSucceeded && waitSucceeded
 }
 
 type cleanupCommandResult struct {
@@ -372,6 +375,8 @@ func canonicalTrackedKind(kind string) (string, bool) {
 		return trackedImageRegistry, true
 	case trackedModelRegistry:
 		return trackedModelRegistry, true
+	case trackedEngine:
+		return trackedEngine, true
 	default:
 		return "", false
 	}

--- a/tests/e2e/cleanup_unit_test.go
+++ b/tests/e2e/cleanup_unit_test.go
@@ -4,14 +4,21 @@ import (
 	"testing"
 )
 
-// resetTrackedForTest clears the package-level registry so each subtest
-// starts from a known state. Direct test on package-private state is fine
-// since this file is in the e2e package.
+// resetTrackedForTest clears the package-level registry both immediately and
+// when the test ends, so the registry is empty entering the test AND when
+// leaving it. The trailing reset matters: TestE2E runs in the same process
+// after these unit tests, and a leaked entry would surface as a phantom
+// resource in AfterSuite's cleanup pass.
 func resetTrackedForTest(t *testing.T) {
 	t.Helper()
-	trackedMu.Lock()
-	trackedResources = nil
-	trackedMu.Unlock()
+
+	reset := func() {
+		trackedMu.Lock()
+		trackedResources = nil
+		trackedMu.Unlock()
+	}
+	reset()
+	t.Cleanup(reset)
 }
 
 func TestTrackResource_AppendsEntry(t *testing.T) {

--- a/tests/e2e/cleanup_unit_test.go
+++ b/tests/e2e/cleanup_unit_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"testing"
+)
+
+// resetTrackedForTest clears the package-level registry so each subtest
+// starts from a known state. Direct test on package-private state is fine
+// since this file is in the e2e package.
+func resetTrackedForTest(t *testing.T) {
+	t.Helper()
+	trackedMu.Lock()
+	trackedResources = nil
+	trackedMu.Unlock()
+}
+
+func TestTrackResource_AppendsEntry(t *testing.T) {
+	resetTrackedForTest(t)
+
+	trackResource("cluster", "e2e-foo", "default")
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if len(trackedResources) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(trackedResources))
+	}
+	got := trackedResources[0]
+	if got.Kind != "cluster" || got.Name != "e2e-foo" || got.Workspace != "default" {
+		t.Fatalf("entry mismatch: %+v", got)
+	}
+}
+
+func TestTrackResource_AllowsDuplicates(t *testing.T) {
+	// Duplicate registrations should each appear separately. cleanupTracked-
+	// Resources uses --ignore-not-found, so duplicate deletes are harmless,
+	// and we prefer simple-and-correct over dedup-on-write.
+	resetTrackedForTest(t)
+
+	trackResource("cluster", "e2e-foo", "default")
+	trackResource("cluster", "e2e-foo", "default")
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if len(trackedResources) != 2 {
+		t.Fatalf("want 2 entries (dedup not expected), got %d", len(trackedResources))
+	}
+}
+
+func TestUntrackResource_RemovesByExactTriple(t *testing.T) {
+	resetTrackedForTest(t)
+
+	trackResource("cluster", "e2e-foo", "default")
+	trackResource("modelregistry", "e2e-mr", "default")
+	trackResource("imageregistry", "e2e-ir", "default")
+
+	untrackResource("modelregistry", "e2e-mr", "default")
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if len(trackedResources) != 2 {
+		t.Fatalf("want 2 entries after untrack, got %d", len(trackedResources))
+	}
+	for _, r := range trackedResources {
+		if r.Kind == "modelregistry" {
+			t.Fatalf("modelregistry should be removed, still present: %+v", r)
+		}
+	}
+}
+
+func TestUntrackResource_NoMatch_NoOp(t *testing.T) {
+	resetTrackedForTest(t)
+
+	trackResource("cluster", "e2e-foo", "default")
+
+	// Different name -> no removal.
+	untrackResource("cluster", "e2e-bar", "default")
+	// Different workspace -> no removal.
+	untrackResource("cluster", "e2e-foo", "other-ws")
+	// Different kind -> no removal.
+	untrackResource("modelregistry", "e2e-foo", "default")
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if len(trackedResources) != 1 {
+		t.Fatalf("untrack with non-matching key should be a no-op; want 1 entry, got %d", len(trackedResources))
+	}
+}
+
+func TestUntrackResource_RemovesAllMatchingDuplicates(t *testing.T) {
+	resetTrackedForTest(t)
+
+	trackResource("cluster", "e2e-foo", "default")
+	trackResource("cluster", "e2e-foo", "default")
+	trackResource("cluster", "e2e-other", "default")
+
+	untrackResource("cluster", "e2e-foo", "default")
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if len(trackedResources) != 1 {
+		t.Fatalf("want 1 entry after removing both duplicates, got %d", len(trackedResources))
+	}
+	if trackedResources[0].Name != "e2e-other" {
+		t.Fatalf("wrong remaining entry: %+v", trackedResources[0])
+	}
+}

--- a/tests/e2e/cleanup_unit_test.go
+++ b/tests/e2e/cleanup_unit_test.go
@@ -3,6 +3,9 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -196,6 +199,59 @@ func TestTestEngineName_TracksCurrentRunEngine(t *testing.T) {
 		Workspace: profileWorkspace(),
 	}]; !ok {
 		t.Fatalf("engine was not tracked: %+v", trackedResources)
+	}
+}
+
+func TestCleanupUpgradeAPIKey_UsesCapturedJWT(t *testing.T) {
+	var patchSeen bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer admin-jwt" {
+			t.Errorf("authorization = %q, want Bearer admin-jwt", r.Header.Get("Authorization"))
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[{"id":"api-key-id","metadata":{"name":"e2e-upgrade-key-123456","workspace":"default"}}]`)
+		case http.MethodPatch:
+			if r.URL.Query().Get("id") != "eq.api-key-id" {
+				t.Errorf("patch id = %q, want eq.api-key-id", r.URL.Query().Get("id"))
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read patch body: %v", err)
+			}
+			if !strings.Contains(string(body), "deletion_timestamp") {
+				t.Errorf("patch body lacks deletion_timestamp: %s", body)
+			}
+			patchSeen = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	upgradeAPIKeyCleanupMu.Lock()
+	upgradeAPIKeyState = nil
+	upgradeAPIKeyCleanupMu.Unlock()
+	t.Cleanup(func() {
+		upgradeAPIKeyCleanupMu.Lock()
+		upgradeAPIKeyState = nil
+		upgradeAPIKeyCleanupMu.Unlock()
+	})
+
+	registerUpgradeAPIKeyCleanup(server.URL, "admin-jwt", "default", "e2e-upgrade-key-123456")
+	cleanupUpgradeAPIKey()
+	cleanupUpgradeAPIKey()
+
+	if !patchSeen {
+		t.Fatal("upgrade API key cleanup did not issue PATCH")
+	}
+	upgradeAPIKeyCleanupMu.Lock()
+	defer upgradeAPIKeyCleanupMu.Unlock()
+	if upgradeAPIKeyState != nil {
+		t.Fatal("successful API key cleanup should clear owner state")
 	}
 }
 

--- a/tests/e2e/cleanup_unit_test.go
+++ b/tests/e2e/cleanup_unit_test.go
@@ -481,6 +481,44 @@ exit 0
 	}
 }
 
+func TestRunCleanupCommands_RunsSameWaveInParallel(t *testing.T) {
+	resources := []trackedResource{
+		{Kind: trackedEndpoint, Name: "e2e-first-123456", Workspace: "default"},
+		{Kind: trackedEndpoint, Name: "e2e-second-123456", Workspace: "default"},
+	}
+	started := make(chan struct{}, len(resources))
+	release := make(chan struct{})
+	defer func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}()
+
+	done := make(chan []cleanupCommandResult, 1)
+	go func() {
+		done <- runCleanupCommands(resources, func(trackedResource) CLIResult {
+			started <- struct{}{}
+			<-release
+			return CLIResult{}
+		})
+	}()
+
+	for range resources {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("cleanup commands did not start in parallel")
+		}
+	}
+	close(release)
+
+	if results := <-done; len(results) != len(resources) {
+		t.Fatalf("result count = %d, want %d", len(results), len(resources))
+	}
+}
+
 func TestRunCLIWithContext_ReturnsTimeoutExitCode(t *testing.T) {
 	useCLIForTest(t, "#!/bin/sh\nexec sleep 1\n")
 

--- a/tests/e2e/cleanup_unit_test.go
+++ b/tests/e2e/cleanup_unit_test.go
@@ -169,13 +169,33 @@ func TestTrackResource_RejectsOtherRunAndUnsupportedKind(t *testing.T) {
 	useRunIDForTest(t, "123456")
 
 	trackResource("cluster", "e2e-cluster-654321", "default")
-	trackResource("engine", "e2e-engine-123456", "default")
+	trackResource("role", "e2e-role-123456", "default")
 	trackResource("cluster", "not-e2e-123456", "default")
 
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
 	if len(trackedResources) != 0 {
 		t.Fatalf("want no ineligible resources, got %+v", trackedResources)
+	}
+}
+
+func TestTestEngineName_TracksCurrentRunEngine(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+
+	name := testEngineName("e2e-engine-test")
+	if name != "e2e-engine-test-123456" {
+		t.Fatalf("engine name = %q", name)
+	}
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if _, ok := trackedResources[trackedResource{
+		Kind:      trackedEngine,
+		Name:      name,
+		Workspace: profileWorkspace(),
+	}]; !ok {
+		t.Fatalf("engine was not tracked: %+v", trackedResources)
 	}
 }
 
@@ -214,14 +234,17 @@ metadata:
 `)
 
 	got := trackedResourcesFromManifest(path, profileWorkspace())
-	if len(got) != 2 {
-		t.Fatalf("want 2 current lifecycle resources, got %+v", got)
+	if len(got) != 3 {
+		t.Fatalf("want 3 current lifecycle resources, got %+v", got)
 	}
 	if got[0] != (trackedResource{Kind: "endpoint", Name: "e2e-endpoint-123456", Workspace: "test-workspace"}) {
 		t.Fatalf("unexpected first resource: %+v", got[0])
 	}
 	if got[1] != (trackedResource{Kind: "externalendpoint", Name: "e2e-external-123456", Workspace: profileWorkspace()}) {
 		t.Fatalf("unexpected second resource: %+v", got[1])
+	}
+	if got[2] != (trackedResource{Kind: trackedEngine, Name: "e2e-engine-123456", Workspace: "test-workspace"}) {
+		t.Fatalf("unexpected third resource: %+v", got[2])
 	}
 }
 
@@ -423,6 +446,7 @@ func TestCleanupTrackedResources_DeletesInDependencyOrder(t *testing.T) {
 	useCLIForTest(t, fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nexit 0\n", logPath))
 
 	trackResource("modelregistry", "e2e-registry-123456", "default")
+	trackResource("engine", "e2e-engine-123456", "default")
 	trackResource("cluster", "e2e-cluster-123456", "default")
 	trackResource("endpoint", "e2e-endpoint-123456", "default")
 
@@ -440,12 +464,14 @@ func TestCleanupTrackedResources_DeletesInDependencyOrder(t *testing.T) {
 	endpointWaitIndex := strings.Index(output, "wait endpoint e2e-endpoint-123456")
 	registryIndex := strings.Index(output, "delete modelregistry e2e-registry-123456")
 	registryWaitIndex := strings.Index(output, "wait modelregistry e2e-registry-123456")
+	engineIndex := strings.Index(output, "delete engine e2e-engine-123456")
+	engineWaitIndex := strings.Index(output, "wait engine e2e-engine-123456")
 	clusterIndex := strings.Index(output, "delete cluster e2e-cluster-123456")
 	clusterWaitIndex := strings.Index(output, "wait cluster e2e-cluster-123456")
-	if endpointIndex < 0 || endpointWaitIndex < 0 || registryIndex < 0 || registryWaitIndex < 0 || clusterIndex < 0 || clusterWaitIndex < 0 {
+	if endpointIndex < 0 || endpointWaitIndex < 0 || registryIndex < 0 || registryWaitIndex < 0 || engineIndex < 0 || engineWaitIndex < 0 || clusterIndex < 0 || clusterWaitIndex < 0 {
 		t.Fatalf("missing cleanup command(s): %q", output)
 	}
-	if endpointIndex > endpointWaitIndex || endpointWaitIndex > registryIndex || registryIndex > registryWaitIndex || registryWaitIndex > clusterIndex || clusterIndex > clusterWaitIndex {
+	if endpointIndex > endpointWaitIndex || endpointWaitIndex > registryIndex || registryIndex > registryWaitIndex || registryWaitIndex > engineIndex || engineIndex > engineWaitIndex || engineWaitIndex > clusterIndex || clusterIndex > clusterWaitIndex {
 		t.Fatalf("cleanup order is not dependency-safe: %q", output)
 	}
 }
@@ -463,6 +489,7 @@ exit 0
 `, logPath))
 
 	trackResource("endpoint", "e2e-endpoint-123456", "default")
+	trackResource("engine", "e2e-engine-123456", "default")
 	trackResource("cluster", "e2e-cluster-123456", "default")
 	trackResource("imageregistry", "e2e-image-registry-123456", "default")
 
@@ -476,8 +503,80 @@ exit 0
 	if strings.Contains(output, "delete cluster e2e-cluster-123456") {
 		t.Fatalf("cluster cleanup must wait for endpoint cleanup success: %q", output)
 	}
+	if strings.Contains(output, "delete engine e2e-engine-123456") {
+		t.Fatalf("engine cleanup must wait for endpoint cleanup success: %q", output)
+	}
 	if strings.Contains(output, "delete imageregistry e2e-image-registry-123456") {
 		t.Fatalf("registry cleanup must wait for cluster cleanup success: %q", output)
+	}
+}
+
+func TestCleanupTrackedResources_WaitsSuccessfulDeletesAfterPartialFailure(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	logPath := filepath.Join(t.TempDir(), "cli.log")
+	useCLIForTest(t, fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$*" in
+  *"delete endpoint e2e-failed-123456"*) exit 1 ;;
+esac
+exit 0
+`, logPath))
+
+	trackResource("endpoint", "e2e-successful-123456", "default")
+	trackResource("endpoint", "e2e-failed-123456", "default")
+	trackResource("cluster", "e2e-cluster-123456", "default")
+
+	cleanupTrackedResourcesWithContext(context.Background())
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake CLI log: %v", err)
+	}
+	output := string(data)
+	if !strings.Contains(output, "wait endpoint e2e-successful-123456") {
+		t.Fatalf("successful delete was not waited: %q", output)
+	}
+	if strings.Contains(output, "wait endpoint e2e-failed-123456") {
+		t.Fatalf("failed delete must not be waited: %q", output)
+	}
+	if strings.Contains(output, "delete cluster e2e-cluster-123456") {
+		t.Fatalf("cluster cleanup must stop after partial endpoint delete failure: %q", output)
+	}
+}
+
+func TestCleanupTrackedResources_ContinuesAfterIndependentDeleteFailure(t *testing.T) {
+	for _, kind := range []string{trackedModelRegistry, trackedEngine} {
+		t.Run(kind, func(t *testing.T) {
+			resetTrackedForTest(t)
+			useRunIDForTest(t, "123456")
+			logPath := filepath.Join(t.TempDir(), "cli.log")
+			useCLIForTest(t, fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$*" in
+  *"delete %s e2e-%s-123456"*) exit 1 ;;
+esac
+exit 0
+`, logPath, kind, kind))
+
+			trackResource(kind, "e2e-"+kind+"-123456", "default")
+			trackResource(trackedCluster, "e2e-cluster-123456", "default")
+			trackResource(trackedImageRegistry, "e2e-image-registry-123456", "default")
+
+			cleanupTrackedResourcesWithContext(context.Background())
+
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("read fake CLI log: %v", err)
+			}
+			output := string(data)
+			if !strings.Contains(output, "delete cluster e2e-cluster-123456") {
+				t.Fatalf("cluster cleanup should continue after %s failure: %q", kind, output)
+			}
+			if !strings.Contains(output, "delete imageregistry e2e-image-registry-123456") {
+				t.Fatalf("image registry cleanup should continue after %s failure: %q", kind, output)
+			}
+		})
 	}
 }
 

--- a/tests/e2e/cleanup_unit_test.go
+++ b/tests/e2e/cleanup_unit_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -314,6 +315,35 @@ metadata:
 	}
 }
 
+func TestRunCLIWithStdin_ForwardsInputArgsAndExitCode(t *testing.T) {
+	argsPath := filepath.Join(t.TempDir(), "args.txt")
+	stdinPath := filepath.Join(t.TempDir(), "stdin.txt")
+	useCLIForTest(t, fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" > %q\ncat > %q\nexit 7\n", argsPath, stdinPath))
+
+	result := RunCLIWithStdin("input", "get", "cluster")
+	if result.ExitCode != 7 {
+		t.Fatalf("exit code = %d, want 7; result=%+v", result.ExitCode, result)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	for _, want := range []string{"--server-url", "--api-key", "--insecure", "get cluster"} {
+		if !strings.Contains(string(args), want) {
+			t.Fatalf("arguments %q do not contain %q", args, want)
+		}
+	}
+
+	stdin, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	if string(stdin) != "input" {
+		t.Fatalf("stdin = %q, want %q", stdin, "input")
+	}
+}
+
 func TestReconcileTrackedResourcesAfterCommand(t *testing.T) {
 	resetTrackedForTest(t)
 	useRunIDForTest(t, "123456")
@@ -386,28 +416,6 @@ metadata:
 	}
 }
 
-func TestSnapshotTrackedResources_OrdersDependentsFirst(t *testing.T) {
-	resetTrackedForTest(t)
-	useRunIDForTest(t, "123456")
-
-	trackResource("modelregistry", "e2e-registry-123456", "default")
-	trackResource("imageregistry", "e2e-image-registry-123456", "default")
-	trackResource("cluster", "e2e-cluster-123456", "default")
-	trackResource("externalendpoint", "e2e-external-123456", "default")
-	trackResource("endpoint", "e2e-endpoint-123456", "default")
-
-	got := snapshotTrackedResources()
-	wantKinds := []string{"endpoint", "externalendpoint", "cluster", "imageregistry", "modelregistry"}
-	if len(got) != len(wantKinds) {
-		t.Fatalf("want %d resources, got %+v", len(wantKinds), got)
-	}
-	for i, want := range wantKinds {
-		if got[i].Kind != want {
-			t.Fatalf("resource %d kind = %q, want %q; all=%+v", i, got[i].Kind, want, got)
-		}
-	}
-}
-
 func TestCleanupTrackedResources_DeletesInDependencyOrder(t *testing.T) {
 	resetTrackedForTest(t)
 	useRunIDForTest(t, "123456")
@@ -418,7 +426,7 @@ func TestCleanupTrackedResources_DeletesInDependencyOrder(t *testing.T) {
 	trackResource("cluster", "e2e-cluster-123456", "default")
 	trackResource("endpoint", "e2e-endpoint-123456", "default")
 
-	cleanupTrackedResources()
+	cleanupTrackedResourcesWithContext(context.Background())
 	if trackedResourceCount() != 0 {
 		t.Fatalf("cleanup should clear current-process registry")
 	}
@@ -458,7 +466,7 @@ exit 0
 	trackResource("cluster", "e2e-cluster-123456", "default")
 	trackResource("imageregistry", "e2e-image-registry-123456", "default")
 
-	cleanupTrackedResources()
+	cleanupTrackedResourcesWithContext(context.Background())
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -473,10 +481,10 @@ exit 0
 	}
 }
 
-func TestRunCLIWithTimeout_ReturnsTimeoutExitCode(t *testing.T) {
+func TestRunCLIWithContext_ReturnsTimeoutExitCode(t *testing.T) {
 	useCLIForTest(t, "#!/bin/sh\nexec sleep 1\n")
 
-	result := runCLIWithTimeout(10*time.Millisecond, "get", "cluster")
+	result := runCLIWithContext(context.Background(), 10*time.Millisecond, "get", "cluster")
 	if result.ExitCode != 124 {
 		t.Fatalf("timeout exit code = %d, want 124; result=%+v", result.ExitCode, result)
 	}

--- a/tests/e2e/cleanup_unit_test.go
+++ b/tests/e2e/cleanup_unit_test.go
@@ -1,7 +1,12 @@
 package e2e
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 // resetTrackedForTest clears the package-level registry both immediately and
@@ -14,60 +19,103 @@ func resetTrackedForTest(t *testing.T) {
 
 	reset := func() {
 		trackedMu.Lock()
-		trackedResources = nil
+		trackedResources = make(map[trackedResource]struct{})
 		trackedMu.Unlock()
 	}
 	reset()
 	t.Cleanup(reset)
 }
 
+func useRunIDForTest(t *testing.T, runID string) {
+	t.Helper()
+
+	original := Cfg.RunID
+	Cfg.RunID = runID
+	t.Cleanup(func() {
+		Cfg.RunID = original
+	})
+}
+
+func writeManifestForTest(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "resources.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	return path
+}
+
+func useCLIForTest(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "neutree-cli")
+	if err := os.WriteFile(path, []byte(content), 0o700); err != nil {
+		t.Fatalf("write fake CLI: %v", err)
+	}
+
+	original := cliBinary
+	cliBinary = path
+	t.Cleanup(func() {
+		cliBinary = original
+	})
+
+	return path
+}
+
 func TestTrackResource_AppendsEntry(t *testing.T) {
 	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
 
-	trackResource("cluster", "e2e-foo", "default")
+	trackResource("cluster", "e2e-foo-123456", "default")
 
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
 	if len(trackedResources) != 1 {
 		t.Fatalf("want 1 entry, got %d", len(trackedResources))
 	}
-	got := trackedResources[0]
-	if got.Kind != "cluster" || got.Name != "e2e-foo" || got.Workspace != "default" {
-		t.Fatalf("entry mismatch: %+v", got)
+	found := false
+	for got := range trackedResources {
+		if got.Kind == "cluster" && got.Name == "e2e-foo-123456" && got.Workspace == "default" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("entry mismatch: %+v", trackedResources)
 	}
 }
 
-func TestTrackResource_AllowsDuplicates(t *testing.T) {
-	// Duplicate registrations should each appear separately. cleanupTracked-
-	// Resources uses --ignore-not-found, so duplicate deletes are harmless,
-	// and we prefer simple-and-correct over dedup-on-write.
+func TestTrackResource_DeduplicatesExactResource(t *testing.T) {
 	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
 
-	trackResource("cluster", "e2e-foo", "default")
-	trackResource("cluster", "e2e-foo", "default")
+	trackResource("cluster", "e2e-foo-123456", "default")
+	trackResource("Cluster", "e2e-foo-123456", "default")
 
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
-	if len(trackedResources) != 2 {
-		t.Fatalf("want 2 entries (dedup not expected), got %d", len(trackedResources))
+	if len(trackedResources) != 1 {
+		t.Fatalf("want 1 deduplicated entry, got %d", len(trackedResources))
 	}
 }
 
 func TestUntrackResource_RemovesByExactTriple(t *testing.T) {
 	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
 
-	trackResource("cluster", "e2e-foo", "default")
-	trackResource("modelregistry", "e2e-mr", "default")
-	trackResource("imageregistry", "e2e-ir", "default")
+	trackResource("cluster", "e2e-foo-123456", "default")
+	trackResource("modelregistry", "e2e-mr-123456", "default")
+	trackResource("imageregistry", "e2e-ir-123456", "default")
 
-	untrackResource("modelregistry", "e2e-mr", "default")
+	untrackResource("modelregistry", "e2e-mr-123456", "default")
 
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
 	if len(trackedResources) != 2 {
 		t.Fatalf("want 2 entries after untrack, got %d", len(trackedResources))
 	}
-	for _, r := range trackedResources {
+	for r := range trackedResources {
 		if r.Kind == "modelregistry" {
 			t.Fatalf("modelregistry should be removed, still present: %+v", r)
 		}
@@ -76,15 +124,16 @@ func TestUntrackResource_RemovesByExactTriple(t *testing.T) {
 
 func TestUntrackResource_NoMatch_NoOp(t *testing.T) {
 	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
 
-	trackResource("cluster", "e2e-foo", "default")
+	trackResource("cluster", "e2e-foo-123456", "default")
 
 	// Different name -> no removal.
-	untrackResource("cluster", "e2e-bar", "default")
+	untrackResource("cluster", "e2e-bar-123456", "default")
 	// Different workspace -> no removal.
-	untrackResource("cluster", "e2e-foo", "other-ws")
+	untrackResource("cluster", "e2e-foo-123456", "other-ws")
 	// Different kind -> no removal.
-	untrackResource("modelregistry", "e2e-foo", "default")
+	untrackResource("modelregistry", "e2e-foo-123456", "default")
 
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
@@ -95,19 +144,340 @@ func TestUntrackResource_NoMatch_NoOp(t *testing.T) {
 
 func TestUntrackResource_RemovesAllMatchingDuplicates(t *testing.T) {
 	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
 
-	trackResource("cluster", "e2e-foo", "default")
-	trackResource("cluster", "e2e-foo", "default")
-	trackResource("cluster", "e2e-other", "default")
+	trackResource("cluster", "e2e-foo-123456", "default")
+	trackResource("cluster", "e2e-other-123456", "default")
 
-	untrackResource("cluster", "e2e-foo", "default")
+	untrackResource("cluster", "e2e-foo-123456", "default")
 
 	trackedMu.Lock()
 	defer trackedMu.Unlock()
 	if len(trackedResources) != 1 {
-		t.Fatalf("want 1 entry after removing both duplicates, got %d", len(trackedResources))
+		t.Fatalf("want 1 entry after untrack, got %d", len(trackedResources))
 	}
-	if trackedResources[0].Name != "e2e-other" {
-		t.Fatalf("wrong remaining entry: %+v", trackedResources[0])
+	for resource := range trackedResources {
+		if resource.Name != "e2e-other-123456" {
+			t.Fatalf("wrong remaining entry: %+v", resource)
+		}
+	}
+}
+
+func TestTrackResource_RejectsOtherRunAndUnsupportedKind(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+
+	trackResource("cluster", "e2e-cluster-654321", "default")
+	trackResource("engine", "e2e-engine-123456", "default")
+	trackResource("cluster", "not-e2e-123456", "default")
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if len(trackedResources) != 0 {
+		t.Fatalf("want no ineligible resources, got %+v", trackedResources)
+	}
+}
+
+func TestTrackedResourcesFromManifest_SelectsCurrentLifecycleResources(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	path := writeManifestForTest(t, `
+apiVersion: v1
+kind: Endpoint
+metadata:
+  name: e2e-endpoint-123456
+  workspace: test-workspace
+---
+apiVersion: v1
+kind: ExternalEndpoint
+metadata:
+  name: e2e-external-123456
+---
+apiVersion: v1
+kind: Cluster
+metadata:
+  name: e2e-cluster-654321
+  workspace: test-workspace
+---
+apiVersion: v1
+kind: Engine
+metadata:
+  name: e2e-engine-123456
+  workspace: test-workspace
+---
+apiVersion: v1
+kind: ImageRegistry
+metadata:
+  name: not-e2e-123456
+  workspace: test-workspace
+`)
+
+	got := trackedResourcesFromManifest(path, profileWorkspace())
+	if len(got) != 2 {
+		t.Fatalf("want 2 current lifecycle resources, got %+v", got)
+	}
+	if got[0] != (trackedResource{Kind: "endpoint", Name: "e2e-endpoint-123456", Workspace: "test-workspace"}) {
+		t.Fatalf("unexpected first resource: %+v", got[0])
+	}
+	if got[1] != (trackedResource{Kind: "externalendpoint", Name: "e2e-external-123456", Workspace: profileWorkspace()}) {
+		t.Fatalf("unexpected second resource: %+v", got[1])
+	}
+}
+
+func TestTrackResourcesForApplyCommand_DeduplicatesMultiDocumentManifest(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	path := writeManifestForTest(t, `
+apiVersion: v1
+kind: ModelRegistry
+metadata:
+  name: e2e-registry-123456
+  workspace: default
+---
+apiVersion: v1
+kind: ModelRegistry
+metadata:
+  name: e2e-registry-123456
+  workspace: default
+`)
+
+	trackResourcesForApplyCommand([]string{"apply", "-f", path})
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if len(trackedResources) != 1 {
+		t.Fatalf("want 1 deduplicated tracked resource, got %+v", trackedResources)
+	}
+}
+
+func TestTrackedResourcesFromManifest_UsesCommandWorkspaceFallback(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	path := writeManifestForTest(t, `
+apiVersion: v1
+kind: Endpoint
+metadata:
+  name: e2e-endpoint-123456
+`)
+
+	got := trackedResourcesFromManifest(path, "other-workspace")
+	if len(got) != 1 {
+		t.Fatalf("want 1 tracked resource, got %+v", got)
+	}
+	if got[0] != (trackedResource{
+		Kind:      "endpoint",
+		Name:      "e2e-endpoint-123456",
+		Workspace: "other-workspace",
+	}) {
+		t.Fatalf("unexpected resource: %+v", got[0])
+	}
+}
+
+func TestTrackedResourcesFromManifest_RejectsMalformedManifest(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	path := writeManifestForTest(t, "kind: Endpoint\nmetadata: [")
+
+	if got := trackedResourcesFromManifest(path, profileWorkspace()); len(got) != 0 {
+		t.Fatalf("malformed manifest should not register resources, got %+v", got)
+	}
+}
+
+func TestRunCLIWithStdin_TracksApplyAndWaitsForConfirmedDelete(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	useCLIForTest(t, "#!/bin/sh\nexit 0\n")
+	path := writeManifestForTest(t, `
+apiVersion: v1
+kind: Endpoint
+metadata:
+  name: e2e-endpoint-123456
+  workspace: default
+`)
+
+	result := RunCLI("apply", "--file="+path)
+	if result.ExitCode != 0 {
+		t.Fatalf("apply result = %+v", result)
+	}
+	if trackedResourceCount() != 1 {
+		t.Fatalf("apply should pre-register current resource")
+	}
+
+	result = RunCLI("delete", "endpoint", "e2e-endpoint-123456", "-w", "default", "--wait=false")
+	if result.ExitCode != 0 || trackedResourceCount() != 1 {
+		t.Fatalf("async delete should retain resource, result=%+v count=%d", result, trackedResourceCount())
+	}
+
+	result = RunCLI("wait", "endpoint", "e2e-endpoint-123456", "-w", "default", "--for=delete")
+	if result.ExitCode != 0 || trackedResourceCount() != 0 {
+		t.Fatalf("successful delete wait should untrack resource, result=%+v count=%d", result, trackedResourceCount())
+	}
+}
+
+func TestReconcileTrackedResourcesAfterCommand(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+
+	resource := trackedResource{Kind: "endpoint", Name: "e2e-endpoint-123456", Workspace: "default"}
+	trackResource(resource.Kind, resource.Name, resource.Workspace)
+
+	reconcileTrackedResourcesAfterCommand([]string{"delete", "endpoint", resource.Name, "-w", resource.Workspace})
+	if trackedResourceCount() != 0 {
+		t.Fatalf("synchronous delete should untrack resource")
+	}
+
+	trackResource(resource.Kind, resource.Name, resource.Workspace)
+	reconcileTrackedResourcesAfterCommand([]string{"delete", "endpoint", resource.Name, "-w", resource.Workspace, "--wait=false"})
+	if trackedResourceCount() != 1 {
+		t.Fatalf("asynchronous delete should retain resource until wait succeeds")
+	}
+
+	reconcileTrackedResourcesAfterCommand([]string{"wait", "endpoint", resource.Name, "-w", resource.Workspace, "--for", "delete"})
+	if trackedResourceCount() != 0 {
+		t.Fatalf("successful delete wait should untrack resource")
+	}
+}
+
+func TestReconcileTrackedResourcesAfterManifestDelete(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	path := writeManifestForTest(t, `
+apiVersion: v1
+kind: ModelRegistry
+metadata:
+  name: e2e-registry-123456
+  workspace: default
+`)
+
+	trackResourcesForApplyCommand([]string{"apply", "-f", path})
+	if trackedResourceCount() != 1 {
+		t.Fatalf("apply should register manifest resource")
+	}
+
+	reconcileTrackedResourcesAfterCommand([]string{"delete", "-f", path, "--force"})
+	if trackedResourceCount() != 0 {
+		t.Fatalf("successful manifest delete should untrack resource")
+	}
+}
+
+func TestTrackResourcesForApplyCommand_UsesCommandWorkspaceFallback(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	path := writeManifestForTest(t, `
+apiVersion: v1
+kind: Endpoint
+metadata:
+  name: e2e-endpoint-123456
+`)
+
+	trackResourcesForApplyCommand([]string{"apply", "-f", path, "-w", "other-workspace"})
+	if trackedResourceCount() != 1 {
+		t.Fatalf("apply should register resource with command workspace fallback")
+	}
+
+	trackedMu.Lock()
+	defer trackedMu.Unlock()
+	if _, ok := trackedResources[trackedResource{
+		Kind:      "endpoint",
+		Name:      "e2e-endpoint-123456",
+		Workspace: "other-workspace",
+	}]; !ok {
+		t.Fatalf("tracked resources = %+v", trackedResources)
+	}
+}
+
+func TestSnapshotTrackedResources_OrdersDependentsFirst(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+
+	trackResource("modelregistry", "e2e-registry-123456", "default")
+	trackResource("imageregistry", "e2e-image-registry-123456", "default")
+	trackResource("cluster", "e2e-cluster-123456", "default")
+	trackResource("externalendpoint", "e2e-external-123456", "default")
+	trackResource("endpoint", "e2e-endpoint-123456", "default")
+
+	got := snapshotTrackedResources()
+	wantKinds := []string{"endpoint", "externalendpoint", "cluster", "imageregistry", "modelregistry"}
+	if len(got) != len(wantKinds) {
+		t.Fatalf("want %d resources, got %+v", len(wantKinds), got)
+	}
+	for i, want := range wantKinds {
+		if got[i].Kind != want {
+			t.Fatalf("resource %d kind = %q, want %q; all=%+v", i, got[i].Kind, want, got)
+		}
+	}
+}
+
+func TestCleanupTrackedResources_DeletesInDependencyOrder(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	logPath := filepath.Join(t.TempDir(), "cli.log")
+	useCLIForTest(t, fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nexit 0\n", logPath))
+
+	trackResource("modelregistry", "e2e-registry-123456", "default")
+	trackResource("cluster", "e2e-cluster-123456", "default")
+	trackResource("endpoint", "e2e-endpoint-123456", "default")
+
+	cleanupTrackedResources()
+	if trackedResourceCount() != 0 {
+		t.Fatalf("cleanup should clear current-process registry")
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake CLI log: %v", err)
+	}
+	output := string(data)
+	endpointIndex := strings.Index(output, "delete endpoint e2e-endpoint-123456")
+	endpointWaitIndex := strings.Index(output, "wait endpoint e2e-endpoint-123456")
+	registryIndex := strings.Index(output, "delete modelregistry e2e-registry-123456")
+	registryWaitIndex := strings.Index(output, "wait modelregistry e2e-registry-123456")
+	clusterIndex := strings.Index(output, "delete cluster e2e-cluster-123456")
+	clusterWaitIndex := strings.Index(output, "wait cluster e2e-cluster-123456")
+	if endpointIndex < 0 || endpointWaitIndex < 0 || registryIndex < 0 || registryWaitIndex < 0 || clusterIndex < 0 || clusterWaitIndex < 0 {
+		t.Fatalf("missing cleanup command(s): %q", output)
+	}
+	if endpointIndex > endpointWaitIndex || endpointWaitIndex > registryIndex || registryIndex > registryWaitIndex || registryWaitIndex > clusterIndex || clusterIndex > clusterWaitIndex {
+		t.Fatalf("cleanup order is not dependency-safe: %q", output)
+	}
+}
+
+func TestCleanupTrackedResources_StopsDependentCleanupAfterEndpointDeleteFailure(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	logPath := filepath.Join(t.TempDir(), "cli.log")
+	useCLIForTest(t, fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$*" in
+  *"delete endpoint e2e-endpoint-123456"*) exit 1 ;;
+esac
+exit 0
+`, logPath))
+
+	trackResource("endpoint", "e2e-endpoint-123456", "default")
+	trackResource("cluster", "e2e-cluster-123456", "default")
+	trackResource("imageregistry", "e2e-image-registry-123456", "default")
+
+	cleanupTrackedResources()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake CLI log: %v", err)
+	}
+	output := string(data)
+	if strings.Contains(output, "delete cluster e2e-cluster-123456") {
+		t.Fatalf("cluster cleanup must wait for endpoint cleanup success: %q", output)
+	}
+	if strings.Contains(output, "delete imageregistry e2e-image-registry-123456") {
+		t.Fatalf("registry cleanup must wait for cluster cleanup success: %q", output)
+	}
+}
+
+func TestRunCLIWithTimeout_ReturnsTimeoutExitCode(t *testing.T) {
+	useCLIForTest(t, "#!/bin/sh\nexec sleep 1\n")
+
+	result := runCLIWithTimeout(10*time.Millisecond, "get", "cluster")
+	if result.ExitCode != 124 {
+		t.Fatalf("timeout exit code = %d, want 124; result=%+v", result.ExitCode, result)
 	}
 }

--- a/tests/e2e/cleanup_unit_test.go
+++ b/tests/e2e/cleanup_unit_test.go
@@ -307,6 +307,25 @@ func TestTrackedResourcesFromManifest_RejectsMalformedManifest(t *testing.T) {
 	}
 }
 
+func TestTrackedResourcesFromManifest_PreservesEntriesBeforeParseError(t *testing.T) {
+	resetTrackedForTest(t)
+	useRunIDForTest(t, "123456")
+	path := writeManifestForTest(t, `
+apiVersion: v1
+kind: Endpoint
+metadata:
+  name: e2e-endpoint-123456
+---
+kind: Endpoint
+metadata: [
+`)
+
+	got := trackedResourcesFromManifest(path, profileWorkspace())
+	if len(got) != 1 || got[0].Name != "e2e-endpoint-123456" {
+		t.Fatalf("valid entries before parse error were lost: %+v", got)
+	}
+}
+
 func TestRunCLIWithStdin_TracksApplyAndWaitsForConfirmedDelete(t *testing.T) {
 	resetTrackedForTest(t)
 	useRunIDForTest(t, "123456")
@@ -613,6 +632,47 @@ func TestRunCleanupCommands_RunsSameWaveInParallel(t *testing.T) {
 	}
 	close(release)
 
+	if results := <-done; len(results) != len(resources) {
+		t.Fatalf("result count = %d, want %d", len(results), len(resources))
+	}
+}
+
+func TestRunCleanupCommands_BoundsSameWaveWorkers(t *testing.T) {
+	resources := make([]trackedResource, cleanupWorkerLimit+1)
+	started := make(chan struct{}, len(resources))
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+
+	done := make(chan []cleanupCommandResult, 1)
+	go func() {
+		done <- runCleanupCommands(resources, func(trackedResource) CLIResult {
+			started <- struct{}{}
+			<-release
+			return CLIResult{}
+		})
+	}()
+
+	for i := 0; i < cleanupWorkerLimit; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("cleanup worker did not start")
+		}
+	}
+
+	select {
+	case <-started:
+		t.Fatal("cleanup exceeded its worker limit")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	released = true
 	if results := <-done; len(results) != len(resources) {
 		t.Fatalf("result count = %d, want %d", len(results), len(resources))
 	}

--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -10,12 +10,14 @@ import (
 	"strings"
 )
 
+const runIDUpperBound int64 = 1_000_000_000_000_000_000
+
 // E2EConfig holds infrastructure-level configuration that is not part of
 // the test profile. Test-specific config lives in profile.go.
 type E2EConfig struct {
 	ServerURL string // NEUTREE_SERVER_URL (required)
 	APIKey    string // NEUTREE_API_KEY (required)
-	RunID     string // auto-generated 6-digit random suffix for resource name uniqueness
+	RunID     string // auto-generated 18-digit random suffix for resource ownership
 }
 
 // Cfg is the global e2e configuration, loaded once at package init.
@@ -33,12 +35,12 @@ func loadConfig() *E2EConfig {
 }
 
 func generateRunID() string {
-	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	n, err := rand.Int(rand.Reader, big.NewInt(runIDUpperBound))
 	if err != nil {
-		return "000000"
+		panic(fmt.Sprintf("generate RunID: %v", err))
 	}
 
-	return fmt.Sprintf("%06d", n.Int64())
+	return fmt.Sprintf("%018d", n.Int64())
 }
 
 // loadDotEnv loads a .env file if present. It does NOT override existing env vars.

--- a/tests/e2e/config_test.go
+++ b/tests/e2e/config_test.go
@@ -1,0 +1,42 @@
+package e2e
+
+import (
+	cryptorand "crypto/rand"
+	"errors"
+	"testing"
+)
+
+type failingRunIDReader struct{}
+
+func (failingRunIDReader) Read([]byte) (int, error) {
+	return 0, errors.New("randomness unavailable")
+}
+
+func TestGenerateRunID_Uses18DigitSuffix(t *testing.T) {
+	runID := generateRunID()
+	if len(runID) != 18 {
+		t.Fatalf("RunID length = %d, want 18; value=%q", len(runID), runID)
+	}
+
+	for _, character := range runID {
+		if character < '0' || character > '9' {
+			t.Fatalf("RunID contains non-digit %q in %q", character, runID)
+		}
+	}
+}
+
+func TestGenerateRunID_PanicsWhenRandomnessUnavailable(t *testing.T) {
+	originalReader := cryptorand.Reader
+	cryptorand.Reader = failingRunIDReader{}
+	t.Cleanup(func() {
+		cryptorand.Reader = originalReader
+	})
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("generateRunID should fail without cryptographic randomness")
+		}
+	}()
+
+	generateRunID()
+}

--- a/tests/e2e/cp_upgrade_test.go
+++ b/tests/e2e/cp_upgrade_test.go
@@ -1,10 +1,16 @@
 package e2e
 
 import (
+	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,7 +41,88 @@ func deleteUpgradeAPIKey(serverURL, jwt, workspace, name string) error {
 		return fmt.Errorf("api key %q response has no id", name)
 	}
 
-	return apiClient.Generic.Delete("ApiKey", id, workspace, name, neutreeclient.DeleteOptions{})
+	var resource struct {
+		Metadata map[string]any `json:"metadata"`
+	}
+	if err := json.Unmarshal(data, &resource); err != nil {
+		return fmt.Errorf("api key %q response has invalid metadata: %w", name, err)
+	}
+	if resource.Metadata == nil {
+		return fmt.Errorf("api key %q response has no metadata", name)
+	}
+
+	resource.Metadata["deletion_timestamp"] = time.Now().UTC().Format(time.RFC3339)
+	payload, err := json.Marshal(map[string]any{"metadata": resource.Metadata})
+	if err != nil {
+		return fmt.Errorf("marshal api key %q delete payload: %w", name, err)
+	}
+
+	endpoint := strings.TrimRight(serverURL, "/") + "/api/v1/api_keys?id=eq." + url.QueryEscape(id)
+	req, err := http.NewRequest(http.MethodPatch, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("build api key %q delete request: %w", name, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Content-Type", "application/json")
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()      //nolint:errcheck
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	resp, err := (&http.Client{Timeout: 30 * time.Second, Transport: transport}).Do(req)
+	if err != nil {
+		return fmt.Errorf("delete api key %q: %w", name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete api key %q returned HTTP %d: %s", name, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	return nil
+}
+
+type upgradeAPIKeyCleanup struct {
+	serverURL string
+	jwt       string
+	workspace string
+	name      string
+}
+
+var (
+	upgradeAPIKeyCleanupMu sync.Mutex
+	upgradeAPIKeyState     *upgradeAPIKeyCleanup
+)
+
+func registerUpgradeAPIKeyCleanup(serverURL, jwt, workspace, name string) {
+	upgradeAPIKeyCleanupMu.Lock()
+	defer upgradeAPIKeyCleanupMu.Unlock()
+
+	upgradeAPIKeyState = &upgradeAPIKeyCleanup{
+		serverURL: serverURL,
+		jwt:       jwt,
+		workspace: workspace,
+		name:      name,
+	}
+}
+
+func cleanupUpgradeAPIKey() {
+	upgradeAPIKeyCleanupMu.Lock()
+	state := upgradeAPIKeyState
+	upgradeAPIKeyCleanupMu.Unlock()
+	if state == nil {
+		return
+	}
+
+	if err := deleteUpgradeAPIKey(state.serverURL, state.jwt, state.workspace, state.name); err != nil {
+		fmt.Fprintf(GinkgoWriter, "failed to delete upgrade API key %s: %v\n", state.name, err)
+		return
+	}
+
+	upgradeAPIKeyCleanupMu.Lock()
+	if upgradeAPIKeyState == state {
+		upgradeAPIKeyState = nil
+	}
+	upgradeAPIKeyCleanupMu.Unlock()
 }
 
 var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgrade"), func() {
@@ -53,10 +140,8 @@ var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgra
 		mrName         string
 
 		// Saved Cfg values, restored in AfterAll after cleanup
-		origServerURL  string
-		origAPIKey     string
-		upgradeJWT     string
-		upgradeKeyName string
+		origServerURL string
+		origAPIKey    string
 
 		// Pre-upgrade snapshots for spec comparison
 		preSSHCluster v1.Cluster
@@ -122,8 +207,8 @@ var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgra
 		Expect(jwt).NotTo(BeEmpty(), "admin login should return JWT")
 
 		// Create a real API key (sk_xxx) via PostgREST RPC — works with both CLI and Kong
-		upgradeJWT = jwt
-		upgradeKeyName = "e2e-upgrade-key-" + Cfg.RunID
+		upgradeKeyName := "e2e-upgrade-key-" + Cfg.RunID
+		registerUpgradeAPIKeyCleanup(cph.APIURL(), jwt, profileWorkspace(), upgradeKeyName)
 		apiKey := createAPIKey(cph.APIURL(), jwt, profileWorkspace(), upgradeKeyName)
 		Cfg.APIKey = apiKey
 
@@ -202,11 +287,7 @@ var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgra
 		RunCLI("delete", "modelregistry", mrName,
 			"-w", profileWorkspace(), "--force", "--ignore-not-found")
 
-		if upgradeJWT != "" && upgradeKeyName != "" {
-			if err := deleteUpgradeAPIKey(cph.APIURL(), upgradeJWT, profileWorkspace(), upgradeKeyName); err != nil {
-				fmt.Fprintf(GinkgoWriter, "failed to delete upgrade API key %s: %v\n", upgradeKeyName, err)
-			}
-		}
+		cleanupUpgradeAPIKey()
 
 		cph.CleanAll()
 

--- a/tests/e2e/cp_upgrade_test.go
+++ b/tests/e2e/cp_upgrade_test.go
@@ -11,7 +11,32 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	neutreeclient "github.com/neutree-ai/neutree/pkg/client"
 )
+
+func deleteUpgradeAPIKey(serverURL, jwt, workspace, name string) error {
+	apiClient := neutreeclient.NewClient(serverURL,
+		neutreeclient.WithAPIKey("Bearer "+jwt),
+		neutreeclient.WithInsecureSkipVerify(),
+		neutreeclient.WithTimeout(30*time.Second),
+	)
+
+	data, err := apiClient.Generic.Get("ApiKey", workspace, name)
+	if err != nil {
+		if neutreeclient.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	id := neutreeclient.ExtractID(data)
+	if id == "" {
+		return fmt.Errorf("api key %q response has no id", name)
+	}
+
+	return apiClient.Generic.Delete("ApiKey", id, workspace, name, neutreeclient.DeleteOptions{})
+}
 
 var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgrade"), func() {
 	var (
@@ -28,8 +53,10 @@ var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgra
 		mrName         string
 
 		// Saved Cfg values, restored in AfterAll after cleanup
-		origServerURL string
-		origAPIKey    string
+		origServerURL  string
+		origAPIKey     string
+		upgradeJWT     string
+		upgradeKeyName string
 
 		// Pre-upgrade snapshots for spec comparison
 		preSSHCluster v1.Cluster
@@ -95,7 +122,9 @@ var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgra
 		Expect(jwt).NotTo(BeEmpty(), "admin login should return JWT")
 
 		// Create a real API key (sk_xxx) via PostgREST RPC — works with both CLI and Kong
-		apiKey := createAPIKey(cph.APIURL(), jwt, profileWorkspace(), "e2e-upgrade-key-"+Cfg.RunID)
+		upgradeJWT = jwt
+		upgradeKeyName = "e2e-upgrade-key-" + Cfg.RunID
+		apiKey := createAPIKey(cph.APIURL(), jwt, profileWorkspace(), upgradeKeyName)
 		Cfg.APIKey = apiKey
 
 		By("Creating test resources on old version")
@@ -174,6 +203,12 @@ var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgra
 			"-w", profileWorkspace(), "--force", "--ignore-not-found")
 
 		cph.CleanAll()
+
+		if upgradeJWT != "" && upgradeKeyName != "" {
+			if err := deleteUpgradeAPIKey(cph.APIURL(), upgradeJWT, profileWorkspace(), upgradeKeyName); err != nil {
+				fmt.Fprintf(GinkgoWriter, "failed to delete upgrade API key %s: %v\n", upgradeKeyName, err)
+			}
+		}
 
 		// Restore Cfg after all cleanup commands that depend on the CP URL/API key.
 		Cfg.ServerURL = origServerURL

--- a/tests/e2e/cp_upgrade_test.go
+++ b/tests/e2e/cp_upgrade_test.go
@@ -202,13 +202,13 @@ var _ = Describe("Control Plane Upgrade", Ordered, Label("control-plane", "upgra
 		RunCLI("delete", "modelregistry", mrName,
 			"-w", profileWorkspace(), "--force", "--ignore-not-found")
 
-		cph.CleanAll()
-
 		if upgradeJWT != "" && upgradeKeyName != "" {
 			if err := deleteUpgradeAPIKey(cph.APIURL(), upgradeJWT, profileWorkspace(), upgradeKeyName); err != nil {
 				fmt.Fprintf(GinkgoWriter, "failed to delete upgrade API key %s: %v\n", upgradeKeyName, err)
 			}
 		}
+
+		cph.CleanAll()
 
 		// Restore Cfg after all cleanup commands that depend on the CP URL/API key.
 		Cfg.ServerURL = origServerURL

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -28,6 +28,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	cleanupTrackedResources()
 	CleanupCLI()
 })
 

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -27,10 +27,10 @@ var _ = BeforeSuite(func() {
 	BuildCLI()
 })
 
-var _ = AfterSuite(func() {
-	cleanupTrackedResources()
+var _ = AfterSuite(func(ctx SpecContext) {
+	cleanupTrackedResourcesWithContext(ctx)
 	CleanupCLI()
-})
+}, NodeTimeout(cleanupNodeTimeout))
 
 var _ = ReportAfterSuite("TestRail Reporter", func(report Report) {
 	trRunID := profileTestrailRunID()

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -29,6 +29,7 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func(ctx SpecContext) {
 	cleanupTrackedResourcesWithContext(ctx)
+	cleanupUpgradeAPIKey()
 	CleanupCLI()
 }, NodeTimeout(cleanupNodeTimeout))
 

--- a/tests/e2e/engine_test.go
+++ b/tests/e2e/engine_test.go
@@ -45,6 +45,13 @@ type EngineHelper struct {
 // EngineH is the package-level instance, initialised in BeforeAll.
 var EngineH *EngineHelper
 
+func testEngineName(prefix string) string {
+	name := prefix + "-" + Cfg.RunID
+	trackResource(trackedEngine, name, profileWorkspace())
+
+	return name
+}
+
 // NewEngineHelper creates an EngineHelper with the test workspace and mirror registry.
 func NewEngineHelper(mirrorRegistry string) *EngineHelper {
 	return &EngineHelper{
@@ -389,7 +396,7 @@ var _ = Describe("Engine", Ordered, func() {
 	Describe("Import", Label("engine", "import"), func() {
 
 		It("should create a new engine via CLI import", Label("C2613227"), func() {
-			name := "e2e-engine-create"
+			name := testEngineName("e2e-engine-create")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			pkg := buildEnginePackage(engineManifest{
@@ -417,7 +424,7 @@ var _ = Describe("Engine", Ordered, func() {
 
 		// NEU-427: TestRail C2649200
 		It("should populate Engine.Spec.SupportedTasks from version-level supported_tasks on create", Label("C2649200"), func() {
-			name := "e2e-engine-tasks-create"
+			name := testEngineName("e2e-engine-tasks-create")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			// buildEnginePackage emits supported_tasks at engine_versions[0] level
@@ -443,7 +450,7 @@ var _ = Describe("Engine", Ordered, func() {
 
 		// NEU-427: TestRail C2649201
 		It("should union version-level supported_tasks into existing Engine.Spec.SupportedTasks on re-import", Label("C2649201"), func() {
-			name := "e2e-engine-tasks-union"
+			name := testEngineName("e2e-engine-tasks-union")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			pkg1 := buildEnginePackage(engineManifest{
@@ -479,7 +486,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should add a new engine version via CLI import", Label("C2613216"), func() {
-			name := "e2e-engine-newver"
+			name := testEngineName("e2e-engine-newver")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			// Import v1
@@ -518,7 +525,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should add accelerator architecture to existing version via CLI import", Label("C2613217"), func() {
-			name := "e2e-engine-accel"
+			name := testEngineName("e2e-engine-accel")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			// Import with nvidia_gpu only
@@ -556,7 +563,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should update K8s deployment config via CLI import", Label("C2613218"), func() {
-			name := "e2e-engine-deploy"
+			name := testEngineName("e2e-engine-deploy")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			// Import without deploy template
@@ -597,7 +604,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should create engine from standalone manifest YAML", Label("manifest"), func() {
-			name := "e2e-engine-manifest-create"
+			name := testEngineName("e2e-engine-manifest-create")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			manifest := buildEngineManifestFile(engineManifest{
@@ -624,7 +631,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should add version to existing engine via manifest import", Label("manifest"), func() {
-			name := "e2e-engine-manifest-addver"
+			name := testEngineName("e2e-engine-manifest-addver")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			m1 := buildEngineManifestFile(engineManifest{
@@ -661,7 +668,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should merge accelerator via manifest import with --force", Label("manifest"), func() {
-			name := "e2e-engine-manifest-accel"
+			name := testEngineName("e2e-engine-manifest-accel")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			m1 := buildEngineManifestFile(engineManifest{
@@ -712,7 +719,7 @@ var _ = Describe("Engine", Ordered, func() {
 
 		It("should download and import images via manifest with package_url", Label("manifest", "docker"), func() {
 
-			name := "e2e-engine-manifest-pkgurl"
+			name := testEngineName("e2e-engine-manifest-pkgurl")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			// Build a real engine package archive to serve via HTTP
@@ -762,7 +769,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should update values schema via CLI import", Label("C2613219"), func() {
-			name := "e2e-engine-schema"
+			name := testEngineName("e2e-engine-schema")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			// Import without schema
@@ -813,7 +820,7 @@ var _ = Describe("Engine", Ordered, func() {
 	Describe("RemoveVersion", Label("engine", "remove-version"), func() {
 
 		It("should remove a version from a multi-version engine", func() {
-			name := "e2e-engine-rmver"
+			name := testEngineName("e2e-engine-rmver")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			// Import v1 and v2
@@ -859,7 +866,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should reject removing the last version without --force", func() {
-			name := "e2e-engine-rmver-last"
+			name := testEngineName("e2e-engine-rmver-last")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			pkg := buildEnginePackage(engineManifest{
@@ -878,7 +885,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should delete engine when force-removing the last version", func() {
-			name := "e2e-engine-rmver-force"
+			name := testEngineName("e2e-engine-rmver-force")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			pkg := buildEnginePackage(engineManifest{
@@ -902,7 +909,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should fail when removing a non-existent version", func() {
-			name := "e2e-engine-rmver-noexist"
+			name := testEngineName("e2e-engine-rmver-noexist")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			pkg := buildEnginePackage(engineManifest{
@@ -920,7 +927,7 @@ var _ = Describe("Engine", Ordered, func() {
 		})
 
 		It("should recalculate SupportedTasks after version removal", func() {
-			name := "e2e-engine-rmver-tasks"
+			name := testEngineName("e2e-engine-rmver-tasks")
 			DeferCleanup(EngineH.EnsureDeleted, name)
 
 			// Import v1 with text-generation

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -447,6 +447,8 @@ func SetupImageRegistry() {
 		"--timeout", "2m",
 	)
 	ExpectSuccess(r)
+
+	trackResource("imageregistry", testImageRegistry(), profileWorkspace())
 }
 
 // TeardownImageRegistry deletes the image registry and cleans up the temp YAML.
@@ -455,6 +457,8 @@ func TeardownImageRegistry() {
 		RunCLI("delete", "-f", imageRegistryYAML, "--force", "--ignore-not-found")
 		os.Remove(imageRegistryYAML)
 		imageRegistryYAML = ""
+
+		untrackResource("imageregistry", testImageRegistry(), profileWorkspace())
 	}
 }
 
@@ -1137,6 +1141,8 @@ func setupSSHCluster(prefix string) (clusterName string) {
 	By("Waiting for cluster Running")
 	ch.EventuallyInPhase(clusterName, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
 
+	trackResource("cluster", clusterName, profileWorkspace())
+
 	return clusterName
 }
 
@@ -1166,6 +1172,8 @@ func setupK8sCluster(prefix string) (clusterName string) {
 	By("Waiting for cluster Running")
 	ch.EventuallyInPhase(clusterName, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
 
+	trackResource("cluster", clusterName, profileWorkspace())
+
 	return clusterName
 }
 
@@ -1174,6 +1182,8 @@ func teardownCluster(clusterName string) {
 	ch := NewClusterHelper()
 
 	ch.EnsureDeleted(clusterName)
+
+	untrackResource("cluster", clusterName, profileWorkspace())
 
 	TeardownImageRegistry()
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -456,9 +456,9 @@ func TeardownImageRegistry() {
 	if imageRegistryYAML != "" {
 		RunCLI("delete", "-f", imageRegistryYAML, "--force", "--ignore-not-found")
 		os.Remove(imageRegistryYAML)
-		imageRegistryYAML = ""
 
 		untrackResource("imageregistry", testImageRegistry(), profileWorkspace())
+		imageRegistryYAML = ""
 	}
 }
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -452,13 +452,20 @@ func SetupImageRegistry() {
 }
 
 // TeardownImageRegistry deletes the image registry and cleans up the temp YAML.
+//
+// Untracks only when the CLI delete succeeded; on a non-zero exit the
+// entry stays in the registry so AfterSuite can retry. Always clears the
+// YAML guard so a future SetupImageRegistry can re-enter (a transient
+// delete failure shouldn't permanently block re-setup).
 func TeardownImageRegistry() {
 	if imageRegistryYAML != "" {
-		RunCLI("delete", "-f", imageRegistryYAML, "--force", "--ignore-not-found")
+		r := RunCLI("delete", "-f", imageRegistryYAML, "--force", "--ignore-not-found")
 		os.Remove(imageRegistryYAML)
-
-		untrackResource("imageregistry", testImageRegistry(), profileWorkspace())
 		imageRegistryYAML = ""
+
+		if r.ExitCode == 0 {
+			untrackResource("imageregistry", testImageRegistry(), profileWorkspace())
+		}
 	}
 }
 
@@ -702,9 +709,13 @@ func (c *ClusterHelper) EventuallyObservedSpecHashAdvanced(name, oldHash string,
 }
 
 // EnsureDeleted deletes a cluster and waits for full removal (for cleanup).
-func (c *ClusterHelper) EnsureDeleted(name string) {
+// Returns the WaitForDelete CLIResult so callers that need to know whether
+// removal actually succeeded can branch on ExitCode (0 = gone, non-zero =
+// still present). Callers that only want fire-and-forget can ignore the
+// return value.
+func (c *ClusterHelper) EnsureDeleted(name string) CLIResult {
 	c.Delete(name)
-	c.WaitForDelete(name, TerminalPhaseTimeout)
+	return c.WaitForDelete(name, TerminalPhaseTimeout)
 }
 
 // --- Cluster JSON parsing ---
@@ -1178,12 +1189,16 @@ func setupK8sCluster(prefix string) (clusterName string) {
 }
 
 // teardownCluster deletes a cluster and image registry.
+//
+// Untracks the cluster only when the API confirms removal — otherwise the
+// entry stays in the registry so AfterSuite can retry. Wiping it out
+// blindly would defeat the safety net this PR is adding.
 func teardownCluster(clusterName string) {
 	ch := NewClusterHelper()
 
-	ch.EnsureDeleted(clusterName)
-
-	untrackResource("cluster", clusterName, profileWorkspace())
+	if ch.EnsureDeleted(clusterName).ExitCode == 0 {
+		untrackResource("cluster", clusterName, profileWorkspace())
+	}
 
 	TeardownImageRegistry()
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -486,9 +486,9 @@ func TeardownImageRegistry() {
 		r := RunCLI("delete", "-f", imageRegistryYAML, "--force", "--ignore-not-found")
 		ExpectSuccess(r)
 		os.Remove(imageRegistryYAML)
-		imageRegistryYAML = ""
 
 		untrackResource("imageregistry", testImageRegistry(), profileWorkspace())
+		imageRegistryYAML = ""
 	}
 }
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -134,6 +134,8 @@ func RunCLI(args ...string) CLIResult {
 
 // RunCLIWithStdin executes the neutree-cli binary with stdin input and given arguments.
 func RunCLIWithStdin(stdin string, args ...string) CLIResult {
+	trackResourcesForApplyCommand(args)
+
 	injected := []string{
 		"--server-url", Cfg.ServerURL,
 		"--api-key", Cfg.APIKey,
@@ -169,11 +171,16 @@ func RunCLIWithStdin(stdin string, args ...string) CLIResult {
 		}
 	}
 
-	return CLIResult{
+	result := CLIResult{
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
 		ExitCode: exitCode,
 	}
+	if result.ExitCode == 0 {
+		reconcileTrackedResourcesAfterCommand(args)
+	}
+
+	return result
 }
 
 // String returns a human-readable representation of the CLI result.
@@ -476,8 +483,6 @@ func SetupImageRegistry() {
 		"--timeout", "2m",
 	)
 	ExpectSuccess(r)
-
-	trackResource("imageregistry", testImageRegistry(), profileWorkspace())
 }
 
 // TeardownImageRegistry deletes the image registry and cleans up the temp YAML.
@@ -1182,8 +1187,6 @@ func setupSSHCluster(prefix string) (clusterName string) {
 	By("Waiting for cluster Running")
 	ch.EventuallyInPhase(clusterName, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
 
-	trackResource("cluster", clusterName, profileWorkspace())
-
 	return clusterName
 }
 
@@ -1213,22 +1216,14 @@ func setupK8sCluster(prefix string) (clusterName string) {
 	By("Waiting for cluster Running")
 	ch.EventuallyInPhase(clusterName, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
 
-	trackResource("cluster", clusterName, profileWorkspace())
-
 	return clusterName
 }
 
 // teardownCluster deletes a cluster and image registry.
-//
-// Untracks the cluster only when the API confirms removal — otherwise the
-// entry stays in the registry so AfterSuite can retry. Wiping it out
-// blindly would defeat the safety net this PR is adding.
 func teardownCluster(clusterName string) {
 	ch := NewClusterHelper()
 
-	if ch.EnsureDeleted(clusterName).ExitCode == 0 {
-		untrackResource("cluster", clusterName, profileWorkspace())
-	}
+	ch.EnsureDeleted(clusterName)
 
 	TeardownImageRegistry()
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -476,6 +476,8 @@ func SetupImageRegistry() {
 		"--timeout", "2m",
 	)
 	ExpectSuccess(r)
+
+	trackResource("imageregistry", testImageRegistry(), profileWorkspace())
 }
 
 // TeardownImageRegistry deletes the image registry and cleans up the temp YAML.
@@ -485,6 +487,8 @@ func TeardownImageRegistry() {
 		ExpectSuccess(r)
 		os.Remove(imageRegistryYAML)
 		imageRegistryYAML = ""
+
+		untrackResource("imageregistry", testImageRegistry(), profileWorkspace())
 	}
 }
 
@@ -1180,6 +1184,8 @@ func setupSSHCluster(prefix string) (clusterName string) {
 	By("Waiting for cluster Running")
 	ch.EventuallyInPhase(clusterName, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
 
+	trackResource("cluster", clusterName, profileWorkspace())
+
 	return clusterName
 }
 
@@ -1209,6 +1215,8 @@ func setupK8sCluster(prefix string) (clusterName string) {
 	By("Waiting for cluster Running")
 	ch.EventuallyInPhase(clusterName, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
 
+	trackResource("cluster", clusterName, profileWorkspace())
+
 	return clusterName
 }
 
@@ -1217,6 +1225,8 @@ func teardownCluster(clusterName string) {
 	ch := NewClusterHelper()
 
 	ch.EnsureDeleted(clusterName)
+
+	untrackResource("cluster", clusterName, profileWorkspace())
 
 	TeardownImageRegistry()
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -486,8 +486,6 @@ func TeardownImageRegistry() {
 		r := RunCLI("delete", "-f", imageRegistryYAML, "--force", "--ignore-not-found")
 		ExpectSuccess(r)
 		os.Remove(imageRegistryYAML)
-
-		untrackResource("imageregistry", testImageRegistry(), profileWorkspace())
 		imageRegistryYAML = ""
 	}
 }
@@ -1221,12 +1219,16 @@ func setupK8sCluster(prefix string) (clusterName string) {
 }
 
 // teardownCluster deletes a cluster and image registry.
+//
+// Untracks the cluster only when the API confirms removal — otherwise the
+// entry stays in the registry so AfterSuite can retry. Wiping it out
+// blindly would defeat the safety net this PR is adding.
 func teardownCluster(clusterName string) {
 	ch := NewClusterHelper()
 
-	ch.EnsureDeleted(clusterName)
-
-	untrackResource("cluster", clusterName, profileWorkspace())
+	if ch.EnsureDeleted(clusterName).ExitCode == 0 {
+		untrackResource("cluster", clusterName, profileWorkspace())
+	}
 
 	TeardownImageRegistry()
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -135,7 +136,16 @@ func RunCLI(args ...string) CLIResult {
 // RunCLIWithStdin executes the neutree-cli binary with stdin input and given arguments.
 func RunCLIWithStdin(stdin string, args ...string) CLIResult {
 	trackResourcesForApplyCommand(args)
+	result := runCLI(context.Background(), stdin, args...)
 
+	if result.ExitCode == 0 {
+		reconcileTrackedResourcesAfterCommand(args)
+	}
+
+	return result
+}
+
+func runCLI(ctx context.Context, stdin string, args ...string) CLIResult {
 	injected := []string{
 		"--server-url", Cfg.ServerURL,
 		"--api-key", Cfg.APIKey,
@@ -145,7 +155,7 @@ func RunCLIWithStdin(stdin string, args ...string) CLIResult {
 	fullArgs = append(fullArgs, injected...)
 	fullArgs = append(fullArgs, args...)
 
-	cmd := exec.Command(cliBinary, fullArgs...)
+	cmd := exec.CommandContext(ctx, cliBinary, fullArgs...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -160,7 +170,9 @@ func RunCLIWithStdin(stdin string, args ...string) CLIResult {
 	exitCode := 0
 
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		if ctx.Err() != nil {
+			exitCode = 124
+		} else if exitErr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 				exitCode = status.ExitStatus()
 			} else {
@@ -171,16 +183,11 @@ func RunCLIWithStdin(stdin string, args ...string) CLIResult {
 		}
 	}
 
-	result := CLIResult{
+	return CLIResult{
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
 		ExitCode: exitCode,
 	}
-	if result.ExitCode == 0 {
-		reconcileTrackedResourcesAfterCommand(args)
-	}
-
-	return result
 }
 
 // String returns a human-readable representation of the CLI result.

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -43,13 +43,20 @@ func SetupModelRegistry() {
 }
 
 // TeardownModelRegistry deletes the model registry and cleans up the temp YAML.
+//
+// Untracks only when the CLI delete succeeded; on a non-zero exit the
+// entry stays in the registry so AfterSuite can retry. Always clears the
+// YAML guard so a future SetupModelRegistry can re-enter (a transient
+// delete failure shouldn't permanently block re-setup).
 func TeardownModelRegistry() {
 	if registryYAML != "" {
-		RunCLI("delete", "-f", registryYAML, "--force", "--ignore-not-found")
+		r := RunCLI("delete", "-f", registryYAML, "--force", "--ignore-not-found")
 		os.Remove(registryYAML)
-
-		untrackResource("modelregistry", testRegistry(), profileWorkspace())
 		registryYAML = ""
+
+		if r.ExitCode == 0 {
+			untrackResource("modelregistry", testRegistry(), profileWorkspace())
+		}
 	}
 }
 

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -47,9 +47,9 @@ func TeardownModelRegistry() {
 	if registryYAML != "" {
 		RunCLI("delete", "-f", registryYAML, "--force", "--ignore-not-found")
 		os.Remove(registryYAML)
-		registryYAML = ""
 
 		untrackResource("modelregistry", testRegistry(), profileWorkspace())
+		registryYAML = ""
 	}
 }
 

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -38,6 +38,8 @@ func SetupModelRegistry() {
 		"--timeout", "2m",
 	)
 	ExpectSuccess(r)
+
+	trackResource("modelregistry", testRegistry(), profileWorkspace())
 }
 
 // TeardownModelRegistry deletes the model registry and cleans up the temp YAML.
@@ -45,6 +47,9 @@ func TeardownModelRegistry() {
 	if registryYAML != "" {
 		RunCLI("delete", "-f", registryYAML, "--force", "--ignore-not-found")
 		os.Remove(registryYAML)
+		registryYAML = ""
+
+		untrackResource("modelregistry", testRegistry(), profileWorkspace())
 	}
 }
 

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -43,6 +43,8 @@ func SetupModelRegistry() {
 		"--timeout", "2m",
 	)
 	ExpectSuccess(r)
+
+	trackResource("modelregistry", testRegistry(), profileWorkspace())
 }
 
 // TeardownModelRegistry deletes the model registry and cleans up the temp YAML.

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -43,8 +43,6 @@ func SetupModelRegistry() {
 		"--timeout", "2m",
 	)
 	ExpectSuccess(r)
-
-	trackResource("modelregistry", testRegistry(), profileWorkspace())
 }
 
 // TeardownModelRegistry deletes the model registry and cleans up the temp YAML.

--- a/tests/e2e/profile.go
+++ b/tests/e2e/profile.go
@@ -13,6 +13,7 @@ const (
 	defaultModelVersion           = "latest"
 	maintainedVLLMVersionPrevious = "v0.17.1"
 	maintainedVLLMVersionCurrent  = "v0.24.0"
+	defaultWorkspace              = "default"
 	// defaultEngineName is the engine looked up by helpers that don't take an
 	// explicit engine name (renderEndpoint default, profileEngineVersion, etc.).
 	// Tests that target a different engine pass it via withEngine(name, version).
@@ -313,7 +314,7 @@ func profileWorkspace() string {
 		return profile.Workspace
 	}
 
-	return "default"
+	return defaultWorkspace
 }
 
 func profileClusterVersion() string {


### PR DESCRIPTION
## Issue\n\nNEU-436\n\n## Summary\n\nKeep lifecycle resources created by the current make e2e-test process recoverable when Ginkgo interrupts normal teardown. The suite owns only current-RunID Cluster, Endpoint, ExternalEndpoint, ImageRegistry, ModelRegistry, and Engine resources; it does not scan or delete resources from prior or concurrent runs.\n\n## Changes\n\n- Register current-run Cluster, Endpoint, ExternalEndpoint, ImageRegistry, ModelRegistry, and Engine resources from every apply -f manifest path, retaining valid earlier documents if a later manifest document is malformed.\n- Make Engine import tests use run-scoped names and pre-register Engines before import.\n- Use an 18-digit cryptographic RunID ownership suffix and fail fast if secure randomness is unavailable.\n- Keep tracked entries through failed or asynchronous deletes, and remove them only after a successful synchronous delete or wait --for delete.\n- Clean resources in dependency-aware waves: run independent same-kind commands concurrently with an 8-worker limit, wait for Endpoint deletion before ModelRegistry, Engine, or Cluster, and wait for Cluster deletion before ImageRegistry. Partial delete failures still wait successful deletes before blocking dependent waves.\n- Revoke the control-plane upgrade test API key through its captured admin JWT after ordinary resource cleanup and before control-plane teardown, without adding credentials to the generic tracker. Retain the owner state for an AfterSuite retry if the upgrade AfterAll is skipped.\n- Bound cleanup with a 4-hour Ginkgo node timeout and 5-minute resource waits; retain an 8-hour finite Go outer timeout as the final process kill switch.\n\n## Test Plan\n\n### Unit test\n\n- [x] go test ./tests/e2e/ -count=1\n- [x] Fake-CLI tests cover manifest registration and malformed-document recovery, current-RunID filtering, run-scoped Engine registration, workspace fallback, delete accounting, dependency waves, partial delete failures, same-wave concurrency/worker bounds, child-delete failure, command timeout handling, and shared runner input/exit-code forwarding.\n- [x] HTTP unit test covers captured-JWT API-key GET/PATCH cleanup, owner-state clearing, and idempotent retry.\n- [x] Focused race test covers API-key cleanup, Engine registration, cleanup result collection, and worker bounds.\n- [x] go vet ./tests/e2e/...\n- [x] bin/golangci-lint run --fast=false ./tests/e2e/...\n- [x] make e2e-test --just-print E2E_GO_TIMEOUT=8h\n\n### DB test\n\n- [x] Not affected: no database schema, migration, RLS, or storage change.\n\n### E2E test\n\n- [x] Not run by explicit user direction. No live control-plane mutation or test-environment lease was used.\n- Residual risk: live Ginkgo interruption and control-plane cleanup timing were not revalidated in this PR.\n\n## Risk & Rollback\n\n- Production API, controller, database, deployment, UI, and enterprise code are unchanged.\n- Generic cleanup owns only the six supported current-RunID lifecycle resource kinds. Credential resources use their owner-specific teardown path; hard process termination and resources from other runs remain intentionally out of scope.\n- Revert the task commits to restore the previous helper-local tracking behavior and E2E timeout invocation.\n