### PR TITLE
Drop sticky ClientError in storage RPC path (postgrest-go v0.0.12)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
 	github.com/supabase-community/gotrue-go v1.2.1
-	github.com/supabase-community/postgrest-go v0.0.11
+	github.com/supabase-community/postgrest-go v0.0.12
 	github.com/tidwall/gjson v1.18.0
 	go.openly.dev/pointy v1.3.0
 	golang.org/x/crypto v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -264,8 +264,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/supabase-community/gotrue-go v1.2.1 h1:8FvrCyx++6evFtOu1aOpbsfEy6s24HGCbBfPMmQW7qI=
 github.com/supabase-community/gotrue-go v1.2.1/go.mod h1:86DXBiAUNcbCfgbeOPEh0PQxScLfowUbYgakETSFQOw=
-github.com/supabase-community/postgrest-go v0.0.11 h1:717GTUMfLJxSBuAeEQG2MuW5Q62Id+YrDjvjprTSErg=
-github.com/supabase-community/postgrest-go v0.0.11/go.mod h1:cw6LfzMyK42AOSBA1bQ/HZ381trIJyuui2GWhraW7Cc=
+github.com/supabase-community/postgrest-go v0.0.12 h1:4xJmimJra904t6Rj+umPyu1qm6ih7rhd7fvgqAblajc=
+github.com/supabase-community/postgrest-go v0.0.12/go.mod h1:cw6LfzMyK42AOSBA1bQ/HZ381trIJyuui2GWhraW7Cc=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/pkg/storage/postgrest.go
+++ b/pkg/storage/postgrest.go
@@ -667,7 +667,7 @@ func (s *postgrestStorage) ListEndpoint(option ListOption) ([]v1.Endpoint, error
 func (s *postgrestStorage) CallDatabaseFunction(method string, params map[string]interface{}, result interface{}) error {
 	resultString, err := s.postgrestClient.RpcWithError(method, "", params)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "rpc %s failed", method)
 	}
 
 	if result == nil {

--- a/pkg/storage/postgrest.go
+++ b/pkg/storage/postgrest.go
@@ -665,20 +665,17 @@ func (s *postgrestStorage) ListEndpoint(option ListOption) ([]v1.Endpoint, error
 }
 
 func (s *postgrestStorage) CallDatabaseFunction(method string, params map[string]interface{}, result interface{}) error {
-	resultString := s.postgrestClient.Rpc(method, "", params)
-
-	if s.postgrestClient.ClientError != nil {
-		return s.postgrestClient.ClientError
+	resultString, err := s.postgrestClient.RpcWithError(method, "", params)
+	if err != nil {
+		return err
 	}
 
 	if result == nil {
 		return nil
 	}
 
-	err := json.Unmarshal([]byte(resultString), result)
-	if err != nil {
+	if err := json.Unmarshal([]byte(resultString), result); err != nil {
 		return errors.Wrapf(err, "failed to unmarshal response: %v Raw response: %s", err, resultString)
-		// ModelCatalog storage methods
 	}
 
 	return nil

--- a/pkg/storage/postgrest.go
+++ b/pkg/storage/postgrest.go
@@ -675,7 +675,7 @@ func (s *postgrestStorage) CallDatabaseFunction(method string, params map[string
 	}
 
 	if err := json.Unmarshal([]byte(resultString), result); err != nil {
-		return errors.Wrapf(err, "failed to unmarshal response: %v Raw response: %s", err, resultString)
+		return errors.Wrapf(err, "failed to unmarshal response, raw: %s", resultString)
 	}
 
 	return nil


### PR DESCRIPTION
## Issue

NEU-447 — postgrest-go Client.ClientError leaks across calls after a single RPC failure, jamming all controllers.

## Summary

`postgrest-go` v0.0.11 exposes a sticky `Client.ClientError` field that is written on any RPC failure but never cleared. The shared `executeHelper` short-circuits on it, so any single failure of the periodic `sync_api_key_usage` RPC (e.g. a transient DNS timeout) freezes the whole storage `*postgrest.Client`: every later `List`/`Get`/`Update`/`Insert`/`Delete`/RPC returns the original error verbatim — including its URL string — and the only recovery is restarting `neutree-core`. In production this manifested as every controller logging failures pointing at `/rpc/sync_api_key_usage` regardless of the resource it actually wanted to read.

## Changes

- Bump `github.com/supabase-community/postgrest-go` from `v0.0.11` to `v0.0.12`. 
- Switch `pkg/storage/postgrest.go` `CallDatabaseFunction` to the new `RpcWithError(name, count, body) (string, error)` API. This was the only remaining read of the sticky `Client.ClientError` field in the codebase; after this change, a stale `ClientError` cannot influence any storage call regardless of how the `*postgrest.Client` is shared.
- Drop one orphaned trailing comment (`// ModelCatalog storage methods`) that sat inside the wrong `errors.Wrapf` block, and remove a redundant `%v` from the same `Wrapf` (the wrapped error was already auto-appended by `Wrapf`, producing a duplicated suffix in the message).

## Test Plan

- [x] `go vet ./...` clean.
- [x] `go test -race ./internal/middleware/... ./internal/routes/proxies/... ./internal/cron/...` — all callers of `CallDatabaseFunction` pass against the new signature (callers use the mocked `Storage` interface, so they exercise the changed call site through `mock_storage.go`).
- [ ] E2E: not affected — change is confined to one storage method's error plumbing and a dep bump that preserves all public API signatures (v0.0.12 is backward-compatible: existing `Execute()`/`Rpc()`/`From()`/`Select()`/... signatures all retained, new methods are additive).
- [ ] DB integration (`make db-test`): not affected — RPC dispatch path doesn't touch SQL behavior.

## Risk & Rollback

- **Backward compat:** postgrest-go `v0.0.12` keeps every public symbol from `v0.0.11`; the `*WithContext` and `RpcWithError` additions are net-new. `transport.header` gains a mutex that is invisible to the Neutree call pattern (single goroutine per controller reconcile).
- **Functional risk:** `RpcWithError` is the underlying call that the old `Rpc` now wraps in v0.0.12 — `Rpc` itself just calls `RpcWithError` and stashes the error into `ClientError`. So `CallDatabaseFunction`'s success path is byte-identical to before; the only changed behavior is failure now travels via Go return value instead of a sticky field, which is the point of the fix.
- **Remaining `ClientError` reads:** `pkg/storage/storage.go:239,288` still check `Client.ClientError` immediately after `postgrest.NewClient()`. These are construction-time URL-parse error checks on a brand-new Client, so they cannot suffer the cross-request leak. v0.0.12 still sets `ClientError` on URL parse failure in `NewClient`, so the behavior is preserved.
- **Known pre-existing gap (not introduced or fixed by this PR):** Neither v0.0.11's `Rpc` nor v0.0.12's `RpcWithError` inspect HTTP status codes — both return the response body string with a nil error on a 4xx/5xx response. The chain-builder path (`From().Select().Execute()`) does check `resp.StatusCode >= 400` in `executeHelper`. `CallDatabaseFunction` consequently can silently miss a PostgREST-side error on the RPC path; this matches v0.0.11 behavior exactly and is out of scope for this fix. Filing a separate ticket / upstream PR is preferable to widening this change.
- **Rollback:** revert this PR; no DB schema change, no data migration, no on-the-wire change.

Classification: Trivial (dep bump + 6-line storage layer change). docs MR + TestRail + E2E intentionally skipped per the `/neutree-dev` Trivial path.