### PR TITLE
fix: run full lint in pre-commit hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,7 +6,7 @@
 #   3. go vet                      — static analysis
 #   4. architecture boundaries     — import-direction rules (scripts/check-boundaries.sh)
 #   5. migration pairs             — every new *.up.sql ships with *.down.sql (scripts/check-migration-pairs.sh)
-#   6. golangci-lint (incremental) — linter on staged files
+#   6. golangci-lint (full)        — CI-equivalent lint for non-test/non-mock files
 #   7. go test -short              — affected packages only
 #
 # Skip with `git commit --no-verify` only in emergencies.
@@ -69,24 +69,40 @@ bash scripts/check-boundaries.sh
 echo "[5/7] migration pairs..."
 bash scripts/check-migration-pairs.sh
 
-# ── Gate 6: golangci-lint (incremental) ──
-echo "[6/7] golangci-lint (incremental)..."
-CHANGED_GO=$(git diff --cached --name-only --diff-filter=ACMR -- '*.go' | grep -v '/mocks/' || true)
-if [ -n "$CHANGED_GO" ]; then
-  if [ -x ./bin/golangci-lint ]; then
-    if ! ./bin/golangci-lint run --new-from-rev=HEAD --timeout=120s; then
-      echo "   ✅ FIX: see contributing/coding-standards.md#lint-error-cheatsheet"
-      exit 1
-    fi
-  else
-    echo "   (skipped: ./bin/golangci-lint not present — run 'make lint' once to install it)"
+# ── Gate 6: golangci-lint (full) ──
+echo "[6/7] golangci-lint (full)..."
+CHANGED_GO=$(git diff --cached --name-only --diff-filter=ACMR -- '*.go' || true)
+CHANGED_LINT_GO=$(echo "$CHANGED_GO" | grep -Ev '(^|/)mock_[^/]*\.go$|_test\.go$' | grep -v '/mocks/' || true)
+if [ -n "$CHANGED_LINT_GO" ]; then
+  if [ ! -x ./bin/golangci-lint ]; then
+    echo "   installing ./bin/golangci-lint..."
+    make golangci-lint
+  fi
+
+  if ! ./bin/golangci-lint run; then
+    echo "   ✅ FIX: see contributing/coding-standards.md#lint-error-cheatsheet"
+    exit 1
   fi
 fi
 
 # ── Gate 7: go test -short on affected packages ──
 echo "[7/7] go test -short on affected packages..."
 if [ -n "$CHANGED_GO" ]; then
-  PKGS=$(echo "$CHANGED_GO" | xargs -n1 dirname 2>/dev/null | sort -u | grep -vE '(^tests/e2e|/mocks$|^db/dbtest)' | sed 's|^|./|' || true)
+  PKGS=$(echo "$CHANGED_GO" | while IFS= read -r file; do
+    [ -z "$file" ] && continue
+
+    dir=$(dirname "$file")
+    if [[ "$dir" == tests/e2e* || "$dir" == db/dbtest* ]]; then
+      continue
+    fi
+    if [[ "$dir" == "mocks" ]]; then
+      dir="."
+    elif [[ "$dir" == */mocks ]]; then
+      dir="${dir%/mocks}"
+    fi
+
+    echo "./$dir"
+  done | sort -u || true)
   if [ -n "$PKGS" ]; then
     # shellcheck disable=SC2086
     if ! go test -short -count=1 $PKGS; then

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,12 @@ help: ## Display this help.
 all: build
 
 .PHONY: install-hooks
-install-hooks: ## Enable .githooks as local git hooks (run once per clone)
-	git config core.hooksPath .githooks
+install-hooks: ## Enable .githooks as local git hooks (run once per worktree)
+	git config extensions.worktreeConfig true
+	git config --worktree core.hooksPath "$(PROJECT_DIR)/.githooks"
 	chmod +x .githooks/pre-commit
 	chmod +x scripts/check-boundaries.sh scripts/check-migration-pairs.sh scripts/builder/sync-controlplane-images.sh
