### PR TITLE
feat(obs): capture provider usage-contract fields (NEU-461)

### DIFF
--- a/db/migrations/062_usage_cache_cost_fields.down.sql
+++ b/db/migrations/062_usage_cache_cost_fields.down.sql
@@ -1,0 +1,82 @@
+-- Revert extended usage fields.
+
+-- Restore the migration 054 version of record_api_usage (without the new params).
+DROP FUNCTION IF EXISTS api.record_api_usage(
+    UUID, TEXT, INTEGER, TEXT, TEXT, TEXT, INTEGER, INTEGER,
+    INTEGER, INTEGER, INTEGER, DOUBLE PRECISION, TEXT
+);
+CREATE FUNCTION api.record_api_usage(
+    p_api_key_id UUID,
+    p_request_id TEXT,
+    p_usage_amount INTEGER,
+    p_endpoint_name TEXT DEFAULT NULL,
+    p_endpoint_type TEXT DEFAULT NULL,
+    p_model_name TEXT DEFAULT NULL,
+    p_prompt_tokens INTEGER DEFAULT NULL,
+    p_completion_tokens INTEGER DEFAULT NULL
+) RETURNS JSONB
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_api_key RECORD;
+    v_workspace TEXT;
+BEGIN
+    SELECT id, (metadata).workspace INTO v_api_key
+    FROM api.api_keys
+    WHERE id = p_api_key_id;
+
+    IF v_api_key.id IS NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', format('Invalid API key: %s', p_api_key_id),
+            'request_id', p_request_id
+        );
+    END IF;
+    v_workspace := v_api_key.workspace;
+
+    INSERT INTO api.api_usage_records (
+        api_key_id,
+        request_id,
+        usage_amount,
+        endpoint_name,
+        endpoint_type,
+        model_name,
+        prompt_tokens,
+        completion_tokens,
+        created_at
+    ) VALUES (
+        p_api_key_id,
+        p_request_id,
+        p_usage_amount,
+        p_endpoint_name,
+        p_endpoint_type,
+        p_model_name,
+        p_prompt_tokens,
+        p_completion_tokens,
+        now()
+    );
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'api_key_id', p_api_key_id,
+        'request_id', p_request_id,
+        'usage_recorded', p_usage_amount
+    );
+
+EXCEPTION WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+        'success', false,
+        'error', SQLERRM,
+        'api_key_id', p_api_key_id,
+        'request_id', p_request_id
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE api.api_usage_records DROP COLUMN IF EXISTS cache_read_tokens;
+ALTER TABLE api.api_usage_records DROP COLUMN IF EXISTS cache_creation_tokens;
+ALTER TABLE api.api_usage_records DROP COLUMN IF EXISTS reasoning_tokens;
+ALTER TABLE api.api_usage_records DROP COLUMN IF EXISTS cost_usd;
+ALTER TABLE api.api_usage_records DROP COLUMN IF EXISTS message_id;
+
+NOTIFY pgrst, 'reload schema';

