### PR TITLE
fix: guard against null tool name in Anthropic non-streaming response

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -476,10 +476,14 @@ local function convert_response(openai_resp, request_model)
                     input = parsed
                 end
             end
+            local fn_name = (tc["function"] or EMPTY).name
+            if fn_name == nil or fn_name == cjson.null then
+                fn_name = ""
+            end
             content[#content + 1] = {
                 type = "tool_use",
                 id = tc.id,
-                name = tc["function"] and tc["function"].name or "",
+                name = fn_name,
                 input = input,
             }
         end


### PR DESCRIPTION
## Issue

NEU-404 

## Summary

`convert_response()` in the Kong `neutree-ai-gateway` plugin propagates `cjson.null` into the Anthropic `tool_use.name` field when an upstream OpenAI-format backend returns `tool_call.function.name: null`. `cjson.null` is a truthy lightuserdata sentinel, so the original `tc["function"] and tc["function"].name or ""` short-circuit never falls back to the empty string and the malformed null leaks into the response body, corrupting downstream consumers that expect `name` to be a string.

The streaming path (line 797) uses `(tc["function"] or EMPTY).name or ""`, which the ticket cites as a reference fix. That pattern only handles a missing `function` table — it still returns `cjson.null` when the `name` field itself decodes to null, so it would not actually fix the bug as described. The codebase's correct, already-used pattern is an explicit `~= cjson.null` check (see `message.content` at line 461 and `finish_reason` at line 808).

## Changes

- `gateway/kong/plugins/neutree-ai-gateway/handler.lua`: extract `name` into a local in `convert_response()` and coerce both `nil` and `cjson.null` to `""` before placing it in the `tool_use` block.

## Test Plan

- [x] E2E: not affected — Kong Lua plugin without an existing e2e harness; behavior covered manually via repro described in the Jira ticket (Anthropic-protocol request, OpenAI-backend tool_call with `function.name: null`).
- [x] DB integration (`make db-test`): not affected.
- Manual verification (e2e cannot cover this): send an Anthropic-protocol request through the gateway against a backend that emits `tool_call.function.name: null`; verify the response `tool_use` block has `name: ""` rather than a JSON `null`.

## Risk & Rollback

- Scope: single 1→5 line change inside a Lua adapter function; no DB, schema, or wire-format change.
- Backward compat: returning an empty string instead of malformed null is strictly safer for downstream consumers; no client breakage expected.
- Rollback: revert the commit.