### PR TITLE
fix: quote endpoint names in Kubernetes engine templates

### DIFF
--- a/internal/engine/llama-cpp/v0.3.7/templates/kubernetes/default.yaml
+++ b/internal/engine/llama-cpp/v0.3.7/templates/kubernetes/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .EndpointName }}
+  name: {{ .EndpointName | quote }}
   namespace: {{ .Namespace }}
   labels:
     engine: {{ .EngineName }}
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       cluster: {{ .ClusterName }}
       workspace: {{ .Workspace }}
-      endpoint: {{ .EndpointName }}
+      endpoint: {{ .EndpointName | quote }}
       app: inference
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
         engine_version: {{ .EngineVersion }}
         cluster: {{ .ClusterName }}
         workspace: {{ .Workspace }}
-        endpoint: {{ .EndpointName }}
+        endpoint: {{ .EndpointName | quote }}
         routing_logic: {{ .RoutingLogic }}
         app: inference
     spec:
@@ -43,7 +43,7 @@ spec:
                     - key: endpoint
                       operator: In
                       values:
-                        - {{ .EndpointName }}
+                        - {{ .EndpointName | quote }}
                 topologyKey: "kubernetes.io/hostname"
       {{- if .NodeSelector }}
       nodeSelector:

--- a/internal/engine/llama-cpp/v0.3.7/templates/kubernetes/default.yaml
+++ b/internal/engine/llama-cpp/v0.3.7/templates/kubernetes/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .EndpointName | quote }}
+  name: "{{ .EndpointName }}"
   namespace: {{ .Namespace }}
   labels:
     engine: {{ .EngineName }}
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       cluster: {{ .ClusterName }}
       workspace: {{ .Workspace }}
-      endpoint: {{ .EndpointName | quote }}
+      endpoint: "{{ .EndpointName }}"
       app: inference
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
         engine_version: {{ .EngineVersion }}
         cluster: {{ .ClusterName }}
         workspace: {{ .Workspace }}
-        endpoint: {{ .EndpointName | quote }}
+        endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference
     spec:
@@ -43,7 +43,7 @@ spec:
                     - key: endpoint
                       operator: In
                       values:
-                        - {{ .EndpointName | quote }}
+                        - "{{ .EndpointName }}"
                 topologyKey: "kubernetes.io/hostname"
       {{- if .NodeSelector }}
       nodeSelector:

--- a/internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml
+++ b/internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .EndpointName }}
+  name: {{ .EndpointName | quote }}
   namespace: {{ .Namespace }}
   labels:
     engine: {{ .EngineName }}
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       cluster: {{ .ClusterName }}
       workspace: {{ .Workspace }}
-      endpoint: {{ .EndpointName }}
+      endpoint: {{ .EndpointName | quote }}
       app: inference
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
         engine_version: {{ .EngineVersion }}
         cluster: {{ .ClusterName }}
         workspace: {{ .Workspace }}
-        endpoint: {{ .EndpointName }}
+        endpoint: {{ .EndpointName | quote }}
         routing_logic: {{ .RoutingLogic }}
         app: inference
     spec:
@@ -43,7 +43,7 @@ spec:
                     - key: endpoint
                       operator: In
                       values:
-                        - {{ .EndpointName }}
+                        - {{ .EndpointName | quote }}
                 topologyKey: "kubernetes.io/hostname"
       {{- if .NodeSelector }}
       nodeSelector:

--- a/internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml
+++ b/internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .EndpointName | quote }}
+  name: "{{ .EndpointName }}"
   namespace: {{ .Namespace }}
   labels:
     engine: {{ .EngineName }}
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       cluster: {{ .ClusterName }}
       workspace: {{ .Workspace }}
-      endpoint: {{ .EndpointName | quote }}
+      endpoint: "{{ .EndpointName }}"
       app: inference
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
         engine_version: {{ .EngineVersion }}
         cluster: {{ .ClusterName }}
         workspace: {{ .Workspace }}
-        endpoint: {{ .EndpointName | quote }}
+        endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference
     spec:
@@ -43,7 +43,7 @@ spec:
                     - key: endpoint
                       operator: In
                       values:
-                        - {{ .EndpointName | quote }}
+                        - "{{ .EndpointName }}"
                 topologyKey: "kubernetes.io/hostname"
       {{- if .NodeSelector }}
       nodeSelector:

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -59,6 +59,45 @@ func TestVLLMV0_17_1TemplateTaskTranslation(t *testing.T) {
 	}
 }
 
