### PR TITLE
fix: select launch node IP from default route

### DIFF
--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -63,14 +63,11 @@ Examples:
 				return fmt.Errorf("--jwt-secret is required")
 			}
 
-			// set default node ip
-			if options.nodeIP == "" {
-				ip, err := util.GetHostIP()
-				if err != nil {
-					return err
-				}
-				options.nodeIP = ip
+			err := resolveNodeIP(cmd.OutOrStdout(), options.commonOptions, util.GetHostIP)
+			if err != nil {
+				return err
 			}
+
 			return installNeutreeCore(exector, options)
 		},
 	}

--- a/cmd/neutree-cli/app/cmd/launch/launch.go
+++ b/cmd/neutree-cli/app/cmd/launch/launch.go
@@ -88,10 +88,12 @@ func resolveNodeIP(out io.Writer, options *commonOptions, getHostIP func() (stri
 		if err != nil {
 			return err
 		}
+
 		options.nodeIP = ip
 	}
 
 	_, err := fmt.Fprintf(out, "Using node IP: %s\n", options.nodeIP)
+
 	return err
 }
 

--- a/cmd/neutree-cli/app/cmd/launch/launch.go
+++ b/cmd/neutree-cli/app/cmd/launch/launch.go
@@ -1,6 +1,8 @@
 package launch
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -78,6 +80,19 @@ Examples:
 	launchCmd.AddCommand(NewNeutreeCoreInstallCmd(exector, commonOptions))
 
 	return launchCmd
+}
+
+func resolveNodeIP(out io.Writer, options *commonOptions, getHostIP func() (string, error)) error {
+	if options.nodeIP == "" {
+		ip, err := getHostIP()
+		if err != nil {
+			return err
+		}
+		options.nodeIP = ip
+	}
+
+	_, err := fmt.Fprintf(out, "Using node IP: %s\n", options.nodeIP)
+	return err
 }
 
 func LaunchWorkDir() string {

--- a/cmd/neutree-cli/app/cmd/launch/launch_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/launch_test.go
@@ -1,6 +1,8 @@
 package launch
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -102,6 +104,34 @@ services:
 			assert.Equal(t, tt.expectedImages, actualImages)
 		})
 	}
