### PR TITLE
fix: harden Anthropic tool-call null handling

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -468,15 +468,16 @@ local function convert_response(openai_resp, request_model)
     if is_table(message.tool_calls) then
         for _, tc in ipairs(message.tool_calls) do
             local input = {}
-            if tc["function"] and tc["function"].arguments then
-                local parsed, err = cjson.decode(tc["function"].arguments)
+            local fn = is_table(tc["function"]) and tc["function"] or EMPTY
+            if fn.arguments and fn.arguments ~= cjson.null then
+                local parsed, err = cjson.decode(fn.arguments)
                 if err or parsed == nil then
-                    input = { raw = tc["function"].arguments }
+                    input = { raw = fn.arguments }
                 else
                     input = parsed
                 end
             end
-            local fn_name = (tc["function"] or EMPTY).name
+            local fn_name = fn.name
             if fn_name == nil or fn_name == cjson.null then
                 fn_name = ""
             end

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -18,6 +18,10 @@ local function is_table(v)
     return type(v) == "table"
 end
 
+local function string_or_empty(v)
+    return type(v) == "string" and v or ""
+end
+
 local SUPPORTED_ROUTE_TYPES = {
     "/v1/chat/completions",
     "/v1/embeddings",
@@ -469,22 +473,19 @@ local function convert_response(openai_resp, request_model)
         for _, tc in ipairs(message.tool_calls) do
             local input = {}
             local fn = is_table(tc["function"]) and tc["function"] or EMPTY
-            if fn.arguments and fn.arguments ~= cjson.null then
-                local parsed, err = cjson.decode(fn.arguments)
+            local args = fn.arguments
+            if type(args) == "string" then
+                local parsed, err = cjson.decode(args)
                 if err or parsed == nil then
-                    input = { raw = fn.arguments }
+                    input = { raw = args }
                 else
                     input = parsed
                 end
             end
-            local fn_name = fn.name
-            if fn_name == nil or fn_name == cjson.null then
-                fn_name = ""
-            end
             content[#content + 1] = {
                 type = "tool_use",
                 id = tc.id,
-                name = fn_name,
+                name = string_or_empty(fn.name),
                 input = input,
             }
         end
@@ -787,6 +788,7 @@ local function handle_anthropic_stream_body()
 
         if is_table(delta.tool_calls) then
             for _, tc in ipairs(delta.tool_calls) do
+                local fn = is_table(tc["function"]) and tc["function"] or EMPTY
                 local tc_index = tc.index or 0
                 if tc_index ~= ctx.current_tool_index then
                     if ctx.current_tool_index ~= nil then
@@ -799,12 +801,12 @@ local function handle_anthropic_stream_body()
                     ctx.current_tool_index = tc_index
                     ctx.anthropic_block_index = ctx.anthropic_block_index + 1
                     local tc_id = tc.id or ""
-                    local tc_name = (tc["function"] or EMPTY).name or ""
+                    local tc_name = string_or_empty(fn.name)
                     output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_tool_use(ctx.anthropic_block_index, tc_id, tc_name))
                 end
 