-	@echo "Git hooks installed. Pre-commit will run on every 'git commit'."
+	@echo "Git hooks installed for this worktree. Pre-commit will run on every 'git commit'."
 
 build: test build-neutree-core build-neutree-cli build-neutree-api
 

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -10,7 +10,7 @@ After cloning the repo, install the local git hooks:
 make install-hooks
 ```
 
-This enables the pre-commit gate (`gofmt` / `go vet` / architecture boundaries / migration-pair check / incremental lint / short tests on affected packages).
+This enables the pre-commit gate (`gofmt` / `go vet` / architecture boundaries / migration-pair check / full lint / short tests on affected packages).
 
 ## Playbooks
 
@@ -35,4 +35,3 @@ For everything else, open the relevant file under [Files in this Directory](#fil
 | [`coding-standards.md`](coding-standards.md) | golangci-lint rules, import organization, commit convention, lint fix cheatsheet |
 | [`database.md`](database.md) | PostgREST + RLS model, migration rules (incl. pairing), auth token layers, common errors |
 | [`playbooks.md`](playbooks.md) | Step-by-step checklists — new engine version, new resource type |
-

--- a/internal/routes/logs/ai_trace_test.go
+++ b/internal/routes/logs/ai_trace_test.go
@@ -128,11 +128,11 @@ func TestStatsWindow_MalformedEndRejected(t *testing.T) {
 
 func TestLogsQLQuoteValue(t *testing.T) {
 	cases := map[string]string{
-		"":                 `""`,
-		"plain":            `"plain"`,
-		`with"quote`:       `"with\"quote"`,
-		`back\slash`:       `"back\\slash"`,
-		"line\nbreak":      `"line\nbreak"`,
+		"":                   `""`,
+		"plain":              `"plain"`,
+		`with"quote`:         `"with\"quote"`,
+		`back\slash`:         `"back\\slash"`,
+		"line\nbreak":        `"line\nbreak"`,
 		`a"b\c` + "\n" + "d": `"a\"b\\c\nd"`,
 	}
 	for in, want := range cases {


### PR DESCRIPTION
## Issue

n/a

## Summary

This PR makes the local pre-commit hook catch the same full golangci-lint failures that CI reports, while avoiding unnecessary lint runs for staged test-only or mock-only Go changes. It also installs hooks through worktree-local config so linked worktrees use their own `.githooks` directory instead of inheriting the main checkout's `.git/hooks` path.

## Changes

- Install `core.hooksPath` through worktree config with an absolute `.githooks` path for the current worktree.
- Change pre-commit lint gate from incremental `golangci-lint run --new-from-rev=HEAD` to full `golangci-lint run`.
- Exclude `_test.go`, `mock_*.go`, and `/mocks/` changes from triggering the full lint gate, matching the repository lint exclusions.
- Keep test-only and mock-only Go changes covered by the affected-package `go test -short` gate; mock directories map to their parent package.
- Update contributor docs from incremental lint to full lint.
- Apply mechanical `gofmt` cleanup to an existing test file so the hook can pass on current main.

## Test Plan

- [x] Unit test
  - Pre-commit smoke test: staged `_test.go` change skipped golangci-lint and ran `go test -short` for `internal/routes/logs`.
  - Pre-commit smoke test: staged `/mocks/mock_*.go` change skipped golangci-lint and ran parent package tests for `internal/accelerator`.
  - Pre-commit smoke test: staged non-test Go change invoked golangci-lint with `run` and ran `go test -short` for `internal/semver`.
  - `bash -n .githooks/pre-commit`
  - `./bin/golangci-lint run`
  - `go test ./internal/routes/logs ./internal/semver ./internal/accelerator`
  - `make install-hooks && git config --get core.hooksPath`
- [x] DB test
  - Not affected: this changes Git hook/tooling behavior only and does not touch DB schema or storage code.
- [x] E2E test
  - Not affected: this changes local Git hook/tooling behavior only and does not affect deployed system behavior.

## Risk & Rollback

Risk is limited to local developer workflow. The full lint gate can make commits slower when non-test Go files are staged, but it matches CI behavior and avoids the previous false sense of safety from incremental lint. Roll back by reverting this PR to restore the prior incremental hook behavior and shared hooksPath install.