+}
+
+func TestResolveNodeIPDetectsAndPrintsNodeIP(t *testing.T) {
+	options := &commonOptions{}
+	var output bytes.Buffer
+
+	err := resolveNodeIP(&output, options, func() (string, error) {
+		return "10.0.0.42", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.42", options.nodeIP)
+	assert.Equal(t, "Using node IP: 10.0.0.42\n", output.String())
+}
+
+func TestResolveNodeIPPrintsExplicitNodeIP(t *testing.T) {
+	options := &commonOptions{
+		nodeIP: "192.168.1.12",
+	}
+	var output bytes.Buffer
+
+	err := resolveNodeIP(&output, options, func() (string, error) {
+		return "", errors.New("should not auto-detect explicit node IP")
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.12", options.nodeIP)
+	assert.Equal(t, "Using node IP: 192.168.1.12\n", output.String())
 }
 
 func TestNewLaunchCmd(t *testing.T) {

--- a/cmd/neutree-cli/app/cmd/launch/obs_stack.go
+++ b/cmd/neutree-cli/app/cmd/launch/obs_stack.go
@@ -44,13 +44,9 @@ Examples:
   # Deploy with custom registry
   neutree-cli launch obs-stack --mirror-registry my.registry.com`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// set default node ip
-			if options.nodeIP == "" {
-				ip, err := util.GetHostIP()
-				if err != nil {
-					return err
-				}
-				options.nodeIP = ip
+			err := resolveNodeIP(cmd.OutOrStdout(), options.commonOptions, util.GetHostIP)
+			if err != nil {
+				return err
 			}
 
 			return installObsStack(exector, options)

--- a/cmd/neutree-cli/app/util/ip.go
+++ b/cmd/neutree-cli/app/util/ip.go
@@ -3,10 +3,29 @@ package util
 import (
 	"fmt"
 	"net"
+
+	netutils "k8s.io/apimachinery/pkg/util/net"
 )
 
 func GetHostIP() (string, error) {
-	addrs, err := net.InterfaceAddrs()
+	return getHostIP(netutils.ChooseHostInterface, net.InterfaceAddrs)
+}
+
+func getHostIP(chooseHostInterface func() (net.IP, error), interfaceAddrs func() ([]net.Addr, error)) (string, error) {
+	ip, err := chooseHostInterface()
+	if err == nil {
+		ipv4 := ip.To4()
+		if ipv4 == nil {
+			return "", fmt.Errorf("no valid host IPv4 found")
+		}
+		return ipv4.String(), nil
+	}
+
+	return getHostIPFromInterfaceAddrs(interfaceAddrs)
+}
+
+func getHostIPFromInterfaceAddrs(interfaceAddrs func() ([]net.Addr, error)) (string, error) {
+	addrs, err := interfaceAddrs()
 	if err != nil {
 		return "", err
 	}

--- a/cmd/neutree-cli/app/util/ip.go
+++ b/cmd/neutree-cli/app/util/ip.go
@@ -18,6 +18,7 @@ func getHostIP(chooseHostInterface func() (net.IP, error), interfaceAddrs func()
 		if ipv4 == nil {
 			return "", fmt.Errorf("no valid host IPv4 found")
 		}
+
 		return ipv4.String(), nil
 	}
 

--- a/cmd/neutree-cli/app/util/ip.go
+++ b/cmd/neutree-cli/app/util/ip.go
@@ -7,38 +7,57 @@ import (
 	netutils "k8s.io/apimachinery/pkg/util/net"
 )
 
+// GetHostIP returns the IPv4 address used by launch templates.
+// It first follows Kubernetes' host-interface selection so multi-NIC hosts
+// prefer the default-route interface. If that cannot produce an IPv4 address,
+// it falls back to the legacy interface scan to preserve behavior on hosts
+// without usable route information.
 func GetHostIP() (string, error) {
-	return getHostIP(netutils.ChooseHostInterface, net.InterfaceAddrs)
-}
-
-func getHostIP(chooseHostInterface func() (net.IP, error), interfaceAddrs func() ([]net.Addr, error)) (string, error) {
-	ip, err := chooseHostInterface()
+	ip, err := getDefaultHostIPv4()
 	if err == nil {
-		ipv4 := ip.To4()
-		if ipv4 == nil {
-			return "", fmt.Errorf("no valid host IPv4 found")
-		}
-
-		return ipv4.String(), nil
+		return ip, nil
 	}
 
-	return getHostIPFromInterfaceAddrs(interfaceAddrs)
+	return getFirstInterfaceIPv4()
 }
 
-func getHostIPFromInterfaceAddrs(interfaceAddrs func() ([]net.Addr, error)) (string, error) {
-	addrs, err := interfaceAddrs()
+func getDefaultHostIPv4() (string, error) {
+	ip, err := netutils.ChooseHostInterface()
 	if err != nil {
 		return "", err
 	}
 
+	return ipv4String(ip)
+}
+
+func getFirstInterfaceIPv4() (string, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", err
+	}
+
+	return getFirstIPv4FromAddrs(addrs)
+}
+
+func getFirstIPv4FromAddrs(addrs []net.Addr) (string, error) {
 	for _, addr := range addrs {
 		ipNet, ok := addr.(*net.IPNet)
 		if ok && !ipNet.IP.IsLoopback() {
-			if ipNet.IP.To4() != nil {
-				return ipNet.IP.String(), nil
+			ip, err := ipv4String(ipNet.IP)
+			if err == nil {
+				return ip, nil
 			}
 		}
 	}
 
 	return "", fmt.Errorf("no valid host IP found")
+}
+
+func ipv4String(ip net.IP) (string, error) {
+	ipv4 := ip.To4()
+	if ipv4 == nil {
+		return "", fmt.Errorf("no valid host IPv4 found")
+	}
+
+	return ipv4.String(), nil
 }

--- a/cmd/neutree-cli/app/util/ip_test.go
+++ b/cmd/neutree-cli/app/util/ip_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"errors"
 	"net"
 	"testing"
 
@@ -9,53 +8,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetHostIPPrefersKubernetesHostInterface(t *testing.T) {
-	ip, err := getHostIP(
-		func() (net.IP, error) {
-			return net.ParseIP("10.0.0.42"), nil
-		},
-		func() ([]net.Addr, error) {
-			return []net.Addr{
-				mustParseCIDR(t, "172.17.0.1/16"),
-				mustParseCIDR(t, "192.168.1.12/24"),
-			}, nil
-		},
-	)
+func TestIPv4StringReturnsIPv4Address(t *testing.T) {
+	ip, err := ipv4String(net.ParseIP("10.0.0.42"))
 
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.42", ip)
 }
 
-func TestGetHostIPFallsBackToInterfaceAddress(t *testing.T) {
-	ip, err := getHostIP(
-		func() (net.IP, error) {
-			return nil, errors.New("no default route")
-		},
-		func() ([]net.Addr, error) {
-			return []net.Addr{
-				mustParseCIDR(t, "127.0.0.1/8"),
-				mustParseCIDR(t, "192.168.1.12/24"),
-			}, nil
-		},
-	)
+func TestIPv4StringRejectsIPv6Address(t *testing.T) {
+	_, err := ipv4String(net.ParseIP("2001:db8::1"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid host IPv4 found")
+}
+
+func TestGetFirstIPv4FromAddrsSkipsLoopbackAndIPv6(t *testing.T) {
+	ip, err := getFirstIPv4FromAddrs([]net.Addr{
+		mustParseCIDR(t, "127.0.0.1/8"),
+		mustParseCIDR(t, "2001:db8::1/64"),
+		mustParseCIDR(t, "192.168.1.12/24"),
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "192.168.1.12", ip)
 }
 
-func TestGetHostIPRejectsIPv6HostInterface(t *testing.T) {
-	_, err := getHostIP(
-		func() (net.IP, error) {
-			return net.ParseIP("2001:db8::1"), nil
-		},
-		func() ([]net.Addr, error) {
-			t.Fatal("should not fall back when Kubernetes host interface returns an IPv6 address")
-			return nil, nil
-		},
-	)
+func TestGetFirstIPv4FromAddrsReturnsErrorWhenNoIPv4Exists(t *testing.T) {
+	_, err := getFirstIPv4FromAddrs([]net.Addr{
+		mustParseCIDR(t, "127.0.0.1/8"),
+		mustParseCIDR(t, "2001:db8::1/64"),
+	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no valid host IPv4 found")
+	assert.Contains(t, err.Error(), "no valid host IP found")
 }
 
 func mustParseCIDR(t *testing.T, cidr string) net.Addr {

--- a/cmd/neutree-cli/app/util/ip_test.go
+++ b/cmd/neutree-cli/app/util/ip_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHostIPPrefersKubernetesHostInterface(t *testing.T) {
+	ip, err := getHostIP(
+		func() (net.IP, error) {
+			return net.ParseIP("10.0.0.42"), nil
+		},
+		func() ([]net.Addr, error) {
+			return []net.Addr{
+				mustParseCIDR(t, "172.17.0.1/16"),
+				mustParseCIDR(t, "192.168.1.12/24"),
+			}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.42", ip)
+}
+
+func TestGetHostIPFallsBackToInterfaceAddress(t *testing.T) {
+	ip, err := getHostIP(
+		func() (net.IP, error) {
+			return nil, errors.New("no default route")
+		},
+		func() ([]net.Addr, error) {
+			return []net.Addr{
+				mustParseCIDR(t, "127.0.0.1/8"),
+				mustParseCIDR(t, "192.168.1.12/24"),
+			}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.12", ip)
+}
+
+func TestGetHostIPRejectsIPv6HostInterface(t *testing.T) {
+	_, err := getHostIP(
+		func() (net.IP, error) {
+			return net.ParseIP("2001:db8::1"), nil
+		},
+		func() ([]net.Addr, error) {
+			t.Fatal("should not fall back when Kubernetes host interface returns an IPv6 address")
+			return nil, nil
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid host IPv4 found")
+}
+
+func mustParseCIDR(t *testing.T, cidr string) net.Addr {
+	t.Helper()
+
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	require.NoError(t, err)
+	ipNet.IP = ip
+
+	return ipNet
+}


### PR DESCRIPTION
## Issue

NEU-451

## Summary

Fix launch node IP auto-detection on multi-NIC hosts. When `--node-ip` is not set, launch now prefers the host IP selected from default-route/interface information instead of returning the first non-loopback IPv4 address from interface enumeration. The selected node IP is printed before rendering/installing so operators can verify it.

## Changes

- Prefer default-route based host IP selection for launch auto-detection.
- Fall back to the legacy IPv4 interface scan when default host selection fails or returns a non-IPv4 address.
- Print the final node IP for both `launch neutree-core` and `launch obs-stack`.
- Add focused unit tests for IPv4 selection, fallback behavior, and launch output.

## Test Plan

- [x] `go test ./cmd/neutree-cli/app/util -count=1 -v`
- [x] `go test ./cmd/neutree-cli/app/cmd/launch -count=1 -v`
- [x] `go vet ./cmd/neutree-cli/app/util ./cmd/neutree-cli/app/cmd/launch`
- [x] `go test ./cmd/neutree-cli/app/... -count=1`
- [x] CI `pr-check`
- [x] E2E: not affected; CLI-only host IP selection and output change
- [x] DB integration: not affected; no database or migration changes

## Risk & Rollback

No DB schema or API contract changes. The main behavior change is the auto-detected launch node IP on multi-NIC hosts. Users can still override detection with `--node-ip`. Rollback is reverting this PR to restore the previous interface scan behavior.