### PR TITLE
test: support multiple model registry profiles

### DIFF
--- a/tests/e2e/cp_upgrade_test.go
+++ b/tests/e2e/cp_upgrade_test.go
@@ -363,8 +363,12 @@ func createUpgradeTestResources(irName, mrName, sshCluster, k8sCluster, sshEp, k
 
 	By("Creating model registry")
 
+	registryProfile := profileModelRegistryForType("")
 	mrPath, err := renderTemplateToTempFile("testdata/model-registry.yaml", map[string]any{
-		"E2E_MODEL_REGISTRY": mrName,
+		"E2E_MODEL_REGISTRY":             mrName,
+		"E2E_MODEL_REGISTRY_TYPE":        registryProfile.Type,
+		"E2E_MODEL_REGISTRY_URL":         registryProfile.URL,
+		"E2E_MODEL_REGISTRY_CREDENTIALS": registryProfile.Credentials,
 	})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -364,7 +364,33 @@ func StopLocalRegistry(containerID string) {
 
 // testRegistry returns the model registry name for tests.
 func testRegistry() string {
-	return "e2e-registry-" + Cfg.RunID
+	return testRegistryForType("")
+}
+
+func testRegistryForType(registryType string) string {
+	if registryType == "" || registryType == "default" {
+		return "e2e-registry-" + Cfg.RunID
+	}
+
+	return "e2e-registry-" + slugName(registryType) + "-" + Cfg.RunID
+}
+
+func slugName(s string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash && b.Len() > 0 {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
 }
 
 // testImageRegistry returns the image registry name for tests.
@@ -744,8 +770,9 @@ func profileVarMap() map[string]string {
 		"E2E_IMAGE_REGISTRY_PASSWORD": profile.ImageRegistry.Password,
 
 		// Model registry
-		"E2E_MODEL_REGISTRY_TYPE": profile.ModelRegistry.Type,
-		"E2E_MODEL_REGISTRY_URL":  profile.ModelRegistry.URL,
+		"E2E_MODEL_REGISTRY_TYPE":        profileModelRegistryForType("").Type,
+		"E2E_MODEL_REGISTRY_URL":         profileModelRegistryForType("").URL,
+		"E2E_MODEL_REGISTRY_CREDENTIALS": profileModelRegistryForType("").Credentials,
 
 		// Engine
 		"E2E_ENGINE_NAME":    profileEngineName(),
@@ -1247,20 +1274,21 @@ func engineArgs(engineName string) []EngineArg {
 
 // endpointOpts holds configurable fields for applyEndpoint.
 type endpointOpts struct {
-	engineName    string
-	engineVersion string
-	model         string
-	modelVersion  string
-	task          string
-	engineArgs    []EngineArg
-	gpu           string
-	cpu           string
-	memory        string
-	accType       string
-	accProduct    string
-	env           map[string]string
-	forceUpdate   bool
-	replicas      int
+	engineName        string
+	engineVersion     string
+	modelRegistryType string
+	model             string
+	modelVersion      string
+	task              string
+	engineArgs        []EngineArg
+	gpu               string
+	cpu               string
+	memory            string
+	accType           string
+	accProduct        string
+	env               map[string]string
+	forceUpdate       bool
+	replicas          int
 }
 
 // EndpointOption configures a single field of endpointOpts.
@@ -1289,6 +1317,10 @@ func withModel(name, version string) EndpointOption {
 		o.model = name
 		o.modelVersion = version
 	}
+}
+
+func withModelRegistryType(registryType string) EndpointOption {
+	return func(o *endpointOpts) { o.modelRegistryType = registryType }
 }
 
 func withTask(task string) EndpointOption {
@@ -1358,7 +1390,7 @@ func renderEndpoint(name, cluster string, opts ...EndpointOption) (string, *endp
 		"E2E_CLUSTER_NAME":        cluster,
 		"E2E_ENGINE_NAME":         o.engineName,
 		"E2E_ENGINE_VERSION":      o.engineVersion,
-		"E2E_MODEL_REGISTRY":      testRegistry(),
+		"E2E_MODEL_REGISTRY":      testRegistryForType(o.modelRegistryType),
 		"E2E_MODEL_NAME":          o.model,
 		"E2E_MODEL_VERSION":       o.modelVersion,
 		"E2E_MODEL_TASK":          o.task,

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -368,7 +368,7 @@ func testRegistry() string {
 }
 
 func testRegistryForType(registryType string) string {
-	if registryType == "" || registryType == defaultRegistryAlias {
+	if profileModelRegistryTypeUsesDefaultName(registryType) {
 		return "e2e-registry-" + Cfg.RunID
 	}
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -368,7 +368,7 @@ func testRegistry() string {
 }
 
 func testRegistryForType(registryType string) string {
-	if registryType == "" || registryType == "default" {
+	if registryType == "" || registryType == defaultRegistryAlias {
 		return "e2e-registry-" + Cfg.RunID
 	}
 
@@ -376,21 +376,15 @@ func testRegistryForType(registryType string) string {
 }
 
 func slugName(s string) string {
-	var b strings.Builder
-	lastDash := false
-	for _, r := range strings.ToLower(s) {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			b.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash && b.Len() > 0 {
-			b.WriteByte('-')
-			lastDash = true
-		}
-	}
+	parts := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !isSlugRune(r)
+	})
 
-	return strings.Trim(b.String(), "-")
+	return strings.Join(parts, "-")
+}
+
+func isSlugRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
 }
 
 // testImageRegistry returns the image registry name for tests.

--- a/tests/e2e/model_registry_profile_test.go
+++ b/tests/e2e/model_registry_profile_test.go
@@ -1,0 +1,177 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+func loadModelRegistryProfileForTest(t *testing.T, content string) {
+	t.Helper()
+
+	oldProfile := profile
+	oldCfg := *Cfg
+	Cfg.RunID = "123456"
+	t.Cleanup(func() {
+		profile = oldProfile
+		*Cfg = oldCfg
+	})
+
+	profile = Profile{}
+	if err := yaml.Unmarshal([]byte(content), &profile); err != nil {
+		t.Fatalf("unmarshal profile: %v", err)
+	}
+}
+
+func TestModelRegistryProfileLegacyDefaultsToBentoML(t *testing.T) {
+	loadModelRegistryProfileForTest(t, `
+model_registry:
+  url: nfs://10.0.0.10:/models
+model:
+  name: global-model
+  version: v1
+  task: text-generation
+`)
+
+	got := profileModelRegistryForType("")
+	if got.Type != "bentoml" {
+		t.Fatalf("default model registry type: got %q want bentoml", got.Type)
+	}
+	if got.URL != "nfs://10.0.0.10:/models" {
+		t.Fatalf("default model registry URL: got %q", got.URL)
+	}
+
+	if got := testRegistryForType(""); got != "e2e-registry-123456" {
+		t.Fatalf("default registry name changed: got %q", got)
+	}
+
+	if got := profileModelRegistryTypes(); !reflect.DeepEqual(got, []string{"bentoml"}) {
+		t.Fatalf("registry types: got %#v want [bentoml]", got)
+	}
+}
+
+func TestModelRegistryProfileTypedMapUsesGlobalModel(t *testing.T) {
+	loadModelRegistryProfileForTest(t, `
+model_registries:
+  hugging-face:
+    url: https://huggingface.co
+  bentoml:
+    url: nfs://10.0.0.10:/models
+model:
+  name: global-model
+  version: v1
+  task: text-generation
+`)
+
+	if got := profileModelRegistryTypes(); !reflect.DeepEqual(got, []string{"bentoml", "hugging-face"}) {
+		t.Fatalf("registry types: got %#v", got)
+	}
+
+	hf := profileModelRegistryForType("hugging-face")
+	if hf.Type != "hugging-face" || hf.URL != "https://huggingface.co" {
+		t.Fatalf("hugging-face registry: got %#v", hf)
+	}
+
+	if profileModelName() != "global-model" || profileModelVersion() != "v1" || profileModelTask() != "text-generation" {
+		t.Fatalf("global model changed: name=%q version=%q task=%q",
+			profileModelName(), profileModelVersion(), profileModelTask())
+	}
+
+	if got := profileModelRegistryForType("").Type; got != "bentoml" {
+		t.Fatalf("implicit default registry type from typed map: got %q", got)
+	}
+}
+
+func TestModelRegistryProfileRejectsTypeMismatch(t *testing.T) {
+	oldProfile := profile
+	oldPath, hadPath := os.LookupEnv("E2E_PROFILE_PATH")
+	t.Cleanup(func() {
+		profile = oldProfile
+		if hadPath {
+			os.Setenv("E2E_PROFILE_PATH", oldPath)
+		} else {
+			os.Unsetenv("E2E_PROFILE_PATH")
+		}
+	})
+
+	path := filepath.Join(t.TempDir(), "profile.yaml")
+	if err := os.WriteFile(path, []byte(`
+model_registries:
+  bentoml:
+    type: hugging-face
+    url: nfs://10.0.0.10:/models
+`), 0644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	os.Setenv("E2E_PROFILE_PATH", path)
+
+	err := LoadProfile()
+	if err == nil || !strings.Contains(err.Error(), "model_registries.bentoml.type") {
+		t.Fatalf("LoadProfile error: got %v want model registry type mismatch", err)
+	}
+}
+
+func TestRenderEndpointWithModelRegistryType(t *testing.T) {
+	gomega.RegisterTestingT(t)
+
+	loadModelRegistryProfileForTest(t, `
+model_registries:
+  bentoml:
+    url: nfs://10.0.0.10:/models
+model:
+  name: global-model
+  version: v2
+  task: text-generation
+engines:
+  vllm:
+    version: v0.11.2
+`)
+
+	Cfg.RunID = "777777"
+	yamlPath, _ := renderEndpoint(
+		"typed-registry-endpoint",
+		"cluster-a",
+		withModelRegistryType("bentoml"),
+		withAccelerator("nvidia_gpu", "NVIDIA-A100"),
+	)
+	t.Cleanup(func() { os.Remove(yamlPath) })
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("read rendered endpoint: %v", err)
+	}
+	rendered := string(data)
+
+	for _, want := range []string{
+		"registry: e2e-registry-bentoml-777777",
+		"name: global-model",
+		"version: v2",
+		"task: text-generation",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered endpoint missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestModelRegistryTemplateRendersCredentialsWhenConfigured(t *testing.T) {
+	rendered, err := renderTemplate("testdata/model-registry.yaml", map[string]any{
+		"E2E_MODEL_REGISTRY":             "registry-with-token",
+		"E2E_WORKSPACE":                  "default",
+		"E2E_MODEL_REGISTRY_TYPE":        "hugging-face",
+		"E2E_MODEL_REGISTRY_URL":         "https://huggingface.co",
+		"E2E_MODEL_REGISTRY_CREDENTIALS": "hf_token",
+	})
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+
+	if !strings.Contains(rendered, "credentials: hf_token") {
+		t.Fatalf("rendered model registry should include credentials:\n%s", rendered)
+	}
+}

--- a/tests/e2e/model_registry_profile_test.go
+++ b/tests/e2e/model_registry_profile_test.go
@@ -159,6 +159,49 @@ engines:
 	}
 }
 
+func TestRenderEndpointWithLegacyModelRegistryTypeUsesDefaultRegistryName(t *testing.T) {
+	gomega.RegisterTestingT(t)
+
+	loadModelRegistryProfileForTest(t, `
+model_registry:
+  type: hugging-face
+  url: https://huggingface.co
+model:
+  name: global-model
+  version: v2
+  task: text-generation
+engines:
+  vllm:
+    version: v0.11.2
+`)
+
+	Cfg.RunID = "777777"
+	yamlPath, _ := renderEndpoint(
+		"legacy-registry-endpoint",
+		"cluster-a",
+		withModelRegistryType("hugging-face"),
+		withAccelerator("nvidia_gpu", "NVIDIA-A100"),
+	)
+	t.Cleanup(func() { os.Remove(yamlPath) })
+
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		t.Fatalf("read rendered endpoint: %v", err)
+	}
+	rendered := string(data)
+
+	for _, want := range []string{
+		"registry: e2e-registry-777777",
+		"name: global-model",
+		"version: v2",
+		"task: text-generation",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered endpoint missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
 func TestModelRegistryTemplateRendersCredentialsWhenConfigured(t *testing.T) {
 	rendered, err := renderTemplate("testdata/model-registry.yaml", map[string]any{
 		"E2E_MODEL_REGISTRY":             "registry-with-token",

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -81,17 +81,6 @@ func TeardownModelRegistries(registryTypes ...string) {
 	}
 }
 
-func configuredModelRegistryTypesWithURL() []string {
-	var registryTypes []string
-	for _, registryType := range profileModelRegistryTypes() {
-		if profileModelRegistryForType(registryType).URL != "" {
-			registryTypes = append(registryTypes, registryType)
-		}
-	}
-
-	return registryTypes
-}
-
 // --- ModelHelper (Page Object for "model" CLI subcommands) ---
 
 // ModelHelper encapsulates common parameters for model CLI operations.
@@ -158,22 +147,6 @@ func pushModel(name, version string, fileSize int, extraArgs ...string) CLIResul
 	Expect(os.WriteFile(filepath.Join(modelDir, "model.bin"), data, 0644)).To(Succeed())
 	return Model.Push(modelDir, name, version, extraArgs...)
 }
-
-// --- Tests ---
-
-var _ = Describe("ModelRegistry Profile", Label("model-registry", "profile"), func() {
-	It("should create all configured registry types", func() {
-		registryTypes := configuredModelRegistryTypesWithURL()
-		if len(registryTypes) < 2 {
-			Skip("requires at least two model registry profiles with URL configured")
-		}
-
-		SetupModelRegistries(registryTypes...)
-		DeferCleanup(func() {
-			TeardownModelRegistries(registryTypes...)
-		})
-	})
-})
 
 var _ = Describe("Model", Ordered, func() {
 

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -12,27 +12,35 @@ import (
 
 // --- Model registry setup/teardown ---
 
-// registryYAML holds the path to the rendered model registry YAML for teardown.
-var registryYAML string
+// registryYAMLs holds rendered model registry YAML paths by registry type.
+var registryYAMLs = map[string]string{}
 
 // SetupModelRegistry creates a model registry from the YAML template
 // and waits for it to reach Connected phase.
 func SetupModelRegistry() {
+	SetupModelRegistryForType("")
+}
+
+func SetupModelRegistryForType(registryType string) {
+	registryProfile := profileModelRegistryForType(registryType)
 	defaults := map[string]any{
-		"E2E_MODEL_REGISTRY":     testRegistry(),
-		"E2E_WORKSPACE":          profileWorkspace(),
-		"E2E_MODEL_REGISTRY_URL": profile.ModelRegistry.URL,
+		"E2E_MODEL_REGISTRY":             testRegistryForType(registryType),
+		"E2E_WORKSPACE":                  profileWorkspace(),
+		"E2E_MODEL_REGISTRY_TYPE":        registryProfile.Type,
+		"E2E_MODEL_REGISTRY_URL":         registryProfile.URL,
+		"E2E_MODEL_REGISTRY_CREDENTIALS": registryProfile.Credentials,
 	}
 	var err error
-	registryYAML, err = renderTemplateToTempFile(
+	registryYAML, err := renderTemplateToTempFile(
 		filepath.Join("testdata", "model-registry.yaml"), defaults,
 	)
 	Expect(err).NotTo(HaveOccurred(), "failed to render model registry template")
+	registryYAMLs[registryType] = registryYAML
 
 	r := RunCLI("apply", "-f", registryYAML)
 	ExpectSuccess(r)
 
-	r = RunCLI("wait", "modelregistry", testRegistry(),
+	r = RunCLI("wait", "modelregistry", testRegistryForType(registryType),
 		"-w", profileWorkspace(),
 		"--for", "jsonpath=.status.phase=Connected",
 		"--timeout", "2m",
@@ -42,10 +50,46 @@ func SetupModelRegistry() {
 
 // TeardownModelRegistry deletes the model registry and cleans up the temp YAML.
 func TeardownModelRegistry() {
-	if registryYAML != "" {
+	TeardownModelRegistryForType("")
+}
+
+func TeardownModelRegistryForType(registryType string) {
+	if registryYAML := registryYAMLs[registryType]; registryYAML != "" {
 		RunCLI("delete", "-f", registryYAML, "--force", "--ignore-not-found")
 		os.Remove(registryYAML)
+		delete(registryYAMLs, registryType)
 	}
+}
+
+func SetupModelRegistries(registryTypes ...string) {
+	if len(registryTypes) == 0 {
+		registryTypes = profileModelRegistryTypes()
+	}
+
+	for _, registryType := range registryTypes {
+		SetupModelRegistryForType(registryType)
+	}
+}
+
+func TeardownModelRegistries(registryTypes ...string) {
+	if len(registryTypes) == 0 {
+		registryTypes = profileModelRegistryTypes()
+	}
+
+	for _, registryType := range registryTypes {
+		TeardownModelRegistryForType(registryType)
+	}
+}
+
+func configuredModelRegistryTypesWithURL() []string {
+	var registryTypes []string
+	for _, registryType := range profileModelRegistryTypes() {
+		if profileModelRegistryForType(registryType).URL != "" {
+			registryTypes = append(registryTypes, registryType)
+		}
+	}
+
+	return registryTypes
 }
 
 // --- ModelHelper (Page Object for "model" CLI subcommands) ---
@@ -116,6 +160,20 @@ func pushModel(name, version string, fileSize int, extraArgs ...string) CLIResul
 }
 
 // --- Tests ---
+
+var _ = Describe("ModelRegistry Profile", Label("model-registry", "profile"), func() {
+	It("should create all configured registry types", func() {
+		registryTypes := configuredModelRegistryTypesWithURL()
+		if len(registryTypes) < 2 {
+			Skip("requires at least two model registry profiles with URL configured")
+		}
+
+		SetupModelRegistries(registryTypes...)
+		DeferCleanup(func() {
+			TeardownModelRegistries(registryTypes...)
+		})
+	})
+})
 
 var _ = Describe("Model", Ordered, func() {
 

--- a/tests/e2e/profile.go
+++ b/tests/e2e/profile.go
@@ -426,6 +426,24 @@ func profileModelRegistryForType(registryType string) ModelRegistryProfile {
 	return ModelRegistryProfile{Type: registryType}
 }
 
+func profileModelRegistryTypeUsesDefaultName(registryType string) bool {
+	if registryType == "" || registryType == defaultRegistryAlias {
+		return true
+	}
+
+	if _, ok := profile.ModelRegistries[registryType]; ok {
+		return false
+	}
+
+	if modelRegistryProfileConfigured(profile.ModelRegistry) {
+		legacy := modelRegistryProfileWithType(defaultModelRegistryType, profile.ModelRegistry)
+
+		return legacy.Type == registryType
+	}
+
+	return false
+}
+
 func profileModelRegistryTypes() []string {
 	seen := map[string]struct{}{}
 

--- a/tests/e2e/profile.go
+++ b/tests/e2e/profile.go
@@ -4,13 +4,15 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	defaultModelVersion = "latest"
+	defaultModelVersion      = "latest"
+	defaultModelRegistryType = "bentoml"
 	// defaultEngineName is the engine looked up by helpers that don't take an
 	// explicit engine name (renderEndpoint default, profileEngineVersion, etc.).
 	// Tests that target a different engine pass it via withEngine(name, version).
@@ -26,6 +28,19 @@ type EngineProfile struct {
 	// into a YAML snippet under spec.variables.engine_args. Empty (or missing)
 	// means rely on the engine's built-in defaults.
 	EngineArgs string `yaml:"engine_args"`
+}
+
+type ModelProfile struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+	File    string `yaml:"file"`
+	Task    string `yaml:"task"`
+}
+
+type ModelRegistryProfile struct {
+	Type        string `yaml:"type"`
+	URL         string `yaml:"url"`
+	Credentials string `yaml:"credentials"`
 }
 
 // Profile represents the test-infra standard profile format (snake_case).
@@ -60,11 +75,8 @@ type Profile struct {
 		Password   string `yaml:"password"`
 	} `yaml:"image_registry"`
 
-	ModelRegistry struct {
-		Type        string `yaml:"type"`
-		URL         string `yaml:"url"`
-		Credentials string `yaml:"credentials"`
-	} `yaml:"model_registry"`
+	ModelRegistry   ModelRegistryProfile            `yaml:"model_registry"`
+	ModelRegistries map[string]ModelRegistryProfile `yaml:"model_registries"`
 
 	Workspace string `yaml:"workspace"`
 
@@ -81,12 +93,7 @@ type Profile struct {
 	// block — no Go struct change required.
 	Engines map[string]EngineProfile `yaml:"engines"`
 
-	Model struct {
-		Name    string `yaml:"name"`
-		Version string `yaml:"version"`
-		File    string `yaml:"file"`
-		Task    string `yaml:"task"`
-	} `yaml:"model"`
+	Model ModelProfile `yaml:"model"`
 
 	EmbeddingModel struct {
 		Name    string `yaml:"name"`
@@ -158,6 +165,10 @@ func LoadProfile() error {
 		return fmt.Errorf("failed to parse profile %s: %w", path, err)
 	}
 
+	if err := validateProfile(); err != nil {
+		return fmt.Errorf("invalid profile %s: %w", path, err)
+	}
+
 	// Compute derived fields.
 
 	// SSH: read key file and base64-encode; compute worker IPs.
@@ -211,6 +222,20 @@ func LoadProfile() error {
 
 	if profile.ControlPlane.K8sNamespace == "" {
 		profile.ControlPlane.K8sNamespace = "neutree-e2e"
+	}
+
+	return nil
+}
+
+func validateProfile() error {
+	for registryType, registryProfile := range profile.ModelRegistries {
+		if registryType == "" {
+			return fmt.Errorf("model_registries contains an empty registry type")
+		}
+		if registryProfile.Type != "" && registryProfile.Type != registryType {
+			return fmt.Errorf("model_registries.%s.type must match map key %q, got %q",
+				registryType, registryType, registryProfile.Type)
+		}
 	}
 
 	return nil
@@ -356,6 +381,77 @@ func profileEngineArgsFor(name string) string {
 	}
 
 	return ""
+}
+
+func modelRegistryProfileConfigured(p ModelRegistryProfile) bool {
+	return p.Type != "" || p.URL != "" || p.Credentials != ""
+}
+
+func modelRegistryProfileWithType(registryType string, p ModelRegistryProfile) ModelRegistryProfile {
+	if p.Type == "" {
+		p.Type = registryType
+	}
+
+	return p
+}
+
+func profileModelRegistryForType(registryType string) ModelRegistryProfile {
+	if registryType == "" || registryType == "default" {
+		if modelRegistryProfileConfigured(profile.ModelRegistry) {
+			return modelRegistryProfileWithType(defaultModelRegistryType, profile.ModelRegistry)
+		}
+
+		if p, ok := profile.ModelRegistries[defaultModelRegistryType]; ok {
+			return modelRegistryProfileWithType(defaultModelRegistryType, p)
+		}
+
+		return ModelRegistryProfile{Type: defaultModelRegistryType}
+	}
+
+	if p, ok := profile.ModelRegistries[registryType]; ok {
+		return modelRegistryProfileWithType(registryType, p)
+	}
+
+	if modelRegistryProfileConfigured(profile.ModelRegistry) {
+		legacy := modelRegistryProfileWithType(defaultModelRegistryType, profile.ModelRegistry)
+		if legacy.Type == registryType {
+			return legacy
+		}
+	}
+
+	return ModelRegistryProfile{Type: registryType}
+}
+
+func profileModelRegistryTypes() []string {
+	seen := map[string]struct{}{}
+
+	if modelRegistryProfileConfigured(profile.ModelRegistry) {
+		seen[profileModelRegistryForType("").Type] = struct{}{}
+	}
+
+	for registryType := range profile.ModelRegistries {
+		if registryType != "" {
+			seen[registryType] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
+		seen[defaultModelRegistryType] = struct{}{}
+	}
+
+	var types []string
+	if _, ok := seen[defaultModelRegistryType]; ok {
+		types = append(types, defaultModelRegistryType)
+		delete(seen, defaultModelRegistryType)
+	}
+
+	var rest []string
+	for registryType := range seen {
+		rest = append(rest, registryType)
+	}
+	sort.Strings(rest)
+
+	return append(types, rest...)
 }
 
 func profileEndpointTimeout() string {

--- a/tests/e2e/profile.go
+++ b/tests/e2e/profile.go
@@ -13,6 +13,9 @@ import (
 const (
 	defaultModelVersion      = "latest"
 	defaultModelRegistryType = "bentoml"
+	defaultProfileName       = "default"
+	defaultRegistryAlias     = defaultProfileName
+	defaultWorkspace         = defaultProfileName
 	// defaultEngineName is the engine looked up by helpers that don't take an
 	// explicit engine name (renderEndpoint default, profileEngineVersion, etc.).
 	// Tests that target a different engine pass it via withEngine(name, version).
@@ -232,6 +235,7 @@ func validateProfile() error {
 		if registryType == "" {
 			return fmt.Errorf("model_registries contains an empty registry type")
 		}
+
 		if registryProfile.Type != "" && registryProfile.Type != registryType {
 			return fmt.Errorf("model_registries.%s.type must match map key %q, got %q",
 				registryType, registryType, registryProfile.Type)
@@ -297,7 +301,7 @@ func profileWorkspace() string {
 		return profile.Workspace
 	}
 
-	return "default"
+	return defaultWorkspace
 }
 
 func profileClusterVersion() string {
@@ -396,7 +400,7 @@ func modelRegistryProfileWithType(registryType string, p ModelRegistryProfile) M
 }
 
 func profileModelRegistryForType(registryType string) ModelRegistryProfile {
-	if registryType == "" || registryType == "default" {
+	if registryType == "" || registryType == defaultRegistryAlias {
 		if modelRegistryProfileConfigured(profile.ModelRegistry) {
 			return modelRegistryProfileWithType(defaultModelRegistryType, profile.ModelRegistry)
 		}
@@ -449,6 +453,7 @@ func profileModelRegistryTypes() []string {
 	for registryType := range seen {
 		rest = append(rest, registryType)
 	}
+
 	sort.Strings(rest)
 
 	return append(types, rest...)

--- a/tests/e2e/profile.yaml.example
+++ b/tests/e2e/profile.yaml.example
@@ -31,6 +31,16 @@ model_registry:
   url: https://huggingface.co
   credentials: ""
 
+# Optional: configure multiple model registry profiles by registry type.
+# Tests that target a specific type select the registry from this map, while
+# all endpoint model names/versions/tasks still come from the top-level model.
+# model_registries:
+#   bentoml:
+#     url: nfs://10.0.0.10:/models
+#   hugging-face:
+#     url: https://huggingface.co
+#     credentials: ""
+
 workspace: default
 
 cluster:

--- a/tests/e2e/testdata/model-registry.yaml
+++ b/tests/e2e/testdata/model-registry.yaml
@@ -6,3 +6,6 @@ metadata:
 spec:
   type: {{ .E2E_MODEL_REGISTRY_TYPE }}
   url: {{ .E2E_MODEL_REGISTRY_URL }}
+{{- if .E2E_MODEL_REGISTRY_CREDENTIALS }}
+  credentials: {{ .E2E_MODEL_REGISTRY_CREDENTIALS }}
+{{- end }}


### PR DESCRIPTION
## Issue

n/a. Direct e2e harness/profile task.

Workflow classification: Standard (`tests/e2e` profile/helper behavior change across multiple files). TestRail is not affected; accidental case `C2682615` was deleted.

## Summary

Extend the e2e profile helpers so one profile can describe multiple ModelRegistry configurations by registry type while preserving the existing single-registry path. Endpoint model name/version/task continue to come from the top-level `model` config.

## Changes

- Add `model_registries` profile support keyed by registry type, alongside legacy `model_registry`.
- Add typed ModelRegistry setup/teardown helpers and typed endpoint registry selection.
- Preserve legacy registry naming when an explicit registry type points at legacy `model_registry`.
- Render optional ModelRegistry credentials when configured.
- Add focused Go tests for profile compatibility, registry naming, validation, endpoint rendering, and credentials rendering.
- Do not add a live Ginkgo e2e case and do not add/sync TestRail cases.

## Test Plan

- [x] E2E (if affected): not affected. No new live Ginkgo e2e case is added; verification is Go unit tests plus compile/lint/vet.
- [x] DB integration (`make db-test`): not affected.
- [x] `go test ./tests/e2e/... -run "TestModelRegistryProfile|TestRenderEndpointWithModelRegistryType|TestRenderEndpointWithLegacyModelRegistryTypeUsesDefaultRegistryName|TestModelRegistryTemplateRendersCredentialsWhenConfigured" -count=1 -v`
- [x] `go test ./tests/e2e/... -run "^$" -count=1`
- [x] `go vet ./tests/e2e/...`
- [x] `./bin/golangci-lint run ./tests/e2e/...`
- [x] `NEUTREE_SERVER_URL= NEUTREE_API_KEY= go test ./tests/e2e/... -count=1`
- [x] `git diff --check`
- [x] PR checks: `pr-check` and `codecov/patch` passed for head `99d53a540143aa9e8881e4f3c64a868c0e1cd7f1`.

Note: unfiltered `go test ./tests/e2e/...` enters the real Ginkgo BeforeSuite when e2e env is set. For local full pre-commit vet, ignored CLI embed tar files were generated from `deploy/docker`.

## Risk & Rollback

Risk is limited to e2e harness/profile behavior. Existing profiles remain compatible through the legacy `model_registry` path and default registry name. Rollback is reverting this PR; no production code, API schema, DB migration, or TestRail state is introduced by the code change.