-                local args = (tc["function"] or EMPTY).arguments
-                if args and args ~= "" then
+                local args = fn.arguments
+                if type(args) == "string" and args ~= "" then
                     output_parts[#output_parts + 1] = sse_frame("content_block_delta", make_content_block_delta_json(ctx.anthropic_block_index, args))
                 end
             end

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -110,6 +110,26 @@ func waitForUpstreamRequest() (last *RecordedRequest, body map[string]any) {
 	return last, body
 }
 
+func assertMalformedToolUseBlocks(content []anthropic.ContentBlockUnion) {
+	toolUses := make(map[string]anthropic.ContentBlockUnion)
+	for _, block := range content {
+		if block.Type == "tool_use" {
+			toolUses[block.ID] = block
+		}
+	}
+
+	Expect(toolUses).To(HaveLen(3))
+
+	Expect(toolUses["call-function-null"].Name).To(Equal(""))
+	Expect(string(toolUses["call-function-null"].Input)).To(MatchJSON(`{}`))
+
+	Expect(toolUses["call-name-null"].Name).To(Equal(""))
+	Expect(string(toolUses["call-name-null"].Input)).To(MatchJSON(`{"city":"shanghai"}`))
+
+	Expect(toolUses["call-arguments-null"].Name).To(Equal("lookup_weather"))
+	Expect(string(toolUses["call-arguments-null"].Input)).To(MatchJSON(`{}`))
+}
+
 // --- Tests ---
 
 var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func() {
@@ -360,6 +380,64 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 
 				Expect(string(message.Role)).To(Equal("assistant"))
 				Expect(len(message.Content)).To(BeNumerically(">", 0))
+
+				last, upstreamReq := waitForUpstreamRequest()
+				Expect(last.Path).To(Equal("/v1/chat/completions"))
+				Expect(upstreamReq["stream"]).To(BeTrue())
+			})
+		})
+
+		// NEU-404: some OpenAI-compatible upstreams can return a real tool_calls
+		// array whose nested function/name/arguments fields are JSON null. This is
+		// distinct from NEU-428's outer tool_calls:null case because the converter
+		// enters the per-tool-call path before seeing the null sentinel.
+		Context("when upstream emits malformed tool call function fields", Label("tool-call-function-null"), func() {
+			BeforeEach(func() {
+				mockUpstream.SetEmitMalformedToolCallFunction(true)
+				mockUpstream.ClearRequests()
+			})
+
+			AfterEach(func() {
+				mockUpstream.SetEmitMalformedToolCallFunction(false)
+			})
+
+			It("should normalize non-stream tool_use fields", func() {
+				msg, err := anthropicClient.Messages.New(context.Background(), anthropic.MessageNewParams{
+					Model:     "fast",
+					MaxTokens: 100,
+					Messages: []anthropic.MessageParam{
+						anthropic.NewUserMessage(anthropic.NewTextBlock("hello malformed tool calls")),
+					},
+				})
+				Expect(err).NotTo(HaveOccurred(),
+					"Anthropic conversion must not fail when tool_call.function/name/arguments contain JSON null")
+
+				assertMalformedToolUseBlocks(msg.Content)
+
+				last, _ := waitForUpstreamRequest()
+				Expect(last.Path).To(Equal("/v1/chat/completions"))
+			})
+
+			It("should normalize stream tool_use fields", func() {
+				stream := anthropicClient.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+					Model:     "smart",
+					MaxTokens: 100,
+					Messages: []anthropic.MessageParam{
+						anthropic.NewUserMessage(anthropic.NewTextBlock("hello stream malformed tool calls")),
+					},
+				})
+				defer stream.Close()
+
+				var message anthropic.Message
+				for stream.Next() {
+					event := stream.Current()
+					err := message.Accumulate(event)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				Expect(stream.Err()).NotTo(HaveOccurred(),
+					"stream must complete cleanly when nested tool_call function fields contain JSON null")
+
+				assertMalformedToolUseBlocks(message.Content)
 
 				last, upstreamReq := waitForUpstreamRequest()
 				Expect(last.Path).To(Equal("/v1/chat/completions"))

--- a/tests/e2e/mock_upstream.go
+++ b/tests/e2e/mock_upstream.go
@@ -10,6 +10,14 @@ import (
 	"sync/atomic"
 )
 
+type mockToolCallMode int32
+
+const (
+	mockToolCallModeDefault mockToolCallMode = iota
+	mockToolCallModeNullToolCalls
+	mockToolCallModeMalformedFunction
+)
+
 // RecordedRequest stores key parts of an HTTP request received by MockUpstream.
 type RecordedRequest struct {
 	Method  string
@@ -27,17 +35,34 @@ type MockUpstream struct {
 	mu       sync.Mutex
 	requests []RecordedRequest
 
-	// emitNullToolCalls makes the mock include "tool_calls": null in chat
-	// completion responses (both non-stream message and stream deltas) to
-	// reproduce the cjson.null userdata bug in the Anthropic conversion path.
-	emitNullToolCalls atomic.Bool
+	// toolCallMode controls malformed tool-call responses used by Anthropic
+	// compatibility tests.
+	toolCallMode atomic.Int32
 }
 
 // SetEmitNullToolCalls toggles whether chat completion responses explicitly
 // include "tool_calls": null. Tests that need the original happy-path payload
 // must reset this back to false (e.g. in AfterEach).
 func (m *MockUpstream) SetEmitNullToolCalls(v bool) {
-	m.emitNullToolCalls.Store(v)
+	if v {
+		m.toolCallMode.Store(int32(mockToolCallModeNullToolCalls))
+		return
+	}
+	m.toolCallMode.Store(int32(mockToolCallModeDefault))
+}
+
+// SetEmitMalformedToolCallFunction toggles responses where tool_calls is a real
+// array, but nested function fields contain JSON null sentinels.
+func (m *MockUpstream) SetEmitMalformedToolCallFunction(v bool) {
+	if v {
+		m.toolCallMode.Store(int32(mockToolCallModeMalformedFunction))
+		return
+	}
+	m.toolCallMode.Store(int32(mockToolCallModeDefault))
+}
+
+func (m *MockUpstream) currentToolCallMode() mockToolCallMode {
+	return mockToolCallMode(m.toolCallMode.Load())
 }
 
 // StartMockUpstream creates and starts a MockUpstream on a random port.
@@ -165,8 +190,11 @@ func (m *MockUpstream) writeChatJSON(w http.ResponseWriter, model string) {
 		"role":    "assistant",
 		"content": "Hello from mock upstream!",
 	}
-	if m.emitNullToolCalls.Load() {
+	switch m.currentToolCallMode() {
+	case mockToolCallModeNullToolCalls:
 		message["tool_calls"] = json.RawMessage("null")
+	case mockToolCallModeMalformedFunction:
+		message["tool_calls"] = malformedToolCalls()
 	}
 
 	resp := map[string]any{
@@ -206,10 +234,15 @@ func (m *MockUpstream) writeChatStream(w http.ResponseWriter, model string) {
 	delta1 := map[string]any{"role": "assistant"}
 	delta2 := map[string]any{"content": "Hello from mock!"}
 	delta3 := map[string]any{}
-	if m.emitNullToolCalls.Load() {
+	switch m.currentToolCallMode() {
+	case mockToolCallModeNullToolCalls:
 		delta1["tool_calls"] = json.RawMessage("null")
 		delta2["tool_calls"] = json.RawMessage("null")
 		delta3["tool_calls"] = json.RawMessage("null")
+	case mockToolCallModeMalformedFunction:
+		delta1["tool_calls"] = []map[string]any{malformedToolCallFunctionNull(0)}
+		delta2["tool_calls"] = []map[string]any{malformedToolCallNameNull(1)}
+		delta3["tool_calls"] = []map[string]any{malformedToolCallArgumentsNull(2)}
 	}
 
 	chunks := []map[string]any{
@@ -250,6 +283,47 @@ func (m *MockUpstream) writeChatStream(w http.ResponseWriter, model string) {
 
 	fmt.Fprint(w, "data: [DONE]\n\n")
 	flusher.Flush()
+}
+
+func malformedToolCalls() []map[string]any {
+	return []map[string]any{
+		malformedToolCallFunctionNull(0),
+		malformedToolCallNameNull(1),
+		malformedToolCallArgumentsNull(2),
+	}
+}
+
+func malformedToolCallFunctionNull(index int) map[string]any {
+	return map[string]any{
+		"index":    index,
+		"id":       "call-function-null",
+		"type":     "function",
+		"function": json.RawMessage("null"),
+	}
+}
+
+func malformedToolCallNameNull(index int) map[string]any {
+	return map[string]any{
+		"index": index,
+		"id":    "call-name-null",
+		"type":  "function",
+		"function": map[string]any{
+			"name":      json.RawMessage("null"),
+			"arguments": `{"city":"shanghai"}`,
+		},
+	}
+}
+
+func malformedToolCallArgumentsNull(index int) map[string]any {
+	return map[string]any{
+		"index": index,
+		"id":    "call-arguments-null",
+		"type":  "function",
+		"function": map[string]any{
+			"name":      "lookup_weather",
+			"arguments": json.RawMessage("null"),
+		},
+	}
 }
 
 func (m *MockUpstream) handleEmbeddings(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Issue

NEU-404

## Summary

This PR hardens the Anthropic compatibility response adapter in the OpenAI Chat Completions -> Anthropic Messages conversion path.

A top-level `tool_calls: null` from an OpenAI-compatible upstream response is treated as "no tool call" and is ignored. However, once `tool_calls` is a real array, nested nulls such as `function: null`, `function.name: null`, or `function.arguments: null` are malformed upstream tool-call data rather than valid tool-call semantics. The gateway still normalizes these values defensively because it is the protocol boundary and must not leak Lua `cjson.null` sentinels into client-visible Anthropic `tool_use` blocks.

## Behavior

- Ignore `content: null` instead of emitting text content from a JSON null sentinel.
- Ignore top-level `tool_calls: null`; no Anthropic `tool_use` block is generated.
- Preserve real `tool_calls` array entries, but normalize malformed nested fields:
  - `function: null` -> `tool_use.name = ""`, `tool_use.input = {}`
  - `function.name: null` or any non-string name -> `tool_use.name = ""`
  - `function.arguments: null` or any non-string arguments value -> `tool_use.input = {}` for non-stream responses, and no `input_json_delta` for stream responses
- Preserve existing behavior for valid string arguments: non-stream responses JSON-decode them into `tool_use.input`, while stream responses forward non-empty argument chunks as `partial_json`.

## Changes

- Normalize each tool call function field to a real table before reading arguments or name.
- Skip non-string/null arguments before JSON decoding or streaming JSON deltas.
- Coerce non-string function names, including nil, `cjson.null`, and boolean false, to an empty string.
- Apply the same guard pattern to both non-streaming and streaming Anthropic adapter paths.
- Extend E2E mock upstream and Anthropic compatibility cases to cover `function:null`, `function.name:null`, and `function.arguments:null` in non-stream and stream responses.
- Preserve existing tool-use input parsing and IDs.

## Test Plan

### Unit test

- [x] Static diff checks: `git diff --check` passed.
- [x] Pre-commit hook: passed (gofmt, go vet, architecture boundaries, migration pairs, short affected-package tests; incremental golangci-lint skipped because `./bin/golangci-lint` is not installed locally).
- [ ] Lua plugin unit/syntax check: not run; no Lua interpreter or Kong plugin test harness is available in this workspace.

### DB test

- [x] DB integration (`make db-test`): not affected.

### E2E test

- [x] E2E compile: `go test ./tests/e2e -run '^$'` passed.
- [x] E2E build: `go build ./tests/e2e/...` passed.
- [x] E2E coverage added: non-stream and stream Anthropic cases now cover `function:null`, `function.name:null`, and `function.arguments:null`.
- [x] Copilot review: latest review on `e061e9b2847ad01833afac05c589d1effc8112ba` generated no new comments; previous coverage thread was updated after adding E2E cases.
- [x] Latest PR head CI: `pr-check` passed on head `e061e9b2847ad01833afac05c589d1effc8112ba`.
- [ ] Live E2E execution: not run locally; the new cases are added and compile, live environment execution remains a separate E2E step if required.

Manual testing is not required because the behavior is covered by Anthropic compatibility E2E cases.

## Risk & Rollback

Low risk. The production change only normalizes malformed or missing tool-call function fields in the Anthropic adapter response paths, and the new E2E changes are limited to ExternalEndpoint mock-upstream test coverage. Roll back by reverting the three commits in this PR if a regression appears.

Workflow classification: Trivial originally; docs MR and TestRail sync were skipped per the Neutree trivial-change path. E2E cases were added after review to cover the malformed tool-call shapes directly.