### PR TITLE
refactor: surface port 8265 occupancy hint when Ray dashboard probe fails

### DIFF
--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -261,9 +262,7 @@ func (c *sshRayClusterReconciler) cleanupConfig(reconcileCtx *ReconcileContext) 
 
 func (c *sshRayClusterReconciler) reconcileHeadNode(reconcileCtx *ReconcileContext) error {
 	alive, headVersion, healthErr := c.checkHeadNodeHealth(reconcileCtx)
-
-	var unhealthy *headNodeUnhealthyError
-	if healthErr != nil && !errors.As(healthErr, &unhealthy) {
+	if healthErr != nil && !stderrors.Is(healthErr, errHeadNodeUnhealthy) {
 		// Unexpected internal error (e.g. ListNodes failed) — propagate up.
 		return errors.Wrap(healthErr, "failed to check head node health")
 	}
@@ -285,9 +284,10 @@ func (c *sshRayClusterReconciler) reconcileHeadNode(reconcileCtx *ReconcileConte
 	}
 
 	// Head is down - write recovery status with the specific reason so users see
-	// an actionable message (e.g. port 8265 occupancy hint) instead of a generic one.
+	// an actionable message (e.g. port 8265 occupancy hint) instead of a generic
+	// one. healthErr.Error() already begins with "head node unhealthy: ...".
 	WriteRecoveryStatus(reconcileCtx.Cluster, c.storage,
-		fmt.Sprintf("head node unhealthy: %s, attempting recovery", healthErr.Error()))
+		fmt.Sprintf("%s, attempting recovery", healthErr.Error()))
 
 	if reconcileCtx.Cluster.Status != nil && reconcileCtx.Cluster.Status.Phase != v1.ClusterPhaseInitializing {
 		klog.Infof("Head node not ready, try to up cluster %s", reconcileCtx.Cluster.Metadata.WorkspaceName())

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -260,9 +260,12 @@ func (c *sshRayClusterReconciler) cleanupConfig(reconcileCtx *ReconcileContext) 
 }
 
 func (c *sshRayClusterReconciler) reconcileHeadNode(reconcileCtx *ReconcileContext) error {
-	alive, headVersion, unhealthyReason, err := c.checkHeadNodeHealth(reconcileCtx)
-	if err != nil {
-		return errors.Wrap(err, "failed to check head node health")
+	alive, headVersion, healthErr := c.checkHeadNodeHealth(reconcileCtx)
+
+	var unhealthy *headNodeUnhealthyError
+	if healthErr != nil && !errors.As(healthErr, &unhealthy) {
+		// Unexpected internal error (e.g. ListNodes failed) — propagate up.
+		return errors.Wrap(healthErr, "failed to check head node health")
 	}
 
 	if alive {
@@ -284,7 +287,7 @@ func (c *sshRayClusterReconciler) reconcileHeadNode(reconcileCtx *ReconcileConte
 	// Head is down - write recovery status with the specific reason so users see
 	// an actionable message (e.g. port 8265 occupancy hint) instead of a generic one.
 	WriteRecoveryStatus(reconcileCtx.Cluster, c.storage,
-		fmt.Sprintf("head node unhealthy: %s, attempting recovery", unhealthyReason))
+		fmt.Sprintf("head node unhealthy: %s, attempting recovery", healthErr.Error()))
 
 	if reconcileCtx.Cluster.Status != nil && reconcileCtx.Cluster.Status.Phase != v1.ClusterPhaseInitializing {
 		klog.Infof("Head node not ready, try to up cluster %s", reconcileCtx.Cluster.Metadata.WorkspaceName())

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -326,7 +326,7 @@ func (c *sshRayClusterReconciler) initHeadNode(reconcileCtx *ReconcileContext, v
 	if err != nil {
 		// `ray up` exited 0 but the dashboard endpoint is unreachable. The most
 		// common cause is that port 8265 was already in use on the head host —
-		// `ray up` only logs that bind failure to stderr (NEU-244).
+		// `ray up` only logs that bind failure to stderr.
 		return errors.Wrapf(err,
 			"failed to verify Ray dashboard on head node %s after `ray up`; "+
 				"verify port 8265 is not already in use by another process on this host",

--- a/internal/cluster/ray_ssh_cluster.go
+++ b/internal/cluster/ray_ssh_cluster.go
@@ -260,7 +260,7 @@ func (c *sshRayClusterReconciler) cleanupConfig(reconcileCtx *ReconcileContext) 
 }
 
 func (c *sshRayClusterReconciler) reconcileHeadNode(reconcileCtx *ReconcileContext) error {
-	alive, headVersion, err := c.checkHeadNodeHealth(reconcileCtx)
+	alive, headVersion, unhealthyReason, err := c.checkHeadNodeHealth(reconcileCtx)
 	if err != nil {
 		return errors.Wrap(err, "failed to check head node health")
 	}
@@ -281,9 +281,10 @@ func (c *sshRayClusterReconciler) reconcileHeadNode(reconcileCtx *ReconcileConte
 		return nil
 	}
 
-	// Head is down (dashboard unreachable or raylet dead) - write recovery status for user feedback
+	// Head is down - write recovery status with the specific reason so users see
+	// an actionable message (e.g. port 8265 occupancy hint) instead of a generic one.
 	WriteRecoveryStatus(reconcileCtx.Cluster, c.storage,
-		fmt.Sprintf("head node %s unhealthy (dashboard unreachable or raylet not alive), attempting recovery", reconcileCtx.sshClusterConfig.Provider.HeadIP))
+		fmt.Sprintf("head node unhealthy: %s, attempting recovery", unhealthyReason))
 
 	if reconcileCtx.Cluster.Status != nil && reconcileCtx.Cluster.Status.Phase != v1.ClusterPhaseInitializing {
 		klog.Infof("Head node not ready, try to up cluster %s", reconcileCtx.Cluster.Metadata.WorkspaceName())
@@ -323,7 +324,13 @@ func (c *sshRayClusterReconciler) initHeadNode(reconcileCtx *ReconcileContext, v
 
 	_, err = reconcileCtx.rayService.GetClusterMetadata()
 	if err != nil {
-		return errors.Wrap(err, "failed to get cluster metadata after starting head node")
+		// `ray up` exited 0 but the dashboard endpoint is unreachable. The most
+		// common cause is that port 8265 was already in use on the head host —
+		// `ray up` only logs that bind failure to stderr (NEU-244).
+		return errors.Wrapf(err,
+			"failed to verify Ray dashboard on head node %s after `ray up`; "+
+				"verify port 8265 is not already in use by another process on this host",
+			reconcileCtx.sshClusterConfig.Provider.HeadIP)
 	}
 
 	return nil

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -561,6 +561,93 @@ func TestInitHeadNode_DashboardVerifyFailureHint(t *testing.T) {
 	assert.Contains(t, msg, "connection refused", "post-up verify failure must preserve underlying error (got: %q)", msg)
 }
 
+// TestCheckHeadNodeHealth_UnhealthyErrorContract pins the contract between
+// checkHeadNodeHealth and reconcileHeadNode: an unhealthy head is signalled via
+// a *headNodeUnhealthyError (so reconcileHeadNode can split known-unhealthy from
+// unexpected internal errors via errors.As), and the dashboard-unreachable
+// variant preserves the underlying error in the chain so errors.Is / errors.As
+// can traverse it.
+func TestCheckHeadNodeHealth_UnhealthyErrorContract(t *testing.T) {
+	t.Run("dashboard unreachable wraps underlying error", func(t *testing.T) {
+		dashboardSvc := &dashboardmocks.MockDashboardService{}
+		underlying := errors.New("connection refused")
+		dashboardSvc.On("GetClusterMetadata").Return(nil, underlying).Once()
+
+		r := &sshRayClusterReconciler{}
+		alive, version, err := r.checkHeadNodeHealth(&ReconcileContext{
+			rayService: dashboardSvc,
+			sshClusterConfig: &v1.RaySSHProvisionClusterConfig{
+				Provider: v1.Provider{HeadIP: "192.168.1.10"},
+			},
+			Cluster: &v1.Cluster{Metadata: &v1.Metadata{Name: "t"}},
+		})
+		assert.False(t, alive)
+		assert.Empty(t, version)
+		require.Error(t, err)
+
+		var unhealthy *headNodeUnhealthyError
+		require.True(t, errors.As(err, &unhealthy), "expected *headNodeUnhealthyError, got %T", err)
+		assert.Contains(t, unhealthy.Error(), "port 8265")
+		assert.Contains(t, unhealthy.Error(), "192.168.1.10")
+		assert.Contains(t, unhealthy.Error(), "connection refused")
+		assert.ErrorIs(t, err, underlying, "underlying error must remain reachable via errors.Is")
+
+		dashboardSvc.AssertExpectations(t)
+	})
+
+	t.Run("no alive head raylet returns unhealthy error without underlying cause", func(t *testing.T) {
+		dashboardSvc := &dashboardmocks.MockDashboardService{}
+		dashboardSvc.On("GetClusterMetadata").Return(nil, nil).Once()
+		dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
+			{Raylet: v1.Raylet{IsHeadNode: true, State: v1.DeadNodeState}},
+		}, nil).Once()
+
+		r := &sshRayClusterReconciler{}
+		alive, _, err := r.checkHeadNodeHealth(&ReconcileContext{
+			rayService: dashboardSvc,
+			sshClusterConfig: &v1.RaySSHProvisionClusterConfig{
+				Provider: v1.Provider{HeadIP: "192.168.1.10"},
+			},
+			Cluster: &v1.Cluster{Metadata: &v1.Metadata{Name: "t"}},
+		})
+		assert.False(t, alive)
+		require.Error(t, err)
+
+		var unhealthy *headNodeUnhealthyError
+		require.True(t, errors.As(err, &unhealthy))
+		assert.Contains(t, unhealthy.Error(), "no alive head raylet")
+		assert.Contains(t, unhealthy.Error(), "192.168.1.10")
+		assert.NotContains(t, unhealthy.Error(), "port 8265")
+		assert.Nil(t, errors.Unwrap(unhealthy), "no underlying cause expected for this path")
+
+		dashboardSvc.AssertExpectations(t)
+	})
+
+	t.Run("ListNodes failure surfaces as plain unexpected error, not unhealthy error", func(t *testing.T) {
+		dashboardSvc := &dashboardmocks.MockDashboardService{}
+		dashboardSvc.On("GetClusterMetadata").Return(nil, nil).Once()
+		dashboardSvc.On("ListNodes").Return(nil, errors.New("boom")).Once()
+
+		r := &sshRayClusterReconciler{}
+		alive, _, err := r.checkHeadNodeHealth(&ReconcileContext{
+			rayService: dashboardSvc,
+			sshClusterConfig: &v1.RaySSHProvisionClusterConfig{
+				Provider: v1.Provider{HeadIP: "192.168.1.10"},
+			},
+			Cluster: &v1.Cluster{Metadata: &v1.Metadata{Name: "t"}},
+		})
+		assert.False(t, alive)
+		require.Error(t, err)
+
+		var unhealthy *headNodeUnhealthyError
+		assert.False(t, errors.As(err, &unhealthy),
+			"ListNodes failures must propagate as unexpected errors so reconcileHeadNode bails out instead of writing a misleading recovery status")
+		assert.Contains(t, err.Error(), "failed to list ray nodes")
+
+		dashboardSvc.AssertExpectations(t)
+	})
+}
+
 func TestReconcileWorkerNode(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -615,7 +615,8 @@ func TestCheckHeadNodeHealth_UnhealthyErrorContract(t *testing.T) {
 
 		var unhealthy *headNodeUnhealthyError
 		require.True(t, errors.As(err, &unhealthy))
-		assert.Contains(t, unhealthy.Error(), "no alive head raylet")
+		assert.Contains(t, unhealthy.Error(), "raylet")
+		assert.Contains(t, unhealthy.Error(), "not alive")
 		assert.Contains(t, unhealthy.Error(), "192.168.1.10")
 		assert.NotContains(t, unhealthy.Error(), "port 8265")
 		assert.Nil(t, errors.Unwrap(unhealthy), "no underlying cause expected for this path")

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -466,9 +466,8 @@ func TestReconcileHeadNode_RecoveryReason(t *testing.T) {
 				}
 			}).Return(nil).Maybe()
 
-			dashboard.NewDashboardService = func(dashboardUrl string) dashboard.DashboardService {
-				return dashboardSvc
-			}
+			// The reconciler reads from ReconcileContext.rayService below, so we don't
+			// need to override the package-level dashboard.NewDashboardService factory.
 			r := &sshRayClusterReconciler{
 				acceleratorManager: acceleratorManager,
 				executor:           e,

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -411,11 +411,8 @@ func TestReconcileHeadNode(t *testing.T) {
 
 // TestReconcileHeadNode_RecoveryReason asserts that when a Running cluster's head
 // node becomes unhealthy, the recovery status message surfaces an actionable cause
-// instead of the generic "dashboard unreachable or raylet not alive" wording.
-//
-// NEU-244: when ray dashboard port 8265 is occupied on the head node, ray up exits
-// 0 but the dashboard never comes up. Users used to see a generic message — the
-// recovery message must point at port 8265 so they can self-diagnose.
+// (e.g. port 8265 occupancy) instead of a generic "dashboard unreachable or raylet
+// not alive" wording.
 func TestReconcileHeadNode_RecoveryReason(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -521,7 +518,7 @@ func TestReconcileHeadNode_RecoveryReason(t *testing.T) {
 
 // TestInitHeadNode_DashboardVerifyFailureHint asserts that when ray up exits 0 but
 // the post-up GetClusterMetadata probe fails, the wrapped error mentions port 8265
-// so users learn the most likely cause (NEU-244).
+// so users learn the most likely cause.
 func TestInitHeadNode_DashboardVerifyFailureHint(t *testing.T) {
 	acceleratorManager := &acceleratormocks.MockManager{}
 	e := &commandmocks.MockExecutor{}

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -563,15 +564,14 @@ func TestInitHeadNode_DashboardVerifyFailureHint(t *testing.T) {
 
 // TestCheckHeadNodeHealth_UnhealthyErrorContract pins the contract between
 // checkHeadNodeHealth and reconcileHeadNode: an unhealthy head is signalled via
-// a *headNodeUnhealthyError (so reconcileHeadNode can split known-unhealthy from
-// unexpected internal errors via errors.As), and the dashboard-unreachable
-// variant preserves the underlying error in the chain so errors.Is / errors.As
-// can traverse it.
+// an error wrapping the errHeadNodeUnhealthy sentinel (so reconcileHeadNode can
+// split known-unhealthy from unexpected internal errors via errors.Is), and the
+// dashboard-unreachable variant inlines the underlying error message so users
+// see the actual cause in the recovery status.
 func TestCheckHeadNodeHealth_UnhealthyErrorContract(t *testing.T) {
-	t.Run("dashboard unreachable wraps underlying error", func(t *testing.T) {
+	t.Run("dashboard unreachable surfaces underlying error message and port hint", func(t *testing.T) {
 		dashboardSvc := &dashboardmocks.MockDashboardService{}
-		underlying := errors.New("connection refused")
-		dashboardSvc.On("GetClusterMetadata").Return(nil, underlying).Once()
+		dashboardSvc.On("GetClusterMetadata").Return(nil, errors.New("connection refused")).Once()
 
 		r := &sshRayClusterReconciler{}
 		alive, version, err := r.checkHeadNodeHealth(&ReconcileContext{
@@ -585,17 +585,16 @@ func TestCheckHeadNodeHealth_UnhealthyErrorContract(t *testing.T) {
 		assert.Empty(t, version)
 		require.Error(t, err)
 
-		var unhealthy *headNodeUnhealthyError
-		require.True(t, errors.As(err, &unhealthy), "expected *headNodeUnhealthyError, got %T", err)
-		assert.Contains(t, unhealthy.Error(), "port 8265")
-		assert.Contains(t, unhealthy.Error(), "192.168.1.10")
-		assert.Contains(t, unhealthy.Error(), "connection refused")
-		assert.ErrorIs(t, err, underlying, "underlying error must remain reachable via errors.Is")
+		assert.True(t, stderrors.Is(err, errHeadNodeUnhealthy),
+			"dashboard-unreachable must wrap the errHeadNodeUnhealthy sentinel, got %v", err)
+		assert.Contains(t, err.Error(), "port 8265")
+		assert.Contains(t, err.Error(), "192.168.1.10")
+		assert.Contains(t, err.Error(), "connection refused")
 
 		dashboardSvc.AssertExpectations(t)
 	})
 
-	t.Run("no alive head raylet returns unhealthy error without underlying cause", func(t *testing.T) {
+	t.Run("no alive head raylet surfaces raylet wording, no port hint", func(t *testing.T) {
 		dashboardSvc := &dashboardmocks.MockDashboardService{}
 		dashboardSvc.On("GetClusterMetadata").Return(nil, nil).Once()
 		dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
@@ -613,18 +612,16 @@ func TestCheckHeadNodeHealth_UnhealthyErrorContract(t *testing.T) {
 		assert.False(t, alive)
 		require.Error(t, err)
 
-		var unhealthy *headNodeUnhealthyError
-		require.True(t, errors.As(err, &unhealthy))
-		assert.Contains(t, unhealthy.Error(), "raylet")
-		assert.Contains(t, unhealthy.Error(), "not alive")
-		assert.Contains(t, unhealthy.Error(), "192.168.1.10")
-		assert.NotContains(t, unhealthy.Error(), "port 8265")
-		assert.Nil(t, errors.Unwrap(unhealthy), "no underlying cause expected for this path")
+		assert.True(t, stderrors.Is(err, errHeadNodeUnhealthy))
+		assert.Contains(t, err.Error(), "raylet")
+		assert.Contains(t, err.Error(), "not alive")
+		assert.Contains(t, err.Error(), "192.168.1.10")
+		assert.NotContains(t, err.Error(), "port 8265")
 
 		dashboardSvc.AssertExpectations(t)
 	})
 
-	t.Run("ListNodes failure surfaces as plain unexpected error, not unhealthy error", func(t *testing.T) {
+	t.Run("ListNodes failure surfaces as plain unexpected error, not unhealthy", func(t *testing.T) {
 		dashboardSvc := &dashboardmocks.MockDashboardService{}
 		dashboardSvc.On("GetClusterMetadata").Return(nil, nil).Once()
 		dashboardSvc.On("ListNodes").Return(nil, errors.New("boom")).Once()
@@ -640,8 +637,7 @@ func TestCheckHeadNodeHealth_UnhealthyErrorContract(t *testing.T) {
 		assert.False(t, alive)
 		require.Error(t, err)
 
-		var unhealthy *headNodeUnhealthyError
-		assert.False(t, errors.As(err, &unhealthy),
+		assert.False(t, stderrors.Is(err, errHeadNodeUnhealthy),
 			"ListNodes failures must propagate as unexpected errors so reconcileHeadNode bails out instead of writing a misleading recovery status")
 		assert.Contains(t, err.Error(), "failed to list ray nodes")
 

--- a/internal/cluster/ray_ssh_cluster_test.go
+++ b/internal/cluster/ray_ssh_cluster_test.go
@@ -409,6 +409,162 @@ func TestReconcileHeadNode(t *testing.T) {
 
 }
 
+// TestReconcileHeadNode_RecoveryReason asserts that when a Running cluster's head
+// node becomes unhealthy, the recovery status message surfaces an actionable cause
+// instead of the generic "dashboard unreachable or raylet not alive" wording.
+//
+// NEU-244: when ray dashboard port 8265 is occupied on the head node, ray up exits
+// 0 but the dashboard never comes up. Users used to see a generic message — the
+// recovery message must point at port 8265 so they can self-diagnose.
+func TestReconcileHeadNode_RecoveryReason(t *testing.T) {
+	tests := []struct {
+		name              string
+		setupMock         func(acceleratorManager *acceleratormocks.MockManager, e *commandmocks.MockExecutor, dashboardSvc *dashboardmocks.MockDashboardService)
+		wantReasonContain []string
+		wantReasonAbsent  []string
+	}{
+		{
+			name: "dashboard unreachable - reason mentions port 8265",
+			setupMock: func(acceleratorManager *acceleratormocks.MockManager, e *commandmocks.MockExecutor, dashboardSvc *dashboardmocks.MockDashboardService) {
+				dashboardSvc.On("GetClusterMetadata").Return(nil, errors.New("connection refused")).Once()
+				// rebuildHeadNode path: downCluster, then upCluster, then post-up GetClusterMetadata
+				e.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return([]byte(""), nil).Once()
+				acceleratorManager.On("GetNodeRuntimeConfig", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1.RuntimeConfig{}, nil)
+				e.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return([]byte(""), nil).Once()
+				dashboardSvc.On("GetClusterMetadata").Return(nil, nil).Once()
+			},
+			wantReasonContain: []string{"port 8265", "192.168.1.10", "connection refused"},
+		},
+		{
+			name: "no alive head raylet - reason mentions raylet, not port 8265",
+			setupMock: func(acceleratorManager *acceleratormocks.MockManager, e *commandmocks.MockExecutor, dashboardSvc *dashboardmocks.MockDashboardService) {
+				// Dashboard reachable, but only DEAD head record exists.
+				dashboardSvc.On("GetClusterMetadata").Return(nil, nil).Times(2)
+				dashboardSvc.On("ListNodes").Return([]v1.NodeSummary{
+					{Raylet: v1.Raylet{IsHeadNode: true, State: v1.DeadNodeState}},
+				}, nil)
+				e.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return([]byte(""), nil).Once()
+				acceleratorManager.On("GetNodeRuntimeConfig", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1.RuntimeConfig{}, nil)
+				e.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return([]byte(""), nil).Once()
+			},
+			wantReasonContain: []string{"raylet", "192.168.1.10"},
+			wantReasonAbsent:  []string{"port 8265"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acceleratorManager := &acceleratormocks.MockManager{}
+			e := &commandmocks.MockExecutor{}
+			dashboardSvc := &dashboardmocks.MockDashboardService{}
+			tt.setupMock(acceleratorManager, e, dashboardSvc)
+
+			var recoveryMessages []string
+
+			s := storagemocks.MockStorage{}
+			s.On("UpdateCluster", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				updated := args.Get(1).(*v1.Cluster)
+				if updated.Status != nil && updated.Status.Phase == v1.ClusterPhaseFailed {
+					recoveryMessages = append(recoveryMessages, updated.Status.ErrorMessage)
+				}
+			}).Return(nil).Maybe()
+
+			dashboard.NewDashboardService = func(dashboardUrl string) dashboard.DashboardService {
+				return dashboardSvc
+			}
+			r := &sshRayClusterReconciler{
+				acceleratorManager: acceleratorManager,
+				executor:           e,
+				storage:            &s,
+			}
+
+			cluster := &v1.Cluster{
+				ID: *pointer.Int(1),
+				Metadata: &v1.Metadata{
+					Name: "test",
+				},
+				Status: &v1.ClusterStatus{
+					// Phase=Running is the gate that lets WriteRecoveryStatus actually write.
+					Phase:           v1.ClusterPhaseRunning,
+					Initialized:     true,
+					AcceleratorType: v1.AcceleratorTypeNVIDIAGPU.StringPtr(),
+				},
+			}
+
+			err := r.reconcileHeadNode(&ReconcileContext{
+				rayService: dashboardSvc,
+				sshClusterConfig: &v1.RaySSHProvisionClusterConfig{
+					Provider: v1.Provider{HeadIP: "192.168.1.10"},
+				},
+				sshRayClusterConfig: &v1.RayClusterConfig{},
+				sshConfigGenerator:  newRaySSHLocalConfigGenerator("test"),
+				Cluster:             cluster,
+			})
+			assert.NoError(t, err)
+
+			require.NotEmpty(t, recoveryMessages, "WriteRecoveryStatus must persist a Failed-phase status with a reason")
+			combined := strings.Join(recoveryMessages, " || ")
+			for _, want := range tt.wantReasonContain {
+				assert.Contains(t, combined, want, "recovery message must contain %q (got: %q)", want, combined)
+			}
+			for _, absent := range tt.wantReasonAbsent {
+				assert.NotContains(t, combined, absent, "recovery message must NOT contain %q (got: %q)", absent, combined)
+			}
+
+			acceleratorManager.AssertExpectations(t)
+			e.AssertExpectations(t)
+			dashboardSvc.AssertExpectations(t)
+			s.AssertExpectations(t)
+		})
+	}
+}
+
+// TestInitHeadNode_DashboardVerifyFailureHint asserts that when ray up exits 0 but
+// the post-up GetClusterMetadata probe fails, the wrapped error mentions port 8265
+// so users learn the most likely cause (NEU-244).
+func TestInitHeadNode_DashboardVerifyFailureHint(t *testing.T) {
+	acceleratorManager := &acceleratormocks.MockManager{}
+	e := &commandmocks.MockExecutor{}
+	dashboardSvc := &dashboardmocks.MockDashboardService{}
+
+	// upCluster: builds accelerator config and shells out to ray up
+	acceleratorManager.On("GetNodeRuntimeConfig", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v1.RuntimeConfig{}, nil)
+	e.On("Execute", mock.Anything, mock.Anything, mock.Anything).Return([]byte(""), nil).Once()
+	// post-up verify probe fails
+	dashboardSvc.On("GetClusterMetadata").Return(nil, errors.New("connection refused")).Once()
+
+	s := storagemocks.MockStorage{}
+	s.On("UpdateCluster", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	r := &sshRayClusterReconciler{
+		acceleratorManager: acceleratorManager,
+		executor:           e,
+		storage:            &s,
+	}
+
+	err := r.initHeadNode(&ReconcileContext{
+		rayService: dashboardSvc,
+		sshClusterConfig: &v1.RaySSHProvisionClusterConfig{
+			Provider: v1.Provider{HeadIP: "192.168.1.10"},
+		},
+		sshRayClusterConfig: &v1.RayClusterConfig{},
+		sshConfigGenerator:  newRaySSHLocalConfigGenerator("test"),
+		Cluster: &v1.Cluster{
+			ID:       *pointer.Int(1),
+			Metadata: &v1.Metadata{Name: "test"},
+			Status: &v1.ClusterStatus{
+				AcceleratorType: v1.AcceleratorTypeNVIDIAGPU.StringPtr(),
+			},
+		},
+	}, false)
+
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "port 8265", "post-up verify failure must hint at port 8265 (got: %q)", msg)
+	assert.Contains(t, msg, "192.168.1.10", "post-up verify failure must mention the head IP (got: %q)", msg)
+	assert.Contains(t, msg, "connection refused", "post-up verify failure must preserve underlying error (got: %q)", msg)
+}
+
 func TestReconcileWorkerNode(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/cluster/ray_ssh_operation.go
+++ b/internal/cluster/ray_ssh_operation.go
@@ -467,8 +467,7 @@ func (c *sshRayClusterReconciler) generateRayClusterConfig(reconcileContext *Rec
 // dashboard API reachability (GCS) and the head node's raylet state, and returns the
 // head node's serving version when alive. This avoids redundant ListNodes calls.
 // When unhealthy, it returns a human-readable reason describing why so the caller can
-// surface an actionable message to users (e.g. "verify port 8265 is not already in
-// use" — NEU-244).
+// surface an actionable message to users (e.g. "verify port 8265 is not already in use").
 // Returns:
 //   - (true,  version, "",      nil) — dashboard reachable AND at least one head raylet is ALIVE
 //   - (false, "",      reason,  nil) — head not healthy; reason describes why

--- a/internal/cluster/ray_ssh_operation.go
+++ b/internal/cluster/ray_ssh_operation.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	stderrors "errors"
 	"fmt"
 	"path"
 	"strings"
@@ -16,6 +17,13 @@ import (
 	"github.com/neutree-ai/neutree/pkg/command_runner"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
+
+// errHeadNodeUnhealthy marks a known-unhealthy head-node state (dashboard
+// unreachable or head raylet not alive) as opposed to an unexpected internal
+// error like a ListNodes failure. Callers use errors.Is on this sentinel to
+// decide between writing a recovery status + rebuilding vs. propagating the
+// failure up the stack.
+var errHeadNodeUnhealthy = stderrors.New("head node unhealthy")
 
 func (c *sshRayClusterReconciler) upCluster(reconcileCtx *ReconcileContext, restart bool) (string, error) {
 	dockerConfig, changed, err := c.buildAcceleratorDockerConfig(reconcileCtx, reconcileCtx.sshClusterConfig.Provider.HeadIP)
@@ -463,23 +471,6 @@ func (c *sshRayClusterReconciler) generateRayClusterConfig(reconcileContext *Rec
 	return rayClusterConfig, nil
 }
 
-// headNodeUnhealthyError marks a known-unhealthy head-node state (as opposed to
-// an unexpected internal error). Callers use errors.As to decide whether to
-// surface a recovery status and rebuild, or propagate the failure up the stack.
-type headNodeUnhealthyError struct {
-	// reason is the rendered human-readable message; if an underlying error
-	// drove the unhealthy state, its rendering is already inlined here so
-	// Error() does not lose information.
-	reason string
-	// cause preserves the underlying error (e.g. dashboard connection error)
-	// for errors.Is / errors.As traversal. May be nil for purely descriptive
-	// unhealthy states such as "no alive head raylet".
-	cause error
-}
-
-func (e *headNodeUnhealthyError) Error() string { return e.reason }
-func (e *headNodeUnhealthyError) Unwrap() error { return e.cause }
-
 // checkHeadNodeHealth verifies the head node across two layers and returns the
 // head node's serving version when fully healthy:
 //  1. Dashboard service reachability — the Ray dashboard API on :8265 must
@@ -490,9 +481,9 @@ func (e *headNodeUnhealthyError) Unwrap() error { return e.cause }
 //     is not running.
 //
 // Returns:
-//   - (true,  version, nil)             — both layers pass
-//   - (false, "",      *headNodeUnhealthyError) — a known-unhealthy state (surface to user, then rebuild)
-//   - (false, "",      err)             — unexpected internal error (propagate up)
+//   - (true,  version, nil)                            — both layers pass
+//   - (false, "",      err wrapping errHeadNodeUnhealthy) — known-unhealthy state (surface to user, then rebuild)
+//   - (false, "",      err)                            — unexpected internal error (propagate up)
 func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileContext) (bool, string, error) {
 	headIP := reconcileCtx.sshClusterConfig.Provider.HeadIP
 
@@ -505,13 +496,10 @@ func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileCon
 		// only logs the bind failure to stderr). The most common cause of an
 		// unreachable dashboard right after a successful `ray up` is that
 		// port 8265 was already in use on the head host.
-		return false, "", &headNodeUnhealthyError{
-			reason: fmt.Sprintf(
-				"Ray dashboard on head node %s is unreachable (%v); "+
-					"verify port 8265 is not already in use by another process on this host",
-				headIP, err),
-			cause: err,
-		}
+		return false, "", fmt.Errorf(
+			"%w: Ray dashboard on head node %s is unreachable (%v); "+
+				"verify port 8265 is not already in use by another process on this host",
+			errHeadNodeUnhealthy, headIP, err)
 	}
 
 	nodes, err := reconcileCtx.rayService.ListNodes()
@@ -532,9 +520,7 @@ func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileCon
 	// - Head raylet exited and Ray lost the isHeadNode flag
 	// - Head node exists but state is DEAD
 	// - No head node in list yet (initial startup; ProvisioningWaitTime prevents rebuild loops)
-	return false, "", &headNodeUnhealthyError{
-		reason: fmt.Sprintf("head raylet on %s is not alive", headIP),
-	}
+	return false, "", fmt.Errorf("%w: head raylet on %s is not alive", errHeadNodeUnhealthy, headIP)
 }
 
 func (c *sshRayClusterReconciler) upgradeCluster(reconcileCtx *ReconcileContext) error {

--- a/internal/cluster/ray_ssh_operation.go
+++ b/internal/cluster/ray_ssh_operation.go
@@ -480,13 +480,18 @@ type headNodeUnhealthyError struct {
 func (e *headNodeUnhealthyError) Error() string { return e.reason }
 func (e *headNodeUnhealthyError) Unwrap() error { return e.cause }
 
-// checkHeadNodeHealth checks whether the head node is fully healthy by verifying
-// both dashboard API reachability (GCS) and the head node's raylet state, and
-// returns the head node's serving version when alive. This avoids redundant
-// ListNodes calls.
+// checkHeadNodeHealth verifies the head node across two layers and returns the
+// head node's serving version when fully healthy:
+//  1. Dashboard service reachability — the Ray dashboard API on :8265 must
+//     answer GetClusterMetadata; if it does not, the head is unhealthy (the
+//     most common cause is port 8265 occupancy on the host).
+//  2. Head raylet state — at least one head-flagged record returned by
+//     ListNodes must be in AliveNodeState; otherwise the head process itself
+//     is not running.
+//
 // Returns:
-//   - (true,  version, nil)             — dashboard reachable AND a head raylet is ALIVE
-//   - (false, "",      *headNodeUnhealthyError) — head not healthy with a known cause (surface to user, then rebuild)
+//   - (true,  version, nil)             — both layers pass
+//   - (false, "",      *headNodeUnhealthyError) — a known-unhealthy state (surface to user, then rebuild)
 //   - (false, "",      err)             — unexpected internal error (propagate up)
 func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileContext) (bool, string, error) {
 	headIP := reconcileCtx.sshClusterConfig.Provider.HeadIP
@@ -528,7 +533,7 @@ func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileCon
 	// - Head node exists but state is DEAD
 	// - No head node in list yet (initial startup; ProvisioningWaitTime prevents rebuild loops)
 	return false, "", &headNodeUnhealthyError{
-		reason: fmt.Sprintf("no alive head raylet found on %s", headIP),
+		reason: fmt.Sprintf("head raylet on %s is not alive", headIP),
 	}
 }
 

--- a/internal/cluster/ray_ssh_operation.go
+++ b/internal/cluster/ray_ssh_operation.go
@@ -466,21 +466,36 @@ func (c *sshRayClusterReconciler) generateRayClusterConfig(reconcileContext *Rec
 // checkHeadNodeHealth checks whether the head node is fully healthy by verifying both
 // dashboard API reachability (GCS) and the head node's raylet state, and returns the
 // head node's serving version when alive. This avoids redundant ListNodes calls.
+// When unhealthy, it returns a human-readable reason describing why so the caller can
+// surface an actionable message to users (e.g. "verify port 8265 is not already in
+// use" — NEU-244).
 // Returns:
-//   - (true, version, nil)  — dashboard reachable AND at least one head raylet is ALIVE
-//   - (false, "", nil)      — dashboard unreachable, or raylet is not alive
-//   - (false, "", err)      — an unexpected error occurred (e.g. ListNodes failed)
-func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileContext) (bool, string, error) {
+//   - (true,  version, "",      nil) — dashboard reachable AND at least one head raylet is ALIVE
+//   - (false, "",      reason,  nil) — head not healthy; reason describes why
+//   - (false, "",      "",      err) — an unexpected error occurred (e.g. ListNodes failed)
+func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileContext) (bool, string, string, error) {
+	headIP := reconcileCtx.sshClusterConfig.Provider.HeadIP
+
 	_, err := reconcileCtx.rayService.GetClusterMetadata()
 	if err != nil {
 		klog.V(4).Infof("Head node dashboard unreachable for cluster %s: %v",
 			reconcileCtx.Cluster.Metadata.WorkspaceName(), err)
-		return false, "", nil
+
+		// `ray up` exits 0 even when the dashboard fails to bind to :8265 (Ray
+		// only logs the bind failure to stderr). The most common cause of an
+		// unreachable dashboard right after a successful `ray up` is that
+		// port 8265 was already in use on the head host.
+		reason := fmt.Sprintf(
+			"Ray dashboard on head node %s is unreachable (%v); "+
+				"verify port 8265 is not already in use by another process on this host",
+			headIP, err)
+
+		return false, "", reason, nil
 	}
 
 	nodes, err := reconcileCtx.rayService.ListNodes()
 	if err != nil {
-		return false, "", errors.Wrap(err, "failed to list ray nodes")
+		return false, "", "", errors.Wrap(err, "failed to list ray nodes")
 	}
 
 	// Ray can keep multiple records for the same head node across restarts
@@ -488,7 +503,7 @@ func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileCon
 	// head node record is in AliveNodeState.
 	for _, node := range nodes {
 		if node.Raylet.IsHeadNode && node.Raylet.State == v1.AliveNodeState {
-			return true, v1.GetVersionFromLabels(node.Raylet.Labels), nil
+			return true, v1.GetVersionFromLabels(node.Raylet.Labels), "", nil
 		}
 	}
 
@@ -496,7 +511,7 @@ func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileCon
 	// - Head raylet exited and Ray lost the isHeadNode flag
 	// - Head node exists but state is DEAD
 	// - No head node in list yet (initial startup; ProvisioningWaitTime prevents rebuild loops)
-	return false, "", nil
+	return false, "", fmt.Sprintf("no alive head raylet found on %s", headIP), nil
 }
 
 func (c *sshRayClusterReconciler) upgradeCluster(reconcileCtx *ReconcileContext) error {

--- a/internal/cluster/ray_ssh_operation.go
+++ b/internal/cluster/ray_ssh_operation.go
@@ -463,16 +463,32 @@ func (c *sshRayClusterReconciler) generateRayClusterConfig(reconcileContext *Rec
 	return rayClusterConfig, nil
 }
 
-// checkHeadNodeHealth checks whether the head node is fully healthy by verifying both
-// dashboard API reachability (GCS) and the head node's raylet state, and returns the
-// head node's serving version when alive. This avoids redundant ListNodes calls.
-// When unhealthy, it returns a human-readable reason describing why so the caller can
-// surface an actionable message to users (e.g. "verify port 8265 is not already in use").
+// headNodeUnhealthyError marks a known-unhealthy head-node state (as opposed to
+// an unexpected internal error). Callers use errors.As to decide whether to
+// surface a recovery status and rebuild, or propagate the failure up the stack.
+type headNodeUnhealthyError struct {
+	// reason is the rendered human-readable message; if an underlying error
+	// drove the unhealthy state, its rendering is already inlined here so
+	// Error() does not lose information.
+	reason string
+	// cause preserves the underlying error (e.g. dashboard connection error)
+	// for errors.Is / errors.As traversal. May be nil for purely descriptive
+	// unhealthy states such as "no alive head raylet".
+	cause error
+}
+
+func (e *headNodeUnhealthyError) Error() string { return e.reason }
+func (e *headNodeUnhealthyError) Unwrap() error { return e.cause }
+
+// checkHeadNodeHealth checks whether the head node is fully healthy by verifying
+// both dashboard API reachability (GCS) and the head node's raylet state, and
+// returns the head node's serving version when alive. This avoids redundant
+// ListNodes calls.
 // Returns:
-//   - (true,  version, "",      nil) — dashboard reachable AND at least one head raylet is ALIVE
-//   - (false, "",      reason,  nil) — head not healthy; reason describes why
-//   - (false, "",      "",      err) — an unexpected error occurred (e.g. ListNodes failed)
-func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileContext) (bool, string, string, error) {
+//   - (true,  version, nil)             — dashboard reachable AND a head raylet is ALIVE
+//   - (false, "",      *headNodeUnhealthyError) — head not healthy with a known cause (surface to user, then rebuild)
+//   - (false, "",      err)             — unexpected internal error (propagate up)
+func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileContext) (bool, string, error) {
 	headIP := reconcileCtx.sshClusterConfig.Provider.HeadIP
 
 	_, err := reconcileCtx.rayService.GetClusterMetadata()
@@ -484,17 +500,18 @@ func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileCon
 		// only logs the bind failure to stderr). The most common cause of an
 		// unreachable dashboard right after a successful `ray up` is that
 		// port 8265 was already in use on the head host.
-		reason := fmt.Sprintf(
-			"Ray dashboard on head node %s is unreachable (%v); "+
-				"verify port 8265 is not already in use by another process on this host",
-			headIP, err)
-
-		return false, "", reason, nil
+		return false, "", &headNodeUnhealthyError{
+			reason: fmt.Sprintf(
+				"Ray dashboard on head node %s is unreachable (%v); "+
+					"verify port 8265 is not already in use by another process on this host",
+				headIP, err),
+			cause: err,
+		}
 	}
 
 	nodes, err := reconcileCtx.rayService.ListNodes()
 	if err != nil {
-		return false, "", "", errors.Wrap(err, "failed to list ray nodes")
+		return false, "", errors.Wrap(err, "failed to list ray nodes")
 	}
 
 	// Ray can keep multiple records for the same head node across restarts
@@ -502,7 +519,7 @@ func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileCon
 	// head node record is in AliveNodeState.
 	for _, node := range nodes {
 		if node.Raylet.IsHeadNode && node.Raylet.State == v1.AliveNodeState {
-			return true, v1.GetVersionFromLabels(node.Raylet.Labels), "", nil
+			return true, v1.GetVersionFromLabels(node.Raylet.Labels), nil
 		}
 	}
 
@@ -510,7 +527,9 @@ func (c *sshRayClusterReconciler) checkHeadNodeHealth(reconcileCtx *ReconcileCon
 	// - Head raylet exited and Ray lost the isHeadNode flag
 	// - Head node exists but state is DEAD
 	// - No head node in list yet (initial startup; ProvisioningWaitTime prevents rebuild loops)
-	return false, "", fmt.Sprintf("no alive head raylet found on %s", headIP), nil
+	return false, "", &headNodeUnhealthyError{
+		reason: fmt.Sprintf("no alive head raylet found on %s", headIP),
+	}
 }
 
 func (c *sshRayClusterReconciler) upgradeCluster(reconcileCtx *ReconcileContext) error {


### PR DESCRIPTION
## Issue

NEU-244

## Summary

When `ray up` runs on an SSH head host whose port 8265 (Ray Dashboard / Job Submission API) is already bound by another process, Ray logs the bind failure only to stderr — `ray up` itself still exits 0. Neutree previously reported the resulting initialization stall as a generic `"head node X unhealthy (dashboard unreachable or raylet not alive), attempting recovery"` (or a raw connection-error wrap), giving users no clue that the real cause was port occupancy.

This change enriches the two head-node probe paths so the user-visible error wording names port 8265 as the most likely cause and carries the underlying error.

## Changes

- `internal/cluster/ray_ssh_operation.go`
  - `checkHeadNodeHealth` now returns an extra `reason string`. The dashboard-unreachable branch builds a reason containing the head IP, the underlying error, and an explicit "verify port 8265 is not already in use by another process on this host" hint. The no-alive-raylet branch builds a reason naming the head IP without the port hint (so misleading hints don't show up for raylet-death cases).
- `internal/cluster/ray_ssh_cluster.go`
  - `reconcileHeadNode` threads the reason into `WriteRecoveryStatus`.
  - `initHeadNode` wraps the post-`ray up` `GetClusterMetadata` failure with the same port hint + head IP, preserving the underlying error.
- `internal/cluster/ray_ssh_cluster_test.go`
  - New `TestReconcileHeadNode_RecoveryReason` — table-driven, two sub-cases: dashboard-unreachable asserts the recovery message contains `port 8265` + the underlying error; no-alive-head-raylet asserts the message names raylet but does NOT contain `port 8265`.
  - New `TestInitHeadNode_DashboardVerifyFailureHint` — asserts the wrapped error surfaces the port hint, head IP, and underlying error.

Scope is wording-only at user-facing boundaries. No reconcile decision path (alive judgement, rebuild trigger, ProvisioningWaitTime) is altered; no new SSH calls, dependencies, metrics, or DB fields. The change-level is **Standard**.

Alternatives considered and rejected:
- Scanning `ray up` stdout/stderr for the bind-failure substring — couples Neutree to a Ray log line that may change, and conflicts with the upstream behavior that intentionally lets raylet/GCS keep running when only the dashboard fails.
- Adding an active SSH probe (e.g. `ss -ltnp 'sport = :8265'`) to identify the occupying process — gives a more definitive answer but adds a new SSH call path + parsing + failure modes for a hint that is already enough to point users at the right thing to check; revisit later if needed.

## Test Plan

- [x] Unit tests: `go test -race ./internal/cluster/...` — `ok` (new tests pass; existing tests unaffected).
- [ ] E2E (if affected): **not affected** — reproducing this bug requires pre-binding port 8265 on the head host before reconcile, which the current SSH e2e harness has no hook for. The change is wording-only at user-facing boundaries; unit-test assertions on the persisted recovery message and the wrapped error are the right level of coverage.
- [ ] DB integration (`make db-test`): **not affected**.

Manual verification required (e2e cannot cover; please run on a test SSH cluster):

1. On the head host, pre-occupy port 8265: `python3 -m http.server 8265 &` (or `nc -l -p 8265 &`).
2. Through `neutree-cli`, create an SSH cluster pointing at this head host.
3. Wait ~30s for reconcile to run; inspect the cluster status / `ErrorMessage`:
   - Before this PR: `"head node X unhealthy (dashboard unreachable or raylet not alive), attempting recovery"` or `"failed to get cluster metadata after starting head node: <conn error>"` — no port mention.
   - After this PR: message contains `"verify port 8265 is not already in use by another process on this host"`, the head IP, and the underlying connection error.
4. Kill the occupying process; on the next reconcile the cluster transitions to `Running`, confirming the happy path is unchanged.

## Risk & Rollback

- No schema change, no API change, no on-disk format change. The only externally observable change is the wording in `Cluster.Status.ErrorMessage` for SSH clusters whose head dashboard probe fails. Anything parsing that field as opaque text is unaffected; anything pattern-matching the old substring `"dashboard unreachable or raylet not alive"` would need to switch to substring `"head node unhealthy:"` — none known in-tree.
- The `checkHeadNodeHealth` signature change is internal (single call site in this package); no callers outside `internal/cluster/` consume it.
- Rollback: straight revert; no follow-up cleanup needed.