### PR TITLE
feat(ai-trace): AI inference trace query API + Kong/Vector collection

### DIFF
--- a/cmd/neutree-api/app/builder.go
+++ b/cmd/neutree-api/app/builder.go
@@ -43,6 +43,7 @@ func NewBuilder() *Builder {
 		"dashboard-proxy": ProxiesRouteFactory(proxies.RegisterRayDashboardProxyRoutes),
 		"k8s-proxy":       ProxiesRouteFactory(proxies.RegisterKubernetesProxyRoutes),
 		"endpoint-logs":   LogsRouteFactory(logs.RegisterEndpointLogsRoutes),
+		"ai-traces":       LogsRouteFactory(logs.RegisterAITraceRoutes),
 		"system":          SystemRouteFactory(system.RegisterSystemRoutes),
 		// Auth route (no auth required for authentication itself)
 		"auth": AuthRouteFactory(auth.RegisterAuthRoutes),
@@ -88,6 +89,7 @@ func NewBuilder() *Builder {
 		"k8s-proxy":     {"auth"},
 		"system":        {"auth"},
 		"endpoint-logs": {"auth"},
+		"ai-traces":     {"auth"},
 		// PostgREST proxy routes now require auth middleware to:
 		// 1. Validate JWT tokens (pass-through to PostgREST)
 		// 2. Convert API keys to PostgREST-compatible JWT tokens

--- a/cmd/neutree-api/app/config/config.go
+++ b/cmd/neutree-api/app/config/config.go
@@ -33,5 +33,6 @@ type APIConfig struct {
 	StorageAccessURL string
 	AuthEndpoint     string
 	GrafanaURL       string
+	AITraceStoreURL  string
 	Version          string
 }

--- a/cmd/neutree-api/app/factory.go
+++ b/cmd/neutree-api/app/factory.go
@@ -124,9 +124,10 @@ type LogsRegisterFunc func(group *gin.RouterGroup, middlewares []gin.HandlerFunc
 func LogsRouteFactory(register LogsRegisterFunc) RouteFactory {
 	return func(deps *RouteOptions) error {
 		register(deps.Group, deps.Middlewares, &logs.Dependencies{
-			Storage:    deps.Config.Storage,
-			HTTPClient: &util.DefaultHTTPClient{},
-			K8sClient:  &util.DefaultK8sClient{},
+			Storage:         deps.Config.Storage,
+			HTTPClient:      &util.DefaultHTTPClient{},
+			K8sClient:       &util.DefaultK8sClient{},
+			AITraceStoreURL: deps.Config.AITraceStoreURL,
 		})
 
 		return nil

--- a/cmd/neutree-api/app/options/external.go
+++ b/cmd/neutree-api/app/options/external.go
@@ -6,15 +6,17 @@ import (
 
 // ExternalOptions holds external service configuration options
 type ExternalOptions struct {
-	AuthEndpoint string
-	GrafanaURL   string
+	AuthEndpoint    string
+	GrafanaURL      string
+	AITraceStoreURL string
 }
 
 // NewExternalOptions creates new external options with default values
 func NewExternalOptions() *ExternalOptions {
 	return &ExternalOptions{
-		AuthEndpoint: "http://auth:9999",
-		GrafanaURL:   "",
+		AuthEndpoint:    "http://auth:9999",
+		GrafanaURL:      "",
+		AITraceStoreURL: "",
 	}
 }
 
@@ -22,6 +24,7 @@ func NewExternalOptions() *ExternalOptions {
 func (o *ExternalOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.AuthEndpoint, "auth-endpoint", o.AuthEndpoint, "auth service endpoint")
 	fs.StringVar(&o.GrafanaURL, "grafana-url", o.GrafanaURL, "grafana url for system info API")
+	fs.StringVar(&o.AITraceStoreURL, "ai-trace-store-url", o.AITraceStoreURL, "VictoriaLogs base URL for AI inference trace queries (e.g. http://victorialogs:9428)")
 }
 
 // Validate validates external options

--- a/cmd/neutree-api/app/options/options.go
+++ b/cmd/neutree-api/app/options/options.go
@@ -109,6 +109,7 @@ func (o *Options) Config() (*config.APIConfig, error) {
 		StorageAccessURL: o.Storage.AccessURL,
 		AuthEndpoint:     o.External.AuthEndpoint,
 		GrafanaURL:       grafanaExternalURL,
+		AITraceStoreURL:  o.External.AITraceStoreURL,
 		Version:          version.Get().AppVersion,
 	}, nil
 }

--- a/db/dbtest/workspace_user_permissions_test.go
+++ b/db/dbtest/workspace_user_permissions_test.go
@@ -45,6 +45,8 @@ func TestWorkspaceUserPermissions_HasExpectedPermissions(t *testing.T) {
 		"external_endpoint:create",
 		"external_endpoint:update",
 		"external_endpoint:delete",
+		"endpoint:trace-read",
+		"external_endpoint:trace-read",
 	}
 
 	var permissions []string

--- a/db/migrations/060_trace_permission.down.sql
+++ b/db/migrations/060_trace_permission.down.sql
@@ -1,0 +1,2 @@
+-- PostgreSQL does not support removing enum values.
+-- The endpoint:trace-read and external_endpoint:trace-read values will remain.

--- a/db/migrations/060_trace_permission.up.sql
+++ b/db/migrations/060_trace_permission.up.sql
@@ -1,0 +1,8 @@
+-- Resource-scoped trace-read permissions for the AI inference trace endpoints
+-- (/api/v1/ai-traces/...): one for internal endpoints, one for external. The
+-- enterprise edition's has_permission override makes these workspace-scoped; in
+-- community they are global (community deliberately omits per-workspace trace
+-- control). Granting happens in 063, since a newly added enum value cannot be
+-- referenced in the same transaction that adds it.
+ALTER TYPE api.permission_action ADD VALUE IF NOT EXISTS 'endpoint:trace-read';
+ALTER TYPE api.permission_action ADD VALUE IF NOT EXISTS 'external_endpoint:trace-read';

--- a/db/migrations/060_trace_permission.up.sql
+++ b/db/migrations/060_trace_permission.up.sql
@@ -2,7 +2,7 @@
 -- (/api/v1/ai-traces/...): one for internal endpoints, one for external. The
 -- enterprise edition's has_permission override makes these workspace-scoped; in
 -- community they are global (community deliberately omits per-workspace trace
--- control). Granting happens in 063, since a newly added enum value cannot be
+-- control). Granting happens in 061, since a newly added enum value cannot be
 -- referenced in the same transaction that adds it.
 ALTER TYPE api.permission_action ADD VALUE IF NOT EXISTS 'endpoint:trace-read';
 ALTER TYPE api.permission_action ADD VALUE IF NOT EXISTS 'external_endpoint:trace-read';

--- a/db/migrations/061_grant_trace_permission.down.sql
+++ b/db/migrations/061_grant_trace_permission.down.sql
@@ -1,0 +1,51 @@
+-- Revert workspace-user permissions to the pre-trace set (mirrors 057).
+-- admin retains the trace-read perms because enum values cannot be removed.
+CREATE OR REPLACE FUNCTION api.update_workspace_user_permissions()
+RETURNS VOID AS $$
+DECLARE
+    workspace_user_permissions api.permission_action[];
+BEGIN
+    workspace_user_permissions := ARRAY[
+        'workspace:read',
+        'endpoint:read',
+        'endpoint:create',
+        'endpoint:update',
+        'endpoint:delete',
+        'image_registry:read',
+        'image_registry:create',
+        'image_registry:update',
+        'image_registry:delete',
+        'model_registry:read',
+        'model_registry:create',
+        'model_registry:update',
+        'model_registry:delete',
+        'model:read',
+        'model:push',
+        'model:pull',
+        'model:delete',
+        'engine:read',
+        'engine:create',
+        'engine:update',
+        'engine:delete',
+        'cluster:read',
+        'cluster:create',
+        'cluster:update',
+        'cluster:delete',
+        'model_catalog:read',
+        'model_catalog:create',
+        'model_catalog:update',
+        'model_catalog:delete',
+        'external_endpoint:read',
+        'external_endpoint:create',
+        'external_endpoint:update',
+        'external_endpoint:delete'
+    ]::api.permission_action[];
+
+    UPDATE api.roles
+    SET spec = ROW((spec).preset_key, workspace_user_permissions)::api.role_spec
+    WHERE (metadata).name = 'workspace-user';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply reverted permissions
+SELECT api.update_workspace_user_permissions();

--- a/db/migrations/061_grant_trace_permission.up.sql
+++ b/db/migrations/061_grant_trace_permission.up.sql
@@ -1,0 +1,60 @@
+-- Grant the trace-read permissions (added in 060) to the built-in roles.
+-- Separate migration because newly added enum values cannot be referenced in
+-- the same transaction that adds them.
+
+-- admin: refresh to every permission in the enum (picks up the trace perms).
+SELECT api.update_admin_permissions();
+
+-- workspace-user: grant both endpoint:trace-read and external_endpoint:trace-read
+-- so workspace members can read inference traces by default.
+CREATE OR REPLACE FUNCTION api.update_workspace_user_permissions()
+RETURNS VOID AS $$
+DECLARE
+    workspace_user_permissions api.permission_action[];
+BEGIN
+    workspace_user_permissions := ARRAY[
+        'workspace:read',
+        'endpoint:read',
+        'endpoint:create',
+        'endpoint:update',
+        'endpoint:delete',
+        'image_registry:read',
+        'image_registry:create',
+        'image_registry:update',
+        'image_registry:delete',
+        'model_registry:read',
+        'model_registry:create',
+        'model_registry:update',
+        'model_registry:delete',
+        'model:read',
+        'model:push',
+        'model:pull',
+        'model:delete',
+        'engine:read',
+        'engine:create',
+        'engine:update',
+        'engine:delete',
+        'cluster:read',
+        'cluster:create',
+        'cluster:update',
+        'cluster:delete',
+        'model_catalog:read',
+        'model_catalog:create',
+        'model_catalog:update',
+        'model_catalog:delete',
+        'external_endpoint:read',
+        'external_endpoint:create',
+        'external_endpoint:update',
+        'external_endpoint:delete',
+        'endpoint:trace-read',
+        'external_endpoint:trace-read'
+    ]::api.permission_action[];
+
+    UPDATE api.roles
+    SET spec = ROW((spec).preset_key, workspace_user_permissions)::api.role_spec
+    WHERE (metadata).name = 'workspace-user';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply updated permissions
+SELECT api.update_workspace_user_permissions();

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -225,6 +225,7 @@ services:
       - --gin-mode=release
       - --auth-endpoint=http://auth:9999
       - --grafana-url={{ .GrafanaURL }}
+      - --ai-trace-store-url=http://victorialogs:9428
     ports:
       - 3000:3000
     networks:
@@ -232,6 +233,8 @@ services:
     restart: always
     depends_on:
       postgrest:
+        condition: service_started
+      victorialogs:
         condition: service_started
     logging:
       driver: "json-file"
@@ -311,6 +314,25 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  victorialogs:
+    container_name: victorialogs
+    image: victoriametrics/victoria-logs:v1.50.0
+    command:
+      - -storageDataPath=/victoria-logs-data
+      # AI-trace request/response bodies can be large; raise the per-line
+      # ingest limit to 16MiB so VictoriaLogs does not drop them.
+      - -insert.maxLineSizeBytes=16777216
+    volumes:
+      - vl_data:/victoria-logs-data
+    networks:
+      - neutree
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   vector:
     container_name: vector
     image: timberio/vector:{{ .VectorVersion }}
@@ -319,11 +341,14 @@ services:
       - /etc/vector/
     volumes:
       - {{ .NeutreeCoreWorkDir }}/vector:/etc/vector
+      - {{ .NeutreeCoreWorkDir }}/vector-trace:/var/log/vector
     restart: always
     networks:
       - neutree
     depends_on:
       neutree-api:
+        condition: service_started
+      victorialogs:
         condition: service_started
     logging:
       driver: "json-file"
@@ -383,6 +408,7 @@ networks:
 
 volumes:
   pg_data:
+  vl_data:
 {{ if .MetricsRemoteWriteURL }}
   vmagentdata:
 {{ end }}

--- a/deploy/docker/neutree-core/vector/vector.yml
+++ b/deploy/docker/neutree-core/vector/vector.yml
@@ -19,10 +19,10 @@ transforms:
       .extracted_data.api_version = .request.api_version
       .extracted_data.api_key_id = .consumer.custom_id
       if exists(.request.uri) {
-          .extracted_data.url_spilt = split!(.request.uri, "/")
-          .extracted_data.workspace = .extracted_data.url_spilt[2]      # workspace name from /workspace/{workspace}/...
-          .extracted_data.endpoint_type = .extracted_data.url_spilt[3]  # "endpoint" or "external-endpoint"
-          .extracted_data.endpoint_name = .extracted_data.url_spilt[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
+          .extracted_data.url_split = split!(.request.uri, "/")
+          .extracted_data.workspace = .extracted_data.url_split[2]      # workspace name from /workspace/{workspace}/...
+          .extracted_data.endpoint_type = .extracted_data.url_split[3]  # "endpoint" or "external-endpoint"
+          .extracted_data.endpoint_name = .extracted_data.url_split[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
       }
 
       if exists(.ai) && exists(.ai."statistics") && exists(.ai."statistics".usage) {
@@ -82,20 +82,26 @@ transforms:
           "workspace":      .extracted_data.workspace || "",
           "endpoint_type":  .extracted_data.endpoint_type || "",
           "endpoint_name":  .extracted_data.endpoint_name || "",
-          "api_key_id":     .consumer.custom_id,
-          "request_uri":    .request.uri,
-          "request_model":  .ai."statistics".meta.request_model,
-          "response_model": .ai."statistics".meta.response_model,
+          # Optional string columns are coalesced to "" so every record carries
+          # the same string type even when the source field is absent (e.g. an
+          # error response that returned early before `ai.statistics`, or a
+          # success with no `finish_reason`). The numeric columns below are left
+          # nullable on purpose: the query API decodes them into pointer/optional
+          # fields and must distinguish "no token/latency data" from a real 0.
+          "api_key_id":     .consumer.custom_id || "",
+          "request_uri":    .request.uri || "",
+          "request_model":  .ai."statistics".meta.request_model || "",
+          "response_model": .ai."statistics".meta.response_model || "",
           "response_status": .response.status,
           "prompt_tokens":     .ai."statistics".usage.prompt_tokens,
           "completion_tokens": .ai."statistics".usage.completion_tokens,
           "total_tokens":      .ai."statistics".usage.total_tokens,
-          "finish_reason":  .ai."trace".finish_reason,
-          "stream":         .ai."trace".stream,
-          "user_agent":     .request.headers."user-agent",
+          "finish_reason":  .ai."trace".finish_reason || "",
+          "stream":         .ai."trace".stream || false,
+          "user_agent":     .request.headers."user-agent" || "",
           "duration_ms":    .latencies.request,
-          "request_body":   .ai."trace".request_body,
-          "response_body":  .ai."trace".response_body,
+          "request_body":   .ai."trace".request_body || "",
+          "response_body":  .ai."trace".response_body || "",
       }
 sinks:
   postgrest_rpc:

--- a/deploy/docker/neutree-core/vector/vector.yml
+++ b/deploy/docker/neutree-core/vector/vector.yml
@@ -13,19 +13,22 @@ transforms:
 
       # Access fields with hyphens using proper VRL syntax
 
+      .extracted_data.request_id = .request.id
+      .extracted_data.timestamp = .started_at
+      .extracted_data.status = .response.status
+      .extracted_data.api_version = .request.api_version
+      .extracted_data.api_key_id = .consumer.custom_id
+      if exists(.request.uri) {
+          .extracted_data.url_spilt = split!(.request.uri, "/")
+          .extracted_data.workspace = .extracted_data.url_spilt[2]      # workspace name from /workspace/{workspace}/...
+          .extracted_data.endpoint_type = .extracted_data.url_spilt[3]  # "endpoint" or "external-endpoint"
+          .extracted_data.endpoint_name = .extracted_data.url_spilt[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
+      }
+
       if exists(.ai) && exists(.ai."statistics") && exists(.ai."statistics".usage) {
-          # Extract fields one by one
-          .extracted_data.request_id = .request.id
           .extracted_data.total_tokens = .ai."statistics".usage.total_tokens
           .extracted_data.prompt_tokens = .ai."statistics".usage.prompt_tokens
           .extracted_data.completion_tokens = .ai."statistics".usage.completion_tokens
-          .extracted_data.timestamp = .started_at
-          .extracted_data.status = .response.status
-          .extracted_data.api_version =.request.api_version
-          .extracted_data.url_spilt = split!(.request.uri, "/")
-          .extracted_data.endpoint_type = .extracted_data.url_spilt[3]  # "endpoint" or "external-endpoint"
-          .extracted_data.endpoint_name = .extracted_data.url_spilt[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
-          .extracted_data.api_key_id = .consumer.custom_id
 
           if exists(.ai."statistics".meta) && exists(.ai."statistics".meta.request_model) {
               .extracted_data.model_name = .ai."statistics".meta.request_model
@@ -59,6 +62,41 @@ transforms:
           "p_prompt_tokens": .extracted_data.prompt_tokens,
           "p_completion_tokens": .extracted_data.completion_tokens
       }
+  filter_trace_logs:
+    type: filter
+    inputs:
+      - parse_kong_logs
+    condition: exists(.ai."trace".request_body) || exists(.ai."trace".response_body)
+  prepare_trace_payload:
+    type: remap
+    inputs:
+      - filter_trace_logs
+    source: |
+      . = {
+          # VictoriaLogs rejects records without a non-empty `_msg`. Failed
+          # requests often carry no response body, so `_msg` must be a field
+          # that is always populated — never the (optional) response body.
+          "_msg":           .request.id || "ai-trace",
+          "request_id":     .request.id,
+          "timestamp":      .started_at,
+          "workspace":      .extracted_data.workspace || "",
+          "endpoint_type":  .extracted_data.endpoint_type || "",
+          "endpoint_name":  .extracted_data.endpoint_name || "",
+          "api_key_id":     .consumer.custom_id,
+          "request_uri":    .request.uri,
+          "request_model":  .ai."statistics".meta.request_model,
+          "response_model": .ai."statistics".meta.response_model,
+          "response_status": .response.status,
+          "prompt_tokens":     .ai."statistics".usage.prompt_tokens,
+          "completion_tokens": .ai."statistics".usage.completion_tokens,
+          "total_tokens":      .ai."statistics".usage.total_tokens,
+          "finish_reason":  .ai."trace".finish_reason,
+          "stream":         .ai."trace".stream,
+          "user_agent":     .request.headers."user-agent",
+          "duration_ms":    .latencies.request,
+          "request_body":   .ai."trace".request_body,
+          "response_body":  .ai."trace".response_body,
+      }
 sinks:
   postgrest_rpc:
     type: http
@@ -78,4 +116,30 @@ sinks:
       Content-Type: application/json
     batch:
       max_events: 1
+      timeout_secs: 1
+  ai_trace_file:
+    type: file
+    inputs:
+      - prepare_trace_payload
+    path: /var/log/vector/ai-trace-%Y-%m-%d.log
+    encoding:
+      codec: json
+    framing:
+      method: newline_delimited
+  ai_trace_victorialogs:
+    type: http
+    inputs:
+      - prepare_trace_payload
+    uri: http://victorialogs:9428/insert/jsonline?_stream_fields=workspace,endpoint_type,endpoint_name&_time_field=timestamp
+    method: post
+    encoding:
+      codec: json
+    framing:
+      method: newline_delimited
+    compression: none
+    request:
+      headers:
+        Content-Type: application/stream+json
+    batch:
+      max_events: 100
       timeout_secs: 1

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -18,10 +18,6 @@ local function is_table(v)
     return type(v) == "table"
 end
 
-local function string_or_empty(v)
-    return type(v) == "string" and v or ""
-end
-
 local SUPPORTED_ROUTE_TYPES = {
     "/v1/chat/completions",
     "/v1/embeddings",
@@ -257,6 +253,10 @@ local function convert_tools(tools)
             },
         }
     end
+    -- An empty Lua table serialises to a JSON object `{}`, which upstreams
+    -- (e.g. vLLM) reject for the array-typed `tools` field. Omit `tools`
+    -- entirely when the client sent an empty list.
+    if #result == 0 then return nil end
     return result
 end
 
@@ -472,20 +472,22 @@ local function convert_response(openai_resp, request_model)
     if is_table(message.tool_calls) then
         for _, tc in ipairs(message.tool_calls) do
             local input = {}
-            local fn = is_table(tc["function"]) and tc["function"] or EMPTY
-            local args = fn.arguments
-            if type(args) == "string" then
-                local parsed, err = cjson.decode(args)
+            if tc["function"] and tc["function"].arguments then
+                local parsed, err = cjson.decode(tc["function"].arguments)
                 if err or parsed == nil then
-                    input = { raw = args }
+                    input = { raw = tc["function"].arguments }
                 else
                     input = parsed
                 end
             end
+            local fn_name = (tc["function"] or EMPTY).name
+            if fn_name == nil or fn_name == cjson.null then
+                fn_name = ""
+            end
             content[#content + 1] = {
                 type = "tool_use",
                 id = tc.id,
-                name = string_or_empty(fn.name),
+                name = fn_name,
                 input = input,
             }
         end
@@ -617,6 +619,8 @@ local function handle_openai_json_response()
         return
     end
 
+    kong.ctx.plugin.response_body_raw = response_body
+
     local ai_response, err = cjson.decode(response_body)
     if err then
         return
@@ -624,6 +628,10 @@ local function handle_openai_json_response()
 
     local route_type = kong.ctx.plugin.route_type
     kong.ctx.plugin.response_model = ai_response.model
+    local first_choice = ((ai_response.choices or EMPTY)[1]) or EMPTY
+    if first_choice.finish_reason and first_choice.finish_reason ~= cjson.null then
+        kong.ctx.plugin.finish_reason = first_choice.finish_reason
+    end
     if is_table(ai_response.usage) then
         if route_type == "/v1/chat/completions" then
             kong.ctx.plugin.completions_tokens = ai_response.usage.completion_tokens
@@ -644,6 +652,10 @@ local function handle_openai_stream_response(chunk, finished)
     end
 
     local body_buffer = kong.ctx.plugin.sse_body_buffer
+    local raw_buffer = kong.ctx.plugin.sse_raw_buffer
+    if raw_buffer and type(chunk) == "string" and chunk ~= "" then
+        raw_buffer:put(chunk)
+    end
     if type(chunk) == "string" and chunk ~= "" then
         local events = ai_shared.frame_to_events(chunk, normalized_content_type)
         if not events then
@@ -657,6 +669,10 @@ local function handle_openai_stream_response(chunk, finished)
                 if not err then
                     if event_t.choices and #event_t.choices > 0 and body_buffer ~= nil then
                         body_buffer:put(get_token_text(event_t))
+                    end
+                    if event_t.choices and event_t.choices[1] and event_t.choices[1].finish_reason
+                        and event_t.choices[1].finish_reason ~= cjson.null then
+                        kong.ctx.plugin.finish_reason = event_t.choices[1].finish_reason
                     end
                     if kong.ctx.plugin.response_model == nil and event_t.model then
                         kong.ctx.plugin.response_model = event_t.model
@@ -687,6 +703,8 @@ local function handle_anthropic_non_stream_body()
     ctx.body_buffer = ctx.body_buffer .. (ngx.arg[1] or "")
 
     if ngx.arg[2] then
+        ctx.response_body_raw = ctx.body_buffer
+
         local openai_resp, err = cjson.decode(ctx.body_buffer)
         if err or openai_resp == nil then
             ngx.arg[1] = ctx.body_buffer
@@ -694,6 +712,10 @@ local function handle_anthropic_non_stream_body()
         end
 
         ctx.response_model = openai_resp.model
+        local first_choice = ((openai_resp.choices or EMPTY)[1]) or EMPTY
+        if first_choice.finish_reason and first_choice.finish_reason ~= cjson.null then
+            ctx.finish_reason = first_choice.finish_reason
+        end
         if is_table(openai_resp.usage) then
             ctx.input_tokens = openai_resp.usage.prompt_tokens or 0
             ctx.output_tokens = openai_resp.usage.completion_tokens or 0
@@ -711,6 +733,9 @@ local function handle_anthropic_stream_body()
     local chunk = ngx.arg[1] or ""
     local is_last = ngx.arg[2]
     ctx.sse_buffer = (ctx.sse_buffer or "") .. chunk
+    -- POC trace: the anthropic streaming path never reaches the SSE buffer
+    -- set up in header_filter, so accumulate the raw upstream response here.
+    ctx.response_body_raw = (ctx.response_body_raw or "") .. chunk
 
     local output_parts = {}
     while true do
@@ -772,6 +797,9 @@ local function handle_anthropic_stream_body()
 
         local delta = choice.delta or EMPTY
         local finish_reason = choice.finish_reason
+        if finish_reason and finish_reason ~= cjson.null then
+            ctx.finish_reason = finish_reason
+        end
 
         if not ctx.message_started then
             output_parts[#output_parts + 1] = sse_frame("message_start", make_message_start(ctx.request_model, ctx.input_tokens))
@@ -788,7 +816,6 @@ local function handle_anthropic_stream_body()
 
         if is_table(delta.tool_calls) then
             for _, tc in ipairs(delta.tool_calls) do
-                local fn = is_table(tc["function"]) and tc["function"] or EMPTY
                 local tc_index = tc.index or 0
                 if tc_index ~= ctx.current_tool_index then
                     if ctx.current_tool_index ~= nil then
@@ -801,12 +828,12 @@ local function handle_anthropic_stream_body()
                     ctx.current_tool_index = tc_index
                     ctx.anthropic_block_index = ctx.anthropic_block_index + 1
                     local tc_id = tc.id or ""
-                    local tc_name = string_or_empty(fn.name)
+                    local tc_name = (tc["function"] or EMPTY).name or ""
                     output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_tool_use(ctx.anthropic_block_index, tc_id, tc_name))
                 end
 
-                local args = fn.arguments
-                if type(args) == "string" and args ~= "" then
+                local args = (tc["function"] or EMPTY).arguments
+                if args and args ~= "" then
                     output_parts[#output_parts + 1] = sse_frame("content_block_delta", make_content_block_delta_json(ctx.anthropic_block_index, args))
                 end
             end
@@ -865,6 +892,8 @@ function AIGatewayHandler:access(conf)
         if request_body == nil or request_body == "" then
             return anthropic_error(400, "invalid_request_error", "Request body is required")
         end
+
+        kong.ctx.plugin.request_body_raw = request_body
 
         local anthropic_req, err = cjson.decode(request_body)
         if err or anthropic_req == nil then
@@ -947,12 +976,15 @@ function AIGatewayHandler:access(conf)
         return fail(400, "request body can not be null")
     end
 
+    kong.ctx.plugin.request_body_raw = request_body
+
     local ai_request, err = cjson.decode(request_body)
     if err then
         return fail(400, "request body is not json format")
     end
 
     kong.ctx.plugin.request_model = ai_request.model
+    kong.ctx.plugin.is_stream = ai_request.stream == true
 
     if conf.upstreams then
         if not ai_request.model or ai_request.model == "" then
@@ -1018,6 +1050,7 @@ function AIGatewayHandler:header_filter(conf)
     local normalized_content_type = content_type and content_type:sub(1, (content_type:find(";") or 0) - 1)
     if normalized_content_type and normalized_content_type == "text/event-stream" then
         kong.ctx.plugin.sse_body_buffer = buffer.new()
+        kong.ctx.plugin.sse_raw_buffer = buffer.new()
         return true
     end
 
@@ -1031,6 +1064,11 @@ function AIGatewayHandler:body_filter(conf)
 
     local response_status = kong.service.response.get_status()
     if response_status ~= 200 then
+        -- POC trace: error responses bypass the transform paths below, and
+        -- streaming requests have no response buffering — so capture the raw
+        -- error body here for the log phase to surface.
+        local ctx = kong.ctx.plugin
+        ctx.response_body_raw = (ctx.response_body_raw or "") .. (ngx.arg[1] or "")
         return
     end
 
@@ -1052,6 +1090,30 @@ function AIGatewayHandler:log(conf)
     end
 
     local response_status = kong.service.response.get_status()
+
+    -- POC: emit raw req/res trace for every request (incl. failures)
+    local response_body = kong.ctx.plugin.response_body_raw
+    if response_body == nil and kong.ctx.plugin.sse_raw_buffer ~= nil then
+        response_body = kong.ctx.plugin.sse_raw_buffer:get()
+    end
+    if response_body == nil then
+        local ok, body = pcall(kong.service.response.get_raw_body)
+        if ok and body ~= nil then
+            response_body = body
+        end
+    end
+    if kong.ctx.plugin.request_body_raw ~= nil then
+        kong.log.set_serialize_value("ai.trace.request_body", kong.ctx.plugin.request_body_raw)
+    end
+    if response_body ~= nil then
+        kong.log.set_serialize_value("ai.trace.response_body", response_body)
+    end
+    if kong.ctx.plugin.finish_reason ~= nil then
+        kong.log.set_serialize_value("ai.trace.finish_reason", kong.ctx.plugin.finish_reason)
+    end
+    -- POC trace: whether the client requested a streaming response.
+    kong.log.set_serialize_value("ai.trace.stream", kong.ctx.plugin.is_stream == true)
+
     if response_status ~= 200 then
         return
     end

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -18,6 +18,10 @@ local function is_table(v)
     return type(v) == "table"
 end
 
+local function string_or_empty(v)
+    return type(v) == "string" and v or ""
+end
+
 local SUPPORTED_ROUTE_TYPES = {
     "/v1/chat/completions",
     "/v1/embeddings",
@@ -472,22 +476,22 @@ local function convert_response(openai_resp, request_model)
     if is_table(message.tool_calls) then
         for _, tc in ipairs(message.tool_calls) do
             local input = {}
-            if tc["function"] and tc["function"].arguments then
-                local parsed, err = cjson.decode(tc["function"].arguments)
+            -- `tc["function"]` may be cjson.null (a truthy userdata), so guard
+            -- with is_table before indexing it (NEU-404).
+            local fn = is_table(tc["function"]) and tc["function"] or EMPTY
+            local args = fn.arguments
+            if type(args) == "string" then
+                local parsed, err = cjson.decode(args)
                 if err or parsed == nil then
-                    input = { raw = tc["function"].arguments }
+                    input = { raw = args }
                 else
                     input = parsed
                 end
             end
-            local fn_name = (tc["function"] or EMPTY).name
-            if fn_name == nil or fn_name == cjson.null then
-                fn_name = ""
-            end
             content[#content + 1] = {
                 type = "tool_use",
                 id = tc.id,
-                name = fn_name,
+                name = string_or_empty(fn.name),
                 input = input,
             }
         end
@@ -733,8 +737,8 @@ local function handle_anthropic_stream_body()
     local chunk = ngx.arg[1] or ""
     local is_last = ngx.arg[2]
     ctx.sse_buffer = (ctx.sse_buffer or "") .. chunk
-    -- POC trace: the anthropic streaming path never reaches the SSE buffer
-    -- set up in header_filter, so accumulate the raw upstream response here.
+    -- The anthropic streaming path never reaches the SSE buffer set up in
+    -- header_filter, so accumulate the raw upstream response here for tracing.
     ctx.response_body_raw = (ctx.response_body_raw or "") .. chunk
 
     local output_parts = {}
@@ -816,6 +820,9 @@ local function handle_anthropic_stream_body()
 
         if is_table(delta.tool_calls) then
             for _, tc in ipairs(delta.tool_calls) do
+                -- `tc["function"]` may be cjson.null (a truthy userdata), so
+                -- guard with is_table before indexing it (NEU-404).
+                local fn = is_table(tc["function"]) and tc["function"] or EMPTY
                 local tc_index = tc.index or 0
                 if tc_index ~= ctx.current_tool_index then
                     if ctx.current_tool_index ~= nil then
@@ -828,19 +835,15 @@ local function handle_anthropic_stream_body()
                     ctx.current_tool_index = tc_index
                     ctx.anthropic_block_index = ctx.anthropic_block_index + 1
                     local tc_id = tc.id or ""
-                    -- Normalise nullish names the same way the non-stream path
-                    -- does: `name or ""` alone leaves cjson.null (a truthy
-                    -- userdata) intact, which would serialise as a non-string
-                    -- name in the emitted SSE frame and break JSON clients.
-                    local tc_name = (tc["function"] or EMPTY).name
-                    if tc_name == nil or tc_name == cjson.null then
-                        tc_name = ""
-                    end
+                    -- Coerce the name through string_or_empty so nil/cjson.null
+                    -- collapse to "" and never leak a non-string into the SSE
+                    -- frame (which would break JSON clients).
+                    local tc_name = string_or_empty(fn.name)
                     output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_tool_use(ctx.anthropic_block_index, tc_id, tc_name))
                 end
 
-                local args = (tc["function"] or EMPTY).arguments
-                if args and args ~= "" then
+                local args = fn.arguments
+                if type(args) == "string" and args ~= "" then
                     output_parts[#output_parts + 1] = sse_frame("content_block_delta", make_content_block_delta_json(ctx.anthropic_block_index, args))
                 end
             end
@@ -1071,9 +1074,9 @@ function AIGatewayHandler:body_filter(conf)
 
     local response_status = kong.service.response.get_status()
     if response_status ~= 200 then
-        -- POC trace: error responses bypass the transform paths below, and
-        -- streaming requests have no response buffering — so capture the raw
-        -- error body here for the log phase to surface.
+        -- Error responses bypass the transform paths below, and streaming
+        -- requests have no response buffering — so capture the raw error body
+        -- here for the log phase to surface.
         local ctx = kong.ctx.plugin
         ctx.response_body_raw = (ctx.response_body_raw or "") .. (ngx.arg[1] or "")
         return
@@ -1098,7 +1101,7 @@ function AIGatewayHandler:log(conf)
 
     local response_status = kong.service.response.get_status()
 
-    -- POC: emit raw req/res trace for every request (incl. failures)
+    -- Emit raw req/res trace for every request (incl. failures).
     local response_body = kong.ctx.plugin.response_body_raw
     if response_body == nil and kong.ctx.plugin.sse_raw_buffer ~= nil then
         response_body = kong.ctx.plugin.sse_raw_buffer:get()
@@ -1118,7 +1121,7 @@ function AIGatewayHandler:log(conf)
     if kong.ctx.plugin.finish_reason ~= nil then
         kong.log.set_serialize_value("ai.trace.finish_reason", kong.ctx.plugin.finish_reason)
     end
-    -- POC trace: whether the client requested a streaming response.
+    -- Whether the client requested a streaming response.
     kong.log.set_serialize_value("ai.trace.stream", kong.ctx.plugin.is_stream == true)
 
     if response_status ~= 200 then

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -828,7 +828,14 @@ local function handle_anthropic_stream_body()
                     ctx.current_tool_index = tc_index
                     ctx.anthropic_block_index = ctx.anthropic_block_index + 1
                     local tc_id = tc.id or ""
-                    local tc_name = (tc["function"] or EMPTY).name or ""
+                    -- Normalise nullish names the same way the non-stream path
+                    -- does: `name or ""` alone leaves cjson.null (a truthy
+                    -- userdata) intact, which would serialise as a non-string
+                    -- name in the emitted SSE frame and break JSON clients.
+                    local tc_name = (tc["function"] or EMPTY).name
+                    if tc_name == nil or tc_name == cjson.null then
+                        tc_name = ""
+                    end
                     output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_tool_use(ctx.anthropic_block_index, tc_id, tc_name))
                 end
 

--- a/internal/middleware/permission.go
+++ b/internal/middleware/permission.go
@@ -97,6 +97,13 @@ func RequirePermission(permission string, deps PermissionDependencies) gin.Handl
 	}
 }
 
+// CheckWorkspacePermission reports whether the user holds the permission in the
+// given workspace. It delegates to the has_permission DB function, which the
+// enterprise edition overrides to honour workspace scope (community is global).
+func CheckWorkspacePermission(s storage.Storage, userID, workspace, permission string) (bool, error) {
+	return checkPermission(s, userID, workspace, permission)
+}
+
 func checkPermission(s storage.Storage, userID string, workspace, permission string) (bool, error) {
 	var result bool
 

--- a/internal/routes/logs/ai_trace.go
+++ b/internal/routes/logs/ai_trace.go
@@ -387,33 +387,46 @@ func handleAITraceStats(deps *Dependencies) gin.HandlerFunc {
 
 // statsWindow resolves the inclusive UTC day-bucket range for the stats query.
 //
-// It prefers an explicit [start, end] window (RFC3339, the same params the list
-// endpoint accepts); when neither is given it falls back to the trailing `days`
-// count (default 7). Both bounds are truncated to their UTC day and the span is
-// clamped to maxStatsDays buckets. ok is false only when start/end is malformed.
+// `start` and `end` (RFC3339, the same params the list endpoint accepts) are
+// independent, optional bounds:
+//   - `end` defaults to the current (partial) UTC day when omitted.
+//   - `start` present anchors an explicit [start, end] window.
+//   - `start` absent falls back to a trailing `days` window (default 7) ending
+//     at `end`. This means an `end`-only request is a valid trailing window
+//     rather than a 400 — only a malformed start/end is rejected.
+//
+// Both bounds are truncated to their UTC day and the span is clamped to
+// maxStatsDays buckets. ok is false only when start/end is malformed RFC3339 or
+// end precedes start.
 func statsWindow(c *gin.Context) (startDay, endDay time.Time, ok bool) {
 	now := time.Now().UTC()
 
 	startStr := strings.TrimSpace(c.Query("start"))
 	endStr := strings.TrimSpace(c.Query("end"))
 
-	if startStr != "" || endStr != "" {
+	// `end` defaults to now; an explicit value overrides it. Day buckets are
+	// aligned to UTC midnight.
+	end := now
+
+	if endStr != "" {
+		parsed, err := time.Parse(time.RFC3339, endStr)
+		if err != nil {
+			return time.Time{}, time.Time{}, false
+		}
+
+		end = parsed
+	}
+
+	endDay = end.UTC().Truncate(24 * time.Hour)
+
+	if startStr != "" {
+		// Explicit window: [start, end].
 		start, err := time.Parse(time.RFC3339, startStr)
 		if err != nil {
 			return time.Time{}, time.Time{}, false
 		}
 
-		end := now
-
-		if endStr != "" {
-			end, err = time.Parse(time.RFC3339, endStr)
-			if err != nil {
-				return time.Time{}, time.Time{}, false
-			}
-		}
-
 		startDay = start.UTC().Truncate(24 * time.Hour)
-		endDay = end.UTC().Truncate(24 * time.Hour)
 
 		if endDay.Before(startDay) {
 			return time.Time{}, time.Time{}, false
@@ -427,6 +440,7 @@ func statsWindow(c *gin.Context) (startDay, endDay time.Time, ok bool) {
 		return startDay, endDay, true
 	}
 
+	// No `start`: trailing `days` window (default 7) ending at `endDay`.
 	days := 7
 
 	if v := c.Query("days"); v != "" {
@@ -435,9 +449,6 @@ func statsWindow(c *gin.Context) (startDay, endDay time.Time, ok bool) {
 		}
 	}
 
-	// Day buckets are aligned to UTC midnight; the window covers the last
-	// `days` days up to and including the current (partial) day.
-	endDay = now.Truncate(24 * time.Hour)
 	startDay = endDay.AddDate(0, 0, -(days - 1))
 
 	return startDay, endDay, true

--- a/internal/routes/logs/ai_trace.go
+++ b/internal/routes/logs/ai_trace.go
@@ -1,0 +1,648 @@
+package logs
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+
+	"github.com/neutree-ai/neutree/internal/middleware"
+)
+
+// AITrace is one inference trace record returned to the SPA.
+//
+// Mirrors the shape Vector pushes to VictoriaLogs, with response_status
+// normalised to int for the UI's filtering convenience. The list endpoint
+// leaves RequestBody/ResponseBody empty — they are large and unused by the
+// list view; the detail endpoint populates them for a single record.
+type AITrace struct {
+	RequestID        string `json:"request_id"`
+	Time             string `json:"time"`
+	Workspace        string `json:"workspace"`
+	EndpointType     string `json:"endpoint_type"`
+	EndpointName     string `json:"endpoint_name"`
+	APIKeyID         string `json:"api_key_id,omitempty"`
+	RequestURI       string `json:"request_uri,omitempty"`
+	RequestModel     string `json:"request_model,omitempty"`
+	ResponseModel    string `json:"response_model,omitempty"`
+	ResponseStatus   int    `json:"response_status"`
+	PromptTokens     *int   `json:"prompt_tokens,omitempty"`
+	CompletionTokens *int   `json:"completion_tokens,omitempty"`
+	TotalTokens      *int   `json:"total_tokens,omitempty"`
+	FinishReason     string `json:"finish_reason,omitempty"`
+	Stream           bool   `json:"stream"`
+	UserAgent        string `json:"user_agent,omitempty"`
+	DurationMs       *int   `json:"duration_ms,omitempty"`
+	RequestBody      string `json:"request_body,omitempty"`
+	ResponseBody     string `json:"response_body,omitempty"`
+}
+
+// listProjection is the LogsQL `fields` projection for the list query: every
+// metadata column the list view renders, deliberately excluding the large
+// request_body / response_body fields so list responses stay small.
+const listProjection = "_time, request_id, workspace, endpoint_type, " +
+	"endpoint_name, api_key_id, request_uri, request_model, response_model, " +
+	"response_status, prompt_tokens, completion_tokens, total_tokens, " +
+	"finish_reason, stream, user_agent, duration_ms"
+
+// AITraceListResponse is the wire format for GET /api/v1/ai-traces/:workspace.
+//
+// NextBefore is the cursor for the next page: passing it as ?before=<ts> on
+// the next call returns the next batch. Empty when there are no older records.
+type AITraceListResponse struct {
+	Items      []AITrace `json:"items"`
+	NextBefore string    `json:"next_before,omitempty"`
+}
+
+// AITraceDayCount is one day's request count in the stats response.
+type AITraceDayCount struct {
+	Date  string `json:"date"` // YYYY-MM-DD, UTC day bucket
+	Count int    `json:"count"`
+}
+
+// AITraceStatsResponse is the wire format for
+// GET /api/v1/ai-traces/:workspace/stats — per-day request counts powering
+// the activity bar chart at the top of the SPA's trace list.
+type AITraceStatsResponse struct {
+	Days []AITraceDayCount `json:"days"`
+}
+
+// RegisterAITraceRoutes mounts the AI inference trace endpoints.
+func RegisterAITraceRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc, deps *Dependencies) {
+	traces := group.Group("/ai-traces/:workspace")
+	traces.Use(middlewares...)
+	traces.Use(requireTracePermission(deps))
+
+	traces.GET("", handleListAITraces(deps))
+	traces.GET("/stats", handleAITraceStats(deps))
+	traces.GET("/:request_id", handleGetAITrace(deps))
+}
+
+const (
+	permEndpointTraceRead         = "endpoint:trace-read"
+	permExternalEndpointTraceRead = "external_endpoint:trace-read"
+	// traceEndpointTypeKey holds, in the gin context, the single endpoint_type a
+	// caller is restricted to ("endpoint" or "external-endpoint"); empty = both.
+	traceEndpointTypeKey = "trace_endpoint_type"
+)
+
+// requireTracePermission gates the ai-trace routes on endpoint:trace-read OR
+// external_endpoint:trace-read for the workspace. A caller holding only one of
+// the two is restricted to that endpoint type (recorded in the context for the
+// handlers to scope their LogsQL query). Both checks pass the workspace to
+// has_permission, which the enterprise edition overrides to be workspace-aware.
+func requireTracePermission(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID := c.GetString("user_id")
+		if userID == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
+			c.Abort()
+
+			return
+		}
+
+		workspace := c.Param("workspace")
+		if workspace == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "workspace parameter is required"})
+			c.Abort()
+
+			return
+		}
+
+		canEndpoint, err := middleware.CheckWorkspacePermission(deps.Storage, userID, workspace, permEndpointTraceRead)
+		if err != nil {
+			tracePermError(c, userID, err)
+
+			return
+		}
+
+		canExternal, err := middleware.CheckWorkspacePermission(deps.Storage, userID, workspace, permExternalEndpointTraceRead)
+		if err != nil {
+			tracePermError(c, userID, err)
+
+			return
+		}
+
+		if !canEndpoint && !canExternal {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error":    "insufficient permissions",
+				"required": permEndpointTraceRead + " or " + permExternalEndpointTraceRead,
+			})
+			c.Abort()
+
+			return
+		}
+
+		// Holding only one permission restricts the caller to that endpoint type.
+		if canEndpoint && !canExternal {
+			c.Set(traceEndpointTypeKey, "endpoint")
+		} else if canExternal && !canEndpoint {
+			c.Set(traceEndpointTypeKey, "external-endpoint")
+		}
+
+		c.Next()
+	}
+}
+
+func tracePermError(c *gin.Context, userID string, err error) {
+	klog.Errorf("ai-trace: permission check failed for user %s: %v", userID, err)
+	c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check permissions"})
+	c.Abort()
+}
+
+// traceEndpointTypeFilter returns a LogsQL clause restricting results to the
+// endpoint_type the caller is permitted to see, or "" when unrestricted.
+func traceEndpointTypeFilter(c *gin.Context) string {
+	et := c.GetString(traceEndpointTypeKey)
+	if et == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("endpoint_type:=%s", logsQLQuoteValue(et))
+}
+
+func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if deps.AITraceStoreURL == "" {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "ai trace store is not configured",
+			})
+
+			return
+		}
+
+		workspace := c.Param("workspace")
+
+		limit := 50
+
+		if v := c.Query("limit"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 500 {
+				limit = n
+			}
+		}
+
+		queryParts := []string{fmt.Sprintf("workspace:=%s", logsQLQuoteValue(workspace))}
+
+		if endpoint := strings.TrimSpace(c.Query("endpoint_name")); endpoint != "" {
+			queryParts = append(queryParts, fmt.Sprintf("endpoint_name:=%s", logsQLQuoteValue(endpoint)))
+		}
+
+		if endpointType := strings.TrimSpace(c.Query("endpoint_type")); endpointType != "" {
+			queryParts = append(queryParts, fmt.Sprintf("endpoint_type:=%s", logsQLQuoteValue(endpointType)))
+		}
+
+		if status := strings.TrimSpace(c.Query("status")); status != "" {
+			queryParts = append(queryParts, fmt.Sprintf("response_status:=%s", logsQLQuoteValue(status)))
+		}
+
+		if apiKeyID := strings.TrimSpace(c.Query("api_key_id")); apiKeyID != "" {
+			queryParts = append(queryParts, fmt.Sprintf("api_key_id:=%s", logsQLQuoteValue(apiKeyID)))
+		}
+
+		if fr := strings.TrimSpace(c.Query("finish_reason")); fr != "" {
+			queryParts = append(queryParts, fmt.Sprintf("finish_reason:=%s", logsQLQuoteValue(fr)))
+		}
+
+		if model := strings.TrimSpace(c.Query("model")); model != "" {
+			// model can match either request or response model
+			queryParts = append(queryParts, fmt.Sprintf(
+				"(request_model:=%s OR response_model:=%s)",
+				logsQLQuoteValue(model), logsQLQuoteValue(model),
+			))
+		}
+
+		// Restrict to the endpoint_type the caller is permitted to see.
+		if f := traceEndpointTypeFilter(c); f != "" {
+			queryParts = append(queryParts, f)
+		}
+
+		// The list view never renders request/response bodies — project them
+		// out so VictoriaLogs returns only the small metadata columns.
+		query := strings.Join(queryParts, " ") +
+			" | sort by (_time) desc | limit " + strconv.Itoa(limit) +
+			" | fields " + listProjection
+
+		params := url.Values{}
+
+		if start := strings.TrimSpace(c.Query("start")); start != "" {
+			params.Set("start", start)
+		}
+		// `before` is the inclusive upper bound from the previous page's last
+		// record's timestamp. To page strictly older we pass it as end.
+		if before := strings.TrimSpace(c.Query("before")); before != "" {
+			params.Set("end", before)
+		} else if end := strings.TrimSpace(c.Query("end")); end != "" {
+			params.Set("end", end)
+		}
+
+		items, err := queryAITraces(deps, query, params)
+		if err != nil {
+			klog.Errorf("ai-trace: list: %v", err)
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error": "failed to query trace store",
+			})
+
+			return
+		}
+
+		var nextBefore string
+		if len(items) == limit {
+			nextBefore = items[len(items)-1].Time
+		}
+
+		c.JSON(http.StatusOK, AITraceListResponse{
+			Items:      items,
+			NextBefore: nextBefore,
+		})
+	}
+}
+
+// handleGetAITrace returns a single trace — including the full request and
+// response bodies — looked up by request id. The list endpoint omits bodies,
+// so the SPA's detail drawer fetches them lazily through this route.
+func handleGetAITrace(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if deps.AITraceStoreURL == "" {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "ai trace store is not configured",
+			})
+
+			return
+		}
+
+		workspace := c.Param("workspace")
+
+		requestID := strings.TrimSpace(c.Param("request_id"))
+		if requestID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "request_id is required",
+			})
+
+			return
+		}
+
+		etFilter := traceEndpointTypeFilter(c)
+		if etFilter != "" {
+			etFilter = " " + etFilter
+		}
+
+		query := fmt.Sprintf(
+			"workspace:=%s request_id:=%s%s | sort by (_time) desc | limit 1",
+			logsQLQuoteValue(workspace), logsQLQuoteValue(requestID), etFilter,
+		)
+
+		items, err := queryAITraces(deps, query, url.Values{})
+		if err != nil {
+			klog.Errorf("ai-trace: detail: %v", err)
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error": "failed to query trace store",
+			})
+
+			return
+		}
+
+		if len(items) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "trace not found",
+			})
+
+			return
+		}
+
+		c.JSON(http.StatusOK, items[0])
+	}
+}
+
+// maxStatsDays caps the number of UTC day buckets the stats endpoint returns,
+// bounding both the trailing-`days` fallback and an explicit [start, end] window.
+const maxStatsDays = 90
+
+// handleAITraceStats returns per-day request counts for the requested window,
+// powering the activity bar chart at the top of the SPA's trace list.
+func handleAITraceStats(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if deps.AITraceStoreURL == "" {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": "ai trace store is not configured",
+			})
+
+			return
+		}
+
+		workspace := c.Param("workspace")
+
+		startDay, endDay, ok := statsWindow(c)
+		if !ok {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "invalid start/end parameter",
+			})
+
+			return
+		}
+
+		etFilter := traceEndpointTypeFilter(c)
+		if etFilter != "" {
+			etFilter = " " + etFilter
+		}
+
+		query := fmt.Sprintf(
+			"workspace:=%s%s | stats by (_time:1d) count() total",
+			logsQLQuoteValue(workspace), etFilter,
+		)
+
+		params := url.Values{}
+		params.Set("start", startDay.Format(time.RFC3339))
+		// `end` is pushed to the start of the day after endDay so the final
+		// (possibly partial) day is always fully covered, regardless of whether
+		// VictoriaLogs treats the bound as inclusive or exclusive.
+		params.Set("end", endDay.AddDate(0, 0, 1).Format(time.RFC3339))
+
+		counts, err := queryAITraceDayCounts(deps, query, params)
+		if err != nil {
+			klog.Errorf("ai-trace: stats: %v", err)
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error": "failed to query trace store",
+			})
+
+			return
+		}
+
+		out := make([]AITraceDayCount, 0)
+
+		for d := startDay; !d.After(endDay); d = d.AddDate(0, 0, 1) {
+			date := d.Format("2006-01-02")
+			out = append(out, AITraceDayCount{Date: date, Count: counts[date]})
+		}
+
+		c.JSON(http.StatusOK, AITraceStatsResponse{Days: out})
+	}
+}
+
+// statsWindow resolves the inclusive UTC day-bucket range for the stats query.
+//
+// It prefers an explicit [start, end] window (RFC3339, the same params the list
+// endpoint accepts); when neither is given it falls back to the trailing `days`
+// count (default 7). Both bounds are truncated to their UTC day and the span is
+// clamped to maxStatsDays buckets. ok is false only when start/end is malformed.
+func statsWindow(c *gin.Context) (startDay, endDay time.Time, ok bool) {
+	now := time.Now().UTC()
+
+	startStr := strings.TrimSpace(c.Query("start"))
+	endStr := strings.TrimSpace(c.Query("end"))
+
+	if startStr != "" || endStr != "" {
+		start, err := time.Parse(time.RFC3339, startStr)
+		if err != nil {
+			return time.Time{}, time.Time{}, false
+		}
+
+		end := now
+
+		if endStr != "" {
+			end, err = time.Parse(time.RFC3339, endStr)
+			if err != nil {
+				return time.Time{}, time.Time{}, false
+			}
+		}
+
+		startDay = start.UTC().Truncate(24 * time.Hour)
+		endDay = end.UTC().Truncate(24 * time.Hour)
+
+		if endDay.Before(startDay) {
+			return time.Time{}, time.Time{}, false
+		}
+
+		// Clamp to maxStatsDays buckets, keeping the most recent end.
+		if minStart := endDay.AddDate(0, 0, -(maxStatsDays - 1)); startDay.Before(minStart) {
+			startDay = minStart
+		}
+
+		return startDay, endDay, true
+	}
+
+	days := 7
+
+	if v := c.Query("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= maxStatsDays {
+			days = n
+		}
+	}
+
+	// Day buckets are aligned to UTC midnight; the window covers the last
+	// `days` days up to and including the current (partial) day.
+	endDay = now.Truncate(24 * time.Hour)
+	startDay = endDay.AddDate(0, 0, -(days - 1))
+
+	return startDay, endDay, true
+}
+
+// queryAITraceDayCounts runs a `stats by (_time:1d)` LogsQL query and returns
+// a map of UTC date (YYYY-MM-DD) to request count.
+func queryAITraceDayCounts(deps *Dependencies, query string, params url.Values) (map[string]int, error) {
+	params.Set("query", query)
+	reqURL := strings.TrimRight(deps.AITraceStoreURL, "/") + "/select/logsql/query?" + params.Encode()
+
+	resp, err := deps.HTTPClient.Get(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("query victorialogs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("victorialogs returned status %d", resp.StatusCode)
+	}
+
+	counts := make(map[string]int)
+	scanner := bufio.NewScanner(resp.Body)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var r struct {
+			Time  string `json:"_time"`
+			Total string `json:"total"`
+		}
+
+		if err := json.Unmarshal(line, &r); err != nil {
+			continue
+		}
+
+		// `_time` is an RFC3339 day bucket; key by the date component.
+		date := r.Time
+		if len(date) >= 10 {
+			date = date[:10]
+		}
+
+		if n, err := strconv.Atoi(r.Total); err == nil {
+			counts[date] = n
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan victorialogs response: %w", err)
+	}
+
+	return counts, nil
+}
+
+// queryAITraces runs a LogsQL query against VictoriaLogs and decodes the
+// NDJSON response into AITrace records.
+func queryAITraces(deps *Dependencies, query string, params url.Values) ([]AITrace, error) {
+	params.Set("query", query)
+	reqURL := strings.TrimRight(deps.AITraceStoreURL, "/") + "/select/logsql/query?" + params.Encode()
+
+	resp, err := deps.HTTPClient.Get(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("query victorialogs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("victorialogs returned status %d", resp.StatusCode)
+	}
+
+	items := make([]AITrace, 0, 64)
+	scanner := bufio.NewScanner(resp.Body)
+	// A detail record can be large because it embeds the full request and
+	// response bodies.
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		item, ok := decodeVLRecord(line)
+		if !ok {
+			continue
+		}
+
+		items = append(items, item)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan victorialogs response: %w", err)
+	}
+
+	return items, nil
+}
+
+// vlRecord matches the shape Vector writes to VictoriaLogs.
+// All values come back as strings; we coerce types we care about.
+type vlRecord struct {
+	Time             string `json:"_time"`
+	Stream           string `json:"_stream,omitempty"`
+	RequestID        string `json:"request_id"`
+	Workspace        string `json:"workspace"`
+	EndpointType     string `json:"endpoint_type"`
+	EndpointName     string `json:"endpoint_name"`
+	APIKeyID         string `json:"api_key_id"`
+	RequestURI       string `json:"request_uri"`
+	RequestModel     string `json:"request_model"`
+	ResponseModel    string `json:"response_model"`
+	ResponseStatus   string `json:"response_status"`
+	PromptTokens     string `json:"prompt_tokens"`
+	CompletionTokens string `json:"completion_tokens"`
+	TotalTokens      string `json:"total_tokens"`
+	FinishReason     string `json:"finish_reason"`
+	IsStream         string `json:"stream"`
+	UserAgent        string `json:"user_agent"`
+	DurationMs       string `json:"duration_ms"`
+	RequestBody      string `json:"request_body"`
+	ResponseBody     string `json:"response_body"`
+}
+
+func decodeVLRecord(line []byte) (AITrace, bool) {
+	var r vlRecord
+	if err := json.Unmarshal(line, &r); err != nil {
+		return AITrace{}, false
+	}
+
+	t := AITrace{
+		RequestID:     r.RequestID,
+		Time:          r.Time,
+		Workspace:     r.Workspace,
+		EndpointType:  r.EndpointType,
+		EndpointName:  r.EndpointName,
+		APIKeyID:      r.APIKeyID,
+		RequestURI:    r.RequestURI,
+		RequestModel:  r.RequestModel,
+		ResponseModel: r.ResponseModel,
+		FinishReason:  r.FinishReason,
+		Stream:        r.IsStream == "true",
+		UserAgent:     r.UserAgent,
+		RequestBody:   r.RequestBody,
+		ResponseBody:  r.ResponseBody,
+	}
+	if r.Time == "" {
+		t.Time = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	if n, err := strconv.Atoi(r.ResponseStatus); err == nil {
+		t.ResponseStatus = n
+	}
+
+	if r.PromptTokens != "" {
+		if n, err := strconv.Atoi(r.PromptTokens); err == nil {
+			t.PromptTokens = &n
+		}
+	}
+
+	if r.CompletionTokens != "" {
+		if n, err := strconv.Atoi(r.CompletionTokens); err == nil {
+			t.CompletionTokens = &n
+		}
+	}
+
+	if r.TotalTokens != "" {
+		if n, err := strconv.Atoi(r.TotalTokens); err == nil {
+			t.TotalTokens = &n
+		}
+	}
+
+	if r.DurationMs != "" {
+		// `latencies.request` arrives as a float-formatted string from Vector.
+		if f, err := strconv.ParseFloat(r.DurationMs, 64); err == nil {
+			n := int(f)
+			t.DurationMs = &n
+		}
+	}
+
+	return t, true
+}
+
+// logsQLQuoteValue wraps a string literal for an exact-match LogsQL filter
+// (`field:=value`). VL accepts double-quoted strings; inner quotes/backslashes
+// are escaped. Empty input is permitted by the caller and produces `""`.
+func logsQLQuoteValue(v string) string {
+	var b strings.Builder
+	b.Grow(len(v) + 2)
+	b.WriteByte('"')
+
+	for _, r := range v {
+		switch r {
+		case '\\', '"':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		case '\n':
+			b.WriteString("\\n")
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	b.WriteByte('"')
+
+	return b.String()
+}

--- a/internal/routes/logs/ai_trace_test.go
+++ b/internal/routes/logs/ai_trace_test.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -8,6 +9,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
 // statsCtx builds a gin.Context whose request carries the given query string.
@@ -86,4 +90,254 @@ func TestStatsWindow_DaysOutOfRangeFallsBackToDefault(t *testing.T) {
 	assert.True(t, ok)
 	bucketCount := int(endDay.Sub(startDay).Hours()/24) + 1
 	assert.Equal(t, 7, bucketCount)
+}
+
+func TestStatsWindow_EndOnlyTrailingWindow(t *testing.T) {
+	// `end` without `start` is a valid trailing window (default 7 days ending at
+	// `end`), not a 400. Regression guard for the end-only handling.
+	q := url.Values{}
+	q.Set("end", "2026-03-10T12:00:00Z")
+
+	startDay, endDay, ok := statsWindow(statsCtx(q.Encode()))
+
+	assert.True(t, ok)
+	assert.Equal(t, "2026-03-10", endDay.Format("2006-01-02"))
+	assert.Equal(t, "2026-03-04", startDay.Format("2006-01-02")) // 7 buckets inclusive
+}
+
+func TestStatsWindow_EndOnlyWithDays(t *testing.T) {
+	q := url.Values{}
+	q.Set("end", "2026-03-10T00:00:00Z")
+	q.Set("days", "3")
+
+	startDay, endDay, ok := statsWindow(statsCtx(q.Encode()))
+
+	assert.True(t, ok)
+	bucketCount := int(endDay.Sub(startDay).Hours()/24) + 1
+	assert.Equal(t, 3, bucketCount)
+	assert.Equal(t, "2026-03-10", endDay.Format("2006-01-02"))
+}
+
+func TestStatsWindow_MalformedEndRejected(t *testing.T) {
+	q := url.Values{}
+	q.Set("end", "not-a-time")
+
+	_, _, ok := statsWindow(statsCtx(q.Encode()))
+	assert.False(t, ok)
+}
+
+func TestLogsQLQuoteValue(t *testing.T) {
+	cases := map[string]string{
+		"":                 `""`,
+		"plain":            `"plain"`,
+		`with"quote`:       `"with\"quote"`,
+		`back\slash`:       `"back\\slash"`,
+		"line\nbreak":      `"line\nbreak"`,
+		`a"b\c` + "\n" + "d": `"a\"b\\c\nd"`,
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, logsQLQuoteValue(in), "input %q", in)
+	}
+}
+
+func TestTraceEndpointTypeFilter(t *testing.T) {
+	// Unrestricted: no endpoint-type key set => no clause.
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	assert.Equal(t, "", traceEndpointTypeFilter(c))
+
+	// Restricted to a single endpoint type => exact-match LogsQL clause.
+	c.Set(traceEndpointTypeKey, "external-endpoint")
+	assert.Equal(t, `endpoint_type:="external-endpoint"`, traceEndpointTypeFilter(c))
+}
+
+func TestDecodeVLRecord_FullRecord(t *testing.T) {
+	line := []byte(`{
+		"_time":"2026-03-01T10:00:00Z",
+		"request_id":"req-1",
+		"workspace":"ws1",
+		"endpoint_type":"endpoint",
+		"endpoint_name":"gpt",
+		"api_key_id":"key-1",
+		"request_uri":"/v1/chat",
+		"request_model":"gpt-4",
+		"response_model":"gpt-4-0613",
+		"response_status":"200",
+		"prompt_tokens":"10",
+		"completion_tokens":"20",
+		"total_tokens":"30",
+		"finish_reason":"stop",
+		"stream":"true",
+		"user_agent":"openai-python",
+		"duration_ms":"1234.5",
+		"request_body":"req",
+		"response_body":"resp"
+	}`)
+
+	tr, ok := decodeVLRecord(line)
+
+	assert.True(t, ok)
+	assert.Equal(t, "req-1", tr.RequestID)
+	assert.Equal(t, "ws1", tr.Workspace)
+	assert.Equal(t, 200, tr.ResponseStatus)
+	assert.Equal(t, "stop", tr.FinishReason)
+	assert.True(t, tr.Stream)
+	if assert.NotNil(t, tr.PromptTokens) {
+		assert.Equal(t, 10, *tr.PromptTokens)
+	}
+	if assert.NotNil(t, tr.TotalTokens) {
+		assert.Equal(t, 30, *tr.TotalTokens)
+	}
+	if assert.NotNil(t, tr.DurationMs) {
+		assert.Equal(t, 1234, *tr.DurationMs) // float string truncated to int ms
+	}
+	assert.Equal(t, "req", tr.RequestBody)
+	assert.Equal(t, "resp", tr.ResponseBody)
+}
+
+func TestDecodeVLRecord_OptionalFieldsAbsent(t *testing.T) {
+	// A minimal record (e.g. an early-returning error response): optional numeric
+	// columns must stay nil rather than coerce to a misleading 0.
+	line := []byte(`{"_time":"2026-03-01T10:00:00Z","request_id":"req-2","workspace":"ws1"}`)
+
+	tr, ok := decodeVLRecord(line)
+
+	assert.True(t, ok)
+	assert.Equal(t, "req-2", tr.RequestID)
+	assert.Equal(t, 0, tr.ResponseStatus)
+	assert.False(t, tr.Stream)
+	assert.Nil(t, tr.PromptTokens)
+	assert.Nil(t, tr.CompletionTokens)
+	assert.Nil(t, tr.TotalTokens)
+	assert.Nil(t, tr.DurationMs)
+}
+
+func TestDecodeVLRecord_MissingTimeFallsBack(t *testing.T) {
+	line := []byte(`{"request_id":"req-3","workspace":"ws1"}`)
+
+	tr, ok := decodeVLRecord(line)
+
+	assert.True(t, ok)
+	assert.NotEmpty(t, tr.Time) // synthesised so the UI always has a timestamp
+}
+
+func TestDecodeVLRecord_InvalidJSON(t *testing.T) {
+	_, ok := decodeVLRecord([]byte(`{not json`))
+	assert.False(t, ok)
+}
+
+// traceCtx builds a gin context + recorder carrying the given user id and
+// workspace param, as the route middleware would have populated them.
+func traceCtx(userID, workspace string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/", nil)
+
+	if userID != "" {
+		c.Set("user_id", userID)
+	}
+
+	if workspace != "" {
+		c.Params = gin.Params{{Key: "workspace", Value: workspace}}
+	}
+
+	return c, w
+}
+
+// permMock returns a MockStorage whose has_permission call resolves to the
+// allow value matching the required_permission argument.
+func permMock(allow map[string]bool) *mocks.MockStorage {
+	m := new(mocks.MockStorage)
+	m.On("CallDatabaseFunction", "has_permission", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			params := args.Get(1).(map[string]interface{})
+			perm, _ := params["required_permission"].(string)
+			out := args.Get(2).(*bool)
+			*out = allow[perm]
+		}).Return(nil)
+
+	return m
+}
+
+func TestRequireTracePermission_Unauthenticated(t *testing.T) {
+	deps := &Dependencies{Storage: new(mocks.MockStorage)}
+	c, w := traceCtx("", "ws1")
+
+	requireTracePermission(deps)(c)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.True(t, c.IsAborted())
+}
+
+func TestRequireTracePermission_MissingWorkspace(t *testing.T) {
+	deps := &Dependencies{Storage: new(mocks.MockStorage)}
+	c, w := traceCtx("user-1", "")
+
+	requireTracePermission(deps)(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.True(t, c.IsAborted())
+}
+
+func TestRequireTracePermission_BothDeniedForbidden(t *testing.T) {
+	deps := &Dependencies{Storage: permMock(map[string]bool{})}
+	c, w := traceCtx("user-1", "ws1")
+
+	requireTracePermission(deps)(c)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.True(t, c.IsAborted())
+}
+
+func TestRequireTracePermission_EndpointOnlyScopes(t *testing.T) {
+	deps := &Dependencies{Storage: permMock(map[string]bool{permEndpointTraceRead: true})}
+	c, _ := traceCtx("user-1", "ws1")
+
+	requireTracePermission(deps)(c)
+
+	assert.False(t, c.IsAborted())
+	assert.Equal(t, "endpoint", c.GetString(traceEndpointTypeKey))
+}
+
+func TestRequireTracePermission_ExternalOnlyScopes(t *testing.T) {
+	deps := &Dependencies{Storage: permMock(map[string]bool{permExternalEndpointTraceRead: true})}
+	c, _ := traceCtx("user-1", "ws1")
+
+	requireTracePermission(deps)(c)
+
+	assert.False(t, c.IsAborted())
+	assert.Equal(t, "external-endpoint", c.GetString(traceEndpointTypeKey))
+}
+
+func TestRequireTracePermission_BothGrantedUnrestricted(t *testing.T) {
+	deps := &Dependencies{Storage: permMock(map[string]bool{
+		permEndpointTraceRead:         true,
+		permExternalEndpointTraceRead: true,
+	})}
+	c, _ := traceCtx("user-1", "ws1")
+
+	requireTracePermission(deps)(c)
+
+	assert.False(t, c.IsAborted())
+	// No single-type restriction recorded => handlers see both endpoint types.
+	assert.Equal(t, "", c.GetString(traceEndpointTypeKey))
+}
+
+func TestAITraceHandlers_StoreNotConfigured(t *testing.T) {
+	// With no --ai-trace-store-url, every trace route returns 503 before any
+	// storage/VictoriaLogs interaction.
+	deps := &Dependencies{}
+
+	handlers := map[string]gin.HandlerFunc{
+		"list":  handleListAITraces(deps),
+		"stats": handleAITraceStats(deps),
+		"get":   handleGetAITrace(deps),
+	}
+
+	for name, h := range handlers {
+		c, w := traceCtx("user-1", "ws1")
+		h(c)
+		assert.Equalf(t, http.StatusServiceUnavailable, w.Code, "handler %s", name)
+		assert.Containsf(t, w.Body.String(), "not configured", "handler %s", name)
+	}
 }

--- a/internal/routes/logs/ai_trace_test.go
+++ b/internal/routes/logs/ai_trace_test.go
@@ -1,0 +1,89 @@
+package logs
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// statsCtx builds a gin.Context whose request carries the given query string.
+func statsCtx(rawQuery string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/?"+rawQuery, nil)
+
+	return c
+}
+
+func TestStatsWindow_ExplicitStartEnd(t *testing.T) {
+	q := url.Values{}
+	q.Set("start", "2026-03-01T08:30:00Z")
+	q.Set("end", "2026-03-05T23:00:00Z")
+
+	startDay, endDay, ok := statsWindow(statsCtx(q.Encode()))
+
+	assert.True(t, ok)
+	// Both bounds truncate to their UTC day.
+	assert.Equal(t, "2026-03-01", startDay.Format("2006-01-02"))
+	assert.Equal(t, "2026-03-05", endDay.Format("2006-01-02"))
+	assert.Equal(t, time.UTC, startDay.Location())
+}
+
+func TestStatsWindow_EndBeforeStartRejected(t *testing.T) {
+	q := url.Values{}
+	q.Set("start", "2026-03-10T00:00:00Z")
+	q.Set("end", "2026-03-01T00:00:00Z")
+
+	_, _, ok := statsWindow(statsCtx(q.Encode()))
+	assert.False(t, ok)
+}
+
+func TestStatsWindow_MalformedRejected(t *testing.T) {
+	_, _, ok := statsWindow(statsCtx("start=not-a-time"))
+	assert.False(t, ok)
+}
+
+func TestStatsWindow_ClampedToMaxDays(t *testing.T) {
+	q := url.Values{}
+	q.Set("start", "2026-01-01T00:00:00Z")
+	q.Set("end", "2026-06-01T00:00:00Z") // far more than maxStatsDays apart
+
+	startDay, endDay, ok := statsWindow(statsCtx(q.Encode()))
+
+	assert.True(t, ok)
+	// Span clamped to maxStatsDays buckets, anchored at the most recent end.
+	bucketCount := int(endDay.Sub(startDay).Hours()/24) + 1
+	assert.Equal(t, maxStatsDays, bucketCount)
+	assert.Equal(t, "2026-06-01", endDay.Format("2006-01-02"))
+}
+
+func TestStatsWindow_DaysFallback(t *testing.T) {
+	startDay, endDay, ok := statsWindow(statsCtx("days=30"))
+
+	assert.True(t, ok)
+	bucketCount := int(endDay.Sub(startDay).Hours()/24) + 1
+	assert.Equal(t, 30, bucketCount)
+	// endDay is today's UTC bucket.
+	assert.Equal(t, time.Now().UTC().Truncate(24*time.Hour).Format("2006-01-02"), endDay.Format("2006-01-02"))
+}
+
+func TestStatsWindow_DefaultSevenDays(t *testing.T) {
+	startDay, endDay, ok := statsWindow(statsCtx(""))
+
+	assert.True(t, ok)
+	bucketCount := int(endDay.Sub(startDay).Hours()/24) + 1
+	assert.Equal(t, 7, bucketCount)
+}
+
+func TestStatsWindow_DaysOutOfRangeFallsBackToDefault(t *testing.T) {
+	// >maxStatsDays is ignored, falling back to the 7-day default.
+	startDay, endDay, ok := statsWindow(statsCtx("days=999"))
+
+	assert.True(t, ok)
+	bucketCount := int(endDay.Sub(startDay).Hours()/24) + 1
+	assert.Equal(t, 7, bucketCount)
+}

--- a/internal/routes/logs/endpoint_logs.go
+++ b/internal/routes/logs/endpoint_logs.go
@@ -20,9 +20,10 @@ import (
 )
 
 type Dependencies struct {
-	Storage    storage.Storage
-	HTTPClient util.HTTPClient
-	K8sClient  util.K8sClient
+	Storage         storage.Storage
+	HTTPClient      util.HTTPClient
+	K8sClient       util.K8sClient
+	AITraceStoreURL string
 }
 
 // LogSourcesResponse represents the response for log sources discovery


### PR DESCRIPTION
## What

Introduces **AI Inference Trace** to the control plane: a read-only,
workspace-scoped event stream of every inference request/response that flows
through the Kong AI Gateway. It complements API usage statistics (which answer
*"how much was used"*) with per-request detail that answers *"what exactly
happened in this one call"* — for prompt debugging and security/compliance
audit.

## Scope

This PR extracts **only** the AI Inference Trace feature from the
`feat/ai-inference-trace-poc` branch. The model-catalog/recipe and model-usage
work that also lived on that POC branch is intentionally left out.

## Changes

**Query API** (`internal/routes/logs/ai_trace.go`)
- `GET /api/v1/ai-traces/:workspace` — list with server-side filtering
  (endpoint_name/type, status, model, api_key_id, finish_reason), cursor
  paging (`before`/`next_before`), and LogsQL field projection so list queries
  skip the large request/response bodies.
- `GET /api/v1/ai-traces/:workspace/stats` — per-day activity counts.
- `GET /api/v1/ai-traces/:workspace/:request_id` — single trace with full
  request/response body (lazy-loaded by the UI).
- Backed by VictoriaLogs via LogsQL; new `--ai-trace-store-url` flag. When
  unset, the trace APIs return `503 ai trace store is not configured`.

**RBAC**
- New permissions `endpoint:trace-read` / `external_endpoint:trace-read`
  (migrations `060`/`061`), granted to admin + workspace-user.
- Routes gated via `middleware.CheckWorkspacePermission` (enterprise overrides
  to workspace scope; community is global).

**Collection path** (off the request path: Kong → Vector → VictoriaLogs)
- Kong `neutree-ai-gateway` plugin: buffers full request/response body,
  captures `finish_reason` and reasoning/thinking across OpenAI & Anthropic,
  stream & non-stream, success & error responses.
- Vector: new trace transform + VictoriaLogs sink (+ on-disk replica).
- docker-compose ships `victoria-logs:v1.50.0`.

## Verification

Built in a sandbox off `main`: `make build-neutree-api` + `make
build-neutree-core` ✅, `go vet ./internal/routes/logs/... ./internal/middleware/...` ✅,
`go test ./internal/routes/logs/...` ✅ (`ok`). Migration up/down pairs present.

## Not included / follow-ups
- VictoriaLogs is in docker-compose only; Helm chart packaging is a follow-up
  (per design doc §4.4).
- DB migration must be run on the target env (`060`/`061`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
