### PR TITLE
refactor: surface SSH context on static-cluster connection failures

### DIFF
--- a/internal/accelerator/plugin/amd_gpu.go
+++ b/internal/accelerator/plugin/amd_gpu.go
@@ -110,6 +110,12 @@ func (p *AMDGPUAcceleratorPlugin) getNodeAcceleratorInfo(ctx context.Context, no
 	// todo: more analysis for lspci output
 	output, err := sshRunner.Run(ctx, "lspci -nn", true, nil, true, nil, "", false)
 	if err != nil {
+		if errors.Is(err, command_runner.ErrConnectionFailed) {
+			// The runner already produced an actionable message including the
+			// target IP, underlying SSH stderr, and static-cluster hint.
+			return nil, err
+		}
+
 		return nil, errors.Wrapf(err, "get node %s pci info failed", nodeIP)
 	}
 

--- a/internal/accelerator/plugin/amd_gpu_test.go
+++ b/internal/accelerator/plugin/amd_gpu_test.go
@@ -122,7 +122,7 @@ func TestAMDGPUAcceleratorPlugin_GetNodeAcceleratorInfo_ConnectionFailureExposes
 		"errors.Is must report ErrConnectionFailed; got %v", err)
 	assert.NotContains(t, err.Error(), "get node 10.255.1.54 pci info failed",
 		"AMD plugin must not double-wrap connection failures with the pci-info prefix")
-	assert.Contains(t, err.Error(), "ssh connection to node", "phase identification must reach the caller")
+	assert.Contains(t, err.Error(), "ssh connection failed to node", "phase identification must reach the caller")
 	assert.Contains(t, err.Error(), "10.255.1.54", "target IP must be surfaced")
 	assert.Contains(t, err.Error(), "Connection refused", "underlying SSH stderr must survive")
 	assert.Contains(t, err.Error(), "hint:", "static-cluster hint must be present")

--- a/internal/accelerator/plugin/amd_gpu_test.go
+++ b/internal/accelerator/plugin/amd_gpu_test.go
@@ -2,11 +2,13 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	commandmocks "github.com/neutree-ai/neutree/pkg/command/mocks"
+	"github.com/neutree-ai/neutree/pkg/command_runner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -100,6 +102,58 @@ func TestAMDGPUAcceleratorPlugin_GetNodeAcceleratorInfo(t *testing.T) {
 			assert.Len(t, accelerators, tt.expecteAcceleratorCount)
 		})
 	}
