### PR TITLE
feat(ai-trace): deploy VictoriaLogs trace store on Kubernetes

### DIFF
--- a/deploy/chart/neutree/templates/_helpers.tpl
+++ b/deploy/chart/neutree/templates/_helpers.tpl
@@ -94,3 +94,17 @@ Get the JWT secret with validation.
 {{- define "neutree.jwtSecret" -}}
 {{- required "jwtSecret is required. Please set it in values.yaml or via --set jwtSecret=<your-secret>" .Values.jwtSecret -}}
 {{- end -}}
+
+{{/*
+Resolve the AI inference trace store (VictoriaLogs) base URL.
+Returns the in-cluster VictoriaLogs service when victorialogs.enabled is true,
+otherwise the externally configured system.aiTraceStoreUrl. Empty when neither
+is set — callers treat the empty result as "AI inference trace disabled".
+*/}}
+{{- define "neutree.aiTraceStoreUrl" -}}
+{{- if .Values.victorialogs.enabled -}}
+{{- printf "http://%s-victorialogs-service:9428" (include "neutree.fullname" .) -}}
+{{- else if .Values.system.aiTraceStoreUrl -}}
+{{- .Values.system.aiTraceStoreUrl -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/chart/neutree/templates/_helpers.tpl
+++ b/deploy/chart/neutree/templates/_helpers.tpl
@@ -105,6 +105,8 @@ is set — callers treat the empty result as "AI inference trace disabled".
 {{- if .Values.victorialogs.enabled -}}
 {{- printf "http://%s-victorialogs-service:9428" (include "neutree.fullname" .) -}}
 {{- else if .Values.system.aiTraceStoreUrl -}}
-{{- .Values.system.aiTraceStoreUrl -}}
+{{- /* Trim a trailing slash so callers (e.g. the Vector sink) never render a
+       double-slash path like https://host//insert/... */ -}}
+{{- .Values.system.aiTraceStoreUrl | trimSuffix "/" -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/chart/neutree/templates/neutree-api-deployment.yaml
+++ b/deploy/chart/neutree/templates/neutree-api-deployment.yaml
@@ -39,6 +39,10 @@ spec:
             {{- else if .Values.system.grafana.url }}
             - --grafana-url={{ .Values.system.grafana.url }}
             {{- end }}
+            {{- $aiTraceStoreUrl := include "neutree.aiTraceStoreUrl" . }}
+            {{- if $aiTraceStoreUrl }}
+            - --ai-trace-store-url={{ $aiTraceStoreUrl }}
+            {{- end }}
           image: {{ include "neutree.image" (dict "global" .Values.global "componentRegistry" .Values.api.image.registry "repository" .Values.api.image.repository "tag" .Values.api.image.tag "defaultTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           securityContext:

--- a/deploy/chart/neutree/templates/vector-install.yaml
+++ b/deploy/chart/neutree/templates/vector-install.yaml
@@ -1,3 +1,4 @@
+{{- $aiTraceStoreUrl := include "neutree.aiTraceStoreUrl" . -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -21,23 +22,27 @@ data:
         type: remap
         inputs:
           - kong_logs
-        source: >
+        source: |
           . = parse_json!(.message)
 
           # Access fields with hyphens using proper VRL syntax
 
+          .extracted_data.request_id = .request.id
+          .extracted_data.timestamp = .started_at
+          .extracted_data.status = .response.status
+          .extracted_data.api_version = .request.api_version
+          .extracted_data.api_key_id = .consumer.custom_id
+          if exists(.request.uri) {
+              .extracted_data.url_split = split!(.request.uri, "/")
+              .extracted_data.workspace = .extracted_data.url_split[2]      # workspace name from /workspace/{workspace}/...
+              .extracted_data.endpoint_type = .extracted_data.url_split[3]  # "endpoint" or "external-endpoint"
+              .extracted_data.endpoint_name = .extracted_data.url_split[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
+          }
+
           if exists(.ai) && exists(.ai."statistics") && exists(.ai."statistics".usage) {
-              # Extract fields one by one
-              .extracted_data.request_id = .request.id
               .extracted_data.total_tokens = .ai."statistics".usage.total_tokens
               .extracted_data.prompt_tokens = .ai."statistics".usage.prompt_tokens
               .extracted_data.completion_tokens = .ai."statistics".usage.completion_tokens
-              .extracted_data.timestamp = .started_at
-              .extracted_data.status = .response.status
-              .extracted_data.url_spilt = split!(.request.uri, "/")
-              .extracted_data.endpoint_type = .extracted_data.url_spilt[3]  # "endpoint" or "external-endpoint"
-              .extracted_data.endpoint_name = .extracted_data.url_spilt[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
-              .extracted_data.api_key_id = .consumer.custom_id
 
               if exists(.ai."statistics".meta) && exists(.ai."statistics".meta.request_model) {
                   .extracted_data.model_name = .ai."statistics".meta.request_model
@@ -71,6 +76,49 @@ data:
               "p_prompt_tokens": .extracted_data.prompt_tokens,
               "p_completion_tokens": .extracted_data.completion_tokens
           }
+      {{- if $aiTraceStoreUrl }}
+      filter_trace_logs:
+        type: filter
+        inputs:
+          - parse_kong_logs
+        condition: exists(.ai."trace".request_body) || exists(.ai."trace".response_body)
+      prepare_trace_payload:
+        type: remap
+        inputs:
+          - filter_trace_logs
+        source: |
+          . = {
+              # VictoriaLogs rejects records without a non-empty `_msg`. Failed
+              # requests often carry no response body, so `_msg` must be a field
+              # that is always populated — never the (optional) response body.
+              "_msg":           .request.id || "ai-trace",
+              "request_id":     .request.id,
+              "timestamp":      .started_at,
+              "workspace":      .extracted_data.workspace || "",
+              "endpoint_type":  .extracted_data.endpoint_type || "",
+              "endpoint_name":  .extracted_data.endpoint_name || "",
+              # Optional string columns are coalesced to "" so every record carries
+              # the same string type even when the source field is absent (e.g. an
+              # error response that returned early before `ai.statistics`, or a
+              # success with no `finish_reason`). The numeric columns below are left
+              # nullable on purpose: the query API decodes them into pointer/optional
+              # fields and must distinguish "no token/latency data" from a real 0.
+              "api_key_id":     .consumer.custom_id || "",
+              "request_uri":    .request.uri || "",
+              "request_model":  .ai."statistics".meta.request_model || "",
+              "response_model": .ai."statistics".meta.response_model || "",
+              "response_status": .response.status,
+              "prompt_tokens":     .ai."statistics".usage.prompt_tokens,
+              "completion_tokens": .ai."statistics".usage.completion_tokens,
+              "total_tokens":      .ai."statistics".usage.total_tokens,
+              "finish_reason":  .ai."trace".finish_reason || "",
+              "stream":         .ai."trace".stream || false,
+              "user_agent":     .request.headers."user-agent" || "",
+              "duration_ms":    .latencies.request,
+              "request_body":   .ai."trace".request_body || "",
+              "response_body":  .ai."trace".response_body || "",
+          }
+      {{- end }}
     sinks:
       postgrest_rpc:
         type: http
@@ -91,6 +139,25 @@ data:
         batch:
           max_events: 1
           timeout_secs: 1
+      {{- if $aiTraceStoreUrl }}
+      ai_trace_victorialogs:
+        type: http
+        inputs:
+          - prepare_trace_payload
+        uri: {{ $aiTraceStoreUrl }}/insert/jsonline?_stream_fields=workspace,endpoint_type,endpoint_name&_time_field=timestamp
+        method: post
+        encoding:
+          codec: json
+        framing:
+          method: newline_delimited
+        compression: none
+        request:
+          headers:
+            Content-Type: application/stream+json
+        batch:
+          max_events: 100
+          timeout_secs: 1
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/chart/neutree/templates/victorialogs-deployment.yaml
+++ b/deploy/chart/neutree/templates/victorialogs-deployment.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.victorialogs.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "neutree.fullname" . }}-victorialogs
+  labels:
+    {{- include "neutree.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: neutree-victorialogs
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: neutree-victorialogs
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: neutree-victorialogs
+          image: {{ include "neutree.image" (dict "global" .Values.global "componentRegistry" .Values.victorialogs.image.registry "repository" .Values.victorialogs.image.repository "tag" .Values.victorialogs.image.tag "defaultTag" .Values.victorialogs.image.tag) }}
+          imagePullPolicy: {{ .Values.victorialogs.image.pullPolicy }}
+          args:
+            - -storageDataPath=/victoria-logs-data
+            # AI-trace request/response bodies can be large; raise the per-line
+            # ingest limit so VictoriaLogs does not drop them.
+            - -insert.maxLineSizeBytes={{ int64 .Values.victorialogs.maxLineSizeBytes }}
+          ports:
+            - name: http
+              containerPort: 9428
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9428
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9428
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 6
+          {{- with .Values.victorialogs.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: victorialogs-data
+              mountPath: /victoria-logs-data
+      volumes:
+        - name: victorialogs-data
+          {{- if .Values.victorialogs.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "neutree.fullname" . }}-victorialogs-pvc
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.victorialogs.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.victorialogs.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.victorialogs.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/chart/neutree/templates/victorialogs-service.yaml
+++ b/deploy/chart/neutree/templates/victorialogs-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.victorialogs.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "neutree.fullname" . }}-victorialogs-service
+  labels:
+    {{- include "neutree.labels" . | nindent 4 }}
+    app.kubernetes.io/component: neutree-victorialogs
+spec:
+  type: {{ .Values.victorialogs.service.type }}
+  ports:
+    - port: 9428
+      targetPort: 9428
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/component: neutree-victorialogs
+{{- end }}

--- a/deploy/chart/neutree/templates/victorialogs-volume.yaml
+++ b/deploy/chart/neutree/templates/victorialogs-volume.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.victorialogs.enabled .Values.victorialogs.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "neutree.fullname" . }}-victorialogs-pvc
+  labels:
+    {{- include "neutree.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.victorialogs.persistence.storageClassName }}
+  storageClassName: {{ .Values.victorialogs.persistence.storageClassName }}
+  {{- end }}
+  accessModes:
+  {{- range .Values.victorialogs.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.victorialogs.persistence.size | quote }}
+{{- end }}

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -24,6 +24,10 @@ adminPassword: ""
 system:
   grafana:
     url: ""
+  # External AI inference trace store (VictoriaLogs) base URL.
+  # Only used when victorialogs.enabled is false. Leave empty to disable the
+  # AI inference trace APIs and the Vector trace pipeline altogether.
+  aiTraceStoreUrl: ""
 
 metrics:
   # Specify the URL for remote write if using an external metrics storage system.
@@ -217,6 +221,35 @@ vector:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+# VictoriaLogs — the AI inference trace store. Vector ships full
+# request/response trace records here, and neutree-api queries it via
+# --ai-trace-store-url. Disable (enabled: false) to use an external store
+# configured through system.aiTraceStoreUrl, or to turn the feature off.
+victorialogs:
+  enabled: true
+  image:
+    registry: ""
+    repository: victoriametrics/victoria-logs
+    tag: "v1.50.0"
+    pullPolicy: IfNotPresent
+  # AI-trace request/response bodies can be large; raise the per-line ingest
+  # limit (bytes) so VictoriaLogs does not drop them. Matches docker-compose.
+  maxLineSizeBytes: 16777216
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  persistence:
+    enabled: true
+    size: 40Gi
+    accessModes:
+      - ReadWriteOnce
+  service:
+    type: ClusterIP
 
 jwtCli:
   image:


### PR DESCRIPTION
## What

Packages the AI inference trace store (VictoriaLogs) and the Vector trace
pipeline into the **Helm chart**, so the feature works on Kubernetes — not just
docker-compose.

This is the follow-up called out in #398 ("VictoriaLogs is in docker-compose
only; Helm chart packaging is a follow-up"). #398 has merged to `main`, and this
branch is rebased onto `main`, so the diff is exactly the k8s delta.

## Changes

- **VictoriaLogs workload** — new `Deployment` / `Service` / `PVC`
  (`victorialogs-{deployment,service,volume}.yaml`): image `v1.50.0`, port
  `9428`, `Recreate` strategy, health probes, optional persistence, and the
  `-insert.maxLineSizeBytes` ingest limit rendered via `int64` to avoid
  scientific-notation arg corruption. Mirrors the docker-compose service.
- **`neutree.aiTraceStoreUrl` helper** (`_helpers.tpl`) — resolves the trace
  store URL with a 3-way precedence: in-cluster VictoriaLogs service when
  `victorialogs.enabled`, else the external `system.aiTraceStoreUrl`, else
  empty (feature off).
- **neutree-api** — passes `--ai-trace-store-url` only when the helper is
  non-empty, matching the API's "unset = 503 / disabled" contract.
- **Vector** (`vector-install.yaml`) — ports the trace filter/transform and the
  VictoriaLogs HTTP sink from the docker `vector.yml`, both gated on the
  resolved trace store URL. The docker-only on-disk file replica sink is
  intentionally omitted (pod-local ephemeral disk is not a useful replica).
- **values.yaml** — new `victorialogs` block and `system.aiTraceStoreUrl`.

## Verification

- `helm lint` ✅
- `helm template` across all three paths:
  - **enabled (default)** → VictoriaLogs Deployment/Service/PVC rendered;
    `--ai-trace-store-url` points at the in-cluster service; Vector trace sink
    targets it.
  - **external store** (`victorialogs.enabled=false`,
    `system.aiTraceStoreUrl=…`) → no VictoriaLogs objects; flag + Vector sink
    point at the external URL.
  - **disabled** (both unset) → no VictoriaLogs objects, no `--ai-trace-store-url`
    flag, no Vector trace pipeline. Feature fully off.
- Rendered manifests parse as valid YAML; `maxLineSizeBytes` renders as a plain
  integer (`16777216`). Vector pipeline structure matches the merged `main`
  `vector.yml` / docker-compose source.

## Notes

- DB migrations `060`/`061` (from #398) already landed in `main`; unchanged here.
- Data-plane (GPU / real cluster) validation and a live `helm install` require
  the fixed stable environment; not runnable in a sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
