### PR TITLE
Fix paused K8s endpoint resume reconciliation

### DIFF
--- a/internal/deploy/manifest_apply.go
+++ b/internal/deploy/manifest_apply.go
@@ -281,12 +281,14 @@ func (m *ManifestApply) addLiveDriftedObjects(ctx context.Context, diff *Manifes
 				continue
 			}
 
-			return errors.Wrapf(err, "failed to get live object %s/%s", newObj.GetKind(), newObj.GetName())
+			return errors.Wrapf(err, "failed to get live object %s/%s/%s",
+				newObj.GetKind(), newObj.GetNamespace(), newObj.GetName())
 		}
 
 		drifted, err := specDrifted(newObj, liveObj)
 		if err != nil {
-			return errors.Wrapf(err, "failed to compare live object %s/%s", newObj.GetKind(), newObj.GetName())
+			return errors.Wrapf(err, "failed to compare live object %s/%s/%s",
+				newObj.GetKind(), newObj.GetNamespace(), newObj.GetName())
 		}
 
 		if !drifted {

--- a/internal/deploy/manifest_apply.go
+++ b/internal/deploy/manifest_apply.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -188,6 +189,10 @@ func (m *ManifestApply) ApplyManifests(
 		return 0, errors.Wrap(err, "failed to compute manifest diff")
 	}
 
+	if err := m.addLiveDriftedObjects(ctx, diff); err != nil {
+		return 0, errors.Wrap(err, "failed to detect live manifest drift")
+	}
+
 	if !diff.NeedsUpdate {
 		m.logger.V(4).Info("No manifest changes to apply")
 		return 0, nil
@@ -240,6 +245,121 @@ func (m *ManifestApply) ApplyManifests(
 	}
 
 	return len(objects) + len(deleteObjects), nil
+}
+
+func (m *ManifestApply) addLiveDriftedObjects(ctx context.Context, diff *ManifestDiff) error {
+	changedKeys := make(map[string]bool, len(diff.ChangedObjects))
+	for i := range diff.ChangedObjects {
+		changedKeys[objectKey(&diff.ChangedObjects[i])] = true
+	}
+
+	for i := range m.newObjects.Items {
+		newObj := &m.newObjects.Items[i]
+		key := objectKey(newObj)
+
+		if changedKeys[key] {
+			continue
+		}
+
+		liveObj := &unstructured.Unstructured{}
+		liveObj.SetAPIVersion(newObj.GetAPIVersion())
+		liveObj.SetKind(newObj.GetKind())
+
+		err := m.ctrlClient.Get(ctx, client.ObjectKey{
+			Namespace: newObj.GetNamespace(),
+			Name:      newObj.GetName(),
+		}, liveObj)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				m.logger.V(4).Info("Live object missing, marking for apply",
+					"kind", newObj.GetKind(),
+					"name", newObj.GetName())
+
+				diff.ChangedObjects = append(diff.ChangedObjects, *newObj)
+				changedKeys[key] = true
+
+				continue
+			}
+
+			return errors.Wrapf(err, "failed to get live object %s/%s", newObj.GetKind(), newObj.GetName())
+		}
+
+		drifted, err := specDrifted(newObj, liveObj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to compare live object %s/%s", newObj.GetKind(), newObj.GetName())
+		}
+
+		if !drifted {
+			continue
+		}
+
+		m.logger.V(4).Info("Live object drift detected, marking for apply",
+			"kind", newObj.GetKind(),
+			"name", newObj.GetName())
+
+		diff.ChangedObjects = append(diff.ChangedObjects, *newObj)
+		changedKeys[key] = true
+	}
+
+	diff.NeedsUpdate = len(diff.ChangedObjects) > 0 || len(diff.DeletedObjects) > 0
+
+	return nil
+}
+
+func specDrifted(desiredObj, liveObj *unstructured.Unstructured) (bool, error) {
+	desiredSpec, found, err := unstructured.NestedFieldNoCopy(desiredObj.Object, "spec")
+	if err != nil {
+		return false, err
+	}
+
+	if !found {
+		return !containsDesiredFields(desiredObj.Object, liveObj.Object), nil
+	}
+
+	liveSpec, found, err := unstructured.NestedFieldNoCopy(liveObj.Object, "spec")
+	if err != nil {
+		return false, err
+	}
+
+	if !found {
+		return true, nil
+	}
+
+	return !containsDesiredFields(desiredSpec, liveSpec), nil
+}
+
+func containsDesiredFields(desired, live interface{}) bool {
+	switch desiredValue := desired.(type) {
+	case map[string]interface{}:
+		liveValue, ok := live.(map[string]interface{})
+		if !ok {
+			return false
+		}
+
+		for key, desiredField := range desiredValue {
+			liveField, ok := liveValue[key]
+			if !ok || !containsDesiredFields(desiredField, liveField) {
+				return false
+			}
+		}
+
+		return true
+	case []interface{}:
+		liveValue, ok := live.([]interface{})
+		if !ok || len(desiredValue) != len(liveValue) {
+			return false
+		}
+
+		for i, desiredItem := range desiredValue {
+			if !containsDesiredFields(desiredItem, liveValue[i]) {
+				return false
+			}
+		}
+
+		return true
+	default:
+		return reflect.DeepEqual(desired, live)
+	}
 }
 
 func (m *ManifestApply) Delete(

--- a/internal/deploy/manifest_apply_test.go
+++ b/internal/deploy/manifest_apply_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -21,6 +23,28 @@ func newFakeClient(objs ...client.Object) client.Client {
 		WithScheme(scheme).
 		WithObjects(objs...).
 		Build()
+}
+
+type fakeApplyClient struct {
+	client.Client
+}
+
+func (c *fakeApplyClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if patch.Type() != types.ApplyPatchType {
+		return c.Client.Patch(ctx, obj, patch, opts...)
+	}
+
+	current := obj.DeepCopyObject().(client.Object)
+	err := c.Client.Get(ctx, client.ObjectKeyFromObject(obj), current)
+	if apierrors.IsNotFound(err) {
+		return c.Client.Create(ctx, obj)
+	}
+	if err != nil {
+		return err
+	}
+
+	obj.SetResourceVersion(current.GetResourceVersion())
+	return c.Client.Update(ctx, obj)
 }
 
 func createTestDeployment(name, namespace string, replicas int64) *unstructured.Unstructured {
@@ -57,7 +81,7 @@ func createTestService(name, namespace string) *unstructured.Unstructured {
 			"spec": map[string]interface{}{
 				"ports": []interface{}{
 					map[string]interface{}{
-						"port": 80,
+						"port": int64(80),
 					},
 				},
 			},
@@ -295,9 +319,8 @@ func TestComputeManifestDiff_InvalidLastAppliedJSON(t *testing.T) {
 }
 
 func TestApplyManifests_NoChanges(t *testing.T) {
-	fakeClient := newFakeClient()
-
 	deployment := createTestDeployment("nginx", "test-ns", 3)
+	fakeClient := newFakeClient(deployment)
 
 	lastApplied := []unstructured.Unstructured{*deployment}
 	lastAppliedJSON, _ := json.Marshal(lastApplied)
@@ -315,6 +338,130 @@ func TestApplyManifests_NoChanges(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count)
+}
+
+func TestApplyManifests_IgnoresLiveDeploymentDefaultedSpecFields(t *testing.T) {
+	desiredDeployment := createTestDeployment("nginx", "test-ns", 1)
+	liveDeployment := createTestDeployment("nginx", "test-ns", 1)
+	assert.NoError(t, unstructured.SetNestedField(liveDeployment.Object, int64(10), "spec", "revisionHistoryLimit"))
+
+	lastApplied := []unstructured.Unstructured{*desiredDeployment}
+	lastAppliedJSON, _ := json.Marshal(lastApplied)
+
+	newObjects := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{*desiredDeployment},
+	}
+
+	fakeClient := &fakeApplyClient{Client: newFakeClient(liveDeployment)}
+	ma := NewManifestApply(fakeClient, "test-ns").
+		WithLastAppliedConfig(string(lastAppliedJSON)).
+		WithNewObjects(newObjects).
+		WithLogger(klog.NewKlogr())
+
+	count, err := ma.ApplyManifests(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestApplyManifests_ReappliesWhenLiveDeploymentDriftsFromLastApplied(t *testing.T) {
+	desiredDeployment := createTestDeployment("nginx", "test-ns", 1)
+	liveDeployment := createTestDeployment("nginx", "test-ns", 0)
+
+	lastApplied := []unstructured.Unstructured{*desiredDeployment}
+	lastAppliedJSON, _ := json.Marshal(lastApplied)
+
+	newObjects := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{*desiredDeployment},
+	}
+
+	fakeClient := &fakeApplyClient{Client: newFakeClient(liveDeployment)}
+	ma := NewManifestApply(fakeClient, "test-ns").
+		WithLastAppliedConfig(string(lastAppliedJSON)).
+		WithNewObjects(newObjects).
+		WithLogger(klog.NewKlogr())
+
+	count, err := ma.ApplyManifests(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	current := createTestDeployment("nginx", "test-ns", 0)
+	err = fakeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: "test-ns",
+		Name:      "nginx",
+	}, current)
+	assert.NoError(t, err)
+
+	replicas, found, err := unstructured.NestedInt64(current.Object, "spec", "replicas")
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, int64(1), replicas)
+}
+
+func TestApplyManifests_RecreatesMissingLiveObjectWhenLastAppliedMatchesDesired(t *testing.T) {
+	desiredService := createTestService("nginx", "test-ns")
+
+	lastApplied := []unstructured.Unstructured{*desiredService}
+	lastAppliedJSON, _ := json.Marshal(lastApplied)
+
+	newObjects := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{*desiredService},
+	}
+
+	fakeClient := &fakeApplyClient{Client: newFakeClient()}
+	ma := NewManifestApply(fakeClient, "test-ns").
+		WithLastAppliedConfig(string(lastAppliedJSON)).
+		WithNewObjects(newObjects).
+		WithLogger(klog.NewKlogr())
+
+	count, err := ma.ApplyManifests(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	current := createTestService("nginx", "test-ns")
+	err = fakeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: "test-ns",
+		Name:      "nginx",
+	}, current)
+	assert.NoError(t, err)
+	assert.Equal(t, "Service", current.GetKind())
+}
+
+func TestApplyManifests_ReappliesWhenLiveNoSpecObjectDriftsFromLastApplied(t *testing.T) {
+	desiredConfigMap := createTestConfigMap("settings", "test-ns", "mode", "expected")
+	liveConfigMap := createTestConfigMap("settings", "test-ns", "mode", "stale")
+
+	lastApplied := []unstructured.Unstructured{*desiredConfigMap}
+	lastAppliedJSON, _ := json.Marshal(lastApplied)
+
+	newObjects := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{*desiredConfigMap},
+	}
+
+	fakeClient := &fakeApplyClient{Client: newFakeClient(liveConfigMap)}
+	ma := NewManifestApply(fakeClient, "test-ns").
+		WithLastAppliedConfig(string(lastAppliedJSON)).
+		WithNewObjects(newObjects).
+		WithLogger(klog.NewKlogr())
+
+	count, err := ma.ApplyManifests(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	current := createTestConfigMap("settings", "test-ns", "mode", "stale")
+	err = fakeClient.Get(context.Background(), client.ObjectKey{
+		Namespace: "test-ns",
+		Name:      "settings",
+	}, current)
+	assert.NoError(t, err)
+
+	mode, found, err := unstructured.NestedString(current.Object, "data", "mode")
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "expected", mode)
 }
 
 func TestDelete_NoLastAppliedConfig(t *testing.T) {

--- a/tests/e2e/endpoint_lifecycle_test.go
+++ b/tests/e2e/endpoint_lifecycle_test.go
@@ -312,6 +312,46 @@ var _ = Describe("Endpoint Lifecycle", Ordered, Label("endpoint", "lifecycle"), 
 			Expect(ep.Status.Phase).To(BeEquivalentTo("Paused"))
 		})
 
