### PR TITLE
fix(gateway): route IE Anthropic /v1/messages to the engine (NEU-413)

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -1225,15 +1225,18 @@ function AIGatewayHandler:access(conf)
             end
             openai_req.model = matched_entry.model_mapping[openai_req.model]
         else
-            local upstream_path = request_path:gsub(
-                "^/workspace/([^/]+)/endpoint/([^/]+)/anthropic/v1/messages/?$",
-                "/%1/%2/v1/chat/completions",
-                1
-            )
-            if upstream_path == request_path then
-                upstream_path = "/v1/chat/completions"
+            -- IE (internal endpoint) routes carry no `upstreams` config and rely on
+            -- Kong's own service/route path translation. By this point the router has
+            -- already populated ngx.var.upstream_uri with the service-aware upstream
+            -- path (e.g. /<workspace>/<endpoint>/anthropic/v1/messages); rewrite only
+            -- the anthropic suffix to the OpenAI chat-completions path the inference
+            -- engine actually serves. Rewriting request_path instead would drop the
+            -- Kong service path and hit the engine with the gateway-facing prefix.
+            local upstream_uri = ngx.var.upstream_uri
+            if upstream_uri == nil or upstream_uri == "" then
+                upstream_uri = request_path
             end
-            kong.service.request.set_path(upstream_path)
+            kong.service.request.set_path((upstream_uri:gsub("/anthropic/v1/messages/?$", "/v1/chat/completions")))
         end
 
         local openai_json = cjson.encode(openai_req)

--- a/internal/gateway/kong.go
+++ b/internal/gateway/kong.go
@@ -289,6 +289,12 @@ func (k *Kong) generateAIGatewayPlugin(ep *v1.Endpoint, curRoute *kong.Route) *k
 		Protocols:    []*string{pointy.String("http"), pointy.String("https")},
 		Config: map[string]interface{}{
 			"route_type": getEndpointRouteType(ep),
+			// route_prefix lets the plugin strip the endpoint route path from the
+			// request URI so it can detect the Anthropic-compatible suffix
+			// (/anthropic/v1/messages) on internal endpoints, matching the external
+			// endpoint behavior. Without it the suffix never matches and the raw
+			// Anthropic request is forwarded to the engine, which 404s.
+			"route_prefix": getEndpointRoutePath(ep),
 		},
 	}
 }


### PR DESCRIPTION
## Problem

Curling an **internal endpoint** (IE) Anthropic-compatible address returns FastAPI's default 404:

```
curl .../workspace/default/endpoint/qwen3.5-27b/anthropic/v1/messages
=> {"detail":"Not Found"}
```

External endpoints (EE) work; IE does not. Reported by a Foxconn production line trying to connect Claude Code.

## Root cause

The Anthropic↔OpenAI translation lives in the `neutree-ai-gateway` Kong plugin. It detects Anthropic requests by stripping `route_prefix` from the URI and matching the `/anthropic/v1/messages` suffix.

The IE plugin (`generateAIGatewayPlugin`) was attached with **only `route_type`, never `route_prefix`** — unlike the EE plugin. Without a prefix, the suffix is the full gateway path, `is_anthropic_messages_path` never matches, the plugin falls through to the `route_type` guard, **skips**, and forwards the raw `/anthropic/v1/messages` to the engine. vLLM/SGLang's FastAPI app has no such route, so it replies `{"detail":"Not Found"}`.

A second latent bug: even once detected, the IE (no-`upstreams`) branch rewrote `request_path` (the gateway-facing path, incl. route prefix) instead of the Kong service-aware upstream path, which would still 404.

## Fix

1. **`internal/gateway/kong.go`** — set `route_prefix: getEndpointRoutePath(ep)` on the IE AI-gateway plugin, mirroring EE so the Anthropic suffix is detected.
2. **`gateway/kong/plugins/.../handler.lua`** — in the no-`upstreams` (IE) branch, rewrite the already service-aware `ngx.var.upstream_uri` (e.g. `/<ws>/<ep>/anthropic/v1/messages`) so the engine receives `/<ws>/<ep>/v1/chat/completions`.

## Compatibility

- `route_prefix` is already declared in `schema.lua`; no schema change.
- IE OpenAI paths (`/v1/chat/completions`, `/v1/models`) are unaffected — `route_prefix` only feeds `suffix`, which IE otherwise uses only for Anthropic detection (`maybe_return_model_list` requires `upstreams`, always false for IE).
- Control plane re-syncs existing endpoints with the new plugin config automatically.

## Verification

- `go build ./internal/gateway/...`, `make build-neutree-api`, `make build-neutree-core` all pass (golang:1.23).
- `handler.lua` validated with LuaJIT (`luajit -bl`).
- Full end-to-end (real cluster + GPU) to run in the stable env: deploy a text-gen IE, confirm the Kong plugin config carries `route_prefix`, then curl `.../endpoint/<ep>/anthropic/v1/messages` and connect Claude Code against the IE address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)