### PR TITLE
docs: document control-plane deployment component checklist

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -14,7 +14,7 @@ This enables the pre-commit gate (`gofmt` / `go vet` / architecture boundaries /
 
 ## Playbooks
 
-Step-by-step checklists for the two highest-cost additions:
+Step-by-step checklists for common high-impact additions:
 
 | Goal | Entry point | Checklist |
 |------|-------------|-----------|
@@ -33,7 +33,7 @@ Required checklist:
 1. Add the component to the relevant Compose stack under `deploy/docker/` (`neutree-core` or `obs-stack`), including image, environment, volumes, ports, dependencies, and config files.
 2. Add the same component to `deploy/chart/neutree/`, including default values, templates, config, volumes, ports, and service account/RBAC resources if needed.
 3. Add every new runtime image to `scripts/builder/image-lists/controlplane/images.txt` so offline control-plane packages include it.
-4. Render the Helm chart and review the Compose template before committing.
+4. Render the Helm chart and review the Compose files before committing.
 
 If the component differs between Compose and Helm, document the reason in the PR description and make sure the offline image list still covers the images required by the Helm chart.
 

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -20,8 +20,22 @@ Step-by-step checklists for the two highest-cost additions:
 |------|-------------|-----------|
 | Add a new version to an existing engine | `internal/engine/<name>/<version>/` + `cluster-image-builder/serve/<name>/<version>/` | 9 steps + verify — [`playbooks.md#adding-a-new-version-to-an-existing-engine`](playbooks.md#adding-a-new-version-to-an-existing-engine) |
 | Add a new resource type | `api/v1/` → `db/migrations/` → `controllers/` → `internal/routes/proxies/` | 12 steps + verify — [`playbooks.md#adding-a-new-resource-type`](playbooks.md#adding-a-new-resource-type) |
+| Add a control-plane deployment component | `deploy/docker/` + `deploy/chart/neutree/` + `scripts/builder/image-lists/controlplane/images.txt` | Dual deployment checklist — [Adding Control-plane Deployment Components](#adding-control-plane-deployment-components) |
 
 For everything else, open the relevant file under [Files in this Directory](#files-in-this-directory).
+
+## Adding Control-plane Deployment Components
+
+Neutree supports both Docker Compose and Helm chart deployments for the control plane. When adding a control-plane component, keep both deployment surfaces in sync unless the component is intentionally limited to one mode.
+
+Required checklist:
+
+1. Add the component to the relevant Compose stack under `deploy/docker/` (`neutree-core` or `obs-stack`), including image, environment, volumes, ports, dependencies, and config files.
+2. Add the same component to `deploy/chart/neutree/`, including default values, templates, config, volumes, ports, and service account/RBAC resources if needed.
+3. Add every new runtime image to `scripts/builder/image-lists/controlplane/images.txt` so offline control-plane packages include it.
+4. Render the Helm chart and review the Compose template before committing.
+
+If the component differs between Compose and Helm, document the reason in the PR description and make sure the offline image list still covers the images required by the Helm chart.
 
 ## Files in this Directory
 
@@ -35,4 +49,3 @@ For everything else, open the relevant file under [Files in this Directory](#fil
 | [`coding-standards.md`](coding-standards.md) | golangci-lint rules, import organization, commit convention, lint fix cheatsheet |
 | [`database.md`](database.md) | PostgREST + RLS model, migration rules (incl. pairing), auth token layers, common errors |
 | [`playbooks.md`](playbooks.md) | Step-by-step checklists — new engine version, new resource type |
-


### PR DESCRIPTION
## Issue

n/a

## Summary

Document the contribution checklist for adding a new control-plane deployment component. Neutree supports both Docker Compose and Helm chart deployments, so new components need to be added to both surfaces and included in the control-plane offline image list.

## Changes

- Add a playbook entry for control-plane deployment components in `contributing/README.md`.
- Add a dedicated checklist covering Docker Compose, Helm chart templates/values, and `scripts/builder/image-lists/controlplane/images.txt`.
- Call out that Compose/Helm differences should be documented in the PR while keeping the offline image list aligned with Helm chart images.

## Test Plan

Unit test:
- [x] `rg -n "Add a control-plane deployment component|Adding Control-plane Deployment Components|image-lists/controlplane/images.txt" contributing/README.md`
- [x] `helm template neutree ./deploy/chart/neutree --set jwtSecret=placeholder >/tmp/neutree-chart-docs-pr.yaml`
- [x] `git diff --check`
- [ ] Full `.githooks/pre-commit` did not complete: existing global gofmt gate fails on unrelated `internal/routes/logs/ai_trace_test.go`.

DB test:
- [x] Not affected; documentation-only change.

E2E test:
- [x] Not affected; documentation-only change. Manual testing is not required.

## Risk & Rollback

Risk is limited to contributor documentation. Roll back by reverting this PR.