+		// TestRail: C2705752
+		It("should resume deployment after pause", Label("C2705752", "resume"), func() {
+			epName := "e2e-ep-lc-pause-resume-" + Cfg.RunID
+			DeferCleanup(func() { deleteEndpoint(epName) })
+
+			By("Creating endpoint with replicas=1 and waiting for Running")
+			yamlPath := applyEndpoint(epName, clusterName, withReplicas(1))
+			defer os.Remove(yamlPath)
+			waitEndpointRunning(epName)
+
+			ep := getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+			code, body, err := inferChat(ep.Status.ServiceURL, "Hello before pause")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(http.StatusOK), "inference failed before pause: %s", body)
+			Expect(body).To(ContainSubstring("choices"))
+
+			By("Re-applying endpoint with replicas=0 (pause)")
+			pauseYAMLPath := applyEndpoint(epName, clusterName, withReplicas(0))
+			defer os.Remove(pauseYAMLPath)
+			waitEndpointPaused(epName)
+
+			ep = getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Paused"))
+
+			By("Re-applying endpoint with replicas=1 (resume)")
+			resumeYAMLPath := applyEndpoint(epName, clusterName, withReplicas(1))
+			defer os.Remove(resumeYAMLPath)
+			waitEndpointRunning(epName)
+
+			ep = getEndpoint(epName)
+			Expect(ep.Status.Phase).To(BeEquivalentTo("Running"))
+			code, body, err = inferChat(ep.Status.ServiceURL, "Hello after resume")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(http.StatusOK), "inference failed after resume: %s", body)
+			Expect(body).To(ContainSubstring("choices"))
+
+			deleteEndpoint(epName)
+		})
+
 		// TestRail: C2682160
 		It("should ignore generated status sort column during full-row PATCH", Label("C2682160"), func() {
 			epName := "e2e-ep-lc-fullpatch-" + Cfg.RunID


### PR DESCRIPTION
## Issue

NEU-455

## Summary

Paused K8s endpoints could stay scaled to zero after resume because the deployer only compared desired manifests with the last-applied snapshot. When both snapshots said `replicas=1`, the apply path skipped the live Deployment even if it had been patched to `replicas=0` during pause. This change detects live drift against the desired manifest before treating a render as a no-op.

## Changes

- Re-apply desired objects when the live object is missing or its desired fields drift from the rendered manifest.
- Use subset comparison for live checks so Kubernetes defaulted fields do not cause perpetual re-apply.
- Cover both `spec` resources and no-`spec` resources such as ConfigMaps.
- Add unit coverage for live Deployment replica drift, missing live objects, defaulted spec fields, and no-`spec` object drift.
- Add E2E coverage for K8s endpoint pause then resume, including inference before and after resume.

## Test Plan

Unit test
- [x] `go test ./internal/deploy/... -count=1`
- [x] `go vet ./internal/deploy/... ./tests/e2e/...`
- [x] `go build ./tests/e2e/...`
- [x] `./bin/golangci-lint run ./internal/deploy/... ./tests/e2e/...`
- [x] `git diff --check`
- [x] `go test ./tests/e2e/... -run TestRenderTemplate_PlainSubstitution -count=1`

DB test
- [ ] Not affected; no DB schema, migration, or storage behavior changed. `make db-test` not run.

E2E test
- [x] Hot-updated validation CP to `78a5a8b8`.
- [x] `make e2e-test LABEL_FILTER='endpoint && lifecycle && pause && resume' E2E_TIMEOUT=30m` passed: `1 Passed | 0 Failed | 237 Skipped`, `ok github.com/neutree-ai/neutree/tests/e2e 527.949s`.
- Manual testing is not required because the scoped E2E covers the pause/resume regression.

Known repo-wide check blocker
- `go test ./...` / `go vet ./...` are blocked in this worktree by missing generated launch artifacts: `cmd/neutree-cli/app/cmd/launch/manifests/core.go:7:12: pattern neutree-core.tar: no matching files found`.

## Risk & Rollback

Risk is limited to manifest apply behavior. The change only adds live drifted objects to the existing apply path and ignores extra live defaulted fields. Rollback is reverting this PR.