+func TestBuiltInKubernetesTemplatesPreserveNumericEndpointName(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+	}{
+		{
+			name:     "vllm v0.11.2",
+			template: vllmV0_11_2DeployTemplate,
+		},
+		{
+			name:     "vllm v0.17.1",
+			template: vllmV0_17_1DeployTemplate,
+		},
+		{
+			name:     "sglang v0.5.10",
+			template: sglangV0_5_10DeployTemplate,
+		},
+		{
+			name:     "llama.cpp v0.3.7",
+			template: llamaCppDefaultDeployTemplate,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vars := newTestVLLMV0_17_1Vars("text-generation")
+			vars["EndpointName"] = "4096"
+
+			objs, err := util.RenderKubernetesManifest(tc.template, vars)
+			require.NoError(t, err)
+
+			deploy := mustFindRenderedObjectByKind(t, objs.Items, "Deployment")
+			assert.Equal(t, "4096", deploy.GetName())
+			assertNestedString(t, deploy.Object, "4096", "spec", "selector", "matchLabels", "endpoint")
+			assertNestedString(t, deploy.Object, "4096", "spec", "template", "metadata", "labels", "endpoint")
+		})
+	}
+}
+
 // newTestVLLMV0_17_1Vars returns the minimum render variables the v0.17.1
 // template requires. We mirror the shape produced by setModelArgs in the
 // kubernetes orchestrator without taking a dependency on that package.
@@ -101,6 +140,26 @@ func mustFindRenderedObject(t *testing.T, objs []unstructured.Unstructured, kind
 	require.Failf(t, "rendered object not found", "%s/%s", kind, name)
 
 	return unstructured.Unstructured{}
+}
+
+func mustFindRenderedObjectByKind(t *testing.T, objs []unstructured.Unstructured, kind string) unstructured.Unstructured {
+	t.Helper()
+	for _, obj := range objs {
+		if obj.GetKind() == kind {
+			return obj
+		}
+	}
+	require.Failf(t, "rendered object kind not found", "%s", kind)
+
+	return unstructured.Unstructured{}
+}
+
+func assertNestedString(t *testing.T, obj map[string]any, want string, fields ...string) {
+	t.Helper()
+	got, found, err := unstructured.NestedString(obj, fields...)
+	require.NoError(t, err)
+	require.Truef(t, found, "%s not found", strings.Join(fields, "."))
+	assert.Equal(t, want, got)
 }
 
 // mustExtractContainerCommand pulls the named container's command list out of

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -94,6 +94,7 @@ func TestBuiltInKubernetesTemplatesPreserveNumericEndpointName(t *testing.T) {
 			assert.Equal(t, "4096", deploy.GetName())
 			assertNestedString(t, deploy.Object, "4096", "spec", "selector", "matchLabels", "endpoint")
 			assertNestedString(t, deploy.Object, "4096", "spec", "template", "metadata", "labels", "endpoint")
+			assertAntiAffinityEndpointValue(t, deploy.Object, "4096")
 		})
 	}
 }
@@ -160,6 +161,38 @@ func assertNestedString(t *testing.T, obj map[string]any, want string, fields ..
 	require.NoError(t, err)
 	require.Truef(t, found, "%s not found", strings.Join(fields, "."))
 	assert.Equal(t, want, got)
+}
+
+func assertAntiAffinityEndpointValue(t *testing.T, obj map[string]any, want string) {
+	t.Helper()
+	spec := requireMap(t, obj["spec"], "spec")
+	tmpl := requireMap(t, spec["template"], "spec.template")
+	pod := requireMap(t, tmpl["spec"], "spec.template.spec")
+	affinity := requireMap(t, pod["affinity"], "spec.template.spec.affinity")
+	podAntiAffinity := requireMap(t, affinity["podAntiAffinity"], "spec.template.spec.affinity.podAntiAffinity")
+	preferred := requireSlice(
+		t,
+		podAntiAffinity["preferredDuringSchedulingIgnoredDuringExecution"],
+		"spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution",
+	)
+	require.NotEmpty(t, preferred)
+	term := requireMap(t, preferred[0], "preferredDuringSchedulingIgnoredDuringExecution[0]")
+	podAffinityTerm := requireMap(t, term["podAffinityTerm"], "preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm")
+	labelSelector := requireMap(t, podAffinityTerm["labelSelector"], "podAffinityTerm.labelSelector")
+	expressions := requireSlice(t, labelSelector["matchExpressions"], "labelSelector.matchExpressions")
+
+	for _, expression := range expressions {
+		expressionMap := requireMap(t, expression, "matchExpression")
+		if key, ok := expressionMap["key"].(string); ok && key == "endpoint" {
+			values := requireSlice(t, expressionMap["values"], "matchExpression.values")
+			require.Len(t, values, 1)
+			assert.Equal(t, want, mustString(t, values[0], "matchExpression.values", 0))
+
+			return
+		}
+	}
+
+	require.Fail(t, "endpoint anti-affinity match expression not found")
 }
 
 // mustExtractContainerCommand pulls the named container's command list out of

--- a/internal/engine/vllm/v0.11.2/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.11.2/templates/kubernetes/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .EndpointName }}
+  name: {{ .EndpointName | quote }}
   namespace: {{ .Namespace }}
   labels:
     engine: {{ .EngineName }}
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       cluster: {{ .ClusterName }}
       workspace: {{ .Workspace }}
-      endpoint: {{ .EndpointName }}
+      endpoint: {{ .EndpointName | quote }}
       app: inference
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
         engine_version: {{ .EngineVersion }}
         cluster: {{ .ClusterName }}
         workspace: {{ .Workspace }}
-        endpoint: {{ .EndpointName }}
+        endpoint: {{ .EndpointName | quote }}
         routing_logic: {{ .RoutingLogic }}
         app: inference
     spec:
@@ -43,7 +43,7 @@ spec:
                     - key: endpoint
                       operator: In
                       values:
-                        - {{ .EndpointName }}
+                        - {{ .EndpointName | quote }}
                 topologyKey: "kubernetes.io/hostname"
       {{- if .NodeSelector }}
       nodeSelector:

--- a/internal/engine/vllm/v0.11.2/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.11.2/templates/kubernetes/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .EndpointName | quote }}
+  name: "{{ .EndpointName }}"
   namespace: {{ .Namespace }}
   labels:
     engine: {{ .EngineName }}
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       cluster: {{ .ClusterName }}
       workspace: {{ .Workspace }}
-      endpoint: {{ .EndpointName | quote }}
+      endpoint: "{{ .EndpointName }}"
       app: inference
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
         engine_version: {{ .EngineVersion }}
         cluster: {{ .ClusterName }}
         workspace: {{ .Workspace }}
-        endpoint: {{ .EndpointName | quote }}
+        endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference
     spec:
@@ -43,7 +43,7 @@ spec:
                     - key: endpoint
                       operator: In
                       values:
-                        - {{ .EndpointName | quote }}
+                        - "{{ .EndpointName }}"
                 topologyKey: "kubernetes.io/hostname"
       {{- if .NodeSelector }}
       nodeSelector:

--- a/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .EndpointName }}
+  name: {{ .EndpointName | quote }}
   namespace: {{ .Namespace }}
   labels:
     engine: {{ .EngineName }}
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       cluster: {{ .ClusterName }}
       workspace: {{ .Workspace }}
-      endpoint: {{ .EndpointName }}
+      endpoint: {{ .EndpointName | quote }}
       app: inference
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
         engine_version: {{ .EngineVersion }}
         cluster: {{ .ClusterName }}
         workspace: {{ .Workspace }}
-        endpoint: {{ .EndpointName }}
+        endpoint: {{ .EndpointName | quote }}
         routing_logic: {{ .RoutingLogic }}
         app: inference
     spec:
@@ -43,7 +43,7 @@ spec:
                     - key: endpoint
                       operator: In
                       values:
-                        - {{ .EndpointName }}
+                        - {{ .EndpointName | quote }}
                 topologyKey: "kubernetes.io/hostname"
       {{- if .NodeSelector }}
       nodeSelector:

--- a/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .EndpointName | quote }}
+  name: "{{ .EndpointName }}"
   namespace: {{ .Namespace }}
   labels:
     engine: {{ .EngineName }}
@@ -20,7 +20,7 @@ spec:
     matchLabels:
       cluster: {{ .ClusterName }}
       workspace: {{ .Workspace }}
-      endpoint: {{ .EndpointName | quote }}
+      endpoint: "{{ .EndpointName }}"
       app: inference
   template:
     metadata:
@@ -29,7 +29,7 @@ spec:
         engine_version: {{ .EngineVersion }}
         cluster: {{ .ClusterName }}
         workspace: {{ .Workspace }}
-        endpoint: {{ .EndpointName | quote }}
+        endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference
     spec:
@@ -43,7 +43,7 @@ spec:
                     - key: endpoint
                       operator: In
                       values:
-                        - {{ .EndpointName | quote }}
+                        - "{{ .EndpointName }}"
                 topologyKey: "kubernetes.io/hostname"
       {{- if .NodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Issue

NEU-460

## Summary

Kubernetes engine deployment templates rendered a numeric Endpoint name such as `4096` without quotes. YAML decoded that value as a number, so the rendered Deployment metadata name became empty in the unstructured object and apply failed with `Deployment/` and `resource name may not be empty`.

## Changes

- Double-quote `EndpointName` in built-in Kubernetes engine templates for vLLM, SGLang, and llama.cpp, matching the existing environment value template style.
- Add a unit regression test that renders all built-in Kubernetes templates with `EndpointName: "4096"` and verifies the Deployment name, endpoint labels, selector, and anti-affinity endpoint value remain strings.
- Change level: Trivial by maintainer override; docs MR, TestRail sync, and E2E are skipped.

## Test Plan

### Unit test

- [x] RED: `go test ./internal/engine -run TestBuiltInKubernetesTemplatesPreserveNumericEndpointName -count=1 -v` failed before the fix with empty Deployment names for all built-in Kubernetes templates.
- [x] GREEN: `go test ./internal/engine -run TestBuiltInKubernetesTemplatesPreserveNumericEndpointName -count=1 -v`
- [x] `go test ./internal/engine -count=1 -v`
- [x] `go vet ./internal/engine`
- [x] `./bin/golangci-lint run ./internal/engine`

### DB test

- [x] Not affected: no database schema, migration, RLS, or storage-layer changes.

### E2E test

- [x] Skipped: Trivial template quoting fix with focused unit coverage; manual testing is not required because E2E is skipped by classification.

## Risk & Rollback

Risk is low. The change only double-quotes an existing Kubernetes-safe string variable in YAML templates, preserving normal names while preventing YAML numeric coercion. Rollback is reverting this PR.