--- a/db/migrations/062_usage_cache_cost_fields.up.sql
+++ b/db/migrations/062_usage_cache_cost_fields.up.sql
@@ -1,0 +1,102 @@
+-- Capture extended usage fields on the per-request ledger.
+-- Upstream OpenAI-compatible responses already carry these (e.g. OpenRouter:
+-- usage.prompt_tokens_details.cached_tokens / cache_write_tokens,
+-- usage.completion_tokens_details.reasoning_tokens, usage.cost, response id),
+-- but neutree previously only persisted prompt_tokens / completion_tokens.
+
+-- 1a. Add breakdown columns to api_usage_records
+ALTER TABLE api.api_usage_records ADD COLUMN cache_read_tokens INTEGER;
+ALTER TABLE api.api_usage_records ADD COLUMN cache_creation_tokens INTEGER;
+ALTER TABLE api.api_usage_records ADD COLUMN reasoning_tokens INTEGER;
+ALTER TABLE api.api_usage_records ADD COLUMN cost_usd DOUBLE PRECISION;
+ALTER TABLE api.api_usage_records ADD COLUMN message_id TEXT;
+
+-- 1b. Extend record_api_usage with the new optional parameters (appended with
+-- DEFAULT NULL so existing callers keep working). Body mirrors migration 054
+-- plus the new columns.
+DROP FUNCTION IF EXISTS api.record_api_usage;
+CREATE FUNCTION api.record_api_usage(
+    p_api_key_id UUID,
+    p_request_id TEXT,
+    p_usage_amount INTEGER,
+    p_endpoint_name TEXT DEFAULT NULL,
+    p_endpoint_type TEXT DEFAULT NULL,
+    p_model_name TEXT DEFAULT NULL,
+    p_prompt_tokens INTEGER DEFAULT NULL,
+    p_completion_tokens INTEGER DEFAULT NULL,
+    p_cache_read_tokens INTEGER DEFAULT NULL,
+    p_cache_creation_tokens INTEGER DEFAULT NULL,
+    p_reasoning_tokens INTEGER DEFAULT NULL,
+    p_cost_usd DOUBLE PRECISION DEFAULT NULL,
+    p_message_id TEXT DEFAULT NULL
+) RETURNS JSONB
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_api_key RECORD;
+    v_workspace TEXT;
+BEGIN
+    SELECT id, (metadata).workspace INTO v_api_key
+    FROM api.api_keys
+    WHERE id = p_api_key_id;
+
+    IF v_api_key.id IS NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', format('Invalid API key: %s', p_api_key_id),
+            'request_id', p_request_id
+        );
+    END IF;
+    v_workspace := v_api_key.workspace;
+
+    INSERT INTO api.api_usage_records (
+        api_key_id,
+        request_id,
+        usage_amount,
+        endpoint_name,
+        endpoint_type,
+        model_name,
+        prompt_tokens,
+        completion_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        reasoning_tokens,
+        cost_usd,
+        message_id,
+        created_at
+    ) VALUES (
+        p_api_key_id,
+        p_request_id,
+        p_usage_amount,
+        p_endpoint_name,
+        p_endpoint_type,
+        p_model_name,
+        p_prompt_tokens,
+        p_completion_tokens,
+        p_cache_read_tokens,
+        p_cache_creation_tokens,
+        p_reasoning_tokens,
+        p_cost_usd,
+        p_message_id,
+        now()
+    );
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'api_key_id', p_api_key_id,
+        'request_id', p_request_id,
+        'usage_recorded', p_usage_amount
+    );
+
+EXCEPTION WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+        'success', false,
+        'error', SQLERRM,
+        'api_key_id', p_api_key_id,
+        'request_id', p_request_id
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Ask PostgREST to reload its schema cache so the new RPC signature is visible.
+NOTIFY pgrst, 'reload schema';

--- a/deploy/chart/neutree/templates/vector-install.yaml
+++ b/deploy/chart/neutree/templates/vector-install.yaml
@@ -43,9 +43,17 @@ data:
               .extracted_data.total_tokens = .ai."statistics".usage.total_tokens
               .extracted_data.prompt_tokens = .ai."statistics".usage.prompt_tokens
               .extracted_data.completion_tokens = .ai."statistics".usage.completion_tokens
+              .extracted_data.cache_read_tokens = .ai."statistics".usage.cache_read_tokens
+              .extracted_data.cache_creation_tokens = .ai."statistics".usage.cache_creation_tokens
+              .extracted_data.reasoning_tokens = .ai."statistics".usage.reasoning_tokens
+              .extracted_data.cost_usd = .ai."statistics".usage.cost
 
               if exists(.ai."statistics".meta) && exists(.ai."statistics".meta.request_model) {
                   .extracted_data.model_name = .ai."statistics".meta.request_model
+              }
+
+              if exists(.ai."statistics".meta) && exists(.ai."statistics".meta.message_id) {
+                  .extracted_data.message_id = .ai."statistics".meta.message_id
               }
 
               if to_int!(.extracted_data.total_tokens) > 0 {
@@ -74,7 +82,12 @@ data:
               "p_endpoint_type": .extracted_data.endpoint_type,
               "p_model_name": .extracted_data.model_name,
               "p_prompt_tokens": .extracted_data.prompt_tokens,
-              "p_completion_tokens": .extracted_data.completion_tokens
+              "p_completion_tokens": .extracted_data.completion_tokens,
+              "p_cache_read_tokens": .extracted_data.cache_read_tokens,
+              "p_cache_creation_tokens": .extracted_data.cache_creation_tokens,
+              "p_reasoning_tokens": .extracted_data.reasoning_tokens,
+              "p_cost_usd": .extracted_data.cost_usd,
+              "p_message_id": .extracted_data.message_id
           }
       {{- if $aiTraceStoreUrl }}
       filter_trace_logs:

