### PR TITLE
fix: translate vLLM task runner by endpoint task

### DIFF
--- a/cluster-image-builder/Dockerfile.engine-vllm
+++ b/cluster-image-builder/Dockerfile.engine-vllm
@@ -23,6 +23,11 @@ ENV BUILDKITE_COMMIT=${RAY_COMMIT}
 ENV TRAVIS_COMMIT=${BUILDKITE_COMMIT}
 ENV BUILD_ONE_PYTHON_ONLY=py312
 ENV RAY_DISABLE_EXTRA_CPP=1
+# Docker build runs this stage as root, while Ray's manylinux script creates a
+# non-root builduser from HOST_UID/HOST_GID. Avoid defaulting those values to
+# 0/0, which makes groupadd collide with the existing root group.
+ENV HOST_UID=1000
+ENV HOST_GID=1000
 WORKDIR /ray
 COPY --from=ray_fetch ${COMMON_WORKDIR}/ray /ray
 RUN /ray/python/build-wheel-manylinux2014.sh

--- a/cluster-image-builder/serve/_utils/test_vllm_task_translate.py
+++ b/cluster-image-builder/serve/_utils/test_vllm_task_translate.py
@@ -1,0 +1,29 @@
+"""Tests for serve._utils.vllm_task_translate."""
+
+from serve._utils.vllm_task_translate import task_kwargs
+
+
+class TestTaskKwargs:
+    def test_text_embedding_maps_to_pooling_embed(self):
+        assert task_kwargs("text-embedding") == {"runner": "pooling", "convert": "embed"}
+
+    def test_text_rerank_maps_to_pooling_classify(self):
+        assert task_kwargs("text-rerank") == {"runner": "pooling", "convert": "classify"}
+
+    def test_text_generation_returns_empty(self):
+        # text-generation relies on vLLM's auto runner (generate); no flags injected.
+        assert task_kwargs("text-generation") == {}
+
+    def test_unknown_task_returns_empty(self):
+        assert task_kwargs("not-a-real-task") == {}
+
+    def test_empty_string_returns_empty(self):
+        assert task_kwargs("") == {}
+
+    def test_returns_fresh_dict_each_call(self):
+        # Mutating the returned dict must not poison subsequent calls.
+        d1 = task_kwargs("text-embedding")
+        d1["runner"] = "mutated"
+        d1["extra"] = "junk"
+        d2 = task_kwargs("text-embedding")
+        assert d2 == {"runner": "pooling", "convert": "embed"}

--- a/cluster-image-builder/serve/_utils/vllm_task_translate.py
+++ b/cluster-image-builder/serve/_utils/vllm_task_translate.py
@@ -1,0 +1,23 @@
+"""Translate Neutree's model_task to vLLM's --runner/--convert engine kwargs.
+
+vLLM removed --task in v0.17.0 and replaced it with --runner + --convert (both
+default "auto"). Auto-detect can fall back to a generate runner for multimodal
+embedding architectures (e.g. Qwen3-VL-Embedding), so Neutree must translate the
+registry-level task explicitly. This table is shared across vllm version-specific
+Ray Serve apps so adding a new vllm version is one import line.
+"""
+
+_TASK_KWARGS: dict[str, dict[str, str]] = {
+    "text-embedding": {"runner": "pooling", "convert": "embed"},
+    "text-rerank":    {"runner": "pooling", "convert": "classify"},
+    # text-generation: leave both defaults at "auto"; vLLM picks generate.
+}
+
+
+def task_kwargs(model_task: str) -> dict[str, str]:
+    """Return a fresh dict of runner/convert kwargs for a Neutree model_task.
+
+    Empty dict for unknown / generation tasks so callers can do
+    ``engine_kwargs.setdefault(k, v)`` without special-casing.
+    """
+    return dict(_TASK_KWARGS.get(model_task, {}))

--- a/cluster-image-builder/serve/_utils/vllm_task_translate.py
+++ b/cluster-image-builder/serve/_utils/vllm_task_translate.py
@@ -14,7 +14,7 @@ _TASK_KWARGS: dict[str, dict[str, str]] = {
 }
 
 
