### PR TITLE
fix(usage): scope get_usage_by_dimension by daily-usage workspace (NEU-463)

### DIFF
--- a/db/dbtest/helper.go
+++ b/db/dbtest/helper.go
@@ -125,9 +125,14 @@ func setUserContext(userID string) SetContextFunc {
 	}
 }
 
-func setJwtSecretContext(jwtSecret string) SetContextFunc {
+// testJwtSecret is the JWT secret used by the database test context. It is the
+// only value ever needed, so setJwtSecretContext takes no parameter (avoids the
+// unparam lint about an always-constant argument).
+const testJwtSecret = "test"
+
+func setJwtSecretContext() SetContextFunc {
 	return func(tx *sql.Tx) error {
-		_, err := tx.Exec(fmt.Sprintf("SET LOCAL app.settings.jwt_secret = '%s'", jwtSecret))
+		_, err := tx.Exec(fmt.Sprintf("SET LOCAL app.settings.jwt_secret = '%s'", testJwtSecret))
 		return errors.Wrap(err, "failed to set jwt secret context")
 	}
 }

--- a/db/dbtest/sync_api_key_usage_test.go
+++ b/db/dbtest/sync_api_key_usage_test.go
@@ -18,7 +18,7 @@ func TestSyncApiKeyUsage(t *testing.T) {
 
 		// Create an API key for the user
 		var apiKeyID string
-		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext("test")}, func(tx *sql.Tx) error {
+		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
 			return tx.QueryRowContext(ctx, `
 			SELECT id FROM api.create_api_key(
 				p_workspace := 'test-workspace',
@@ -106,7 +106,7 @@ func TestSyncApiKeyUsage(t *testing.T) {
 
 		// Create an API key
 		var apiKeyID string
-		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext("test")}, func(tx *sql.Tx) error {
+		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
 			return tx.QueryRowContext(ctx, `
 			SELECT id FROM api.create_api_key(
 				p_workspace := 'test-workspace-2',
@@ -174,7 +174,7 @@ func TestSyncApiKeyUsage(t *testing.T) {
 
 		// Create an API key
 		var apiKeyID string
-		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext("test")}, func(tx *sql.Tx) error {
+		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
 			return tx.QueryRowContext(ctx, `
 			SELECT id FROM api.create_api_key(
 				p_workspace := 'test-workspace-3',

--- a/db/dbtest/usage_by_dimension_workspace_test.go
+++ b/db/dbtest/usage_by_dimension_workspace_test.go
@@ -36,7 +36,7 @@ func TestGetUsageByDimensionWorkspaceFilter(t *testing.T) {
 
 	createKey := func(workspace, name string) string {
 		var id string
-		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext("test")}, func(tx *sql.Tx) error {
+		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
 			return tx.QueryRowContext(ctx, `
 				SELECT id FROM api.create_api_key(
 					p_workspace := $1,

--- a/db/dbtest/usage_by_dimension_workspace_test.go
+++ b/db/dbtest/usage_by_dimension_workspace_test.go
@@ -1,0 +1,179 @@
+package dbtest
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestGetUsageByDimensionWorkspaceFilter is a regression test for NEU-463.
+//
+// get_usage_by_dimension used to derive each usage row's workspace by joining
+// the dimension's endpoint_name against api.endpoints / api.external_endpoints.
+// endpoint names are unique only within a workspace (unique index is
+// workspace+name), so the name-only join (1) bled usage from same-named
+// endpoints across workspaces and (2) dropped historical usage once an endpoint
+// was deleted. Migration 063 sources the workspace from the daily-usage row's
+// metadata.workspace instead, removing the endpoint joins.
+//
+// The scenario below reproduces the exact repro from the ticket: one user owns
+// API keys in two workspaces, both keys report usage under the SAME dimension
+// name, and a same-named endpoint exists in both workspaces.
+func TestGetUsageByDimensionWorkspaceFilter(t *testing.T) {
+	db := GetTestDB(t)
+	ctx := context.Background()
+
+	const (
+		wsA          = "neu-463-ws-a"
+		wsB          = "neu-463-ws-b"
+		dimension    = "neu-463-gpt" // same dimension/endpoint name used in both workspaces
+		usageA int64 = 100
+		usageB int64 = 200
+	)
+
+	// One user owns API keys in two different workspaces.
+	user := CreateTestUser(t, "neu463user", "neu463@example.com", "testpassword")
+
+	createKey := func(workspace, name string) string {
+		var id string
+		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext("test")}, func(tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx, `
+				SELECT id FROM api.create_api_key(
+					p_workspace := $1,
+					p_name := $2,
+					p_quota := 1000
+				)`, workspace, name).Scan(&id)
+		})
+		if err != nil {
+			t.Fatalf("failed to create API key %s/%s: %v", workspace, name, err)
+		}
+		return id
+	}
+
+	keyA := createKey(wsA, "neu-463-key-a")
+	keyB := createKey(wsB, "neu-463-key-b")
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, "DELETE FROM api.api_keys WHERE id IN ($1, $2)", keyA, keyB)
+		_, _ = db.ExecContext(ctx, "DELETE FROM api.endpoints WHERE (metadata).name = $1", dimension)
+	})
+
+	// Daily usage: both keys report usage under the SAME dimension name.
+	// metadata.workspace mirrors the owning key's workspace, as written by
+	// aggregate_usage_records at aggregation time.
+	insertDaily := func(keyID, workspace string, amount int64) {
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO api.api_daily_usage (api_version, kind, metadata, spec, status)
+			VALUES (
+				'v1',
+				'ApiDailyUsage',
+				ROW('neu-463-du-' || $2, NULL, $2, NULL, now(), now(), '{}'::json, '{}'::json)::api.metadata,
+				ROW($1::uuid, CURRENT_DATE, $3, jsonb_build_object($4::text, $3), NULL::jsonb)::api.api_daily_usage_spec,
+				ROW(now())::api.api_daily_usage_status
+			)`, keyID, workspace, amount, dimension)
+		if err != nil {
+			t.Fatalf("failed to insert daily usage for %s: %v", workspace, err)
+		}
+	}
+	insertDaily(keyA, wsA, usageA)
+	insertDaily(keyB, wsB, usageB)
+
+	// Same-named endpoint in BOTH workspaces (the condition that broke the
+	// name-only join). The endpoint rows are intentionally irrelevant to the
+	// fixed query — it no longer joins them.
+	insertEndpoint := func(workspace string) {
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO api.endpoints (api_version, kind, spec, metadata)
+			VALUES (
+				'v1',
+				'Endpoint',
+				ROW(
+					'neu-463-cluster',
+					ROW('neu-463-registry', 'neu-463-model', '', 'v1', '')::api.model_spec,
+					ROW('vllm', 'v0.11.2')::api.endpoint_engine_spec,
+					ROW('4', '2', NULL, '16')::api.resource_spec,
+					ROW(1)::api.replica_spec,
+					NULL,
+					NULL,
+					NULL
+				)::api.endpoint_spec,
+				ROW($1, NULL, $2, NULL, now(), now(), '{}'::json, '{}'::json)::api.metadata
+			)`, dimension, workspace)
+		if err != nil {
+			t.Fatalf("failed to insert endpoint in %s: %v", workspace, err)
+		}
+	}
+	insertEndpoint(wsA)
+	insertEndpoint(wsB)
+
+	type usageRow struct {
+		workspace string
+		endpoint  string
+		usage     int64
+	}
+
+	// queryDim runs get_usage_by_dimension within the user's auth context
+	// (the RPC scopes to auth.uid()). A nil pWorkspace passes SQL NULL.
+	queryDim := func(pWorkspace *string) []usageRow {
+		var rows []usageRow
+		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID)}, func(tx *sql.Tx) error {
+			r, err := tx.QueryContext(ctx, `
+				SELECT workspace, endpoint_name, usage
+				FROM api.get_usage_by_dimension(CURRENT_DATE - 1, CURRENT_DATE + 1, NULL, NULL, $1)
+				ORDER BY workspace, usage`, pWorkspace)
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+			for r.Next() {
+				var x usageRow
+				if err := r.Scan(&x.workspace, &x.endpoint, &x.usage); err != nil {
+					return err
+				}
+				rows = append(rows, x)
+			}
+			return r.Err()
+		})
+		if err != nil {
+			t.Fatalf("failed to query get_usage_by_dimension: %v", err)
+		}
+		return rows
+	}
+	ws := func(s string) *string { return &s }
+
+	t.Run("workspace filter returns only that workspace's usage", func(t *testing.T) {
+		got := queryDim(ws(wsA))
+		if len(got) != 1 || got[0].workspace != wsA || got[0].usage != usageA {
+			t.Fatalf("expected exactly [%s/%d], got %+v", wsA, usageA, got)
+		}
+
+		got = queryDim(ws(wsB))
+		if len(got) != 1 || got[0].workspace != wsB || got[0].usage != usageB {
+			t.Fatalf("expected exactly [%s/%d], got %+v", wsB, usageB, got)
+		}
+	})
+
+	t.Run("no cross-workspace bleed for same-named endpoints", func(t *testing.T) {
+		got := queryDim(nil)
+		// Exactly two rows. The pre-fix name-only join matched the same-named
+		// endpoint in both workspaces and produced four rows (each usage row
+		// duplicated into the other workspace).
+		if len(got) != 2 ||
+			got[0].workspace != wsA || got[0].usage != usageA ||
+			got[1].workspace != wsB || got[1].usage != usageB {
+			t.Fatalf("expected [%s/%d, %s/%d], got %+v", wsA, usageA, wsB, usageB, got)
+		}
+	})
+
+	t.Run("history retained after endpoint deletion", func(t *testing.T) {
+		if _, err := db.ExecContext(ctx, "DELETE FROM api.endpoints WHERE (metadata).name = $1", dimension); err != nil {
+			t.Fatalf("failed to delete endpoints: %v", err)
+		}
+		got := queryDim(ws(wsA))
+		// Pre-fix the workspace could not be resolved once the endpoint was
+		// gone, so the workspace filter dropped the row entirely (0 rows).
+		if len(got) != 1 || got[0].workspace != wsA || got[0].usage != usageA {
+			t.Fatalf("expected [%s/%d] to survive endpoint deletion, got %+v", wsA, usageA, got)
+		}
+	})
+}

