### PR TITLE
fix: normalize Anthropic gateway message roles

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -260,11 +260,33 @@ local function convert_tools(tools)
     return result
 end
 
+local function append_system_content(parts, content)
+    if type(content) == "string" then
+        if content ~= "" then
+            parts[#parts + 1] = content
+        end
+    elseif type(content) == "table" then
+        for _, block in ipairs(content) do
+            if type(block) == "table" and type(block.text) == "string" and block.text ~= "" then
+                parts[#parts + 1] = block.text
+            elseif type(block) == "string" and block ~= "" then
+                parts[#parts + 1] = block
+            end
+        end
+    end
+end
+
 local function convert_messages(anthropic_messages)
     local openai_messages = {}
+    local system_parts = {}
 
     for _, msg in ipairs(anthropic_messages) do
-        if msg.role == "user" then
+        local role = msg.role
+        if role == "ctx" or role == "msg" then
+            role = "user"
+        end
+
+        if role == "user" then
             if type(msg.content) == "string" then
                 openai_messages[#openai_messages + 1] = {
                     role = "user",
@@ -362,7 +384,7 @@ local function convert_messages(anthropic_messages)
                     }
                 end
             end
-        elseif msg.role == "assistant" then
+        elseif role == "assistant" then
             if type(msg.content) == "string" then
                 openai_messages[#openai_messages + 1] = {
                     role = "assistant",
@@ -401,12 +423,14 @@ local function convert_messages(anthropic_messages)
                 end
                 openai_messages[#openai_messages + 1] = assistant_msg
             end
+        elseif role == "system" then
+            append_system_content(system_parts, msg.content)
         else
             openai_messages[#openai_messages + 1] = msg
         end
     end
 
-    return openai_messages
+    return openai_messages, system_parts
 end
 
 local function convert_request(anthropic_req)
@@ -419,23 +443,18 @@ local function convert_request(anthropic_req)
     }
 
     local messages = {}
+    local system_parts = {}
     if anthropic_req.system then
-        if type(anthropic_req.system) == "string" then
-            messages[#messages + 1] = { role = "system", content = anthropic_req.system }
-        elseif type(anthropic_req.system) == "table" then
-            local parts = {}
-            for _, block in ipairs(anthropic_req.system) do
-                if type(block) == "table" and block.text then
-                    parts[#parts + 1] = block.text
-                elseif type(block) == "string" then
-                    parts[#parts + 1] = block
-                end
-            end
-            messages[#messages + 1] = { role = "system", content = table.concat(parts, "\n\n") }
-        end
+        append_system_content(system_parts, anthropic_req.system)
     end
 
-    local converted = convert_messages(anthropic_req.messages or {})
+    local converted, inline_system_parts = convert_messages(anthropic_req.messages or {})
+    for _, part in ipairs(inline_system_parts) do
+        system_parts[#system_parts + 1] = part
+    end
+    if #system_parts > 0 then
+        messages[#messages + 1] = { role = "system", content = table.concat(system_parts, "\n\n") }
+    end
     for _, m in ipairs(converted) do
         messages[#messages + 1] = m
     end

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -360,13 +360,23 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 			Expect(last.Path).To(Equal("/v1/chat/completions"))
 
 			messages := upstreamMessages(upstreamReq)
-			Expect(messages).NotTo(BeEmpty())
+			Expect(messages).To(HaveLen(3))
 			Expect(countMessagesByRole(messages, "system")).To(Equal(1))
 
 			first, ok := messages[0].(map[string]any)
 			Expect(ok).To(BeTrue())
 			Expect(first["role"]).To(Equal("system"))
 			Expect(first["content"]).To(Equal("Top-level system.\n\nInline system hint."))
+
+			second, ok := messages[1].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(second["role"]).To(Equal("user"))
+			Expect(second["content"]).To(Equal("Hi"))
+
+			third, ok := messages[2].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(third["role"]).To(Equal("assistant"))
+			Expect(third["content"]).To(Equal("Previous answer."))
 		})
 
 		It("should normalize Claude Code ctx and msg roles to user messages", Label("C2705750", "role-normalization"), func() {

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -110,6 +110,36 @@ func waitForUpstreamRequest() (last *RecordedRequest, body map[string]any) {
 	return last, body
 }
 
+func sendRawAnthropicMessage(serviceURL string, payload map[string]any) (map[string]any, int) {
+	status, body, err := doInferenceRequest(serviceURL, "/anthropic/v1/messages", payload)
+	Expect(err).NotTo(HaveOccurred())
+
+	var resp map[string]any
+	Expect(json.Unmarshal([]byte(body), &resp)).To(Succeed())
+
+	return resp, status
+}
+
+func upstreamMessages(upstreamReq map[string]any) []any {
+	messages, ok := upstreamReq["messages"].([]any)
+	Expect(ok).To(BeTrue(), "upstream request should contain a messages array")
+
+	return messages
+}
+
+func countMessagesByRole(messages []any, role string) int {
+	count := 0
+	for _, raw := range messages {
+		msg, ok := raw.(map[string]any)
+		Expect(ok).To(BeTrue(), "message entries should be objects")
+		if msg["role"] == role {
+			count++
+		}
+	}
+
+	return count
+}
+
 func assertMalformedToolUseBlocks(content []anthropic.ContentBlockUnion) {
 	toolUses := make(map[string]anthropic.ContentBlockUnion)
 	for _, block := range content {
@@ -309,6 +339,88 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 			Expect(last.Path).To(Equal("/v1/chat/completions"))
 			Expect(upstreamReq["model"]).To(Equal("gpt-4o"))
 			Expect(upstreamReq["stream"]).To(BeTrue())
+		})
+
+		It("should merge inline system messages into the first OpenAI system message", Label("C2705749", "system-normalization"), func() {
+			mockUpstream.ClearRequests()
+
+			resp, status := sendRawAnthropicMessage(serviceURL, map[string]any{
+				"model":      "fast",
+				"max_tokens": 32,
+				"system":     "Top-level system.",
+				"messages": []map[string]any{
+					{"role": "user", "content": "Hi"},
+					{"role": "system", "content": "Inline system hint."},
+					{"role": "assistant", "content": "Previous answer."},
+				},
+			})
+			Expect(status).To(Equal(http.StatusOK), "unexpected Anthropic response: %v", resp)
+
+			last, upstreamReq := waitForUpstreamRequest()
+			Expect(last.Path).To(Equal("/v1/chat/completions"))
+
+			messages := upstreamMessages(upstreamReq)
+			Expect(messages).NotTo(BeEmpty())
+			Expect(countMessagesByRole(messages, "system")).To(Equal(1))
+
+			first, ok := messages[0].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(first["role"]).To(Equal("system"))
+			Expect(first["content"]).To(Equal("Top-level system.\n\nInline system hint."))
+		})
+
+		It("should normalize Claude Code ctx and msg roles to user messages", Label("C2705750", "role-normalization"), func() {
+			mockUpstream.ClearRequests()
+
+			resp, status := sendRawAnthropicMessage(serviceURL, map[string]any{
+				"model":      "fast",
+				"max_tokens": 32,
+				"messages": []map[string]any{
+					{"role": "ctx", "content": "Context note."},
+					{"role": "msg", "content": "Current user message."},
+				},
+			})
+			Expect(status).To(Equal(http.StatusOK), "unexpected Anthropic response: %v", resp)
+
+			last, upstreamReq := waitForUpstreamRequest()
+			Expect(last.Path).To(Equal("/v1/chat/completions"))
+
+			messages := upstreamMessages(upstreamReq)
+			Expect(messages).To(HaveLen(2))
+
+			first, ok := messages[0].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(first["role"]).To(Equal("user"))
+			Expect(first["content"]).To(Equal("Context note."))
+
+			second, ok := messages[1].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(second["role"]).To(Equal("user"))
+			Expect(second["content"]).To(Equal("Current user message."))
+		})
+
+		It("should pass unrecognized message roles through unchanged", Label("C2705751", "role-pass-through"), func() {
+			mockUpstream.ClearRequests()
+
+			resp, status := sendRawAnthropicMessage(serviceURL, map[string]any{
+				"model":      "fast",
+				"max_tokens": 32,
+				"messages": []map[string]any{
+					{"role": "developer", "content": "unsupported"},
+				},
+			})
+			Expect(status).To(Equal(http.StatusOK), "unexpected Anthropic response: %v", resp)
+
+			last, upstreamReq := waitForUpstreamRequest()
+			Expect(last.Path).To(Equal("/v1/chat/completions"))
+
+			messages := upstreamMessages(upstreamReq)
+			Expect(messages).To(HaveLen(1))
+
+			first, ok := messages[0].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(first["role"]).To(Equal("developer"))
+			Expect(first["content"]).To(Equal("unsupported"))
 		})
 
 		// NEU-428: when an OpenAI-compatible upstream returns "tool_calls": null


### PR DESCRIPTION
## Issue

NEU-458

## Summary

Fix the Anthropic compatibility gateway translation so inline `system` messages from `/anthropic/v1/messages` are folded into the leading OpenAI `system` message instead of being forwarded after user/assistant turns. This also normalizes Claude Code `ctx` and `msg` roles to `user` while preserving pass-through behavior for other unrecognized roles.

## Changes

- Merge top-level Anthropic `system` content and inline `role: system` message content into one leading OpenAI `system` message.
- Normalize Claude Code `ctx` and `msg` roles to OpenAI `user` messages.
- Keep unknown Anthropic message roles unchanged for upstream compatibility.
- Add focused ExternalEndpoint Anthropic E2E coverage for TestRail cases `C2705749`, `C2705750`, and `C2705751`.

## Test Plan

### Unit test

- [x] `go vet ./tests/e2e/...`
- [x] `go build ./tests/e2e/...`
- [x] `NEUTREE_SERVER_URL= NEUTREE_API_KEY= go test ./tests/e2e/... -count=1`
- [x] `git diff --check`
- [ ] `golangci-lint run ./tests/e2e/...` was attempted but blocked by existing package-wide E2E typecheck diagnostics unrelated to this change.

### DB test

- [x] Not affected. No DB schema, migration, or storage behavior changes.

### E2E test

- [x] Remote scoped E2E passed: `make e2e-test LABEL_FILTER='external-endpoint && anthropic && (system-normalization || role-normalization || role-pass-through)' E2E_TIMEOUT=30m`
- [x] Result: 3 of 240 specs ran, 3 passed, 0 failed, 237 skipped, duration 36.233s.
- [x] Covered cases: `C2705749`, `C2705750`, `C2705751`.
- [x] Manual testing is not required because the scoped E2E covers the affected gateway request translation path end to end.

## Risk & Rollback

Risk is limited to Anthropic request translation in the Kong gateway plugin. Rollback is to revert this commit or restore the previous `gateway/kong/plugins/neutree-ai-gateway/handler.lua` behavior; no DB or persistent data migration is involved.
