### PR TITLE
fix: sync controlplane image list from deploy manifests

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # Neutree pre-commit hook. Activate once with `make install-hooks`.
 # Gates:
-#   1. gofmt                       — format check
-#   2. go vet                      — static analysis
-#   3. architecture boundaries     — import-direction rules (scripts/check-boundaries.sh)
-#   4. migration pairs             — every new *.up.sql ships with *.down.sql (scripts/check-migration-pairs.sh)
-#   5. golangci-lint (incremental) — linter on staged files
-#   6. go test -short              — affected packages only
+#   1. controlplane images list    — auto-sync when deploy image sources change
+#   2. gofmt                       — format check
+#   3. go vet                      — static analysis
+#   4. architecture boundaries     — import-direction rules (scripts/check-boundaries.sh)
+#   5. migration pairs             — every new *.up.sql ships with *.down.sql (scripts/check-migration-pairs.sh)
+#   6. golangci-lint (incremental) — linter on staged files
+#   7. go test -short              — affected packages only
 #
 # Skip with `git commit --no-verify` only in emergencies.
 set -e
@@ -14,8 +15,35 @@ set -e
 ROOT=$(git rev-parse --show-toplevel)
 cd "$ROOT"
 
-# ── Gate 1: gofmt ──
-echo "[1/6] gofmt..."
+# ── Gate 1: controlplane images list ──
+echo "[1/7] controlplane images list..."
+IMAGE_SOURCE_PATTERN='^(deploy/chart/neutree/.*|scripts/builder/sync-controlplane-images\.sh|scripts/builder/image-lists/controlplane/images\.txt|Makefile)$'
+IMAGE_SOURCE_CHANGES=$(git diff --cached --name-only --diff-filter=ACMRD | grep -E "$IMAGE_SOURCE_PATTERN" || true)
+if [ -n "$IMAGE_SOURCE_CHANGES" ]; then
+  UNSTAGED_IMAGE_SOURCE_CHANGES=$(git diff --name-only --diff-filter=ACMRD | grep -E "$IMAGE_SOURCE_PATTERN" || true)
+  if [ -n "$UNSTAGED_IMAGE_SOURCE_CHANGES" ]; then
+    echo "❌ unstaged deploy image source changes:"
+    echo "$UNSTAGED_IMAGE_SOURCE_CHANGES" | sed 's/^/   /'
+    echo "   ✅ FIX: stage or discard these changes before committing so images.txt matches the commit"
+    exit 1
+  fi
+  UNTRACKED_IMAGE_SOURCE_CHANGES=$(git ls-files --others --exclude-standard | grep -E "$IMAGE_SOURCE_PATTERN" || true)
+  if [ -n "$UNTRACKED_IMAGE_SOURCE_CHANGES" ]; then
+    echo "❌ untracked deploy image source files:"
+    echo "$UNTRACKED_IMAGE_SOURCE_CHANGES" | sed 's/^/   /'
+    echo "   ✅ FIX: stage or remove these files before committing so images.txt matches the commit"
+    exit 1
+  fi
+
+  bash scripts/builder/sync-controlplane-images.sh --write
+  git add scripts/builder/image-lists/controlplane/images.txt
+  bash scripts/builder/sync-controlplane-images.sh --check
+else
+  echo "   (skipped: no staged deploy image source changes)"
+fi
+
+# ── Gate 2: gofmt ──
+echo "[2/7] gofmt..."
 FMT=$(gofmt -l . 2>/dev/null | grep -vE '^(vendor|bin|out|tmp|.*/mocks)/' || true)
 if [ -n "$FMT" ]; then
   echo "❌ gofmt violations:"
@@ -24,8 +52,8 @@ if [ -n "$FMT" ]; then
   exit 1
 fi
 
-# ── Gate 2: go vet ──
-echo "[2/6] go vet..."
+# ── Gate 3: go vet ──
+echo "[3/7] go vet..."
 if ! go vet ./... >/tmp/neutree-vet.log 2>&1; then
   echo "❌ go vet failed:"
   sed 's/^/   /' /tmp/neutree-vet.log
@@ -33,16 +61,16 @@ if ! go vet ./... >/tmp/neutree-vet.log 2>&1; then
   exit 1
 fi
 
-# ── Gate 3: architecture boundaries ──
-echo "[3/6] architecture boundaries..."
+# ── Gate 4: architecture boundaries ──
+echo "[4/7] architecture boundaries..."
 bash scripts/check-boundaries.sh
 
-# ── Gate 4: migration pairs ──
-echo "[4/6] migration pairs..."
+# ── Gate 5: migration pairs ──
+echo "[5/7] migration pairs..."
 bash scripts/check-migration-pairs.sh
 
