### PR TITLE
fix: ignore generated endpoint columns during proxy writes (#395)

### DIFF
--- a/internal/routes/proxies/resource_proxy.go
+++ b/internal/routes/proxies/resource_proxy.go
@@ -163,6 +163,39 @@ func extractExcludeFieldsFromTag(t reflect.Type) map[string]struct{} {
 	return excludeFields
 }
 
+func extractTopLevelJSONFields(t reflect.Type) []string {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	fields := make([]string, 0, t.NumField())
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" || jsonTag == "-" {
+			continue
+		}
+
+		jsonName := strings.Split(jsonTag, ",")[0]
+		if jsonName == "" {
+			continue
+		}
+
+		fields = append(fields, jsonName)
+	}
+
+	return fields
+}
+
 // extractFieldsRecursive recursively extracts fields with api:"-" tag
 func extractFieldsRecursive(t reflect.Type, prefix string, excludeFields map[string]struct{}) {
 	// Handle pointer types
@@ -322,6 +355,59 @@ func buildSelectParam(excludeFields map[string]struct{}) string {
 	return strings.Join(fields, ",")
 }
 
+func filterPayloadToTopLevelFields(bodyBytes []byte, topLevelFields []string) ([]byte, error) {
+	if len(topLevelFields) == 0 || len(bytes.TrimSpace(bodyBytes)) == 0 {
+		return bodyBytes, nil
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(bodyBytes, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse request body: %w", err)
+	}
+
+	filteredPayload := make(map[string]json.RawMessage, len(payload))
+
+	for _, field := range topLevelFields {
+		value, ok := payload[field]
+		if !ok {
+			continue
+		}
+
+		filteredPayload[field] = value
+	}
+
+	filteredBodyBytes, err := json.Marshal(filteredPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	return filteredBodyBytes, nil
+}
+
+func filterPatchPayloadToTopLevelFields(req *http.Request, topLevelFields []string) error {
+	if req.Body == nil {
+		return nil
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read request body: %w", err)
+	}
+
+	req.Body.Close()
+
+	filteredBodyBytes, err := filterPayloadToTopLevelFields(bodyBytes, topLevelFields)
+	if err != nil {
+		return err
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(filteredBodyBytes))
+	req.ContentLength = int64(len(filteredBodyBytes))
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(filteredBodyBytes)))
+
+	return nil
+}
+
 // queryParamsToFilters converts URL query params to storage.Filter array
 func queryParamsToFilters(queryParams url.Values) []storage.Filter {
 	filters := make([]storage.Filter, 0)
@@ -404,9 +490,21 @@ func fetchCurrentResource(
 func CreateStructProxyHandler[T any](deps *Dependencies, tableName string) gin.HandlerFunc {
 	// Extract exclude fields from struct type at initialization time (compile-time type safety)
 	var zero T
-	excludeFields := extractExcludeFieldsFromTag(reflect.TypeOf(zero))
+	structType := reflect.TypeOf(zero)
+	excludeFields := extractExcludeFieldsFromTag(structType)
+	topLevelFields := extractTopLevelJSONFields(structType)
 
 	return func(c *gin.Context) {
+		if c.Request.Method == "PATCH" {
+			if err := filterPatchPayloadToTopLevelFields(c.Request, topLevelFields); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": err.Error(),
+				})
+
+				return
+			}
+		}
+
 		// Handle PATCH requests with excluded fields backfilling
 		if c.Request.Method == "PATCH" && len(excludeFields) > 0 {
 			handlePatchWithBackfill(c, deps, tableName, excludeFields)

--- a/internal/routes/proxies/resource_proxy_test.go
+++ b/internal/routes/proxies/resource_proxy_test.go
@@ -1,16 +1,22 @@
 package proxies
 
 import (
+	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/utils/request"
+	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 func Test_filterObject(t *testing.T) {
@@ -471,6 +477,216 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 		}
 		assert.Equal(t, expected, result)
 	})
+}
+
+func Test_extractTopLevelJSONFields(t *testing.T) {
+	type testObject struct {
+		ID       string `json:"id"`
+		Name     string `json:"name,omitempty"`
+		Ignored  string `json:"-"`
+		NoTag    string
+		internal string
+	}
+
+	cases := []struct {
+		name     string
+		input    reflect.Type
+		expected []string
+	}{
+		{
+			name:  "extract endpoint writable table columns from API struct",
+			input: reflect.TypeOf(v1.Endpoint{}),
+			expected: []string{
+				"id",
+				"api_version",
+				"kind",
+				"metadata",
+				"spec",
+				"status",
+			},
+		},
+		{
+			name:     "ignore json dash empty and unexported fields",
+			input:    reflect.TypeOf(testObject{}),
+			expected: []string{"id", "name"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := extractTopLevelJSONFields(tc.input)
+
+			assert.Equal(t, tc.expected, fields)
+			assert.NotContains(t, fields, "status_sort_priority")
+		})
+	}
+}
+
+func TestCreateStructProxyHandlerFiltersUnknownTopLevelFieldsAndInfersColumns(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/endpoints", r.URL.Path)
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.NotContains(t, r.URL.Query(), "columns")
+		assert.Equal(t, "*", r.URL.Query().Get("select"))
+
+		var payload map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		assert.Contains(t, payload, "spec")
+		assert.Contains(t, payload, "status")
+		assert.NotContains(t, payload, "status_sort_priority")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	handler := CreateStructProxyHandler[v1.Endpoint](&Dependencies{
+		StorageAccessURL: upstream.URL,
+	}, storage.ENDPOINT_TABLE)
+	router.PATCH("/api/v1/endpoints", handler)
+
+	body := strings.NewReader(`{"id":118,"api_version":"v1","kind":"Endpoint","metadata":{"name":"sshgpu","workspace":"default"},"spec":{"replicas":{"num":0}},"status":{"phase":"Running"},"status_sort_priority":1}`)
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		`/api/v1/endpoints?metadata->>name=eq.sshgpu&metadata->>workspace=eq.default&select=*`,
+		body,
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.ResponseRecorder.Code)
+}
+
+func TestCreateStructProxyHandlerFiltersSoftDeletePayloadAndInfersColumns(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/endpoints", r.URL.Path)
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.NotContains(t, r.URL.Query(), "columns")
+
+		var payload map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		assert.Contains(t, payload, "metadata")
+		assert.NotContains(t, payload, "spec")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	handler := CreateStructProxyHandler[v1.Endpoint](&Dependencies{
+		StorageAccessURL: upstream.URL,
+	}, storage.ENDPOINT_TABLE)
+	router.PATCH("/api/v1/endpoints", handler)
+
+	body := strings.NewReader(`{"metadata":{"name":"sshgpu","workspace":"default","deletion_timestamp":"2026-05-28T07:20:48Z","annotations":{"neutree.ai/force-delete":"true"}}}`)
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		`/api/v1/endpoints?id=eq.118`,
+		body,
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+}
+
+func TestCreateStructProxyHandlerSkipsBackfillForSoftDeleteOnMaskedResource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/image_registries", r.URL.Path)
+		assert.Equal(t, http.MethodPatch, r.Method)
+
+		var payload map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		assert.Contains(t, payload, "metadata")
+		assert.NotContains(t, payload, "spec")
+		assert.NotContains(t, payload, "status")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	handler := CreateStructProxyHandler[v1.ImageRegistry](&Dependencies{
+		StorageAccessURL: upstream.URL,
+	}, storage.IMAGE_REGISTRY_TABLE)
+	router.PATCH("/api/v1/image_registries", handler)
+
+	body := strings.NewReader(`{"metadata":{"name":"registry","workspace":"default","deletion_timestamp":"2026-05-28T07:20:48Z"}}`)
+	req := httptest.NewRequest(
+		http.MethodPatch,
+		`/api/v1/image_registries?id=eq.118`,
+		body,
+	)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+}
+
+func TestCreateStructProxyHandlerDoesNotApplyWriteColumnsToPost(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/image_registries", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.NotContains(t, r.URL.Query(), "columns")
+
+		var payload map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		assert.NotContains(t, payload, "id")
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	handler := CreateStructProxyHandler[v1.ImageRegistry](&Dependencies{
+		StorageAccessURL: upstream.URL,
+	}, storage.IMAGE_REGISTRY_TABLE)
+	router.POST("/api/v1/image_registries", handler)
+
+	body := strings.NewReader(`{"api_version":"v1","kind":"ImageRegistry","metadata":{"name":"registry","workspace":"default"},"spec":{"url":"https://registry.example.com","repository":"neutree"}}`)
+	req := httptest.NewRequest(http.MethodPost, `/api/v1/image_registries`, body)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusCreated, recorder.ResponseRecorder.Code)
+}
+
+type closeNotifyRecorder struct {
+	*httptest.ResponseRecorder
+	closeCh chan bool
+}
+
+func newCloseNotifyRecorder() *closeNotifyRecorder {
+	return &closeNotifyRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		closeCh:          make(chan bool, 1),
+	}
+}
+
+func (r *closeNotifyRecorder) CloseNotify() <-chan bool {
+	return r.closeCh
 }
 
 func Test_mergeExcludedFields(t *testing.T) {

--- a/tests/e2e/endpoint_lifecycle_test.go
+++ b/tests/e2e/endpoint_lifecycle_test.go
@@ -1,6 +1,9 @@
 package e2e
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -307,6 +310,50 @@ var _ = Describe("Endpoint Lifecycle", Ordered, Label("endpoint", "lifecycle"), 
 			waitEndpointPaused(epName)
 			ep := getEndpoint(epName)
 			Expect(ep.Status.Phase).To(BeEquivalentTo("Paused"))
+		})
+
+		// TestRail: C2682160
+		It("should ignore generated status sort column during full-row PATCH", Label("C2682160"), func() {
+			epName := "e2e-ep-lc-fullpatch-" + Cfg.RunID
+			defer deleteEndpoint(epName)
+
+			yamlPath := applyEndpoint(epName, clusterName)
+			defer os.Remove(yamlPath)
+
+			waitEndpointRunning(epName)
+
+			query := url.Values{}
+			query.Set("metadata->>name", "eq."+epName)
+			query.Set("metadata->>workspace", "eq."+profileWorkspace())
+			query.Set("select", "*")
+			path := "/api/v1/endpoints?" + query.Encode()
+
+			By("Reading the endpoint with select=* so the generated column is present")
+			body, code := callNeutreeAPI(http.MethodGet, path)
+			Expect(code).To(Equal(http.StatusOK), "GET endpoint failed: %s", string(body))
+
+			var rows []map[string]any
+			Expect(json.Unmarshal(body, &rows)).To(Succeed(), "failed to parse endpoint list: %s", string(body))
+			Expect(rows).To(HaveLen(1), "expected exactly one endpoint row: %s", string(body))
+			Expect(rows[0]).To(HaveKey("status_sort_priority"))
+
+			payload := rows[0]
+			spec, ok := payload["spec"].(map[string]any)
+			Expect(ok).To(BeTrue(), "endpoint row missing spec object: %s", string(body))
+			replicas, ok := spec["replicas"].(map[string]any)
+			Expect(ok).To(BeTrue(), "endpoint row missing spec.replicas object: %s", string(body))
+			replicas["num"] = float64(0)
+
+			By("Patching the full row back with status_sort_priority still in the payload")
+			patchBody, patchCode := callNeutreeAPIWithJSON(http.MethodPatch, path, payload)
+			Expect(patchCode).To(BeNumerically(">=", 200), "PATCH endpoint failed: %s", string(patchBody))
+			Expect(patchCode).To(BeNumerically("<", 300), "PATCH endpoint failed: %s", string(patchBody))
+			Expect(string(patchBody)).NotTo(ContainSubstring("can only be updated to DEFAULT"))
+
+			waitEndpointPaused(epName)
+			ep := getEndpoint(epName)
+			Expect(ep.Spec.Replicas.Num).NotTo(BeNil())
+			Expect(*ep.Spec.Replicas.Num).To(Equal(0))
 		})
 	})
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -452,7 +452,8 @@ func SetupImageRegistry() {
 // TeardownImageRegistry deletes the image registry and cleans up the temp YAML.
 func TeardownImageRegistry() {
 	if imageRegistryYAML != "" {
-		RunCLI("delete", "-f", imageRegistryYAML, "--force", "--ignore-not-found")
+		r := RunCLI("delete", "-f", imageRegistryYAML, "--force", "--ignore-not-found")
+		ExpectSuccess(r)
 		os.Remove(imageRegistryYAML)
 		imageRegistryYAML = ""
 	}
@@ -699,8 +700,11 @@ func (c *ClusterHelper) EventuallyObservedSpecHashAdvanced(name, oldHash string,
 
 // EnsureDeleted deletes a cluster and waits for full removal (for cleanup).
 func (c *ClusterHelper) EnsureDeleted(name string) {
-	c.Delete(name)
-	c.WaitForDelete(name, TerminalPhaseTimeout)
+	r := c.Delete(name)
+	ExpectSuccess(r)
+
+	r = c.WaitForDelete(name, TerminalPhaseTimeout)
+	ExpectSuccess(r)
 }
 
 // --- Cluster JSON parsing ---
@@ -1075,13 +1079,30 @@ func createAPIKey(serverURL, jwt, workspace, name string) string {
 // boilerplate without merging the auth conventions, and would give
 // future tests one obvious place to look for "how do I call the API".
 func callNeutreeAPI(method, path string) ([]byte, int) {
+	return callNeutreeAPIWithBody(method, path, nil)
+}
+
+func callNeutreeAPIWithJSON(method, path string, payload any) ([]byte, int) {
+	GinkgoHelper()
+
+	body, err := json.Marshal(payload)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	return callNeutreeAPIWithBody(method, path, bytes.NewReader(body))
+}
+
+func callNeutreeAPIWithBody(method, path string, requestBody io.Reader) ([]byte, int) {
 	GinkgoHelper()
 
 	url := strings.TrimRight(Cfg.ServerURL, "/") + path
-	req, err := http.NewRequest(method, url, nil)
+	req, err := http.NewRequest(method, url, requestBody)
 	Expect(err).NotTo(HaveOccurred())
 
 	req.Header.Set("Authorization", Cfg.APIKey)
+
+	if requestBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	client := &http.Client{Timeout: 60 * time.Second}
 	resp, err := client.Do(req)
@@ -1476,12 +1497,15 @@ func getEndpoint(name string) v1.Endpoint {
 
 // deleteEndpoint deletes an endpoint and waits for it to be removed.
 func deleteEndpoint(name string) {
-	RunCLI("delete", "endpoint", name, "-w", profileWorkspace(), "--force", "--ignore-not-found")
-	RunCLI("wait", "endpoint", name,
+	r := RunCLI("delete", "endpoint", name, "-w", profileWorkspace(), "--force", "--ignore-not-found")
+	ExpectSuccess(r)
+
+	r = RunCLI("wait", "endpoint", name,
 		"-w", profileWorkspace(),
 		"--for", "delete",
 		"--timeout", "5m",
 	)
+	ExpectSuccess(r)
 }
 
 func parseEndpointJSON(stdout string) v1.Endpoint {

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -43,8 +43,10 @@ func SetupModelRegistry() {
 // TeardownModelRegistry deletes the model registry and cleans up the temp YAML.
 func TeardownModelRegistry() {
 	if registryYAML != "" {
-		RunCLI("delete", "-f", registryYAML, "--force", "--ignore-not-found")
+		r := RunCLI("delete", "-f", registryYAML, "--force", "--ignore-not-found")
+		ExpectSuccess(r)
 		os.Remove(registryYAML)
+		registryYAML = ""
 	}
 }
 


### PR DESCRIPTION
## Issue

Jira: NEU-439
TestRail: C2682160

## Summary

Endpoint PATCH can fail when clients read with `select=*` and send a full row back, because the payload includes PostgreSQL generated column `status_sort_priority`. This change makes typed resource proxy PATCH requests drop unknown top-level fields from the request body, so PostgREST infers write columns from the filtered payload instead of attempting to write DB-only generated columns.

## Changes

- Derive top-level JSON fields from typed resource structs in `CreateStructProxyHandler`.
- For PATCH, remove top-level payload fields that are not present in the typed API struct while preserving nested `metadata`/`spec`/`status` content.
- Do not set a PostgREST `columns` query parameter; current UI payloads omit it and PostgREST infers write columns from the filtered body.
- Keep soft-delete PATCH requests metadata-only, so database triggers do not see `spec`/`status` changes when only `metadata.deletion_timestamp` is updated.
- Leave POST requests without an explicit `columns` list so database defaults such as serial IDs still apply.
- Add unit coverage for top-level unknown field removal and soft-delete metadata-only payloads.
- Add E2E coverage for endpoint full-row PATCH with `status_sort_priority` present.
- Make relevant E2E cleanup helpers assert delete/wait results and ensure C2682160 deletes its endpoint before suite-level cluster/model registry teardown.

## Test Plan

- [x] E2E affected: `make e2e-test LABEL_FILTER='C2682160' E2E_TIMEOUT=60m` passed against hot-updated commit `9a4d43a`; run id `180423` left no endpoint/cluster/model_registry/image_registry resources.
- [x] DB integration (`make db-test`): passed in CI.
- [x] `go test ./internal/routes/proxies/...`
- [x] `go build ./tests/e2e/...`
- [x] `go vet ./internal/routes/proxies/... ./tests/e2e/...`
- [x] Pre-commit gate during amend: gofmt, full `go vet`, architecture boundaries, migration pairs, incremental golangci-lint, affected package short test.
- [x] `make prepare-build-cli` and `./bin/golangci-lint run`
- [x] CI `pr-check`: lint, test, db-test, build, architecture boundaries, migration pairs.
- [x] `git diff --check`

## Risk & Rollback

No schema change. The behavioral change is limited to typed resource PATCH proxy requests: unknown top-level API fields are removed and PostgREST infers write columns from the filtered body. Rollback is reverting this commit; affected clients would again need to avoid sending generated DB columns in full-row PATCH payloads.