--- a/deploy/docker/neutree-core/vector/vector.yml
+++ b/deploy/docker/neutree-core/vector/vector.yml
@@ -29,9 +29,17 @@ transforms:
           .extracted_data.total_tokens = .ai."statistics".usage.total_tokens
           .extracted_data.prompt_tokens = .ai."statistics".usage.prompt_tokens
           .extracted_data.completion_tokens = .ai."statistics".usage.completion_tokens
+          .extracted_data.cache_read_tokens = .ai."statistics".usage.cache_read_tokens
+          .extracted_data.cache_creation_tokens = .ai."statistics".usage.cache_creation_tokens
+          .extracted_data.reasoning_tokens = .ai."statistics".usage.reasoning_tokens
+          .extracted_data.cost_usd = .ai."statistics".usage.cost
 
           if exists(.ai."statistics".meta) && exists(.ai."statistics".meta.request_model) {
               .extracted_data.model_name = .ai."statistics".meta.request_model
+          }
+
+          if exists(.ai."statistics".meta) && exists(.ai."statistics".meta.message_id) {
+              .extracted_data.message_id = .ai."statistics".meta.message_id
           }
 
           if to_int!(.extracted_data.total_tokens) > 0 {
@@ -60,7 +68,12 @@ transforms:
           "p_endpoint_type": .extracted_data.endpoint_type,
           "p_model_name": .extracted_data.model_name,
           "p_prompt_tokens": .extracted_data.prompt_tokens,
-          "p_completion_tokens": .extracted_data.completion_tokens
+          "p_completion_tokens": .extracted_data.completion_tokens,
+          "p_cache_read_tokens": .extracted_data.cache_read_tokens,
+          "p_cache_creation_tokens": .extracted_data.cache_creation_tokens,
+          "p_reasoning_tokens": .extracted_data.reasoning_tokens,
+          "p_cost_usd": .extracted_data.cost_usd,
+          "p_message_id": .extracted_data.message_id
       }
   filter_trace_logs:
     type: filter

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -22,6 +22,52 @@ local function string_or_empty(v)
     return type(v) == "string" and v or ""
 end
 
+-- Capture usage breakdown fields (cache / reasoning / cost) from an
+-- OpenAI-compatible `usage` object into kong.ctx.plugin so the log phase can
+-- forward them to the usage ledger. Only sets values that are actually present.
+local function record_extended_usage(ctx, usage)
+    if not is_table(usage) then
+        return
+    end
+    local ptd = is_table(usage.prompt_tokens_details) and usage.prompt_tokens_details or EMPTY
+    local ctd = is_table(usage.completion_tokens_details) and usage.completion_tokens_details or EMPTY
+    if ptd.cached_tokens ~= nil then
+        ctx.cache_read_tokens = ptd.cached_tokens
+    end
+    local cache_creation = ptd.cache_write_tokens or ptd.cache_creation_tokens
+    if cache_creation ~= nil then
+        ctx.cache_creation_tokens = cache_creation
+    end
+    if ctd.reasoning_tokens ~= nil then
+        ctx.reasoning_tokens = ctd.reasoning_tokens
+    end
+    if usage.cost ~= nil then
+        ctx.cost_usd = usage.cost
+    end
+end
+
+-- Anthropic reports cache tokens separately from input_tokens, while OpenAI
+-- `prompt_tokens` already includes cached tokens. So the Anthropic input_tokens
+-- is prompt_tokens minus the cache read/creation portions.
+local function anthropic_usage_from_openai(usage)
+    usage = is_table(usage) and usage or EMPTY
+    local ptd = is_table(usage.prompt_tokens_details) and usage.prompt_tokens_details or EMPTY
+    local prompt = usage.prompt_tokens or 0
+    local cache_read = ptd.cached_tokens or 0
+    local cache_creation = ptd.cache_write_tokens or ptd.cache_creation_tokens or 0
+    local input = prompt - cache_read - cache_creation
+    if input < 0 then
+        -- provider did not include cache tokens inside prompt_tokens; keep raw
+        input = prompt
+    end
+    return {
+        input_tokens = input,
+        output_tokens = usage.completion_tokens or 0,
+        cache_read_input_tokens = cache_read,
+        cache_creation_input_tokens = cache_creation,
+    }
+end
+
 local SUPPORTED_ROUTE_TYPES = {
     "/v1/chat/completions",
     "/v1/embeddings",
@@ -523,7 +569,6 @@ local function convert_response(openai_resp, request_model)
         }
     end
 