-def task_kwargs(model_task: str) -> dict[str, str]:
+def task_kwargs(model_task: str | None) -> dict[str, str]:
     """Return a fresh dict of runner/convert kwargs for a Neutree model_task.
 
     Empty dict for unknown / generation tasks so callers can do

--- a/cluster-image-builder/serve/vllm/v0_17_1/app.py
+++ b/cluster-image-builder/serve/vllm/v0_17_1/app.py
@@ -34,6 +34,7 @@ from downloader import get_downloader, build_request_from_model_args
 from serve._metrics.ray_stat_logger import NeutreeRayStatLogger
 from serve._utils import coerce_args, filter_engine_args
 from serve._utils.runtime_env import build_backend_runtime_env
+from serve._utils.vllm_task_translate import task_kwargs as _task_kwargs
 
 
 class SchedulerType(str, enum.Enum):
@@ -149,8 +150,12 @@ class Backend:
         engine_kwargs.pop("enable_server_load_tracking", None)
         engine_kwargs.pop("enable_tokenizer_info_endpoint", None)
 
-        # v0.17.1: --task removed, replaced by --runner/--convert (both default "auto").
-        # vLLM auto-detects the correct mode from model architecture.
+        # vLLM v0.17.1 removed --task; auto-detect can fall back to a
+        # generate runner for multimodal embedding architectures, so the
+        # registry-level task is translated to --runner/--convert kwargs
+        # here. setdefault keeps user-supplied engine_args overrides intact.
+        for _k, _v in _task_kwargs(model_task).items():
+            engine_kwargs.setdefault(_k, _v)
 
         # merge engine args
         # NOTE: enable_prefix_caching is intentionally NOT set here.

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/neutree-ai/neutree/internal/util"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // TestVLLMV0_17_1TemplateTaskTranslation locks in the contract that the
@@ -50,7 +51,8 @@ func TestVLLMV0_17_1TemplateTaskTranslation(t *testing.T) {
 				t.Fatalf("no objects rendered")
 			}
 
-			cmd := mustExtractContainerCommand(t, objs.Items[0].Object, "vllm-engine")
+			deploy := mustFindRenderedObject(t, objs.Items, "Deployment", "ep-test")
+			cmd := mustExtractContainerCommand(t, deploy.Object, "vllm-engine")
 
 			gotRunner := flagValue(cmd, "--runner")
 			if gotRunner != tc.wantRunner {
@@ -96,6 +98,17 @@ func newTestVLLMV0_17_1Vars(task string) map[string]any {
 	}
 }
 
+func mustFindRenderedObject(t *testing.T, objs []unstructured.Unstructured, kind, name string) unstructured.Unstructured {
+	t.Helper()
+	for _, obj := range objs {
+		if obj.GetKind() == kind && obj.GetName() == name {
+			return obj
+		}
+	}
+	t.Fatalf("rendered object %s/%s not found", kind, name)
+	return unstructured.Unstructured{}
+}
+
 // mustExtractContainerCommand pulls the named container's command list out of
 // a rendered unstructured Deployment object.
 func mustExtractContainerCommand(t *testing.T, obj map[string]any, containerName string) []string {
@@ -109,8 +122,8 @@ func mustExtractContainerCommand(t *testing.T, obj map[string]any, containerName
 		if name, _ := cm["name"].(string); name == containerName {
 			cmd, _ := cm["command"].([]any)
 			out := make([]string, 0, len(cmd))
-			for _, s := range cmd {
-				out = append(out, asString(s))
+			for i, s := range cmd {
+				out = append(out, mustString(t, s, "command", i))
 			}
 			return out
 		}
@@ -130,9 +143,11 @@ func flagValue(cmd []string, flag string) string {
 	return ""
 }
 
-func asString(v any) string {
+func mustString(t *testing.T, v any, field string, index int) string {
+	t.Helper()
 	if s, ok := v.(string); ok {
 		return s
 	}
+	t.Fatalf("%s[%d] must be string, got %T (%v)", field, index, v, v)
 	return ""
 }

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -1,0 +1,138 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neutree-ai/neutree/internal/util"
+)
+
+// TestVLLMV0_17_1TemplateTaskTranslation locks in the contract that the
+// v0.17.1 K8s deploy template explicitly translates the Neutree model task
+// to vLLM's --runner / --convert flags. Without this, vLLM's auto-detect
+// falls back to a generate runner for multimodal embedding architectures
+// and silently breaks /v1/embeddings.
+func TestVLLMV0_17_1TemplateTaskTranslation(t *testing.T) {
+	tests := []struct {
+		name        string
+		task        string
+		wantRunner  string // empty = should NOT appear
+		wantConvert string // empty = should NOT appear
+	}{
+		{
+			name:        "text-embedding pins pooling runner and embed convert",
+			task:        "text-embedding",
+			wantRunner:  "pooling",
+			wantConvert: "embed",
+		},
+		{
+			name:        "text-rerank pins pooling runner and classify convert",
+			task:        "text-rerank",
+			wantRunner:  "pooling",
+			wantConvert: "classify",
+		},
+		{
+			name:        "text-generation leaves runner/convert at vLLM auto default",
+			task:        "text-generation",
+			wantRunner:  "",
+			wantConvert: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vars := newTestVLLMV0_17_1Vars(tc.task)
+			objs, err := util.RenderKubernetesManifest(vllmV0_17_1DeployTemplate, vars)
+			if err != nil {
+				t.Fatalf("render failed: %v", err)
+			}
+			if len(objs.Items) == 0 {
+				t.Fatalf("no objects rendered")
+			}
+
+			cmd := mustExtractContainerCommand(t, objs.Items[0].Object, "vllm-engine")
+
+			gotRunner := flagValue(cmd, "--runner")
+			if gotRunner != tc.wantRunner {
+				t.Errorf("--runner: got %q, want %q (full cmd=%v)", gotRunner, tc.wantRunner, cmd)
+			}
+			gotConvert := flagValue(cmd, "--convert")
+			if gotConvert != tc.wantConvert {
+				t.Errorf("--convert: got %q, want %q (full cmd=%v)", gotConvert, tc.wantConvert, cmd)
+			}
+		})
+	}
+}
+
+// newTestVLLMV0_17_1Vars returns the minimum render variables the v0.17.1
+// template requires. We mirror the shape produced by setModelArgs in the
+// kubernetes orchestrator without taking a dependency on that package.
+func newTestVLLMV0_17_1Vars(task string) map[string]any {
+	return map[string]any{
+		"EndpointName":   "ep-test",
+		"Namespace":      "default",
+		"EngineName":     "vllm-engine",
+		"EngineVersion":  "v0.17.1",
+		"RoutingLogic":   "rr",
+		"ClusterName":    "test",
+		"Workspace":      "ws",
+		"Replicas":       1,
+		"ImagePrefix":    "registry.test",
+		"ImageRepo":      "neutree/engine-vllm",
+		"ImageTag":       "v0.17.1",
+		"NeutreeVersion": "v0.0.0",
+		"ModelArgs": map[string]any{
+			"name":          "test-model",
+			"registry_type": "hugging-face",
+			"registry_path": "",
+			"path":          "/tmp/model",
+			"version":       "main",
+			"file":          "",
+			"task":          task,
+			"serve_name":    "test-model",
+		},
+		"Env":       map[string]any{},
+		"Resources": map[string]any{},
+	}
+}
+
+// mustExtractContainerCommand pulls the named container's command list out of
+// a rendered unstructured Deployment object.
+func mustExtractContainerCommand(t *testing.T, obj map[string]any, containerName string) []string {
+	t.Helper()
+	spec, _ := obj["spec"].(map[string]any)
+	tmpl, _ := spec["template"].(map[string]any)
+	pod, _ := tmpl["spec"].(map[string]any)
+	containers, _ := pod["containers"].([]any)
+	for _, c := range containers {
+		cm, _ := c.(map[string]any)
+		if name, _ := cm["name"].(string); name == containerName {
+			cmd, _ := cm["command"].([]any)
+			out := make([]string, 0, len(cmd))
+			for _, s := range cmd {
+				out = append(out, asString(s))
+			}
+			return out
+		}
+	}
+	t.Fatalf("container %q not found in rendered deployment", containerName)
+	return nil
+}
+
+// flagValue returns the argument that follows the given flag in a command
+// list, or "" if the flag isn't present.
+func flagValue(cmd []string, flag string) string {
+	for i, tok := range cmd {
+		if tok == flag && i+1 < len(cmd) {
+			return strings.Trim(cmd[i+1], `"`)
+		}
+	}
+	return ""
+}
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -4,8 +4,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/neutree-ai/neutree/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/neutree-ai/neutree/internal/util"
 )
 
 // TestVLLMV0_17_1TemplateTaskTranslation locks in the contract that the
@@ -44,24 +47,14 @@ func TestVLLMV0_17_1TemplateTaskTranslation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			vars := newTestVLLMV0_17_1Vars(tc.task)
 			objs, err := util.RenderKubernetesManifest(vllmV0_17_1DeployTemplate, vars)
-			if err != nil {
-				t.Fatalf("render failed: %v", err)
-			}
-			if len(objs.Items) == 0 {
-				t.Fatalf("no objects rendered")
-			}
+			require.NoError(t, err)
+			require.NotEmpty(t, objs.Items)
 
 			deploy := mustFindRenderedObject(t, objs.Items, "Deployment", "ep-test")
 			cmd := mustExtractContainerCommand(t, deploy.Object, "vllm-engine")
 
-			gotRunner := flagValue(cmd, "--runner")
-			if gotRunner != tc.wantRunner {
-				t.Errorf("--runner: got %q, want %q (full cmd=%v)", gotRunner, tc.wantRunner, cmd)
-			}
-			gotConvert := flagValue(cmd, "--convert")
-			if gotConvert != tc.wantConvert {
-				t.Errorf("--convert: got %q, want %q (full cmd=%v)", gotConvert, tc.wantConvert, cmd)
-			}
+			assert.Equal(t, tc.wantRunner, flagValue(cmd, "--runner"), "full cmd=%v", cmd)
+			assert.Equal(t, tc.wantConvert, flagValue(cmd, "--convert"), "full cmd=%v", cmd)
 		})
 	}
 }
@@ -105,7 +98,8 @@ func mustFindRenderedObject(t *testing.T, objs []unstructured.Unstructured, kind
 			return obj
 		}
 	}
-	t.Fatalf("rendered object %s/%s not found", kind, name)
+	require.Failf(t, "rendered object not found", "%s/%s", kind, name)
+
 	return unstructured.Unstructured{}
 }
 
@@ -113,22 +107,27 @@ func mustFindRenderedObject(t *testing.T, objs []unstructured.Unstructured, kind
 // a rendered unstructured Deployment object.
 func mustExtractContainerCommand(t *testing.T, obj map[string]any, containerName string) []string {
 	t.Helper()
-	spec, _ := obj["spec"].(map[string]any)
-	tmpl, _ := spec["template"].(map[string]any)
-	pod, _ := tmpl["spec"].(map[string]any)
-	containers, _ := pod["containers"].([]any)
+	spec := requireMap(t, obj["spec"], "spec")
+	tmpl := requireMap(t, spec["template"], "spec.template")
+	pod := requireMap(t, tmpl["spec"], "spec.template.spec")
+	containers := requireSlice(t, pod["containers"], "spec.template.spec.containers")
+
 	for _, c := range containers {
-		cm, _ := c.(map[string]any)
-		if name, _ := cm["name"].(string); name == containerName {
-			cmd, _ := cm["command"].([]any)
+		cm := requireMap(t, c, "container")
+		name, ok := cm["name"].(string)
+		if ok && name == containerName {
+			cmd := requireSlice(t, cm["command"], "container.command")
 			out := make([]string, 0, len(cmd))
+
 			for i, s := range cmd {
 				out = append(out, mustString(t, s, "command", i))
 			}
+
 			return out
 		}
 	}
-	t.Fatalf("container %q not found in rendered deployment", containerName)
+	require.Failf(t, "container not found in rendered deployment", "%q", containerName)
+
 	return nil
 }
 
@@ -148,6 +147,23 @@ func mustString(t *testing.T, v any, field string, index int) string {
 	if s, ok := v.(string); ok {
 		return s
 	}
-	t.Fatalf("%s[%d] must be string, got %T (%v)", field, index, v, v)
+	require.Failf(t, "field must be string", "%s[%d] got %T (%v)", field, index, v, v)
+
 	return ""
+}
+
+func requireMap(t *testing.T, v any, field string) map[string]any {
+	t.Helper()
+	out, ok := v.(map[string]any)
+	require.Truef(t, ok, "%s must be map[string]any, got %T (%v)", field, v, v)
+
+	return out
+}
+
+func requireSlice(t *testing.T, v any, field string) []any {
+	t.Helper()
+	out, ok := v.([]any)
+	require.Truef(t, ok, "%s must be []any, got %T (%v)", field, v, v)
+
+	return out
 }

--- a/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
@@ -99,6 +99,22 @@ spec:
           - "8000"
           - --served-model-name
           - {{ .ModelArgs.serve_name }}
+          {{/* vLLM v0.17.1 removed --task; auto-detect can fall back to a
+               generate runner for multimodal embedding architectures, so
+               translate the registry-level task explicitly. The shared
+               serve/_utils/vllm_task_translate table mirrors these flags
+               on the Ray Serve path. */}}
+          {{- if eq .ModelArgs.task "text-embedding" }}
+          - --runner
+          - pooling
+          - --convert
+          - embed
+          {{- else if eq .ModelArgs.task "text-rerank" }}
+          - --runner
+          - pooling
+          - --convert
+          - classify
+          {{- end }}
           {{- if .EngineArgs }}
           {{- range $key, $value := .EngineArgs }}
           - --{{ $key }}

--- a/tests/e2e/endpoint_k8s_config_test.go
+++ b/tests/e2e/endpoint_k8s_config_test.go
@@ -440,7 +440,7 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 		})
 	})
 
-	Describe("vLLM v0.17.1 Task Translation", Ordered, Label("config", "task-translation", "vllm"), func() {
+	Describe("vLLM Task Translation", Ordered, Label("config", "task-translation", "vllm"), func() {
 		type taskCase struct {
 			suffix      string
 			task        string
@@ -452,9 +452,6 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 			func(tc taskCase) {
 				if profileEngineName() != v1.EngineNameVLLM {
 					Skip("vLLM task translation is only applicable to the vLLM engine")
-				}
-				if !strings.HasPrefix(profileEngineVersion(), "v0.17.1") {
-					Skip("vLLM task translation is only applicable to v0.17.1-derived engine versions")
 				}
 
 				epName := "e2e-ep-k8s-task-" + tc.suffix + "-" + Cfg.RunID

--- a/tests/e2e/endpoint_k8s_config_test.go
+++ b/tests/e2e/endpoint_k8s_config_test.go
@@ -461,8 +461,8 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 				yamlPath := applyEndpoint(epName, clusterName,
 					withTask(tc.task),
 					withEngineArgs([]EngineArg{{Key: "dtype", Value: "half"}}))
-				defer os.Remove(yamlPath)
-				defer deleteEndpoint(epName)
+				DeferCleanup(func() { deleteEndpoint(epName) })
+				DeferCleanup(os.Remove, yamlPath)
 
 				cmd := eventuallyEndpointContainerCommand(k8sH, namespace, epName, profileEngineName())
 				Expect(commandFlagValue(cmd, "--runner")).To(Equal(tc.wantRunner),

--- a/tests/e2e/endpoint_k8s_config_test.go
+++ b/tests/e2e/endpoint_k8s_config_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -439,6 +440,57 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 		})
 	})
 
+	Describe("vLLM v0.17.1 Task Translation", Ordered, Label("config", "task-translation", "vllm"), func() {
+		type taskCase struct {
+			suffix      string
+			task        string
+			wantRunner  string
+			wantConvert string
+		}
+
+		DescribeTable("should translate model task into runner and convert flags",
+			func(tc taskCase) {
+				if profileEngineName() != v1.EngineNameVLLM {
+					Skip("vLLM task translation is only applicable to the vLLM engine")
+				}
+				if !strings.HasPrefix(profileEngineVersion(), "v0.17.1") {
+					Skip("vLLM task translation is only applicable to v0.17.1-derived engine versions")
+				}
+
+				epName := "e2e-ep-k8s-task-" + tc.suffix + "-" + Cfg.RunID
+				yamlPath := applyEndpoint(epName, clusterName,
+					withTask(tc.task),
+					withEngineArgs([]EngineArg{{Key: "dtype", Value: "half"}}))
+				defer os.Remove(yamlPath)
+				defer deleteEndpoint(epName)
+
+				cmd := eventuallyEndpointContainerCommand(k8sH, namespace, epName, profileEngineName())
+				Expect(commandFlagValue(cmd, "--runner")).To(Equal(tc.wantRunner),
+					"--runner mismatch for task %s (command=%v)", tc.task, cmd)
+				Expect(commandFlagValue(cmd, "--convert")).To(Equal(tc.wantConvert),
+					"--convert mismatch for task %s (command=%v)", tc.task, cmd)
+			},
+			Entry("text-embedding uses pooling/embed", taskCase{
+				suffix:      "embed",
+				task:        "text-embedding",
+				wantRunner:  "pooling",
+				wantConvert: "embed",
+			}),
+			Entry("text-rerank uses pooling/classify", taskCase{
+				suffix:      "rerank",
+				task:        "text-rerank",
+				wantRunner:  "pooling",
+				wantConvert: "classify",
+			}),
+			Entry("text-generation keeps vLLM auto defaults", taskCase{
+				suffix:      "gen",
+				task:        "text-generation",
+				wantRunner:  "",
+				wantConvert: "",
+			}),
+		)
+	})
+
 	// --- All Schema Types ---
 
 	Describe("All Schema Types Engine Args", Ordered, Label("config", "schema"), func() {
@@ -576,3 +628,41 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 		})
 	})
 })
+
+func eventuallyEndpointContainerCommand(k8sH *K8sHelper, namespace, epName, containerName string) []string {
+	var cmd []string
+	Eventually(func() error {
+		var err error
+		cmd, err = endpointContainerCommand(context.Background(), k8sH, namespace, epName, containerName)
+		return err
+	}, TerminalPhaseTimeout).Should(Succeed(), "should find container %s in endpoint deployment %s", containerName, epName)
+
+	return cmd
+}
+
+func endpointContainerCommand(ctx context.Context, k8sH *K8sHelper, namespace, epName, containerName string) ([]string, error) {
+	d, err := k8sH.GetDeployment(ctx, namespace, epName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range d.Spec.Template.Spec.Containers {
+		if c.Name == containerName {
+			cmd := append([]string{}, c.Command...)
+			cmd = append(cmd, c.Args...)
+			return cmd, nil
+		}
+	}
+
+	return nil, fmt.Errorf("container %q not found in deployment %s/%s", containerName, namespace, epName)
+}
+
+func commandFlagValue(cmd []string, flag string) string {
+	for i, tok := range cmd {
+		if tok == flag && i+1 < len(cmd) {
+			return strings.Trim(cmd[i+1], `"`)
+		}
+	}
+
+	return ""
+}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1180,18 +1180,16 @@ func teardownCluster(clusterName string) {
 
 // --- Endpoint helpers ---
 
-// engineArgs parses the named engine's profile engine_args
-// ("k=v,k2=v2,...") into a structured slice for direct injection into the
-// endpoint template via {{range}}.
-func engineArgs(engineName string) []EngineArg {
-	raw := profileEngineArgsFor(engineName)
+// parseEngineArgs parses a comma-separated "k=v,k2=v2" string into a structured
+// slice for direct injection into the endpoint template via {{range}}.
+func parseEngineArgs(raw string) []EngineArg {
 	if raw == "" {
 		return nil
 	}
 
 	var args []EngineArg
 
-	for _, pair := range strings.Split(raw, ",") {
+	for _, pair := range splitEngineArgPairs(raw) {
 		k, v, ok := strings.Cut(strings.TrimSpace(pair), "=")
 		if !ok || k == "" {
 			continue
@@ -1201,6 +1199,92 @@ func engineArgs(engineName string) []EngineArg {
 	}
 
 	return args
+}
+
+func splitEngineArgPairs(raw string) []string {
+	var pairs []string
+	start := 0
+	depth := 0
+	inString := false
+	escaped := false
+
+	for i, r := range raw {
+		if escaped {
+			escaped = false
+			continue
+		}
+
+		if inString {
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == '"' {
+				inString = false
+			}
+			continue
+		}
+
+		switch r {
+		case '"':
+			inString = true
+		case '{', '[':
+			depth++
+		case '}', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				pairs = append(pairs, raw[start:i])
+				start = i + 1
+			}
+		}
+	}
+
+	pairs = append(pairs, raw[start:])
+	return pairs
+}
+
+// engineArgs parses the named engine's profile engine_args.
+func engineArgs(engineName string) []EngineArg {
+	return parseEngineArgs(profileEngineArgsFor(engineName))
+}
+
+// mergeEngineArgs overlays model-level engine args onto engine-level defaults.
+// Existing keys keep their position; model-level values win on duplicate keys.
+func mergeEngineArgs(base, overlay []EngineArg) []EngineArg {
+	if len(base) == 0 {
+		return append([]EngineArg(nil), overlay...)
+	}
+
+	merged := append([]EngineArg(nil), base...)
+	indexByKey := make(map[string]int, len(merged))
+	for i, arg := range merged {
+		indexByKey[arg.Key] = i
+	}
+
+	for _, arg := range overlay {
+		if arg.Key == "" {
+			continue
+		}
+		if i, ok := indexByKey[arg.Key]; ok {
+			merged[i] = arg
+			continue
+		}
+
+		indexByKey[arg.Key] = len(merged)
+		merged = append(merged, arg)
+	}
+
+	return merged
+}
+
+func defaultEndpointEngineArgs(engineName, task string) []EngineArg {
+	return mergeEngineArgs(
+		engineArgs(engineName),
+		parseEngineArgs(profileModelEngineArgsFor(task)),
+	)
 }
 
 // endpointOpts holds configurable fields for applyEndpoint.
@@ -1295,7 +1379,7 @@ func renderEndpoint(name, cluster string, opts ...EndpointOption) (string, *endp
 	}
 
 	if len(o.engineArgs) == 0 {
-		o.engineArgs = engineArgs(o.engineName)
+		o.engineArgs = defaultEndpointEngineArgs(o.engineName, o.task)
 	}
 
 	if o.accType == "" || o.accProduct == "" {

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1219,9 +1219,11 @@ func splitEngineArgPairs(raw string) []string {
 				escaped = true
 				continue
 			}
+
 			if r == '"' {
 				inString = false
 			}
+
 			continue
 		}
 
@@ -1243,6 +1245,7 @@ func splitEngineArgPairs(raw string) []string {
 	}
 
 	pairs = append(pairs, raw[start:])
+
 	return pairs
 }
 
@@ -1259,6 +1262,7 @@ func mergeEngineArgs(base, overlay []EngineArg) []EngineArg {
 	}
 
 	merged := append([]EngineArg(nil), base...)
+
 	indexByKey := make(map[string]int, len(merged))
 	for i, arg := range merged {
 		indexByKey[arg.Key] = i
@@ -1268,6 +1272,7 @@ func mergeEngineArgs(base, overlay []EngineArg) []EngineArg {
 		if arg.Key == "" {
 			continue
 		}
+
 		if i, ok := indexByKey[arg.Key]; ok {
 			merged[i] = arg
 			continue

--- a/tests/e2e/helpers_template_test.go
+++ b/tests/e2e/helpers_template_test.go
@@ -272,6 +272,40 @@ func TestRenderTemplate_EngineArgsRange(t *testing.T) {
 	}
 }
 
+func TestDefaultEndpointEngineArgsMergesModelOverrides(t *testing.T) {
+	originalProfile := profile
+	t.Cleanup(func() { profile = originalProfile })
+
+	hfOverrides := `{"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}`
+	profile = Profile{
+		Engines: map[string]EngineProfile{
+			defaultEngineName: {
+				EngineArgs: "dtype=half,max-model-len=4096,enforce_eager=true",
+			},
+		},
+	}
+	profile.RerankModel.EngineArgs = "max-model-len=8192,language_model_only=true,hf_overrides=" + hfOverrides
+
+	got := defaultEndpointEngineArgs(defaultEngineName, "text-rerank")
+	want := []EngineArg{
+		{Key: "dtype", Value: "half"},
+		{Key: "max-model-len", Value: "8192"},
+		{Key: "enforce_eager", Value: "true"},
+		{Key: "language_model_only", Value: "true"},
+		{Key: "hf_overrides", Value: hfOverrides},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d want=%d; got=%#v", len(got), len(want), got)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d]=%#v want=%#v; got=%#v", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestRenderTemplate_RolePermissionsRange(t *testing.T) {
 	tmpl := `permissions:
 {{- range .PERMS }}

--- a/tests/e2e/helpers_template_test.go
+++ b/tests/e2e/helpers_template_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func writeTempTemplate(t *testing.T, content string) string {
@@ -295,15 +297,7 @@ func TestDefaultEndpointEngineArgsMergesModelOverrides(t *testing.T) {
 		{Key: "hf_overrides", Value: hfOverrides},
 	}
 
-	if len(got) != len(want) {
-		t.Fatalf("len(got)=%d want=%d; got=%#v", len(got), len(want), got)
-	}
-
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("got[%d]=%#v want=%#v; got=%#v", i, got[i], want[i], got)
-		}
-	}
+	require.Equal(t, want, got)
 }
 
 func TestRenderTemplate_RolePermissionsRange(t *testing.T) {

--- a/tests/e2e/profile.go
+++ b/tests/e2e/profile.go
@@ -82,20 +82,23 @@ type Profile struct {
 	Engines map[string]EngineProfile `yaml:"engines"`
 
 	Model struct {
-		Name    string `yaml:"name"`
-		Version string `yaml:"version"`
-		File    string `yaml:"file"`
-		Task    string `yaml:"task"`
+		Name       string `yaml:"name"`
+		Version    string `yaml:"version"`
+		File       string `yaml:"file"`
+		Task       string `yaml:"task"`
+		EngineArgs string `yaml:"engine_args"`
 	} `yaml:"model"`
 
 	EmbeddingModel struct {
-		Name    string `yaml:"name"`
-		Version string `yaml:"version"`
+		Name       string `yaml:"name"`
+		Version    string `yaml:"version"`
+		EngineArgs string `yaml:"engine_args"`
 	} `yaml:"embedding_model"`
 
 	RerankModel struct {
-		Name    string `yaml:"name"`
-		Version string `yaml:"version"`
+		Name       string `yaml:"name"`
+		Version    string `yaml:"version"`
+		EngineArgs string `yaml:"engine_args"`
 	} `yaml:"rerank_model"`
 
 	Endpoint struct {
@@ -356,6 +359,17 @@ func profileEngineArgsFor(name string) string {
 	}
 
 	return ""
+}
+
+func profileModelEngineArgsFor(task string) string {
+	switch task {
+	case "text-embedding":
+		return profile.EmbeddingModel.EngineArgs
+	case "text-rerank":
+		return profile.RerankModel.EngineArgs
+	default:
+		return profile.Model.EngineArgs
+	}
 }
 
 func profileEndpointTimeout() string {

--- a/tests/e2e/profile.yaml.example
+++ b/tests/e2e/profile.yaml.example
@@ -60,16 +60,19 @@ model:
   version: "1.0"
   file: model.safetensors
   task: text-generation
+  engine_args: ""                  # merged with engines.<name>.engine_args; model value wins on duplicate keys
 
 # Optional: embedding inference tests (skip if not configured)
 embedding_model:
   name: ""
   version: ""
+  engine_args: ""                  # merged with engines.<name>.engine_args for text-embedding endpoints
 
 # Optional: rerank inference tests (skip if not configured)
 rerank_model:
   name: ""
   version: ""
+  engine_args: ""                  # merged with engines.<name>.engine_args for text-rerank endpoints
 
 endpoint:
   # accelerator_type and accelerator_product are auto-detected from cluster status


### PR DESCRIPTION
## Issue

NEU-444

## Summary

Neutree should treat the endpoint model `task` as the authoritative source for vLLM runtime mode. vLLM v0.17.1 removed `--task` and defaults `--runner` / `--convert` to auto-detection, which can misclassify multimodal embedding models such as Qwen3-VL-Embedding as generation workloads. This change explicitly translates Neutree tasks into vLLM v0.17.1 runner/convert flags on both the Kubernetes template and Ray Serve paths.

## Changes

- Add a shared Python helper that maps `text-embedding` to `runner=pooling, convert=embed` and `text-rerank` to `runner=pooling, convert=classify`.
- Wire vLLM v0.17.1 Ray Serve startup to apply the task-derived runner/convert defaults while preserving user-supplied `engine_args` overrides.
- Update the vLLM v0.17.1 Kubernetes deployment template to emit matching `--runner` / `--convert` flags for embedding and rerank tasks.
- Add model-specific E2E `engine_args` support and merge them with per-engine defaults so rerank/embedding models can carry validation-only overrides without affecting generation endpoints.
- Add Go template-render coverage, Python unit coverage, and K8s E2E config coverage for the task translation contract.

## Test Plan

- [x] Unit test: `PYTHONPATH=cluster-image-builder python3 -m pytest cluster-image-builder/serve/_utils/test_vllm_task_translate.py -v`; `go test ./internal/engine`; `go vet ./internal/engine`; targeted `go test` / `go vet` for `tests/e2e` template/profile helpers, including model-specific engine args merge; WSL formatting check with golangci-lint v1.64.6.
- [x] DB test: covered by successful PR CI `pull-request/pr-check` run `26519104361` for head SHA `5f2387ee` (`make db-test` passed).
- [x] E2E test: K8s task-translation config E2E passed (3 specs); live K8s embedding inference passed with `qwen3-vl-embedding-2b`, `language_model_only=true`, and `max-model-len=8192`; live K8s rerank inference passed with `qwen3-vl-reranker-2b` and merged model-level `engine_args`, including `language_model_only=true`, `max-model-len=8192`, and Qwen3-VL reranker `hf_overrides`; SSH rerun was intentionally not included in the latest scoped validation.
- [x] Manual test: not required; task-translation, embedding, and rerank paths are covered by unit tests plus K8s E2E. During the latest E2E cleanup, the environment's generic soft-delete API returned `P0001` for test resources, so only the run-id-scoped test resources had `metadata.deletion_timestamp` set directly to let controller cleanup complete.

## Risk & Rollback

Risk is limited to vLLM v0.17.1 task-to-engine-mode translation. Generation workloads still omit runner/convert flags and keep vLLM defaults. User-provided `engine_args` continue to win on the Ray Serve path through `setdefault`. Rollback is reverting this PR, which restores vLLM auto-detection behavior.

Classification: Standard. This changes deployed engine behavior across the vLLM Kubernetes template and Ray Serve path.