-# ── Gate 5: golangci-lint (incremental) ──
-echo "[5/6] golangci-lint (incremental)..."
+# ── Gate 6: golangci-lint (incremental) ──
+echo "[6/7] golangci-lint (incremental)..."
 CHANGED_GO=$(git diff --cached --name-only --diff-filter=ACMR -- '*.go' | grep -v '/mocks/' || true)
 if [ -n "$CHANGED_GO" ]; then
   if [ -x ./bin/golangci-lint ]; then
@@ -55,8 +83,8 @@ if [ -n "$CHANGED_GO" ]; then
   fi
 fi
 
-# ── Gate 6: go test -short on affected packages ──
-echo "[6/6] go test -short on affected packages..."
+# ── Gate 7: go test -short on affected packages ──
+echo "[7/7] go test -short on affected packages..."
 if [ -n "$CHANGED_GO" ]; then
   PKGS=$(echo "$CHANGED_GO" | xargs -n1 dirname 2>/dev/null | sort -u | grep -vE '(^tests/e2e|/mocks$|^db/dbtest)' | sed 's|^|./|' || true)
   if [ -n "$PKGS" ]; then

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ all: build
 install-hooks: ## Enable .githooks as local git hooks (run once per clone)
 	git config core.hooksPath .githooks
 	chmod +x .githooks/pre-commit
-	chmod +x scripts/check-boundaries.sh scripts/check-migration-pairs.sh
+	chmod +x scripts/check-boundaries.sh scripts/check-migration-pairs.sh scripts/builder/sync-controlplane-images.sh
 	@echo "Git hooks installed. Pre-commit will run on every 'git commit'."
 
 build: test build-neutree-core build-neutree-cli build-neutree-api
@@ -369,9 +369,8 @@ build-engine-manifest: ## Build engine manifest only (no Docker image export, co
 
 .PHONY: sync-images-list
 sync-images-list: ## Sync images list for building package
-	helm template neutree ./deploy/chart/neutree \
-	  --set api.image.tag=latest \
-	  --set core.image.tag=latest \
-	  --set dbScripts.image.tag=latest | \
-	  grep -Eoh 'image:\s*["]?[a-zA-Z0-9./_-]+:[a-zA-Z0-9._-]+["]?' | \
-	  awk '{print $$2}' | tr -d '"' | sort -u > scripts/builder/image-lists/controlplane/images.txt
+	bash scripts/builder/sync-controlplane-images.sh --write
+
+.PHONY: check-images-list
+check-images-list: ## Check controlplane images list is up to date
+	bash scripts/builder/sync-controlplane-images.sh --check

--- a/scripts/builder/image-lists/controlplane/images.txt
+++ b/scripts/builder/image-lists/controlplane/images.txt
@@ -1,8 +1,8 @@
-neutree/jwt-cli:6.2.0
-grafana/grafana:11.5.3
 ghcr.io/groundnuty/k8s-wait-for:v2.0
+grafana/grafana:11.5.3
 kong/kong:3.9
 migrate/migrate:v4.18.3
+neutree/jwt-cli:6.2.0
 neutree/neutree-api:latest
 neutree/neutree-core:latest
 neutree/neutree-db-scripts:latest
@@ -11,6 +11,7 @@ postgrest/postgrest:v14.0
 supabase/gotrue:v2.170.0
 supabase/postgres-meta:v0.86.0
 timberio/vector:0.47.0-debian
+victoriametrics/victoria-logs:v1.50.0
 victoriametrics/vmagent:v1.115.0
 victoriametrics/vminsert:v1.115.0-cluster
 victoriametrics/vmselect:v1.115.0-cluster