-    local usage = is_table(openai_resp.usage) and openai_resp.usage or EMPTY
     return {
         id = openai_resp.id or ("msg_" .. ngx.now()),
         type = "message",
@@ -532,12 +577,7 @@ local function convert_response(openai_resp, request_model)
         content = content,
         stop_reason = map_finish_reason(choice.finish_reason),
         stop_sequence = cjson.null,
-        usage = {
-            input_tokens = usage.prompt_tokens or 0,
-            output_tokens = usage.completion_tokens or 0,
-            cache_creation_input_tokens = 0,
-            cache_read_input_tokens = 0,
-        },
+        usage = anthropic_usage_from_openai(openai_resp.usage),
     }
 end
 
@@ -655,6 +695,9 @@ local function handle_openai_json_response()
     if first_choice.finish_reason and first_choice.finish_reason ~= cjson.null then
         kong.ctx.plugin.finish_reason = first_choice.finish_reason
     end
+    if ai_response.id ~= nil then
+        kong.ctx.plugin.message_id = ai_response.id
+    end
     if is_table(ai_response.usage) then
         if route_type == "/v1/chat/completions" then
             kong.ctx.plugin.completions_tokens = ai_response.usage.completion_tokens
@@ -664,6 +707,7 @@ local function handle_openai_json_response()
             kong.ctx.plugin.prompt_tokens = ai_response.usage.prompt_tokens
             kong.ctx.plugin.total_tokens = ai_response.usage.total_tokens
         end
+        record_extended_usage(kong.ctx.plugin, ai_response.usage)
     end
 end
 
@@ -700,10 +744,14 @@ local function handle_openai_stream_response(chunk, finished)
                     if kong.ctx.plugin.response_model == nil and event_t.model then
                         kong.ctx.plugin.response_model = event_t.model
                     end
+                    if event_t.id ~= nil then
+                        kong.ctx.plugin.message_id = event_t.id
+                    end
                     if is_table(event_t.usage) then
                         kong.ctx.plugin.prompt_tokens = event_t.usage.prompt_tokens
                         kong.ctx.plugin.completions_tokens = event_t.usage.completion_tokens
                         kong.ctx.plugin.total_tokens = event_t.usage.total_tokens
+                        record_extended_usage(kong.ctx.plugin, event_t.usage)
                     end
                 end
             end
@@ -739,9 +787,13 @@ local function handle_anthropic_non_stream_body()
         if first_choice.finish_reason and first_choice.finish_reason ~= cjson.null then
             ctx.finish_reason = first_choice.finish_reason
         end
+        if openai_resp.id ~= nil then
+            ctx.message_id = openai_resp.id
+        end
         if is_table(openai_resp.usage) then
             ctx.input_tokens = openai_resp.usage.prompt_tokens or 0
             ctx.output_tokens = openai_resp.usage.completion_tokens or 0
+            record_extended_usage(ctx, openai_resp.usage)
         end
 
         local anthropic_resp = convert_response(openai_resp, ctx.request_model)
@@ -808,9 +860,13 @@ local function handle_anthropic_stream_body()
         if event_t.model and ctx.response_model == nil then
             ctx.response_model = event_t.model
         end
+        if event_t.id ~= nil then
+            ctx.message_id = event_t.id
+        end
         if is_table(event_t.usage) then
             ctx.input_tokens = event_t.usage.prompt_tokens or ctx.input_tokens
             ctx.output_tokens = event_t.usage.completion_tokens or ctx.output_tokens
+            record_extended_usage(ctx, event_t.usage)
         end
 
         local choice = ((event_t.choices or EMPTY)[1]) or nil
@@ -1151,6 +1207,7 @@ function AIGatewayHandler:log(conf)
         plugin_id = conf.__plugin_id,
         request_model = kong.ctx.plugin.request_model,
         response_model = kong.ctx.plugin.response_model,
+        message_id = kong.ctx.plugin.message_id,
     }
     kong.log.set_serialize_value("ai.statistics.meta", meta)
 
@@ -1168,6 +1225,11 @@ function AIGatewayHandler:log(conf)
             total_tokens = kong.ctx.plugin.total_tokens,
         }
     end