--- a/db/dbtest/usage_by_dimension_workspace_test.go
+++ b/db/dbtest/usage_by_dimension_workspace_test.go
@@ -67,8 +67,8 @@ func TestGetUsageByDimensionWorkspaceFilter(t *testing.T) {
 			VALUES (
 				'v1',
 				'ApiDailyUsage',
-				ROW('neu-463-du-' || $2, NULL, $2, NULL, now(), now(), '{}'::json, '{}'::json)::api.metadata,
-				ROW($1::uuid, CURRENT_DATE, $3, jsonb_build_object($4::text, $3), NULL::jsonb)::api.api_daily_usage_spec,
+				ROW('neu-463-du-' || $2::text, NULL, $2::text, NULL, now(), now(), '{}'::json, '{}'::json)::api.metadata,
+				ROW($1::uuid, CURRENT_DATE, $3::bigint, jsonb_build_object($4::text, $3::bigint), NULL::jsonb)::api.api_daily_usage_spec,
 				ROW(now())::api.api_daily_usage_status
 			)`, keyID, workspace, amount, dimension)
 		if err != nil {
@@ -97,7 +97,7 @@ func TestGetUsageByDimensionWorkspaceFilter(t *testing.T) {
 					NULL,
 					NULL
 				)::api.endpoint_spec,
-				ROW($1, NULL, $2, NULL, now(), now(), '{}'::json, '{}'::json)::api.metadata
+				ROW($1::text, NULL, $2::text, NULL, now(), now(), '{}'::json, '{}'::json)::api.metadata
 			)`, dimension, workspace)
 		if err != nil {
 			t.Fatalf("failed to insert endpoint in %s: %v", workspace, err)

--- a/db/migrations/063_usage_by_dimension_workspace_filter.down.sql
+++ b/db/migrations/063_usage_by_dimension_workspace_filter.down.sql
@@ -1,0 +1,106 @@
+-- Restore the endpoint-join based get_usage_by_dimension from migration 054.
+DROP FUNCTION IF EXISTS api.get_usage_by_dimension;
+CREATE FUNCTION api.get_usage_by_dimension(
+    p_start_date DATE,
+    p_end_date DATE,
+    p_api_key_id UUID DEFAULT NULL,
+    p_endpoint_name TEXT DEFAULT NULL,
+    p_workspace TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    date DATE,
+    api_key_id UUID,
+    api_key_name TEXT,
+    endpoint_type TEXT,
+    endpoint_name TEXT,
+    model_name TEXT,
+    workspace TEXT,
+    usage BIGINT,
+    prompt_tokens BIGINT,
+    completion_tokens BIGINT
+)
+SECURITY DEFINER
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH user_api_keys AS (
+        SELECT ak.id, (ak.metadata).name AS key_name
+        FROM api.api_keys ak
+        WHERE ak.user_id = auth.uid()
+        AND (p_api_key_id IS NULL OR ak.id = p_api_key_id)
+    ),
+    -- Old data: records without detailed_dimensional_usage
+    old_dimension_data AS (
+        SELECT
+            (u.spec).usage_date,
+            (u.spec).api_key_id,
+            k.key_name,
+            NULL::text AS endpoint_type,
+            kv.key AS endpoint_name,
+            NULL::text AS model_name,
+            (kv.value)::bigint AS dimension_usage,
+            NULL::bigint AS p_tokens,
+            NULL::bigint AS c_tokens
+        FROM
+            api.api_daily_usage u
+            JOIN user_api_keys k ON (u.spec).api_key_id = k.id,
+            jsonb_each((u.spec).dimensional_usage) kv
+        WHERE
+            (u.spec).usage_date BETWEEN p_start_date AND p_end_date
+            AND (u.spec).detailed_dimensional_usage IS NULL
+    ),
+    -- New data: records with detailed_dimensional_usage
+    new_dimension_data AS (
+        SELECT
+            (u.spec).usage_date,
+            (u.spec).api_key_id,
+            k.key_name,
+            split_part(kv.key, '|', 1) AS endpoint_type,
+            split_part(kv.key, '|', 2) AS endpoint_name,
+            NULLIF(split_part(kv.key, '|', 3), '') AS model_name,
+            (kv.value->>'total')::bigint AS dimension_usage,
+            (kv.value->>'prompt')::bigint AS p_tokens,
+            (kv.value->>'completion')::bigint AS c_tokens
+        FROM
+            api.api_daily_usage u
+            JOIN user_api_keys k ON (u.spec).api_key_id = k.id,
+            jsonb_each((u.spec).detailed_dimensional_usage) kv
+        WHERE
+            (u.spec).usage_date BETWEEN p_start_date AND p_end_date
+            AND (u.spec).detailed_dimensional_usage IS NOT NULL
+    ),
+    dimension_data AS (
+        SELECT * FROM old_dimension_data
+        UNION ALL
+        SELECT * FROM new_dimension_data
+    )
+    SELECT
+        d.usage_date,
+        d.api_key_id,
+        d.key_name,
+        d.endpoint_type,
+        d.endpoint_name,
+        d.model_name,
+        COALESCE(e.workspace, ee.workspace, 'unknown') AS workspace,
+        d.dimension_usage,
+        d.p_tokens,
+        d.c_tokens
+    FROM
+        dimension_data d
+        LEFT JOIN (
+            SELECT (metadata).name AS ep_name, (metadata).workspace AS workspace
+            FROM api.endpoints
+        ) e ON d.endpoint_name = e.ep_name AND (d.endpoint_type IS NULL OR d.endpoint_type = 'endpoint')
+        LEFT JOIN (
+            SELECT (metadata).name AS ep_name, (metadata).workspace AS workspace
+            FROM api.external_endpoints
+        ) ee ON d.endpoint_name = ee.ep_name AND d.endpoint_type = 'external-endpoint'
+    WHERE
+        (p_endpoint_name IS NULL OR d.endpoint_name = p_endpoint_name) AND
+        (p_workspace IS NULL OR COALESCE(e.workspace, ee.workspace, 'unknown') = p_workspace)
+    ORDER BY
+        d.usage_date DESC,
+        d.api_key_id,
+        d.endpoint_name;
+END;
+$$ LANGUAGE plpgsql;

--- a/db/migrations/063_usage_by_dimension_workspace_filter.up.sql
+++ b/db/migrations/063_usage_by_dimension_workspace_filter.up.sql
@@ -1,0 +1,118 @@
+-- Fix cross-workspace bleed in get_usage_by_dimension (NEU-463).
+--
+-- Previously the workspace of each usage row was derived by joining the
+-- dimension's endpoint_name against api.endpoints / api.external_endpoints and
+-- reading that endpoint's workspace. endpoint names are only unique *within* a
+-- workspace (unique index is workspace+name), so a name-only join:
+--   1. mixed usage from same-named endpoints across different workspaces, and
+--   2. dropped historical usage once an endpoint was deleted (the join — and
+--      therefore the workspace filter — produced no row).
+--
+-- api_daily_usage already records the owning API key's workspace in
+-- metadata.workspace at aggregation time, so the workspace is sourced from the
+-- daily-usage row (falling back to the API key's current workspace), and the
+-- endpoint joins are dropped entirely. This makes both the returned workspace
+-- and the p_workspace filter stable across same-named endpoints and endpoint
+-- deletion. The function signature and result columns are unchanged.
+DROP FUNCTION IF EXISTS api.get_usage_by_dimension;
+CREATE FUNCTION api.get_usage_by_dimension(
+    p_start_date DATE,
+    p_end_date DATE,
+    p_api_key_id UUID DEFAULT NULL,
+    p_endpoint_name TEXT DEFAULT NULL,
+    p_workspace TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    date DATE,
+    api_key_id UUID,
+    api_key_name TEXT,
+    endpoint_type TEXT,
+    endpoint_name TEXT,
+    model_name TEXT,
+    workspace TEXT,
+    usage BIGINT,
+    prompt_tokens BIGINT,
+    completion_tokens BIGINT
+)
+SECURITY DEFINER
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH user_api_keys AS (
+        SELECT
+            ak.id,
+            (ak.metadata).name AS key_name,
+            (ak.metadata).workspace AS key_workspace
+        FROM api.api_keys ak
+        WHERE ak.user_id = auth.uid()
+        AND (p_api_key_id IS NULL OR ak.id = p_api_key_id)
+    ),
+    -- Old data: records without detailed_dimensional_usage
+    old_dimension_data AS (
+        SELECT
+            (u.spec).usage_date,
+            (u.spec).api_key_id,
+            k.key_name,
+            NULL::text AS endpoint_type,
+            kv.key AS endpoint_name,
+            NULL::text AS model_name,
+            COALESCE((u.metadata).workspace, k.key_workspace, 'unknown') AS workspace,
+            (kv.value)::bigint AS dimension_usage,
+            NULL::bigint AS p_tokens,
+            NULL::bigint AS c_tokens
+        FROM
+            api.api_daily_usage u
+            JOIN user_api_keys k ON (u.spec).api_key_id = k.id,
+            jsonb_each((u.spec).dimensional_usage) kv
+        WHERE
+            (u.spec).usage_date BETWEEN p_start_date AND p_end_date
+            AND (u.spec).detailed_dimensional_usage IS NULL
+    ),
+    -- New data: records with detailed_dimensional_usage
+    new_dimension_data AS (
+        SELECT
+            (u.spec).usage_date,
+            (u.spec).api_key_id,
+            k.key_name,
+            split_part(kv.key, '|', 1) AS endpoint_type,
+            split_part(kv.key, '|', 2) AS endpoint_name,
+            NULLIF(split_part(kv.key, '|', 3), '') AS model_name,
+            COALESCE((u.metadata).workspace, k.key_workspace, 'unknown') AS workspace,
+            (kv.value->>'total')::bigint AS dimension_usage,
+            (kv.value->>'prompt')::bigint AS p_tokens,
+            (kv.value->>'completion')::bigint AS c_tokens
+        FROM
+            api.api_daily_usage u
+            JOIN user_api_keys k ON (u.spec).api_key_id = k.id,
+            jsonb_each((u.spec).detailed_dimensional_usage) kv
+        WHERE
+            (u.spec).usage_date BETWEEN p_start_date AND p_end_date
+            AND (u.spec).detailed_dimensional_usage IS NOT NULL
+    ),
+    dimension_data AS (
+        SELECT * FROM old_dimension_data
+        UNION ALL
+        SELECT * FROM new_dimension_data
+    )
+    SELECT
+        d.usage_date,
+        d.api_key_id,
+        d.key_name,
+        d.endpoint_type,
+        d.endpoint_name,
+        d.model_name,
+        d.workspace,
+        d.dimension_usage,
+        d.p_tokens,
+        d.c_tokens
+    FROM
+        dimension_data d
+    WHERE
+        (p_endpoint_name IS NULL OR d.endpoint_name = p_endpoint_name) AND
+        (p_workspace IS NULL OR d.workspace = p_workspace)
+    ORDER BY
+        d.usage_date DESC,
+        d.api_key_id,
+        d.endpoint_name;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Problem

The Model Usage page (`useWorkspaceUsage` → `get_usage_by_dimension` RPC) could attribute usage to the wrong workspace.

The RPC derived each usage row's workspace by joining the dimension's `endpoint_name` against `api.endpoints` / `api.external_endpoints` and reading that endpoint's `workspace`. endpoint names are unique only **within** a workspace (unique index is `workspace + name`), so the name-only join:

1. **Cross-workspace bleed** — same-named endpoints in different workspaces all matched, so one usage row was duplicated/attributed across every workspace owning an endpoint of that name.
2. **History loss after deletion** — once an endpoint was deleted, the join produced no row, so the `p_workspace` filter excluded the historical usage entirely.

## Fix

`api_daily_usage` already records the owning API key's workspace in `metadata.workspace` at aggregation time. Migration `063` sources the workspace from the daily-usage row (falling back to the API key's current workspace via `user_api_keys`) and **removes the endpoint joins entirely**. Both the returned `workspace` column and the `p_workspace` filter are now stable across same-named endpoints and endpoint deletion.

The function signature and result columns are unchanged, so no caller (UI / API) changes are required.

## Verification

Ran the full migration chain (`001..063`) against PostgreSQL 15 and reproduced the bug end-to-end with two same-named `gpt` endpoints across `ws-a` / `ws-b`:

| Scenario | Old (buggy) | New (063) |
|---|---|---|
| no filter, same-named endpoint in 2 ws | **4 rows** (each usage bled into both ws) | **2 rows** (correct) |
| filter `ws-a` | mixed | only `ws-a` / 100 |
| after endpoint deleted, filter `ws-a` | **0 rows** (history lost) | `ws-a` / 100 retained |

`down` → `up` reversibility confirmed; `check-migration-pairs.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)