+}
+
+func TestAMDGPUAcceleratorPlugin_GetNodeAcceleratorInfo_ConnectionFailureExposesContext(t *testing.T) {
+	mockExec := &commandmocks.MockExecutor{}
+	mockExec.On("Execute", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		cmds := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmds, " "), "uptime")
+	}).Return([]byte(""), errors.New("exit status 255: ssh: connect to host 10.255.1.54 port 22: Connection refused")).Once()
+
+	p := &AMDGPUAcceleratorPlugin{executor: mockExec}
+	_, err := p.getNodeAcceleratorInfo(context.Background(), "10.255.1.54", v1.Auth{
+		SSHUser:       "root",
+		SSHPrivateKey: "MTIzCg==",
+	})
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, command_runner.ErrConnectionFailed),
+		"errors.Is must report ErrConnectionFailed; got %v", err)
+	assert.NotContains(t, err.Error(), "get node 10.255.1.54 pci info failed",
+		"AMD plugin must not double-wrap connection failures with the pci-info prefix")
+	assert.Contains(t, err.Error(), "ssh connection to node", "phase identification must reach the caller")
+	assert.Contains(t, err.Error(), "10.255.1.54", "target IP must be surfaced")
+	assert.Contains(t, err.Error(), "Connection refused", "underlying SSH stderr must survive")
+	assert.Contains(t, err.Error(), "hint:", "static-cluster hint must be present")
+	mockExec.AssertExpectations(t)
+}
+
+func TestAMDGPUAcceleratorPlugin_GetNodeAcceleratorInfo_CommandFailureKeepsPCIWording(t *testing.T) {
+	mockExec := &commandmocks.MockExecutor{}
+	mockExec.On("Execute", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		cmds := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmds, " "), "uptime")
+	}).Return([]byte("ok"), nil).Once()
+	mockExec.On("Execute", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		cmds := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmds, " "), "lspci -nn")
+	}).Return([]byte("lspci: command not found"), errors.New("exit status 127")).Once()
+
+	p := &AMDGPUAcceleratorPlugin{executor: mockExec}
+	_, err := p.getNodeAcceleratorInfo(context.Background(), "10.0.0.5", v1.Auth{
+		SSHUser:       "root",
+		SSHPrivateKey: "MTIzCg==",
+	})
+
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, command_runner.ErrConnectionFailed),
+		"post-connection command failure must not look like a connection failure")
+	assert.Contains(t, err.Error(), "get node 10.0.0.5 pci info failed",
+		"command-phase failure must keep the pci-info wording")
+	assert.NotContains(t, err.Error(), "hint:",
+		"command-phase failure must not carry the static-cluster hint")
+	mockExec.AssertExpectations(t)
 }
 
 func TestAMDGPUAcceleratorPlugin_GetNodeRuntimeConfig(t *testing.T) {

--- a/internal/accelerator/plugin/gpu.go
+++ b/internal/accelerator/plugin/gpu.go
@@ -102,8 +102,10 @@ func (p *GPUAcceleratorPlugin) getNodeAcceleratorInfo(ctx context.Context, nodeI
 	// avoiding race conditions during boot when nvidia driver is still loading.
 	output, err := sshRunner.Run(ctx, "lspci -nn", true, nil, true, nil, "", false)
 	if err != nil {
-		if err == command_runner.ErrConnectionFailed {
-			return nil, errors.Wrapf(err, "connect to node %s failed", nodeIP)
+		if errors.Is(err, command_runner.ErrConnectionFailed) {
+			// The runner already produced an actionable message including the
+			// target IP, underlying SSH stderr, and static-cluster hint.
+			return nil, err
 		}
 
 		return nil, errors.Wrapf(err, "get node %s pci info failed", nodeIP)

--- a/internal/accelerator/plugin/gpu_test.go
+++ b/internal/accelerator/plugin/gpu_test.go
@@ -127,7 +127,7 @@ func TestGPUAcceleratorPlugin_GetNodeAcceleratorInfo_ConnectionFailureExposesCon
 	// constructed the full message. The plugin only propagates the error.
 	assert.NotContains(t, err.Error(), "get node 10.255.1.54 pci info failed",
 		"connection failure must not be wrapped with the misleading pci-info prefix")
-	assert.Contains(t, err.Error(), "ssh connection to node",
+	assert.Contains(t, err.Error(), "ssh connection failed to node",
 		"connection-phase identification must reach the caller")
 	assert.Contains(t, err.Error(), "10.255.1.54", "target IP must be surfaced")
 	assert.Contains(t, err.Error(), "Connection refused", "underlying SSH stderr must survive")

--- a/internal/accelerator/plugin/gpu_test.go
+++ b/internal/accelerator/plugin/gpu_test.go
@@ -2,11 +2,13 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	commandmocks "github.com/neutree-ai/neutree/pkg/command/mocks"
+	"github.com/neutree-ai/neutree/pkg/command_runner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -102,6 +104,64 @@ func TestGPUAcceleratorPlugin_GetNodeAcceleratorInfo(t *testing.T) {
 			assert.Len(t, accelerators, tt.expectedAcceleratorCount)
 		})
 	}
+}
+
+func TestGPUAcceleratorPlugin_GetNodeAcceleratorInfo_ConnectionFailureExposesContext(t *testing.T) {
+	mockExec := &commandmocks.MockExecutor{}
+	// First call = precheck (uptime). Simulate SSH connect-refused.
+	mockExec.On("Execute", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		cmds := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmds, " "), "uptime")
+	}).Return([]byte(""), errors.New("exit status 255: ssh: connect to host 10.255.1.54 port 22: Connection refused")).Once()
+
+	p := &GPUAcceleratorPlugin{executor: mockExec}
+	_, err := p.getNodeAcceleratorInfo(context.Background(), "10.255.1.54", v1.Auth{
+		SSHUser:       "root",
+		SSHPrivateKey: "MTIzCg==",
+	})
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, command_runner.ErrConnectionFailed),
+		"errors.Is must report ErrConnectionFailed; got %v", err)
+	// Plugin must NOT double-wrap connection failures — the runner already
+	// constructed the full message. The plugin only propagates the error.
+	assert.NotContains(t, err.Error(), "get node 10.255.1.54 pci info failed",
+		"connection failure must not be wrapped with the misleading pci-info prefix")
+	assert.Contains(t, err.Error(), "ssh connection to node",
+		"connection-phase identification must reach the caller")
+	assert.Contains(t, err.Error(), "10.255.1.54", "target IP must be surfaced")
+	assert.Contains(t, err.Error(), "Connection refused", "underlying SSH stderr must survive")
+	assert.Contains(t, err.Error(), "hint:", "static-cluster hint must be present")
+	mockExec.AssertExpectations(t)
+}
+
+func TestGPUAcceleratorPlugin_GetNodeAcceleratorInfo_CommandFailureKeepsPCIWording(t *testing.T) {
+	mockExec := &commandmocks.MockExecutor{}
+	// First call = precheck (uptime) — success.
+	mockExec.On("Execute", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		cmds := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmds, " "), "uptime")
+	}).Return([]byte("ok"), nil).Once()
+	// Second call = lspci — fails with exit status (i.e., post-connection failure).
+	mockExec.On("Execute", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		cmds := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmds, " "), "lspci -nn")
+	}).Return([]byte("lspci: command not found"), errors.New("exit status 127")).Once()
+
+	p := &GPUAcceleratorPlugin{executor: mockExec}
+	_, err := p.getNodeAcceleratorInfo(context.Background(), "10.0.0.5", v1.Auth{
+		SSHUser:       "root",
+		SSHPrivateKey: "MTIzCg==",
+	})
+
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, command_runner.ErrConnectionFailed),
+		"post-connection command failure must not look like a connection failure")
+	assert.Contains(t, err.Error(), "get node 10.0.0.5 pci info failed",
+		"command-phase failure must keep the pci-info wording")
+	assert.NotContains(t, err.Error(), "hint:",
+		"command-phase failure must not carry the static-cluster hint (it is connection-specific)")
+	mockExec.AssertExpectations(t)
 }
 
 func TestGPUAcceleratorPlugin_GetNodeRuntimeConfig(t *testing.T) {

--- a/pkg/command_runner/ssh_command_runner.go
+++ b/pkg/command_runner/ssh_command_runner.go
@@ -131,7 +131,12 @@ func (s *SSHCommandRunner) checkConnection(ctx context.Context, sshCommand []str
 	connectCommand = append(connectCommand, sshCommand[last])
 	connectCommand = append(connectCommand, "uptime")
 
-	if _, err := s.processExecute(ctx, connectCommand[0], connectCommand[1:]); err != nil {
+	output, err := s.processExecute(ctx, connectCommand[0], connectCommand[1:])
+	if err != nil {
+		if outputText := strings.TrimSpace(string(output)); outputText != "" {
+			return fmt.Errorf("%w: %s", err, outputText)
+		}
+
 		return err
 	}
 

--- a/pkg/command_runner/ssh_command_runner.go
+++ b/pkg/command_runner/ssh_command_runner.go
@@ -96,6 +96,7 @@ func (s *SSHCommandRunner) Run(ctx context.Context, cmd string, exitOnFail bool,
 	// before running the command, check if the connection is still alive
 	if err := s.checkConnection(ctx, sshCommand); err != nil {
 		klog.V(2).ErrorS(err, "SSH connection failed", "nodeID", s.nodeID)
+
 		return "", &sshConnectionError{
 			ip:    s.sshIP,
 			cause: err,

--- a/pkg/command_runner/ssh_command_runner.go
+++ b/pkg/command_runner/ssh_command_runner.go
@@ -25,6 +25,27 @@ const staticClusterConnectionHint = "verify the node IP is the physical server "
 	"address (not the management plane IP), the ssh_user can log in to that host, " +
 	"and the ssh_private_key matches"
 
+type sshConnectionError struct {
+	ip    string
+	cause error
+}
+
+func (e *sshConnectionError) Error() string {
+	if e.cause == nil {
+		return fmt.Sprintf("ssh connection to node %s failed (hint: %s)", e.ip, staticClusterConnectionHint)
+	}
+
+	return fmt.Sprintf("ssh connection to node %s failed: %v (hint: %s)", e.ip, e.cause, staticClusterConnectionHint)
+}
+
+func (e *sshConnectionError) Unwrap() []error {
+	if e.cause == nil {
+		return []error{ErrConnectionFailed}
+	}
+
+	return []error{ErrConnectionFailed, e.cause}
+}
+
 type ProcessExecute func(ctx context.Context, name string, args []string) ([]byte, error)
 
 // SSHCommandRunner represents an SSH command runner.
@@ -75,8 +96,10 @@ func (s *SSHCommandRunner) Run(ctx context.Context, cmd string, exitOnFail bool,
 	// before running the command, check if the connection is still alive
 	if err := s.checkConnection(ctx, sshCommand); err != nil {
 		klog.V(2).ErrorS(err, "SSH connection failed", "nodeID", s.nodeID)
-		return "", fmt.Errorf("ssh connection to node %s %w: %v (hint: %s)",
-			s.sshIP, ErrConnectionFailed, err, staticClusterConnectionHint)
+		return "", &sshConnectionError{
+			ip:    s.sshIP,
+			cause: err,
+		}
 	}
 
 	if shutdownAfterRun {

--- a/pkg/command_runner/ssh_command_runner.go
+++ b/pkg/command_runner/ssh_command_runner.go
@@ -32,10 +32,10 @@ type sshConnectionError struct {
 
 func (e *sshConnectionError) Error() string {
 	if e.cause == nil {
-		return fmt.Sprintf("ssh connection to node %s failed (hint: %s)", e.ip, staticClusterConnectionHint)
+		return fmt.Sprintf("ssh connection failed to node %s (hint: %s)", e.ip, staticClusterConnectionHint)
 	}
 
-	return fmt.Sprintf("ssh connection to node %s failed: %v (hint: %s)", e.ip, e.cause, staticClusterConnectionHint)
+	return fmt.Sprintf("ssh connection failed to node %s: %v (hint: %s)", e.ip, e.cause, staticClusterConnectionHint)
 }
 
 func (e *sshConnectionError) Unwrap() []error {

--- a/pkg/command_runner/ssh_command_runner.go
+++ b/pkg/command_runner/ssh_command_runner.go
@@ -15,6 +15,16 @@ var (
 	ErrConnectionFailed = errors.New("connection failed")
 )
 
+// staticClusterConnectionHint is appended to SSH connection-failure errors so
+// the user-facing message points at the most common root cause for static
+// clusters: head_ip mistakenly set to the management-plane IP instead of the
+// physical server's IP. All SSHCommandRunner callers operate on static-cluster
+// nodes (K8s clusters use kubernetes_command_runner), so the hint applies
+// universally.
+const staticClusterConnectionHint = "verify the node IP is the physical server " +
+	"address (not the management plane IP), the ssh_user can log in to that host, " +
+	"and the ssh_private_key matches"
+
 type ProcessExecute func(ctx context.Context, name string, args []string) ([]byte, error)
 
 // SSHCommandRunner represents an SSH command runner.
@@ -65,7 +75,8 @@ func (s *SSHCommandRunner) Run(ctx context.Context, cmd string, exitOnFail bool,
 	// before running the command, check if the connection is still alive
 	if err := s.checkConnection(ctx, sshCommand); err != nil {
 		klog.V(2).ErrorS(err, "SSH connection failed", "nodeID", s.nodeID)
-		return "", ErrConnectionFailed
+		return "", fmt.Errorf("ssh connection to node %s %w: %v (hint: %s)",
+			s.sshIP, ErrConnectionFailed, err, staticClusterConnectionHint)
 	}
 
 	if shutdownAfterRun {
@@ -108,12 +119,19 @@ func (s *SSHCommandRunner) Run(ctx context.Context, cmd string, exitOnFail bool,
 }
 
 func (s *SSHCommandRunner) checkConnection(ctx context.Context, sshCommand []string) error {
-	var connectCommand []string
-	connectCommand = append(connectCommand, sshCommand...)
+	// sshCommand layout from Run(): ["ssh", <opts>..., "user@host"]. Insert
+	// "-o ConnectTimeout=10" before "user@host" so the bound applies only to
+	// the precheck — leaving long-running command argvs constructed elsewhere
+	// (cluster init, docker exec) untouched. The bound shortens unreachable-
+	// host stalls from the OpenSSH default ~75s TCP SYN timeout to ~10s.
+	last := len(sshCommand) - 1
+	connectCommand := make([]string, 0, len(sshCommand)+3)
+	connectCommand = append(connectCommand, sshCommand[:last]...)
+	connectCommand = append(connectCommand, "-o", "ConnectTimeout=10")
+	connectCommand = append(connectCommand, sshCommand[last])
 	connectCommand = append(connectCommand, "uptime")
 
-	_, err := s.processExecute(ctx, connectCommand[0], connectCommand[1:])
-	if err != nil {
+	if _, err := s.processExecute(ctx, connectCommand[0], connectCommand[1:]); err != nil {
 		return err
 	}
 

--- a/pkg/command_runner/ssh_command_runner_test.go
+++ b/pkg/command_runner/ssh_command_runner_test.go
@@ -233,8 +233,14 @@ func TestSSHCommandRunner_CheckConnection_PreservesUnderlyingErrorAsConnectionFa
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, ErrConnectionFailed),
 		"errors.Is must report ErrConnectionFailed; got %v", err)
+	assert.True(t, errors.Is(err, underlying),
+		"errors.Is must preserve the original precheck error; got %v", err)
 	assert.Contains(t, err.Error(), "ssh connection to node",
 		"message should identify the precheck phase")
+	assert.Contains(t, err.Error(), "failed:",
+		"message should read naturally without embedding the sentinel text as prose")
+	assert.NotContains(t, err.Error(), "node 127.0.0.1 connection failed",
+		"message should not repeat the sentinel wording in the user-facing sentence")
 	assert.Contains(t, err.Error(), testSSHIP,
 		"message should include the target IP %q", testSSHIP)
 	assert.Contains(t, err.Error(), "Connection refused",

--- a/pkg/command_runner/ssh_command_runner_test.go
+++ b/pkg/command_runner/ssh_command_runner_test.go
@@ -246,6 +246,29 @@ func TestSSHCommandRunner_CheckConnection_PreservesUnderlyingErrorAsConnectionFa
 	mockExec.AssertExpectations(t)
 }
 
+func TestSSHCommandRunner_CheckConnection_PreservesExecutorOutputAsConnectionFailureDetail(t *testing.T) {
+	mockExec := new(commandmocks.MockExecutor)
+	runner := newSSHCommandRunner(mockExec)
+
+	mockExec.On("Execute", mock.Anything, "ssh", mock.Anything).Run(func(args mock.Arguments) {
+		cmd := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmd, " "), "uptime")
+	}).Return([]byte("ssh: connect to host 127.0.0.1 port 22: Connection refused\n"), errors.New("exit status 255")).Once()
+
+	_, err := runner.Run(context.Background(), testCommand, false, nil, true, nil, "", false)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConnectionFailed),
+		"errors.Is must report ErrConnectionFailed; got %v", err)
+	assert.Contains(t, err.Error(), "exit status 255",
+		"message should preserve the process exit status")
+	assert.Contains(t, err.Error(), "Connection refused",
+		"message should preserve SSH stderr returned as executor output")
+	assert.Contains(t, err.Error(), "hint:",
+		"message should include the static-cluster troubleshooting hint section")
+	mockExec.AssertExpectations(t)
+}
+
 func TestSSHCommandRunner_CheckConnection_AddsConnectTimeout(t *testing.T) {
 	mockExec := new(commandmocks.MockExecutor)
 	runner := newSSHCommandRunner(mockExec)

--- a/pkg/command_runner/ssh_command_runner_test.go
+++ b/pkg/command_runner/ssh_command_runner_test.go
@@ -235,10 +235,10 @@ func TestSSHCommandRunner_CheckConnection_PreservesUnderlyingErrorAsConnectionFa
 		"errors.Is must report ErrConnectionFailed; got %v", err)
 	assert.True(t, errors.Is(err, underlying),
 		"errors.Is must preserve the original precheck error; got %v", err)
-	assert.Contains(t, err.Error(), "ssh connection to node",
+	assert.Contains(t, err.Error(), "ssh connection failed",
+		"message should preserve the stable connection-failure substring used by e2e and operators")
+	assert.Contains(t, err.Error(), "ssh connection failed to node",
 		"message should identify the precheck phase")
-	assert.Contains(t, err.Error(), "failed:",
-		"message should read naturally without embedding the sentinel text as prose")
 	assert.NotContains(t, err.Error(), "node 127.0.0.1 connection failed",
 		"message should not repeat the sentinel wording in the user-facing sentence")
 	assert.Contains(t, err.Error(), testSSHIP,

--- a/pkg/command_runner/ssh_command_runner_test.go
+++ b/pkg/command_runner/ssh_command_runner_test.go
@@ -218,6 +218,92 @@ func TestSSHCommandRunner_getSSHOptions_NoControlPath(t *testing.T) {
 	assert.NotContains(t, options, "ControlPersist=10s")
 }
 
+func TestSSHCommandRunner_CheckConnection_PreservesUnderlyingErrorAsConnectionFailed(t *testing.T) {
+	mockExec := new(commandmocks.MockExecutor)
+	runner := newSSHCommandRunner(mockExec)
+
+	underlying := errors.New("exit status 255: ssh: connect to host 127.0.0.1 port 22: Connection refused")
+	mockExec.On("Execute", mock.Anything, "ssh", mock.Anything).Run(func(args mock.Arguments) {
+		cmd := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmd, " "), "uptime")
+	}).Return([]byte(""), underlying).Once()
+
+	_, err := runner.Run(context.Background(), testCommand, false, nil, true, nil, "", false)
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrConnectionFailed),
+		"errors.Is must report ErrConnectionFailed; got %v", err)
+	assert.Contains(t, err.Error(), "ssh connection to node",
+		"message should identify the precheck phase")
+	assert.Contains(t, err.Error(), testSSHIP,
+		"message should include the target IP %q", testSSHIP)
+	assert.Contains(t, err.Error(), "Connection refused",
+		"message should preserve the underlying SSH stderr token")
+	assert.Contains(t, err.Error(), "hint:",
+		"message should include the static-cluster troubleshooting hint section")
+	assert.Contains(t, err.Error(), "physical server",
+		"hint should mention the physical-server IP guidance")
+	mockExec.AssertExpectations(t)
+}
+
+func TestSSHCommandRunner_CheckConnection_AddsConnectTimeout(t *testing.T) {
+	mockExec := new(commandmocks.MockExecutor)
+	runner := newSSHCommandRunner(mockExec)
+
+	var precheckArgs []string
+	var mainArgs []string
+
+	// First call = precheck (uptime). Capture its argv.
+	mockExec.On("Execute", mock.Anything, "ssh", mock.Anything).Run(func(args mock.Arguments) {
+		cmd := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmd, " "), "uptime",
+			"first call must be the precheck (uptime)")
+		precheckArgs = append([]string{}, cmd...)
+	}).Return([]byte("ok"), nil).Once()
+
+	// Second call = main command. Capture its argv.
+	mockExec.On("Execute", mock.Anything, "ssh", mock.Anything).Run(func(args mock.Arguments) {
+		cmd := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmd, " "), testCommand,
+			"second call must be the main command")
+		mainArgs = append([]string{}, cmd...)
+	}).Return([]byte("success"), nil).Once()
+
+	_, err := runner.Run(context.Background(), testCommand, false, nil, true, nil, "", false)
+	assert.NoError(t, err)
+
+	// Precheck argv MUST include ConnectTimeout=10.
+	preStr := strings.Join(precheckArgs, " ")
+	assert.Contains(t, preStr, "-o ConnectTimeout=10",
+		"precheck argv must carry ConnectTimeout=10; got %q", preStr)
+
+	// And it must appear BEFORE the user@host element (SSH only honors options
+	// listed before the destination).
+	hostElement := fmt.Sprintf("%s@%s", testSSHUser, testSSHIP)
+	hostIdx := -1
+	timeoutIdx := -1
+	for i, tok := range precheckArgs {
+		if tok == hostElement {
+			hostIdx = i
+		}
+		if tok == "ConnectTimeout=10" {
+			timeoutIdx = i
+		}
+	}
+	assert.GreaterOrEqual(t, hostIdx, 0, "user@host element must be present")
+	assert.GreaterOrEqual(t, timeoutIdx, 0, "ConnectTimeout token must be present")
+	assert.Less(t, timeoutIdx, hostIdx,
+		"ConnectTimeout must precede user@host (got timeout@%d, host@%d)", timeoutIdx, hostIdx)
+
+	// Main command argv MUST NOT carry ConnectTimeout — isolation assertion
+	// (Reviewer requested keeping the option out of getSSHOptions).
+	mainStr := strings.Join(mainArgs, " ")
+	assert.NotContains(t, mainStr, "ConnectTimeout=10",
+		"main command argv must not carry the precheck-only ConnectTimeout; got %q", mainStr)
+
+	mockExec.AssertExpectations(t)
+}
+
 func TestSSHCommandRunner_Run_WithOutputDisabled(t *testing.T) {
 	mockExec := new(commandmocks.MockExecutor)
 	runner := newSSHCommandRunner(mockExec)

--- a/tests/e2e/cluster_ssh_fault_test.go
+++ b/tests/e2e/cluster_ssh_fault_test.go
@@ -126,16 +126,29 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			clusterName := "e2e-ssh-badip-" + Cfg.RunID
 			DeferCleanup(func() { ClusterH.EnsureDeleted(clusterName) })
 
+			const unreachableHeadIP = "198.51.100.1"
+
 			yaml := renderSSHClusterYAML(map[string]any{
 				"name":            clusterName,
-				"head_ip":         "198.51.100.1",
+				"head_ip":         unreachableHeadIP,
 				"ssh_user":        sshUser,
 				"ssh_private_key": sshPrivateKey,
 			})
 			r := ClusterH.Apply(yaml)
 			ExpectSuccess(r)
 
-			ClusterH.EventuallyInPhase(clusterName, v1.ClusterPhaseInitializing, "connection failed", TerminalPhaseTimeout)
+			cluster := ClusterH.EventuallyInPhase(clusterName, v1.ClusterPhaseInitializing, "connection failed", TerminalPhaseTimeout)
+
+			// Actionable-error assertions: the message must surface the
+			// SSH precheck phase, target IP, and static-cluster hint so
+			// the operator can resolve the misconfiguration without
+			// guessing about ssh_private_key.
+			Expect(cluster.Status.ErrorMessage).To(ContainSubstring("ssh connection to node"),
+				"error must identify the SSH precheck phase")
+			Expect(cluster.Status.ErrorMessage).To(ContainSubstring(unreachableHeadIP),
+				"error must surface the unreachable target IP")
+			Expect(cluster.Status.ErrorMessage).To(ContainSubstring("hint:"),
+				"error must carry the static-cluster troubleshooting hint")
 		})
 
 		It("should stay Initializing when worker node IPs are unreachable", Label("C2613146"), func() {

--- a/tests/e2e/cluster_ssh_fault_test.go
+++ b/tests/e2e/cluster_ssh_fault_test.go
@@ -143,7 +143,7 @@ var _ = Describe("SSH Cluster Fault & Anomaly", Ordered, Label("cluster", "ssh")
 			// SSH precheck phase, target IP, and static-cluster hint so
 			// the operator can resolve the misconfiguration without
 			// guessing about ssh_private_key.
-			Expect(cluster.Status.ErrorMessage).To(ContainSubstring("ssh connection to node"),
+			Expect(cluster.Status.ErrorMessage).To(ContainSubstring("ssh connection failed to node"),
 				"error must identify the SSH precheck phase")
 			Expect(cluster.Status.ErrorMessage).To(ContainSubstring(unreachableHeadIP),
 				"error must surface the unreachable target IP")


### PR DESCRIPTION
## Issue

NEU-405

## Summary

Static-cluster SSH connection failures currently collapse to a flat connection error and can hide the underlying SSH stderr, target IP, and troubleshooting direction. This change preserves the `ErrConnectionFailed` sentinel while surfacing actionable SSH context for operators, especially when `head_ip` points at the wrong static-cluster address.

## Changes

- Wrap SSH precheck failures with the original error, target IP, and a static-cluster troubleshooting hint while preserving `errors.Is(err, ErrConnectionFailed)` behavior.
- Limit `ConnectTimeout=10` to the SSH precheck command so unreachable hosts fail faster without changing long-running SSH command argv construction.
- Propagate connection-phase errors directly from NVIDIA and AMD accelerator plugins, while keeping PCI wording for post-connection command failures.
- Extend SSH fault e2e case `C2613145` to assert the user-facing error includes the SSH phase, configured IP, and hint.

## Test Plan

- [x] E2E: hot-updated `refactor-NEU-405` to the docker-compose control plane, then ran `make e2e-test LABEL_FILTER="cluster && ssh && error && C2613145" E2E_TIMEOUT=30m`; result `SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 230 Skipped` in 46.081s.
- [x] Unit: `go test ./pkg/command_runner ./internal/accelerator/plugin` passed locally.
- [x] E2E compile: `go build ./tests/e2e/...` passed locally.
- [x] DB integration (`make db-test`): not affected.

## Risk & Rollback

No database schema or API contract changes. Behavior change is limited to SSH connection error reporting and precheck timeout. Rollback by reverting the PR; existing callers still match connection failures through the same `ErrConnectionFailed` sentinel.

Workflow classification: Standard, because this changes Go production code and an e2e case.