+    -- Usage breakdown fields (nil when upstream did not provide them).
+    usage.cache_read_tokens = kong.ctx.plugin.cache_read_tokens
+    usage.cache_creation_tokens = kong.ctx.plugin.cache_creation_tokens
+    usage.reasoning_tokens = kong.ctx.plugin.reasoning_tokens
+    usage.cost = kong.ctx.plugin.cost_usd
     kong.log.set_serialize_value("ai.statistics.usage", usage)
 end
 

--- a/gateway/kong/plugins/neutree-ai-statistics/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-statistics/handler.lua
@@ -9,6 +9,8 @@ local AIStatisticsPluginHandler = {
     VERSION = "0.0.1",
 }
 
+local EMPTY = {}
+
 local function is_table(v)
     return type(v) == "table"
 end
@@ -84,7 +86,7 @@ local function handle_json_response()
     if ai_response.id ~= nil then
         kong.ctx.plugin.message_id = ai_response.id
     end
-    if ai_response.usage then
+    if is_table(ai_response.usage) then
         if route_type == "/v1/chat/completions" then
             kong.ctx.plugin.completions_tokens = ai_response.usage.completion_tokens
             kong.ctx.plugin.prompt_tokens = ai_response.usage.prompt_tokens
@@ -132,7 +134,7 @@ local function handle_stream_response(conf, chunk, finished)
                         kong.ctx.plugin.message_id = event_t.id
                     end
                     -- some upstream stream api return token usage in the last event, if exist, record it.
-                    if event_t.usage then
+                    if is_table(event_t.usage) then
                         kong.ctx.plugin.prompt_tokens = event_t.usage.prompt_tokens
                         kong.ctx.plugin.completions_tokens = event_t.usage.completion_tokens
                         kong.ctx.plugin.total_tokens = event_t.usage.total_tokens

--- a/gateway/kong/plugins/neutree-ai-statistics/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-statistics/handler.lua
@@ -9,6 +9,34 @@ local AIStatisticsPluginHandler = {
     VERSION = "0.0.1",
 }
 
+local function is_table(v)
+    return type(v) == "table"
+end
+
+-- Capture usage breakdown fields (cache / reasoning / cost) from an
+-- OpenAI-compatible `usage` object into kong.ctx.plugin.
+local function record_extended_usage(ctx, usage)
+    if not is_table(usage) then
+        return
+    end
+    if is_table(usage.prompt_tokens_details) then
+        local ptd = usage.prompt_tokens_details
+        if ptd.cached_tokens ~= nil then
+            ctx.cache_read_tokens = ptd.cached_tokens
+        end
+        local cache_creation = ptd.cache_write_tokens or ptd.cache_creation_tokens
+        if cache_creation ~= nil then
+            ctx.cache_creation_tokens = cache_creation
+        end
+    end
+    if is_table(usage.completion_tokens_details) and usage.completion_tokens_details.reasoning_tokens ~= nil then
+        ctx.reasoning_tokens = usage.completion_tokens_details.reasoning_tokens
+    end
+    if usage.cost ~= nil then
+        ctx.cost_usd = usage.cost
+    end
+end
+
 local SUPPORTED_ROUTE_TYPES = {
     "/v1/chat/completions",
     "/v1/embeddings",
@@ -53,6 +81,9 @@ local function handle_json_response()
     local route_type = kong.ctx.plugin.route_type
 
     kong.ctx.plugin.response_model = ai_response.model
+    if ai_response.id ~= nil then
+        kong.ctx.plugin.message_id = ai_response.id
+    end
     if ai_response.usage then
         if route_type == "/v1/chat/completions" then
             kong.ctx.plugin.completions_tokens = ai_response.usage.completion_tokens
@@ -65,6 +96,7 @@ local function handle_json_response()
             kong.ctx.plugin.prompt_tokens = ai_response.usage.prompt_tokens
             kong.ctx.plugin.total_tokens = ai_response.usage.total_tokens
         end
+        record_extended_usage(kong.ctx.plugin, ai_response.usage)
     end
 end
 
@@ -96,11 +128,15 @@ local function handle_stream_response(conf, chunk, finished)
                     if kong.ctx.plugin.response_model == nil and event_t.model then
                         kong.ctx.plugin.response_model = event_t.model
                     end
+                    if event_t.id ~= nil then
+                        kong.ctx.plugin.message_id = event_t.id
+                    end
                     -- some upstream stream api return token usage in the last event, if exist, record it.
                     if event_t.usage then
                         kong.ctx.plugin.prompt_tokens = event_t.usage.prompt_tokens
                         kong.ctx.plugin.completions_tokens = event_t.usage.completion_tokens
                         kong.ctx.plugin.total_tokens = event_t.usage.total_tokens
+                        record_extended_usage(kong.ctx.plugin, event_t.usage)
                     end
                 end
             end
@@ -215,6 +251,7 @@ function AIStatisticsPluginHandler:log(conf)
         plugin_id = conf.__plugin_id,
         request_model = kong.ctx.plugin.request_model,
         response_model = kong.ctx.plugin.response_model,
+        message_id = kong.ctx.plugin.message_id,
     }
 
     kong.log.set_serialize_value("ai.statistics.meta", meta)
