### PR TITLE
fix(serve/llama_cpp): drop OpenAI params llama_cpp does not accept

### DIFF
--- a/cluster-image-builder/serve/llama_cpp/v0_3_7/app.py
+++ b/cluster-image-builder/serve/llama_cpp/v0_3_7/app.py
@@ -3,6 +3,7 @@ import os
 import enum
 import json
 import time
+import inspect
 import fnmatch
 from typing import Dict, Any, AsyncGenerator, Optional
 
@@ -31,6 +32,30 @@ class SchedulerType(str, enum.Enum):
     POW2 = "pow2"
     STATIC_HASH = "static_hash"
     CONSISTENT_HASH = "consistent_hash"
+
+
+def _supported_params(func) -> set:
+    """Names of keyword parameters accepted by a llama_cpp API, minus `self`."""
+    return set(inspect.signature(func).parameters) - {"self"}
+
+
+# llama-cpp-python exposes a narrower API than the OpenAI request schema. Clients
+# (including the neutree gateway's Anthropic->OpenAI translation) may send fields
+# llama_cpp does not accept, e.g. `stream_options`. Forwarding them verbatim makes
+# `Llama.create_*(**payload)` raise TypeError, which aborts the (streaming) response
+# and surfaces as an empty body / "upstream prematurely closed". Drop unsupported
+# keys up front. Computed from the real signatures so new OpenAI fields stay safe.
+_CHAT_PARAMS = _supported_params(Llama.create_chat_completion)
+_COMPLETION_PARAMS = _supported_params(Llama.create_completion)
+_EMBEDDING_PARAMS = _supported_params(Llama.create_embedding)
+
+
+def _filter_supported(payload: Dict[str, Any], allowed: set) -> Dict[str, Any]:
+    """Return payload without keys llama_cpp does not accept (logs what it drops)."""
+    dropped = [k for k in payload if k not in allowed]
+    if dropped:
+        print(f"[Backend] dropping params unsupported by llama_cpp: {dropped}")
+    return {k: v for k, v in payload.items() if k in allowed}
 
 
 # Mapping from scheduler type to request router class path
@@ -165,16 +190,16 @@ class Backend:
         llama = LlamaProxy.load_llama_from_model_settings(self.model_settings)
         if "messages" in payload:
             # Chat completion
-            response = llama.create_chat_completion(**payload)
+            response = llama.create_chat_completion(**_filter_supported(payload, _CHAT_PARAMS))
             return response
         else:
             # Regular completion
-            response = llama.create_completion(**payload)
+            response = llama.create_completion(**_filter_supported(payload, _COMPLETION_PARAMS))
             return response
 
     async def generate_embeddings(self, payload: Any):
         llama = LlamaProxy.load_llama_from_model_settings(self.model_settings)
-        response = llama.create_embedding(**payload)
+        response = llama.create_embedding(**_filter_supported(payload, _EMBEDDING_PARAMS))
         return response
 
     async def show_available_models(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Problem

Streaming requests to a **llama.cpp** endpoint return HTTP 200 with an **empty body**; Kong logs `upstream prematurely closed connection`. This blocks Claude Code (and any client) from streaming against a llama.cpp-backed internal endpoint.

It surfaced while verifying #413 (IE Anthropic `/v1/messages` routing) on a minimal `llama.cpp` endpoint: the routing fix is correct and the request reaches the engine, but the streaming response is empty.

## Root cause

`llama-cpp-python` exposes a **narrower** API than the OpenAI request schema. The serve wrapper forwards the raw request body straight through:

```python
response = llama.create_chat_completion(**payload)
```

When `payload` carries a field `llama_cpp` doesn't know — e.g. `stream_options` — this raises:

```
TypeError: Llama.create_chat_completion() got an unexpected keyword argument 'stream_options'
```

The exception aborts the (streaming) Ray Serve response, so the client sees an empty body and Kong reports the upstream closing early. `stream_options.include_usage` is always added by the neutree gateway's Anthropic→OpenAI translation on streaming requests, but any OpenAI client sending it hits the same wall.

Captured from the live replica log:

```
File ".../serve/llama_cpp/v0_3_7/app.py", line 168, in generate
    response = llama.create_chat_completion(**payload)
TypeError: Llama.create_chat_completion() got an unexpected keyword argument 'stream_options'
```

(`llama_cpp` 0.3.7; `inspect.signature(Llama.create_chat_completion)` has no `stream_options` parameter.)

## Fix

`cluster-image-builder/serve/llama_cpp/v0_3_7/app.py` — filter the payload to each API's **real signature** before calling `create_chat_completion` / `create_completion` / `create_embedding`, dropping (and logging) unsupported keys. Param sets are computed once via `inspect.signature`, so new OpenAI fields are handled automatically rather than needing a hardcoded blacklist.

The vLLM wrapper already tolerates extra OpenAI fields (it builds a `ChatCompletionRequest(**payload)` pydantic model); this brings the llama_cpp wrapper in line.

## Why the engine wrapper (not the gateway)

The wrapper is the layer that adapts the standard OpenAI surface to a specific engine's API, so defensively dropping params the engine can't take belongs here. Putting per-engine capability knowledge in the gateway (e.g. only inject `include_usage` for capable engines) is brittle — the gateway has no reliable capability signal for internal endpoints.

## Compatibility / no regression

- `llama_cpp` 0.3.7 streaming does not emit a usage chunk anyway, so dropping `stream_options.include_usage` loses nothing on llama.cpp; the gateway's Anthropic translation already falls back to an estimated final usage when the upstream sends none.
- Only `stream_options`-style unknown fields are dropped; all parameters llama_cpp accepts pass through unchanged.

## Verification

- `python -m py_compile app.py` passes.
- Against the real `llama_cpp` 0.3.7 signature: the filter drops `stream_options` while keeping `messages` / `max_tokens` / `stream`, and the filtered payload binds cleanly to `create_chat_completion` (no `TypeError`).
- Equivalent native-OpenAI streaming **without** `stream_options` already streams correctly through the same engine, so the filtered call takes the known-good path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
