### PR TITLE
fix: guard against nil Spec in ModelCatalogController sync

### DIFF
--- a/controllers/model_catalog_controller.go
+++ b/controllers/model_catalog_controller.go
@@ -82,6 +82,11 @@ func (c *ModelCatalogController) sync(modelCatalog *v1.ModelCatalog) error {
 		modelCatalog.Kind = "ModelCatalog"
 	}
 
+	// Initialize spec if nil; process* helpers dereference Spec fields without nil-guards
+	if modelCatalog.Spec == nil {
+		modelCatalog.Spec = &v1.ModelCatalogSpec{}
+	}
+
 	// Initialize status if nil
 	if modelCatalog.Status == nil {
 		modelCatalog.Status = &v1.ModelCatalogStatus{

--- a/controllers/model_catalog_controller_test.go
+++ b/controllers/model_catalog_controller_test.go
@@ -268,6 +268,8 @@ func TestModelCatalogController_sync_NilSpec(t *testing.T) {
 				return mc.Spec != nil &&
 					mc.Spec.Resources != nil &&
 					mc.Spec.Replicas != nil &&
+					mc.Spec.DeploymentOptions != nil &&
+					mc.Spec.Variables != nil &&
 					mc.Status.Phase == v1.ModelCatalogPhaseREADY
 			})).Return(nil)
 

--- a/controllers/model_catalog_controller_test.go
+++ b/controllers/model_catalog_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
@@ -227,6 +228,59 @@ func TestModelCatalogController_sync_Delete(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			mockStorage.AssertExpectations(t)
+		})
+	}
+}
+
+func TestModelCatalogController_sync_NilSpec(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *v1.ModelCatalog
+	}{
+		{
+			name: "Spec nil with nil Status defaults to Pending and initializes Spec",
+			input: &v1.ModelCatalog{
+				ID: 1,
+				Metadata: &v1.Metadata{
+					Name:      "test-catalog",
+					Workspace: "default",
+				},
+			},
+		},
+		{
+			name: "Spec nil with Pending Status initializes Spec",
+			input: &v1.ModelCatalog{
+				ID: 1,
+				Metadata: &v1.Metadata{
+					Name:      "test-catalog",
+					Workspace: "default",
+				},
+				Status: &v1.ModelCatalogStatus{Phase: v1.ModelCatalogPhasePENDING},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := &storageMocks.MockStorage{}
+			mockStorage.On("UpdateModelCatalog", "1", mock.MatchedBy(func(mc *v1.ModelCatalog) bool {
+				return mc.Spec != nil &&
+					mc.Spec.Resources != nil &&
+					mc.Spec.Replicas != nil &&
+					mc.Status.Phase == v1.ModelCatalogPhaseREADY
+			})).Return(nil)
+
+			controller, _ := NewModelCatalogController(&ModelCatalogControllerOption{
+				Storage: mockStorage,
+			})
+
+			require.NotPanics(t, func() {
+				err := controller.sync(tt.input)
+				assert.NoError(t, err)
+			})
+
+			assert.NotNil(t, tt.input.Spec)
 			mockStorage.AssertExpectations(t)
 		})
 	}


### PR DESCRIPTION
## Issue

NEU-416 — ModelCatalogController panics when reconciling records whose `spec` is NULL (or deserializes to `Spec == nil`).

## Summary

`ModelCatalogController.sync()` initialized `Metadata` and `Status` when nil, but missed the symmetric guard for `Spec`. A `model_catalogs` row with NULL `spec` therefore reached `processPendingModelCatalog` and panicked on the very first `modelCatalog.Spec.Resources` dereference, taking the `neutree-core` process down.

This change adds a one-line nil-init for `Spec` next to the existing `Status` init so all downstream `Spec.*` field accesses are safe.

## Changes

- `controllers/model_catalog_controller.go`: initialize `Spec` to an empty `ModelCatalogSpec{}` when nil, right before the existing `Status` init.
- `controllers/model_catalog_controller_test.go`: add `TestModelCatalogController_sync_NilSpec` table test covering two nil-Spec scenarios (nil Status + Pending Status); each subtest reproduces the crash on the unfixed code path via `require.NotPanics` and asserts `Spec` is initialized and the row transitions to `READY`.

## Test Plan

- [x] Unit: `go test ./controllers/... -race` — passes; new `TestModelCatalogController_sync_NilSpec` validates the fix (pre-fix runs reproduce the original `model_catalog_controller.go:113` nil-pointer panic from the ticket stack).
- [ ] E2E (if affected): not affected — control-plane reconcile code with full unit coverage; no data-plane / deployment surface touched.
- [ ] DB integration (`make db-test`): not affected — no schema or storage-layer changes.

## Risk & Rollback

- No schema or API contract changes; only adds a defensive nil-init inside an existing reconcile entry point.
- Behavior on the previously panicking path: row now reaches `processPendingModelCatalog` with an empty `Spec`, which then receives its standard default Resources/Replicas/DeploymentOptions/Variables and transitions to `READY`. This matches the behavior of a freshly created `ModelCatalog` whose optional sub-fields were omitted.
- Backward-compatible with running clients; no migration required.
- Rollback: revert the commit; the nil-guard removal restores the pre-fix behavior (and re-introduces the panic).