@@ -223,6 +260,11 @@ function AIStatisticsPluginHandler:log(conf)
         completion_tokens = kong.ctx.plugin.completions_tokens,
         prompt_tokens = kong.ctx.plugin.prompt_tokens,
         total_tokens = kong.ctx.plugin.total_tokens,
+        -- Usage breakdown fields (nil when upstream did not provide them).
+        cache_read_tokens = kong.ctx.plugin.cache_read_tokens,
+        cache_creation_tokens = kong.ctx.plugin.cache_creation_tokens,
+        reasoning_tokens = kong.ctx.plugin.reasoning_tokens,
+        cost = kong.ctx.plugin.cost_usd,
     }
 
     kong.log.set_serialize_value("ai.statistics.usage",usage)


### PR DESCRIPTION
## Summary

Capture the provider usage-contract fields defined in **NEU-461** through neutree's usage pipeline, and stop the Anthropic gateway from reporting hardcoded-zero cache tokens.

Upstream OpenAI-compatible responses (e.g. OpenRouter, vLLM) already carry these fields, but neutree previously persisted only `prompt_tokens` / `completion_tokens` and zeroed the Anthropic cache fields:

- `usage.prompt_tokens_details.cached_tokens` / `cache_write_tokens`
- `usage.completion_tokens_details.reasoning_tokens`
- `usage.cost`
- the response `id` (stable message id for dedup)

This was verified live against the `openrouter-free` / `openai/gpt-oss-20b:free` endpoint: the same call that reports `cached_tokens: 64` in OpenAI format was emitting `cache_read_input_tokens: 0` in Anthropic format.

## Changes

- **gateway (both Kong plugins: `neutree-ai-gateway`, `neutree-ai-statistics`)**: capture the extra usage fields and the response id at all capture points (OpenAI / Anthropic, streaming / non-streaming). The Anthropic converter now derives `input_tokens` and `cache_read/creation_input_tokens` from upstream usage instead of hardcoding zeros. `input_tokens = prompt_tokens - cache_read - cache_creation` to match Anthropic semantics (input excludes cache), with a guard against negative values.
- **vector (`deploy/docker/.../vector.yml` + `deploy/chart/.../vector-install.yaml`)**: forward the new fields to the `record_api_usage` RPC.
- **db (`migration 060`)**: add `cache_read_tokens`, `cache_creation_tokens`, `reasoning_tokens`, `cost_usd`, `message_id` columns to `api.api_usage_records` and extend `record_api_usage` with matching optional (`DEFAULT NULL`) parameters. Backward compatible.

All fields fall back to nil/NULL when absent (never throw), per the NEU-461 fault-tolerance rule.

## Verification

- **Migration**: applied against the dev DB inside a `BEGIN…ROLLBACK` (no persistence); `record_api_usage(...)` populated `cache_read_tokens=64, reasoning_tokens=24, message_id` correctly.
- **Lua**: both plugins pass `luajit` parse on the dev Kong.
- **Anthropic mapper (live, reversible patch → verify → restore)**: `cache_read_input_tokens` went `0 → 64` with `input_tokens: 10` (10 + 64 = 74); OpenAI passthrough unchanged. Dev env restored afterwards.

## Out of scope (follow-ups)

- `contextWindow` model-catalog metadata (the one strongly-recommended field upstream does not provide).
- Local pricing table for `total_cost_usd` on self-hosted vLLM endpoints (proxy endpoints' `cost` is already captured here).
- Rolling the new fields into the `api_daily_usage` daily aggregation.
- Streaming Anthropic `message_start` cache-field population.

Refs: NEU-461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