--- a/scripts/builder/sync-controlplane-images.sh
+++ b/scripts/builder/sync-controlplane-images.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Sync or verify the control-plane offline image list from the Helm chart.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/builder/sync-controlplane-images.sh [--write|--check|--stdout]
+
+  --write   update scripts/builder/image-lists/controlplane/images.txt (default)
+  --check   fail if the checked-in image list is stale
+  --stdout  print the generated list
+EOF
+}
+
+mode="write"
+case "${1:---write}" in
+    --write)
+        mode="write"
+        ;;
+    --check)
+        mode="check"
+        ;;
+    --stdout)
+        mode="stdout"
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    *)
+        usage >&2
+        exit 2
+        ;;
+esac
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+OUTPUT="scripts/builder/image-lists/controlplane/images.txt"
+
+require_command() {
+    local command_name="$1"
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        echo "ERROR: required command not found: $command_name" >&2
+        exit 1
+    fi
+}
+
+normalize_image() {
+    local image="$1"
+    image="${image#docker.io/}"
+    image="${image#library/}"
+    printf '%s\n' "$image"
+}
+
+extract_images() {
+    awk '
+        /^[[:space:]]*image:[[:space:]]*/ {
+            line = $0
+            sub(/^[[:space:]]*image:[[:space:]]*/, "", line)
+            sub(/[[:space:]]+#.*$/, "", line)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+            gsub(/^["'\'']|["'\'']$/, "", line)
+            if (line != "") {
+                print line
+            }
+        }
+    '
+}
+
+collect_helm_images() {
+    require_command helm
+    helm template neutree ./deploy/chart/neutree \
+        --set jwtSecret=offline-image-list-placeholder \
+        --set api.image.tag=latest \
+        --set core.image.tag=latest \
+        --set dbScripts.image.tag=latest \
+        | extract_images
+}
+
+generate_images() {
+    collect_helm_images | while IFS= read -r image; do
+        if [[ "$image" == *"{{"* || "$image" == *"}}"* ]]; then
+            echo "ERROR: unresolved image template placeholder: $image" >&2
+            exit 1
+        fi
+        normalize_image "$image"
+    done | sort -u
+}
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+generate_images > "$tmp"
+
+case "$mode" in
+    write)
+        cp "$tmp" "$OUTPUT"
+        ;;
+    check)
+        if ! diff -u "$OUTPUT" "$tmp"; then
+            echo "ERROR: $OUTPUT is stale." >&2
+            echo "FIX: run 'make sync-images-list' and stage the result." >&2
+            exit 1
+        fi
+        ;;
+    stdout)
+        cat "$tmp"
+        ;;
+esac


### PR DESCRIPTION
## Issue

NEU-464

## Summary

Keep the control-plane offline image list in sync with the Helm chart so chart image changes are packaged automatically. This also adds the missing VictoriaLogs image required by the default AI trace store deployment.

## Changes

- Add `scripts/builder/sync-controlplane-images.sh` to generate or check `scripts/builder/image-lists/controlplane/images.txt` from Helm chart rendering.
- Render the Helm chart with a dummy `jwtSecret` so image-list sync works without requiring a real secret.
- Normalize Docker Hub aliases from Helm render output to the existing image-list format.
- Route `make sync-images-list` through the script and add `make check-images-list`.
- Add a pre-commit gate that auto-syncs and stages the control-plane image list when Helm chart, Makefile, or image-list sync files are staged.
- Fail pre-commit when deploy image source files have unstaged changes, so auto-generated `images.txt` cannot mix staged and unstaged source state.
- Add `victoriametrics/victoria-logs:v1.50.0` to the control-plane offline image list.

## Test Plan

Unit test:
- [x] `bash scripts/builder/sync-controlplane-images.sh --check` failed before syncing because the list was stale and missing `victoriametrics/victoria-logs:v1.50.0`.
- [x] `make sync-images-list && bash scripts/builder/sync-controlplane-images.sh --check`
- [x] `bash -n scripts/builder/sync-controlplane-images.sh && bash -n .githooks/pre-commit`
- [x] `make check-images-list`
- [x] `git diff --check` and `git diff --cached --check`
- [x] Pre-commit sync gate restored and staged `victoriametrics/victoria-logs:v1.50.0` after the staged image list was made stale intentionally.
- [x] Copilot comment on the Helm chart trigger pattern was addressed by matching `deploy/chart/neutree/.*`.
- [x] Pre-commit image-list gate failed fast when a watched Helm chart file had unstaged changes.
- [x] Pre-commit image-list gate failed fast when a watched Helm chart file had an untracked file in the working tree.
- [ ] Full `.githooks/pre-commit` did not complete: after the new image-list gate passed, the existing global gofmt gate failed on unrelated `internal/routes/logs/ai_trace_test.go`.
- [ ] Full `go test ./...` did not run successfully: baseline fails before tests because `cmd/neutree-cli/app/cmd/launch/manifests/core.go` expects generated `neutree-core.tar`.

DB test:
- [x] Not affected; no DB schema or storage changes.

E2E test:
- [x] Not affected; Trivial build/tooling-only change. Manual testing is not required.

## Risk & Rollback

Risk is limited to developer/release tooling. If sync logic behaves unexpectedly, rollback by reverting this PR; the offline image list remains a plain text file and package generation continues to consume it as before.

Change level: Trivial. This touches build/developer tooling and deploy image-list metadata only, so docs MR, TestRail, and E2E validation were skipped.