### PR TITLE
fix(gateway): align Anthropic streaming output with the standard spec

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -932,8 +932,23 @@ local function handle_anthropic_stream_body()
     end
 
     local function finish_stream(stop_reason)
-        if ctx.finish_events_sent or not ctx.message_started then
+        if ctx.finish_events_sent then
             return
+        end
+        -- Only synthesise terminal events for a genuine SSE stream. ctx.saw_event
+        -- is set once we have decoded an upstream SSE event (or seen [DONE]); a
+        -- non-SSE 200 body (e.g. an error JSON) leaves it false, so we don't
+        -- fabricate a fake successful message for it.
+        if not ctx.message_started and not ctx.saw_event then
+            return
+        end
+        ensure_started()
+        -- An upstream stream with no content/tool deltas (only a usage chunk or
+        -- a role-only delta) still needs a content block to be a valid Anthropic
+        -- sequence; emit an empty text block when nothing was opened.
+        if (ctx.next_block_index or 0) == 0 then
+            local idx = open_block("text")
+            output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_text(idx))
         end
         close_block()
         output_parts[#output_parts + 1] = sse_frame("message_delta", make_message_delta(stop_reason or map_finish_reason(ctx.finish_reason), anthropic_stream_final_usage(ctx)))
@@ -965,6 +980,7 @@ local function handle_anthropic_stream_body()
         if data_line == "[DONE]" then
             -- By the time [DONE] arrives the trailing usage-only chunk has
             -- already been processed, so finish_stream sees the final usage.
+            ctx.saw_event = true
             finish_stream(map_finish_reason(ctx.finish_reason))
             output_parts[#output_parts + 1] = "data: [DONE]\n\n"
             ctx.done_emitted = true
@@ -975,6 +991,7 @@ local function handle_anthropic_stream_body()
         if parse_err or event_t == nil then
             goto continue
         end
+        ctx.saw_event = true
 
         if event_t.model and ctx.response_model == nil then
             ctx.response_model = event_t.model
@@ -1152,12 +1169,18 @@ function AIGatewayHandler:access(conf)
             kong.ctx.plugin.output_tokens = 0
             kong.ctx.plugin.output_chars = 0
             kong.ctx.plugin.usage_seen = false
+            kong.ctx.plugin.saw_event = false
             kong.ctx.plugin.finish_events_sent = false
             kong.ctx.plugin.done_emitted = false
             -- Streaming never returns usage until the trailing chunk, so the
             -- message_start input_tokens can only be a best-effort estimate
             -- (Anthropic emits input_tokens up front; we approximate it here).
+            -- Unlike the OpenAI path we do not fail the request on an estimation
+            -- error, but we log it so an unexpected 0 input_tokens is traceable.
             local est, est_err = ai_shared.calculate_cost(openai_req or {}, {}, 1.0)
+            if est_err then
+                kong.log.warn("unable to estimate anthropic stream input tokens: ", est_err)
+            end
             kong.ctx.plugin.input_tokens_estimate = (not est_err and est) or 0
         end
 

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -531,6 +531,21 @@ local function convert_response(openai_resp, request_model)
     local message = choice.message or EMPTY
     local content = {}
 
+    -- Surface the model's reasoning as an Anthropic thinking block (OpenRouter
+    -- uses message.reasoning, vLLM/DeepSeek use message.reasoning_content)
+    -- instead of dropping it. Thinking blocks precede the text block.
+    local reasoning = message.reasoning_content
+    if reasoning == nil or reasoning == cjson.null then
+        reasoning = message.reasoning
+    end
+    if type(reasoning) == "string" and reasoning ~= "" then
+        content[#content + 1] = {
+            type = "thinking",
+            thinking = reasoning,
+            signature = "",
+        }
+    end
+
     if message.content and message.content ~= "" and message.content ~= cjson.null then
         content[#content + 1] = {
             type = "text",
@@ -626,6 +641,18 @@ local function make_content_block_start_tool_use(index, id, name)
     }
 end
 
+local function make_content_block_start_thinking(index)
+    return {
+        type = "content_block_start",
+        index = index,
+        content_block = {
+            type = "thinking",
+            thinking = "",
+            signature = "",
+        },
+    }
+end
+
 local function make_content_block_delta_text(index, text)
     return {
         type = "content_block_delta",
@@ -633,6 +660,28 @@ local function make_content_block_delta_text(index, text)
         delta = {
             type = "text_delta",
             text = text,
+        },
+    }
+end
+
+local function make_content_block_delta_thinking(index, thinking)
+    return {
+        type = "content_block_delta",
+        index = index,
+        delta = {
+            type = "thinking_delta",
+            thinking = thinking,
+        },
+    }
+end
+
+local function make_content_block_delta_signature(index, signature)
+    return {
+        type = "content_block_delta",
+        index = index,
+        delta = {
+            type = "signature_delta",
+            signature = signature,
         },
     }
 end
@@ -659,16 +708,17 @@ local function make_ping()
     return { type = "ping" }
 end
 
-local function make_message_delta(stop_reason, output_tokens)
+-- usage is the full Anthropic usage table (input/output/cache). Anthropic
+-- repeats the cumulative usage on the terminal message_delta, so we forward the
+-- whole object rather than output_tokens alone.
+local function make_message_delta(stop_reason, usage)
     return {
         type = "message_delta",
         delta = {
             stop_reason = stop_reason or "end_turn",
             stop_sequence = cjson.null,
         },
-        usage = {
-            output_tokens = output_tokens or 0,
-        },
+        usage = usage or { output_tokens = 0 },
     }
 end
 
@@ -803,6 +853,37 @@ local function handle_anthropic_non_stream_body()
     end
 end
 
+-- Build the Anthropic usage table for the terminal message_delta from whatever
+-- upstream usage we captured. Anthropic input_tokens excludes the cache tokens
+-- (OpenAI folds them into prompt_tokens), matching anthropic_usage_from_openai
+-- on the non-streaming path. When the upstream never sent a usage block, fall
+-- back to the access-phase prompt estimate and a char-based completion estimate
+-- so the client still sees non-zero, plausible numbers.
+local function anthropic_stream_final_usage(ctx)
+    local cache_read = ctx.cache_read_tokens or 0
+    local cache_creation = ctx.cache_creation_tokens or 0
+    local input, output
+    if ctx.usage_seen then
+        input = (ctx.input_tokens or 0) - cache_read - cache_creation
+        if input < 0 then
+            input = ctx.input_tokens or 0
+        end
+        output = ctx.output_tokens or 0
+        if output == 0 and (ctx.output_chars or 0) > 0 then
+            output = math.ceil(ctx.output_chars / 4)
+        end
+    else
+        input = ctx.input_tokens_estimate or 0
+        output = math.ceil((ctx.output_chars or 0) / 4)
+    end
+    return {
+        input_tokens = input,
+        output_tokens = output,
+        cache_read_input_tokens = cache_read,
+        cache_creation_input_tokens = cache_creation,
+    }
+end
+
 local function handle_anthropic_stream_body()
     local ctx = kong.ctx.plugin
     local chunk = ngx.arg[1] or ""
@@ -813,6 +894,53 @@ local function handle_anthropic_stream_body()
     ctx.response_body_raw = (ctx.response_body_raw or "") .. chunk
 
     local output_parts = {}
+
+    -- message_start + ping are emitted lazily on the first content delta so the
+    -- per-block structure can adapt to thinking / text / tool_use ordering.
+    local function ensure_started()
+        if ctx.message_started then
+            return
+        end
+        output_parts[#output_parts + 1] = sse_frame("message_start", make_message_start(ctx.request_model, ctx.input_tokens_estimate))
+        output_parts[#output_parts + 1] = sse_frame("ping", make_ping())
+        ctx.message_started = true
+    end
+
+    -- Close the currently open content block (if any). Thinking blocks flush a
+    -- trailing signature_delta first when the upstream provided a signature.
+    local function close_block()
+        if ctx.open_block_type == nil then
+            return
+        end
+        if ctx.open_block_type == "thinking" and type(ctx.pending_signature) == "string"
+            and ctx.pending_signature ~= "" then
+            output_parts[#output_parts + 1] = sse_frame("content_block_delta", make_content_block_delta_signature(ctx.anthropic_block_index, ctx.pending_signature))
+        end
+        ctx.pending_signature = nil
+        output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(ctx.anthropic_block_index))
+        ctx.open_block_type = nil
+    end
+
+    -- Close any open block and allocate the next block index for block_type.
+    local function open_block(block_type)
+        close_block()
+        local idx = ctx.next_block_index or 0
+        ctx.next_block_index = idx + 1
+        ctx.anthropic_block_index = idx
+        ctx.open_block_type = block_type
+        return idx
+    end
+
+    local function finish_stream(stop_reason)
+        if ctx.finish_events_sent or not ctx.message_started then
+            return
+        end
+        close_block()
+        output_parts[#output_parts + 1] = sse_frame("message_delta", make_message_delta(stop_reason or map_finish_reason(ctx.finish_reason), anthropic_stream_final_usage(ctx)))
+        output_parts[#output_parts + 1] = sse_frame("message_stop", make_message_stop())
+        ctx.finish_events_sent = true
+    end
+
     while true do
         local event_end = string.find(ctx.sse_buffer, "\n\n", 1, true)
         if not event_end then
@@ -835,20 +963,11 @@ local function handle_anthropic_stream_body()
         end
 
         if data_line == "[DONE]" then
-            if not ctx.finish_events_sent then
-                if ctx.current_tool_index ~= nil then
-                    output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(ctx.anthropic_block_index))
-                    ctx.current_tool_index = nil
-                end
-                if ctx.text_block_open then
-                    output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(0))
-                    ctx.text_block_open = false
-                end
-                output_parts[#output_parts + 1] = sse_frame("message_delta", make_message_delta("end_turn", ctx.output_tokens))
-                output_parts[#output_parts + 1] = sse_frame("message_stop", make_message_stop())
-                ctx.finish_events_sent = true
-            end
+            -- By the time [DONE] arrives the trailing usage-only chunk has
+            -- already been processed, so finish_stream sees the final usage.
+            finish_stream(map_finish_reason(ctx.finish_reason))
             output_parts[#output_parts + 1] = "data: [DONE]\n\n"
+            ctx.done_emitted = true
             goto continue
         end
 
@@ -866,6 +985,7 @@ local function handle_anthropic_stream_body()
         if is_table(event_t.usage) then
             ctx.input_tokens = event_t.usage.prompt_tokens or ctx.input_tokens
             ctx.output_tokens = event_t.usage.completion_tokens or ctx.output_tokens
+            ctx.usage_seen = true
             record_extended_usage(ctx, event_t.usage)
         end
 
@@ -880,41 +1000,58 @@ local function handle_anthropic_stream_body()
             ctx.finish_reason = finish_reason
         end
 
-        if not ctx.message_started then
-            output_parts[#output_parts + 1] = sse_frame("message_start", make_message_start(ctx.request_model, ctx.input_tokens))
-            output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_text(0))
-            output_parts[#output_parts + 1] = sse_frame("ping", make_ping())
-            ctx.message_started = true
-            ctx.text_block_open = true
-            ctx.anthropic_block_index = 0
+        -- Reasoning / thinking: OpenRouter uses delta.reasoning, vLLM/DeepSeek
+        -- use delta.reasoning_content. Emit an Anthropic thinking block so the
+        -- model's chain-of-thought is not silently dropped.
+        local reasoning = delta.reasoning_content
+        if reasoning == nil or reasoning == cjson.null then
+            reasoning = delta.reasoning
+        end
+        if type(reasoning) == "string" and reasoning ~= "" then
+            ensure_started()
+            if ctx.open_block_type ~= "thinking" then
+                local idx = open_block("thinking")
+                output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_thinking(idx))
+            end
+            output_parts[#output_parts + 1] = sse_frame("content_block_delta", make_content_block_delta_thinking(ctx.anthropic_block_index, reasoning))
+            ctx.output_chars = (ctx.output_chars or 0) + #reasoning
+        end
+        -- Capture a reasoning signature if the upstream supplies one; it is
+        -- flushed as a signature_delta when the thinking block closes.
+        if is_table(delta.reasoning_details) then
+            for _, rd in ipairs(delta.reasoning_details) do
+                if is_table(rd) and type(rd.signature) == "string" and rd.signature ~= "" then
+                    ctx.pending_signature = rd.signature
+                end
+            end
         end
 
-        if delta.content and delta.content ~= "" and delta.content ~= cjson.null then
-            output_parts[#output_parts + 1] = sse_frame("content_block_delta", make_content_block_delta_text(0, delta.content))
+        if type(delta.content) == "string" and delta.content ~= "" then
+            ensure_started()
+            if ctx.open_block_type ~= "text" then
+                local idx = open_block("text")
+                output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_text(idx))
+            end
+            output_parts[#output_parts + 1] = sse_frame("content_block_delta", make_content_block_delta_text(ctx.anthropic_block_index, delta.content))
+            ctx.output_chars = (ctx.output_chars or 0) + #delta.content
         end
 
         if is_table(delta.tool_calls) then
+            ensure_started()
             for _, tc in ipairs(delta.tool_calls) do
                 -- `tc["function"]` may be cjson.null (a truthy userdata), so
                 -- guard with is_table before indexing it (NEU-404).
                 local fn = is_table(tc["function"]) and tc["function"] or EMPTY
                 local tc_index = tc.index or 0
-                if tc_index ~= ctx.current_tool_index then
-                    if ctx.current_tool_index ~= nil then
-                        output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(ctx.anthropic_block_index))
-                    elseif ctx.text_block_open then
-                        output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(0))
-                        ctx.text_block_open = false
-                    end
-
+                if ctx.open_block_type ~= "tool_use" or tc_index ~= ctx.current_tool_index then
+                    local idx = open_block("tool_use")
                     ctx.current_tool_index = tc_index
-                    ctx.anthropic_block_index = ctx.anthropic_block_index + 1
                     local tc_id = tc.id or ""
                     -- Coerce the name through string_or_empty so nil/cjson.null
                     -- collapse to "" and never leak a non-string into the SSE
                     -- frame (which would break JSON clients).
                     local tc_name = string_or_empty(fn.name)
-                    output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_tool_use(ctx.anthropic_block_index, tc_id, tc_name))
+                    output_parts[#output_parts + 1] = sse_frame("content_block_start", make_content_block_start_tool_use(idx, tc_id, tc_name))
                 end
 
                 local args = fn.arguments
@@ -924,36 +1061,19 @@ local function handle_anthropic_stream_body()
             end
         end
 
-        if finish_reason and finish_reason ~= cjson.null and not ctx.finish_events_sent then
-            if ctx.current_tool_index ~= nil then
-                output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(ctx.anthropic_block_index))
-                ctx.current_tool_index = nil
-            end
-            if ctx.text_block_open then
-                output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(0))
-                ctx.text_block_open = false
-            end
-            output_parts[#output_parts + 1] = sse_frame("message_delta", make_message_delta(map_finish_reason(finish_reason), ctx.output_tokens))
-            output_parts[#output_parts + 1] = sse_frame("message_stop", make_message_stop())
-            ctx.finish_events_sent = true
-        end
+        -- Do NOT emit the terminal events on finish_reason: the upstream sends
+        -- its usage in a separate trailing chunk after the finish_reason chunk,
+        -- so deferring to [DONE] / is_last lets message_delta carry real tokens.
 
         ::continue::
     end
 
-    if is_last and not ctx.finish_events_sent then
-        if ctx.message_started then
-            if ctx.current_tool_index ~= nil then
-                output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(ctx.anthropic_block_index))
-            end
-            if ctx.text_block_open then
-                output_parts[#output_parts + 1] = sse_frame("content_block_stop", make_content_block_stop(0))
-            end
-            output_parts[#output_parts + 1] = sse_frame("message_delta", make_message_delta("end_turn", ctx.output_tokens))
-            output_parts[#output_parts + 1] = sse_frame("message_stop", make_message_stop())
+    if is_last then
+        finish_stream(map_finish_reason(ctx.finish_reason))
+        if not ctx.done_emitted then
+            output_parts[#output_parts + 1] = "data: [DONE]\n\n"
+            ctx.done_emitted = true
         end
-        output_parts[#output_parts + 1] = "data: [DONE]\n\n"
-        ctx.finish_events_sent = true
     end
 
     ngx.arg[1] = table.concat(output_parts)
@@ -1022,13 +1142,23 @@ function AIGatewayHandler:access(conf)
             kong.service.request.enable_buffering()
         else
             kong.ctx.plugin.message_started = false
-            kong.ctx.plugin.text_block_open = false
+            kong.ctx.plugin.open_block_type = nil
             kong.ctx.plugin.current_tool_index = nil
+            kong.ctx.plugin.next_block_index = 0
             kong.ctx.plugin.anthropic_block_index = 0
+            kong.ctx.plugin.pending_signature = nil
             kong.ctx.plugin.sse_buffer = ""
             kong.ctx.plugin.input_tokens = 0
             kong.ctx.plugin.output_tokens = 0
+            kong.ctx.plugin.output_chars = 0
+            kong.ctx.plugin.usage_seen = false
             kong.ctx.plugin.finish_events_sent = false
+            kong.ctx.plugin.done_emitted = false
+            -- Streaming never returns usage until the trailing chunk, so the
+            -- message_start input_tokens can only be a best-effort estimate
+            -- (Anthropic emits input_tokens up front; we approximate it here).
+            local est, est_err = ai_shared.calculate_cost(openai_req or {}, {}, 1.0)
+            kong.ctx.plugin.input_tokens_estimate = (not est_err and est) or 0
         end
 
         return


### PR DESCRIPTION
## Summary

Follow-up to #403 (NEUTREE-GENERAL-5). The Anthropic **streaming** converter in the `neutree-ai-gateway` Kong plugin diverged from the real Anthropic SSE contract. This aligns it with the standard output.

Recall the architecture: `/anthropic/v1/messages` is **not** a passthrough to a native Anthropic upstream — the gateway converts the Anthropic request to OpenAI, calls an OpenAI-compatible upstream, then converts the OpenAI SSE stream **back** into Anthropic SSE. Three things were wrong in that back-conversion:

### 1. `message_delta.usage.output_tokens` was always `0`
The terminal `message_delta` / `message_stop` were emitted on the upstream `finish_reason` chunk, but OpenAI `include_usage` sends `usage` in a **separate trailing chunk** that arrives *after* `finish_reason`. So `ctx.output_tokens` was still 0 at emit time. Fix: defer the terminal events to the `[DONE]` / last-frame boundary, after the usage chunk is processed. `message_delta` now also repeats the cumulative usage (`input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`), matching Anthropic.

### 2. Reasoning / thinking content was dropped
The converter only forwarded `delta.content`. Upstreams stream chain-of-thought via `delta.reasoning` (OpenRouter) or `delta.reasoning_content` (vLLM/DeepSeek). It is now mapped to an Anthropic `thinking` content block (+ optional `signature_delta` when the upstream provides a signature). The non-streaming `convert_response` gets the same `thinking` block for consistency.

### 3. `message_start.usage.input_tokens` was hardcoded `0`
Streaming cannot know the real prompt size until the trailing usage chunk, so it is seeded with the access-phase `calculate_cost` estimate as a best-effort value (Anthropic reports `input_tokens` up front).

The streaming emission was reworked from a hardcoded single text block at index 0 into a small block manager (open/close by type) so `thinking` / `text` / `tool_use` blocks get correct sequential indices. `tool_use` behaviour is preserved.

The billing ledger (`api_usage_records`) is **unchanged**: `ctx.input_tokens` / `ctx.output_tokens` still hold raw upstream usage for the log phase.

## Before / after (live, streaming, `openai/gpt-oss-20b:free`)

Before — thinking dropped, `output_tokens: 0`:
```
message_start  usage.input_tokens=0
content_block_start index0 (text)
content_block_delta index0 text_delta "4"
message_delta  usage.output_tokens=0
```

After — aligns with standard:
```
message_start  usage.input_tokens=5
content_block_start index0 (thinking)
content_block_delta index0 thinking_delta "Answer" " " "4" "."
content_block_stop  index0
content_block_start index1 (text)
content_block_delta index1 text_delta "4"
content_block_stop  index1
message_delta  usage{input_tokens=13, output_tokens=15, cache_read_input_tokens=64}
message_stop
data: [DONE]
```

## Verification

Live on the dev gateway (`192.168.24.140`), against two providers and both modes:
- **OpenRouter** `openai/gpt-oss-20b:free` (streaming): thinking blocks relayed; `message_delta` `output_tokens=15`, `input_tokens=13` (= prompt 77 − cache 64), `cache_read_input_tokens=64`.
- **DashScope** `qwen3.7-plus` (streaming + non-streaming): thinking block surfaced; streaming `message_delta` `output_tokens=317` (was 0); non-streaming returns `thinking` + `text` with correct usage.
- `api.api_usage_records` row unchanged (prompt=77 / completion=15 / cache_read=64 / reasoning=3 / message_id) — no billing regression.
- `luajit` parse OK on the dev Kong; no plugin errors in `kong` logs after reload.

Refs: NEU-461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
