### PR TITLE
feat(usage): workspace-scoped usage-read permission for usage analytics

### DIFF
--- a/db/dbtest/usage_by_dimension_permission_test.go
+++ b/db/dbtest/usage_by_dimension_permission_test.go
@@ -1,0 +1,97 @@
+package dbtest
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestGetUsageByDimensionPermissionScope verifies that api.get_usage_by_dimension
+// returns own keys PLUS every key in any workspace where the caller holds
+// workspace:usage-read. In the community edition has_permission ignores the
+// workspace argument and degrades to a global check, so the permission is
+// exercised here via a global role assignment.
+func TestGetUsageByDimensionPermissionScope(t *testing.T) {
+	db := GetTestDB(t)
+	ctx := context.Background()
+
+	const workspace = "usage-scope-ws"
+
+	// owner: creates an API key in the workspace and accrues usage on it.
+	owner := CreateTestUser(t, "usage-owner", "usage-owner@example.com", "password123")
+
+	var ownerKeyID string
+	err := execWithContext(t, db, []SetContextFunc{setUserContext(owner.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT id FROM api.create_api_key(
+				p_workspace := $1,
+				p_name := 'owner-key',
+				p_quota := 1000
+			)
+		`, workspace).Scan(&ownerKeyID)
+	})
+	if err != nil {
+		t.Fatalf("failed to create owner API key: %v", err)
+	}
+
+	// Seed one daily-usage row for the owner's key (old-data path: only
+	// dimensional_usage populated), so the RPC has a row to surface.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO api.api_daily_usage (api_version, kind, metadata, spec, status)
+		VALUES (
+			'v1', 'ApiDailyUsage',
+			ROW('usage-scope-daily', NULL, $2, NULL, now(), now(), '{}'::json, '{}'::json)::api.metadata,
+			ROW($1::uuid, CURRENT_DATE, 100, '{"endpoint-x": 100}'::jsonb, NULL::jsonb)::api.api_daily_usage_spec,
+			ROW(now())::api.api_daily_usage_status
+		)
+	`, ownerKeyID, workspace)
+	if err != nil {
+		t.Fatalf("failed to insert daily usage: %v", err)
+	}
+
+	// countOwnerRows returns how many get_usage_by_dimension rows for the
+	// owner's key are visible to the given caller.
+	countOwnerRows := func(t *testing.T, userID string) int {
+		t.Helper()
+		var n int
+		qErr := execWithContext(t, db, []SetContextFunc{setUserContext(userID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx, `
+				SELECT count(*) FROM api.get_usage_by_dimension(
+					CURRENT_DATE - 1, CURRENT_DATE + 1, NULL, NULL, NULL
+				) WHERE api_key_id = $1
+			`, ownerKeyID).Scan(&n)
+		})
+		if qErr != nil {
+			t.Fatalf("failed to call get_usage_by_dimension: %v", qErr)
+		}
+		return n
+	}
+
+	t.Run("user without usage-read cannot see other users' key usage", func(t *testing.T) {
+		var outsiderID string
+		if cErr := execWithContext(t, db, nil, func(tx *sql.Tx) error {
+			outsiderID = createUserWithPermissions(t, tx, "usage-outsider", "usage-outsider@example.com", []string{"workspace:read"})
+			return nil
+		}); cErr != nil {
+			t.Fatalf("failed to create outsider user: %v", cErr)
+		}
+
+		if n := countOwnerRows(t, outsiderID); n != 0 {
+			t.Errorf("expected 0 rows for user without workspace:usage-read, got %d", n)
+		}
+	})
+
+	t.Run("user with usage-read sees other users' key usage", func(t *testing.T) {
+		var readerID string
+		if cErr := execWithContext(t, db, nil, func(tx *sql.Tx) error {
+			readerID = createUserWithPermissions(t, tx, "usage-reader", "usage-reader@example.com", []string{"workspace:usage-read"})
+			return nil
+		}); cErr != nil {
+			t.Fatalf("failed to create reader user: %v", cErr)
+		}
+
+		if n := countOwnerRows(t, readerID); n < 1 {
+			t.Errorf("expected >=1 row for user with workspace:usage-read, got %d", n)
+		}
+	})
+}

--- a/db/migrations/064_usage_read_permission.down.sql
+++ b/db/migrations/064_usage_read_permission.down.sql
@@ -1,0 +1,2 @@
+-- PostgreSQL does not support removing enum values.
+-- The workspace:usage-read value will remain.

--- a/db/migrations/064_usage_read_permission.up.sql
+++ b/db/migrations/064_usage_read_permission.up.sql
@@ -1,0 +1,8 @@
+-- Workspace-scoped usage-read permission for the model-usage analytics RPC
+-- (api.get_usage_by_dimension). The enterprise edition's has_permission
+-- override makes this workspace-scoped, so a member granted it in a given
+-- workspace can read every API key's usage in that workspace; in community it
+-- degrades to a global check (community has no per-workspace usage control).
+-- Granting happens in 065, since a newly added enum value cannot be referenced
+-- in the same transaction that adds it.
+ALTER TYPE api.permission_action ADD VALUE IF NOT EXISTS 'workspace:usage-read';

--- a/db/migrations/065_grant_usage_read_permission.down.sql
+++ b/db/migrations/065_grant_usage_read_permission.down.sql
@@ -1,0 +1,4 @@
+-- No-op. admin retains workspace:usage-read because enum values cannot be
+-- removed and update_admin_permissions() always re-aggregates the full enum.
+-- workspace-user was never granted this permission, so there is nothing to
+-- revert here.

--- a/db/migrations/065_grant_usage_read_permission.up.sql
+++ b/db/migrations/065_grant_usage_read_permission.up.sql
@@ -1,0 +1,13 @@
+-- Grant the workspace:usage-read permission (added in 064) to the built-in
+-- roles. Separate migration because newly added enum values cannot be
+-- referenced in the same transaction that adds them.
+
+-- admin: refresh to every permission in the enum (picks up workspace:usage-read
+-- automatically). Admin can therefore read usage across all workspaces.
+SELECT api.update_admin_permissions();
+
+-- workspace-user: intentionally NOT granted by default. Unlike the trace
+-- permissions, usage-read is not part of the baseline workspace-user role; it is
+-- granted on demand per workspace (in EE, via a workspace-scoped role
+-- assignment carrying this permission). Leaving update_workspace_user_permissions
+-- untouched keeps the default workspace-user set unchanged.

--- a/db/migrations/066_usage_by_dimension_permission_scope.down.sql
+++ b/db/migrations/066_usage_by_dimension_permission_scope.down.sql
@@ -1,0 +1,105 @@
+-- Restore the own-keys-only api.get_usage_by_dimension as left by migration
+-- 063 (daily-usage workspace sourcing, no permission widening): usage
+-- analytics revert to strictly per-user, ignoring workspace:usage-read.
+DROP FUNCTION IF EXISTS api.get_usage_by_dimension;
+CREATE FUNCTION api.get_usage_by_dimension(
+    p_start_date DATE,
+    p_end_date DATE,
+    p_api_key_id UUID DEFAULT NULL,
+    p_endpoint_name TEXT DEFAULT NULL,
+    p_workspace TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    date DATE,
+    api_key_id UUID,
+    api_key_name TEXT,
+    endpoint_type TEXT,
+    endpoint_name TEXT,
+    model_name TEXT,
+    workspace TEXT,
+    usage BIGINT,
+    prompt_tokens BIGINT,
+    completion_tokens BIGINT
+)
+SECURITY DEFINER
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH user_api_keys AS (
+        SELECT
+            ak.id,
+            (ak.metadata).name AS key_name,
+            (ak.metadata).workspace AS key_workspace
+        FROM api.api_keys ak
+        WHERE ak.user_id = auth.uid()
+        AND (p_api_key_id IS NULL OR ak.id = p_api_key_id)
+    ),
+    -- Old data: records without detailed_dimensional_usage
+    old_dimension_data AS (
+        SELECT
+            (u.spec).usage_date,
+            (u.spec).api_key_id,
+            k.key_name,
+            NULL::text AS endpoint_type,
+            kv.key AS endpoint_name,
+            NULL::text AS model_name,
+            COALESCE((u.metadata).workspace, k.key_workspace, 'unknown') AS workspace,
+            (kv.value)::bigint AS dimension_usage,
+            NULL::bigint AS p_tokens,
+            NULL::bigint AS c_tokens
+        FROM
+            api.api_daily_usage u
+            JOIN user_api_keys k ON (u.spec).api_key_id = k.id,
+            jsonb_each((u.spec).dimensional_usage) kv
+        WHERE
+            (u.spec).usage_date BETWEEN p_start_date AND p_end_date
+            AND (u.spec).detailed_dimensional_usage IS NULL
+    ),
+    -- New data: records with detailed_dimensional_usage
+    new_dimension_data AS (
+        SELECT
+            (u.spec).usage_date,
+            (u.spec).api_key_id,
+            k.key_name,
+            split_part(kv.key, '|', 1) AS endpoint_type,
+            split_part(kv.key, '|', 2) AS endpoint_name,
+            NULLIF(split_part(kv.key, '|', 3), '') AS model_name,
+            COALESCE((u.metadata).workspace, k.key_workspace, 'unknown') AS workspace,
+            (kv.value->>'total')::bigint AS dimension_usage,
+            (kv.value->>'prompt')::bigint AS p_tokens,
+            (kv.value->>'completion')::bigint AS c_tokens
+        FROM
+            api.api_daily_usage u
+            JOIN user_api_keys k ON (u.spec).api_key_id = k.id,
+            jsonb_each((u.spec).detailed_dimensional_usage) kv
+        WHERE
+            (u.spec).usage_date BETWEEN p_start_date AND p_end_date
+            AND (u.spec).detailed_dimensional_usage IS NOT NULL
+    ),
+    dimension_data AS (
+        SELECT * FROM old_dimension_data
+        UNION ALL
+        SELECT * FROM new_dimension_data
+    )
+    SELECT
+        d.usage_date,
+        d.api_key_id,
+        d.key_name,
+        d.endpoint_type,
+        d.endpoint_name,
+        d.model_name,
+        d.workspace,
+        d.dimension_usage,
+        d.p_tokens,
+        d.c_tokens
+    FROM
+        dimension_data d
+    WHERE
+        (p_endpoint_name IS NULL OR d.endpoint_name = p_endpoint_name) AND
+        (p_workspace IS NULL OR d.workspace = p_workspace)
+    ORDER BY
+        d.usage_date DESC,
+        d.api_key_id,
+        d.endpoint_name;
+END;
+$$ LANGUAGE plpgsql;

--- a/db/migrations/066_usage_by_dimension_permission_scope.up.sql
+++ b/db/migrations/066_usage_by_dimension_permission_scope.up.sql
@@ -1,0 +1,126 @@
+-- Widen api.get_usage_by_dimension from own-keys-only to
+-- own-keys ∪ permission-scoped.
+--
+-- The function (last rewritten in 063 to source each usage row's workspace from
+-- the daily-usage row instead of joining endpoints) hard-filtered to the
+-- caller's own API keys (WHERE ak.user_id = auth.uid()), so usage analytics were
+-- strictly per-user. It now also admits every API key in any workspace where the
+-- caller holds workspace:usage-read (added in 064, granted to admin in 065). In
+-- the enterprise edition has_permission is workspace-scoped, so this resolves to
+-- exactly the workspaces where the caller was granted the permission; in the
+-- community edition has_permission ignores the workspace argument and degrades
+-- to a global check (community has no per-workspace usage control).
+--
+-- Only the user_api_keys CTE's WHERE clause changes relative to migration 063;
+-- the daily-usage workspace sourcing introduced there is preserved verbatim.
+-- api_keys resource visibility (RLS) is deliberately left untouched: this RPC
+-- widens aggregate usage visibility only, not access to the key rows or their
+-- plaintext secrets.
+DROP FUNCTION IF EXISTS api.get_usage_by_dimension;
+CREATE FUNCTION api.get_usage_by_dimension(
+    p_start_date DATE,
+    p_end_date DATE,
+    p_api_key_id UUID DEFAULT NULL,
+    p_endpoint_name TEXT DEFAULT NULL,
+    p_workspace TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    date DATE,
+    api_key_id UUID,
+    api_key_name TEXT,
+    endpoint_type TEXT,
+    endpoint_name TEXT,
+    model_name TEXT,
+    workspace TEXT,
+    usage BIGINT,
+    prompt_tokens BIGINT,
+    completion_tokens BIGINT
+)
+SECURITY DEFINER
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH user_api_keys AS (
+        SELECT
+            ak.id,
+            (ak.metadata).name AS key_name,
+            (ak.metadata).workspace AS key_workspace
+        FROM api.api_keys ak
+        WHERE (
+            -- own keys: always visible to their creator
+            ak.user_id = auth.uid()
+            -- plus every key in any workspace where the caller holds
+            -- workspace:usage-read (workspace-scoped in EE, global in CE)
+            OR api.has_permission(auth.uid(), 'workspace:usage-read', (ak.metadata).workspace)
+        )
+        AND (p_api_key_id IS NULL OR ak.id = p_api_key_id)
+    ),
+    -- Old data: records without detailed_dimensional_usage
+    old_dimension_data AS (
+        SELECT
+            (u.spec).usage_date,
+            (u.spec).api_key_id,
+            k.key_name,
+            NULL::text AS endpoint_type,
+            kv.key AS endpoint_name,
+            NULL::text AS model_name,
+            COALESCE((u.metadata).workspace, k.key_workspace, 'unknown') AS workspace,
+            (kv.value)::bigint AS dimension_usage,
+            NULL::bigint AS p_tokens,
+            NULL::bigint AS c_tokens
+        FROM
+            api.api_daily_usage u
+            JOIN user_api_keys k ON (u.spec).api_key_id = k.id,
+            jsonb_each((u.spec).dimensional_usage) kv
+        WHERE
+            (u.spec).usage_date BETWEEN p_start_date AND p_end_date
+            AND (u.spec).detailed_dimensional_usage IS NULL
+    ),
+    -- New data: records with detailed_dimensional_usage
+    new_dimension_data AS (
+        SELECT
+            (u.spec).usage_date,
+            (u.spec).api_key_id,
+            k.key_name,
+            split_part(kv.key, '|', 1) AS endpoint_type,
+            split_part(kv.key, '|', 2) AS endpoint_name,
+            NULLIF(split_part(kv.key, '|', 3), '') AS model_name,
+            COALESCE((u.metadata).workspace, k.key_workspace, 'unknown') AS workspace,
+            (kv.value->>'total')::bigint AS dimension_usage,
+            (kv.value->>'prompt')::bigint AS p_tokens,
+            (kv.value->>'completion')::bigint AS c_tokens
+        FROM
+            api.api_daily_usage u
+            JOIN user_api_keys k ON (u.spec).api_key_id = k.id,
+            jsonb_each((u.spec).detailed_dimensional_usage) kv
+        WHERE
+            (u.spec).usage_date BETWEEN p_start_date AND p_end_date
+            AND (u.spec).detailed_dimensional_usage IS NOT NULL
+    ),
+    dimension_data AS (
+        SELECT * FROM old_dimension_data
+        UNION ALL
+        SELECT * FROM new_dimension_data
+    )
+    SELECT
+        d.usage_date,
+        d.api_key_id,
+        d.key_name,
+        d.endpoint_type,
+        d.endpoint_name,
+        d.model_name,
+        d.workspace,
+        d.dimension_usage,
+        d.p_tokens,
+        d.c_tokens
+    FROM
+        dimension_data d
+    WHERE
+        (p_endpoint_name IS NULL OR d.endpoint_name = p_endpoint_name) AND
+        (p_workspace IS NULL OR d.workspace = p_workspace)
+    ORDER BY
+        d.usage_date DESC,
+        d.api_key_id,
+        d.endpoint_name;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Implements the `workspace:usage-read` permission and widens the model-usage analytics RPC so a permitted user can read usage across a workspace, not just their own API keys. Aligns the implementation with the updated Model Usage design.

Closes NEUTREE-MODEL-USAGE-5.

## Changes (DB migrations)

- **063 `usage_read_permission`** — add `workspace:usage-read` to the `api.permission_action` enum. Standalone migration, because a newly added enum value cannot be referenced in the same transaction that adds it (mirrors the trace `060` migration).
- **064 `grant_usage_read_permission`** — grant it to `admin` via `update_admin_permissions()` (auto-picks up every enum value). `workspace-user` is **intentionally not** granted by default; it is meant to be granted on demand per workspace (in EE, via a workspace-scoped role assignment).
- **065 `usage_by_dimension_permission_scope`** — redefine `api.get_usage_by_dimension`. The `user_api_keys` CTE changes from own-only (`WHERE ak.user_id = auth.uid()`) to **own keys ∪ every key in any workspace where the caller holds `workspace:usage-read`** (`OR api.has_permission(auth.uid(), 'workspace:usage-read', (ak.metadata).workspace)`). The rest of the function body is unchanged from `054`.

Plus a `dbtest` regression test covering own-only vs. permission-scoped visibility.

## Edition behavior

- **EE**: `has_permission` (enterprise `002`/`003`) is action-generic and workspace-scoped, so the new permission is workspace-scoped automatically — a member granted it in workspace A sees A's keys, not B's. No EE code change required; EE picks up the enum + RPC when its community dependency is bumped.
- **CE**: `has_permission` ignores the workspace argument and degrades to a global check (community has no per-workspace usage control).

## Deliberately unchanged

- **`api_keys` visibility (RLS)**: still creator-only. This PR widens **aggregate usage** visibility only — not access to key rows or their plaintext secrets. Admins still cannot see others' keys.
- **UI**: no change. The page already calls the RPC by workspace + time window; a permitted user simply receives more rows.

## Verification

Validated against a real PostgreSQL 15 with all 65 migrations applied (Supabase `auth` deps stubbed):

- All migrations apply cleanly; the enum-add → grant → RPC ordering works with no "unsafe use of new value" error.
- After the seed's `update_*_permissions()`: `admin` has `workspace:usage-read`, `workspace-user` does not.
- **CE RPC**: owner sees own key (1 row); a user without the permission sees 0 rows for another user's key; with a global grant, sees the row.
- **EE RPC** (override applied): a user scoped to `ws1` sees the `ws1` key (1 row) but **not** the `ws2` key (0 rows).
- `go vet ./db/dbtest/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)