### PR TITLE
fix(ai-trace): support the "All workspaces" aggregate view

### DIFF
--- a/internal/routes/logs/ai_trace.go
+++ b/internal/routes/logs/ai_trace.go
@@ -209,48 +209,63 @@ func resolveAllWorkspacesTraceScope(c *gin.Context, deps *Dependencies, userID s
 		return
 	}
 
-	// Otherwise scope to the per-workspace grants the caller actually holds. We
-	// enumerate workspaces and OR together a clause per workspace the caller can
-	// read, narrowing to a single endpoint_type where only one permission is held.
-	// A permission already granted globally holds in every workspace, so skip its
-	// per-workspace check and only query the DB for the permission(s) not global.
-	workspaces, err := deps.Storage.ListWorkspace(storage.ListOption{})
-	if err != nil {
-		tracePermError(c, userID, err)
+	clauses := make([]string, 0)
 
-		return
+	// A trace permission held globally grants that endpoint type across *every*
+	// workspace — including retained traces of since-deleted workspaces — so emit
+	// an unscoped endpoint_type clause instead of enumerating current workspaces.
+	// This keeps "_all_" consistent with the both-global "*" fast path above:
+	// whether a caller holds one or both permissions globally, deleted-workspace
+	// traces for the permitted endpoint type(s) stay visible.
+	if globalEndpoint {
+		clauses = append(clauses, fmt.Sprintf("endpoint_type:=%s", logsQLQuoteValue("endpoint")))
 	}
 
-	clauses := make([]string, 0, len(workspaces))
+	if globalExternal {
+		clauses = append(clauses, fmt.Sprintf("endpoint_type:=%s", logsQLQuoteValue("external-endpoint")))
+	}
 
-	for i := range workspaces {
-		name := workspaces[i].GetName()
-		if name == "" {
-			continue
+	// Enumerate per-workspace grants only for the permission(s) NOT held globally;
+	// the global ones are already covered by the unscoped clauses above. Each
+	// workspace the caller can read contributes an OR clause, narrowed to a single
+	// endpoint_type where only one permission is held there.
+	if !globalEndpoint || !globalExternal {
+		workspaces, err := deps.Storage.ListWorkspace(storage.ListOption{})
+		if err != nil {
+			tracePermError(c, userID, err)
+
+			return
 		}
 
-		canEndpoint := globalEndpoint
-		if !canEndpoint {
-			canEndpoint, err = middleware.CheckWorkspacePermission(deps.Storage, userID, name, permEndpointTraceRead)
-			if err != nil {
-				tracePermError(c, userID, err)
-
-				return
+		for i := range workspaces {
+			name := workspaces[i].GetName()
+			if name == "" {
+				continue
 			}
-		}
 
-		canExternal := globalExternal
-		if !canExternal {
-			canExternal, err = middleware.CheckWorkspacePermission(deps.Storage, userID, name, permExternalEndpointTraceRead)
-			if err != nil {
-				tracePermError(c, userID, err)
+			canEndpoint := false
+			if !globalEndpoint {
+				canEndpoint, err = middleware.CheckWorkspacePermission(deps.Storage, userID, name, permEndpointTraceRead)
+				if err != nil {
+					tracePermError(c, userID, err)
 
-				return
+					return
+				}
 			}
-		}
 
-		if clause := workspaceScopeClause(name, canEndpoint, canExternal); clause != "" {
-			clauses = append(clauses, clause)
+			canExternal := false
+			if !globalExternal {
+				canExternal, err = middleware.CheckWorkspacePermission(deps.Storage, userID, name, permExternalEndpointTraceRead)
+				if err != nil {
+					tracePermError(c, userID, err)
+
+					return
+				}
+			}
+
+			if clause := workspaceScopeClause(name, canEndpoint, canExternal); clause != "" {
+				clauses = append(clauses, clause)
+			}
 		}
 	}
 

--- a/internal/routes/logs/ai_trace.go
+++ b/internal/routes/logs/ai_trace.go
@@ -212,6 +212,8 @@ func resolveAllWorkspacesTraceScope(c *gin.Context, deps *Dependencies, userID s
 	// Otherwise scope to the per-workspace grants the caller actually holds. We
 	// enumerate workspaces and OR together a clause per workspace the caller can
 	// read, narrowing to a single endpoint_type where only one permission is held.
+	// A permission already granted globally holds in every workspace, so skip its
+	// per-workspace check and only query the DB for the permission(s) not global.
 	workspaces, err := deps.Storage.ListWorkspace(storage.ListOption{})
 	if err != nil {
 		tracePermError(c, userID, err)
@@ -227,18 +229,24 @@ func resolveAllWorkspacesTraceScope(c *gin.Context, deps *Dependencies, userID s
 			continue
 		}
 
-		canEndpoint, err := middleware.CheckWorkspacePermission(deps.Storage, userID, name, permEndpointTraceRead)
-		if err != nil {
-			tracePermError(c, userID, err)
+		canEndpoint := globalEndpoint
+		if !canEndpoint {
+			canEndpoint, err = middleware.CheckWorkspacePermission(deps.Storage, userID, name, permEndpointTraceRead)
+			if err != nil {
+				tracePermError(c, userID, err)
 
-			return
+				return
+			}
 		}
 
-		canExternal, err := middleware.CheckWorkspacePermission(deps.Storage, userID, name, permExternalEndpointTraceRead)
-		if err != nil {
-			tracePermError(c, userID, err)
+		canExternal := globalExternal
+		if !canExternal {
+			canExternal, err = middleware.CheckWorkspacePermission(deps.Storage, userID, name, permExternalEndpointTraceRead)
+			if err != nil {
+				tracePermError(c, userID, err)
 
-			return
+				return
+			}
 		}
 
 		if clause := workspaceScopeClause(name, canEndpoint, canExternal); clause != "" {
@@ -267,7 +275,7 @@ func resolveAllWorkspacesTraceScope(c *gin.Context, deps *Dependencies, userID s
 func workspaceScopeClause(workspace string, canEndpoint, canExternal bool) string {
 	switch {
 	case canEndpoint && canExternal:
-		return fmt.Sprintf("workspace:=%s", logsQLQuoteValue(workspace))
+		return fmt.Sprintf("(workspace:=%s)", logsQLQuoteValue(workspace))
 	case canEndpoint:
 		return fmt.Sprintf("(workspace:=%s endpoint_type:=%s)",
 			logsQLQuoteValue(workspace), logsQLQuoteValue("endpoint"))

--- a/internal/routes/logs/ai_trace.go
+++ b/internal/routes/logs/ai_trace.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/neutree-ai/neutree/internal/middleware"
+	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 // AITrace is one inference trace record returned to the SPA.
@@ -91,6 +92,17 @@ const (
 	// traceEndpointTypeKey holds, in the gin context, the single endpoint_type a
 	// caller is restricted to ("endpoint" or "external-endpoint"); empty = both.
 	traceEndpointTypeKey = "trace_endpoint_type"
+	// traceScopeFilterKey holds, in the gin context, a ready-to-use LogsQL
+	// boolean expression constraining results to the workspaces (and per-workspace
+	// endpoint types) the caller may read. Set only on the "all workspaces" path;
+	// empty for a concrete workspace, where traceScopeClause builds the clause
+	// from the path param instead.
+	traceScopeFilterKey = "trace_scope_filter"
+	// allWorkspacesSentinel mirrors the SPA's ALL_WORKSPACES constant
+	// (foundation/hooks/use-workspace.ts). It is a UI-only value, never a real
+	// workspace name; selecting it asks for traces aggregated across every
+	// workspace the caller is permitted to read.
+	allWorkspacesSentinel = "_all_"
 )
 
 // requireTracePermission gates the ai-trace routes on endpoint:trace-read OR
@@ -112,6 +124,16 @@ func requireTracePermission(deps *Dependencies) gin.HandlerFunc {
 		if workspace == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "workspace parameter is required"})
 			c.Abort()
+
+			return
+		}
+
+		// "All workspaces" is a cross-workspace aggregate, not a real workspace.
+		// It needs its own permission resolution: the caller may read traces in
+		// only a subset of workspaces, so we compute a scope filter rather than a
+		// single yes/no check against a (non-existent) workspace named "_all_".
+		if workspace == allWorkspacesSentinel {
+			resolveAllWorkspacesTraceScope(c, deps, userID)
 
 			return
 		}
@@ -157,6 +179,124 @@ func tracePermError(c *gin.Context, userID string, err error) {
 	c.Abort()
 }
 
+// resolveAllWorkspacesTraceScope handles the "_all_" aggregate: it computes the
+// LogsQL scope filter restricting results to the workspaces (and per-workspace
+// endpoint types) the caller is permitted to read, stores it under
+// traceScopeFilterKey, and continues — or aborts 403 when the caller may read
+// no workspace at all.
+func resolveAllWorkspacesTraceScope(c *gin.Context, deps *Dependencies, userID string) {
+	// Fast path: a global grant on both trace permissions lets the caller read
+	// every workspace's traces — including any belonging to since-deleted
+	// workspaces — so we impose no workspace constraint at all.
+	globalEndpoint, err := middleware.CheckWorkspacePermission(deps.Storage, userID, "", permEndpointTraceRead)
+	if err != nil {
+		tracePermError(c, userID, err)
+
+		return
+	}
+
+	globalExternal, err := middleware.CheckWorkspacePermission(deps.Storage, userID, "", permExternalEndpointTraceRead)
+	if err != nil {
+		tracePermError(c, userID, err)
+
+		return
+	}
+
+	if globalEndpoint && globalExternal {
+		c.Set(traceScopeFilterKey, "*")
+		c.Next()
+
+		return
+	}
+
+	// Otherwise scope to the per-workspace grants the caller actually holds. We
+	// enumerate workspaces and OR together a clause per workspace the caller can
+	// read, narrowing to a single endpoint_type where only one permission is held.
+	workspaces, err := deps.Storage.ListWorkspace(storage.ListOption{})
+	if err != nil {
+		tracePermError(c, userID, err)
+
+		return
+	}
+
+	clauses := make([]string, 0, len(workspaces))
+
+	for i := range workspaces {
+		name := workspaces[i].GetName()
+		if name == "" {
+			continue
+		}
+
+		canEndpoint, err := middleware.CheckWorkspacePermission(deps.Storage, userID, name, permEndpointTraceRead)
+		if err != nil {
+			tracePermError(c, userID, err)
+
+			return
+		}
+
+		canExternal, err := middleware.CheckWorkspacePermission(deps.Storage, userID, name, permExternalEndpointTraceRead)
+		if err != nil {
+			tracePermError(c, userID, err)
+
+			return
+		}
+
+		if clause := workspaceScopeClause(name, canEndpoint, canExternal); clause != "" {
+			clauses = append(clauses, clause)
+		}
+	}
+
+	if len(clauses) == 0 {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error":    "insufficient permissions",
+			"required": permEndpointTraceRead + " or " + permExternalEndpointTraceRead,
+		})
+		c.Abort()
+
+		return
+	}
+
+	c.Set(traceScopeFilterKey, "("+strings.Join(clauses, " OR ")+")")
+	c.Next()
+}
+
+// workspaceScopeClause builds the LogsQL sub-clause for one workspace given which
+// trace permissions the caller holds there. A caller holding both permissions
+// sees the whole workspace; holding only one is narrowed to that endpoint type.
+// Returns "" when the caller may read neither endpoint type.
+func workspaceScopeClause(workspace string, canEndpoint, canExternal bool) string {
+	switch {
+	case canEndpoint && canExternal:
+		return fmt.Sprintf("workspace:=%s", logsQLQuoteValue(workspace))
+	case canEndpoint:
+		return fmt.Sprintf("(workspace:=%s endpoint_type:=%s)",
+			logsQLQuoteValue(workspace), logsQLQuoteValue("endpoint"))
+	case canExternal:
+		return fmt.Sprintf("(workspace:=%s endpoint_type:=%s)",
+			logsQLQuoteValue(workspace), logsQLQuoteValue("external-endpoint"))
+	default:
+		return ""
+	}
+}
+
+// traceScopeClause returns the LogsQL expression constraining a query to the
+// workspace(s) and endpoint type(s) the caller may read. For the "_all_"
+// aggregate it is the scope filter precomputed by the permission middleware; for
+// a concrete workspace it is `workspace:="<ws>"` plus any single-endpoint-type
+// restriction the caller is limited to.
+func traceScopeClause(c *gin.Context) string {
+	if scope := c.GetString(traceScopeFilterKey); scope != "" {
+		return scope
+	}
+
+	clause := fmt.Sprintf("workspace:=%s", logsQLQuoteValue(c.Param("workspace")))
+	if et := traceEndpointTypeFilter(c); et != "" {
+		clause += " " + et
+	}
+
+	return clause
+}
+
 // traceEndpointTypeFilter returns a LogsQL clause restricting results to the
 // endpoint_type the caller is permitted to see, or "" when unrestricted.
 func traceEndpointTypeFilter(c *gin.Context) string {
@@ -178,8 +318,6 @@ func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		workspace := c.Param("workspace")
-
 		limit := 50
 
 		if v := c.Query("limit"); v != "" {
@@ -188,7 +326,9 @@ func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
 			}
 		}
 
-		queryParts := []string{fmt.Sprintf("workspace:=%s", logsQLQuoteValue(workspace))}
+		// Leading clause scopes the query to the workspace(s) the caller may read
+		// (a concrete workspace, or the cross-workspace "_all_" aggregate).
+		queryParts := []string{traceScopeClause(c)}
 
 		if endpoint := strings.TrimSpace(c.Query("endpoint_name")); endpoint != "" {
 			queryParts = append(queryParts, fmt.Sprintf("endpoint_name:=%s", logsQLQuoteValue(endpoint)))
@@ -216,11 +356,6 @@ func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
 				"(request_model:=%s OR response_model:=%s)",
 				logsQLQuoteValue(model), logsQLQuoteValue(model),
 			))
-		}
-
-		// Restrict to the endpoint_type the caller is permitted to see.
-		if f := traceEndpointTypeFilter(c); f != "" {
-			queryParts = append(queryParts, f)
 		}
 
 		// The list view never renders request/response bodies — project them
@@ -277,8 +412,6 @@ func handleGetAITrace(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		workspace := c.Param("workspace")
-
 		requestID := strings.TrimSpace(c.Param("request_id"))
 		if requestID == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
@@ -288,14 +421,12 @@ func handleGetAITrace(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		etFilter := traceEndpointTypeFilter(c)
-		if etFilter != "" {
-			etFilter = " " + etFilter
-		}
-
+		// The scope clause confines the lookup to workspaces/endpoint types the
+		// caller may read, so an "_all_" detail fetch cannot read a trace the
+		// caller has no permission for.
 		query := fmt.Sprintf(
-			"workspace:=%s request_id:=%s%s | sort by (_time) desc | limit 1",
-			logsQLQuoteValue(workspace), logsQLQuoteValue(requestID), etFilter,
+			"%s request_id:=%s | sort by (_time) desc | limit 1",
+			traceScopeClause(c), logsQLQuoteValue(requestID),
 		)
 
 		items, err := queryAITraces(deps, query, url.Values{})
@@ -336,8 +467,6 @@ func handleAITraceStats(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		workspace := c.Param("workspace")
-
 		startDay, endDay, ok := statsWindow(c)
 		if !ok {
 			c.JSON(http.StatusBadRequest, gin.H{
@@ -347,14 +476,9 @@ func handleAITraceStats(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		etFilter := traceEndpointTypeFilter(c)
-		if etFilter != "" {
-			etFilter = " " + etFilter
-		}
-
 		query := fmt.Sprintf(
-			"workspace:=%s%s | stats by (_time:1d) count() total",
-			logsQLQuoteValue(workspace), etFilter,
+			"%s | stats by (_time:1d) count() total",
+			traceScopeClause(c),
 		)
 
 		params := url.Values{}

--- a/internal/routes/logs/ai_trace_test.go
+++ b/internal/routes/logs/ai_trace_test.go
@@ -405,9 +405,10 @@ func TestRequireTracePermission_AllWorkspaces_ScopedBuildsFilter(t *testing.T) {
 }
 
 func TestRequireTracePermission_AllWorkspaces_GlobalEndpointOnly(t *testing.T) {
-	// A global grant on only the endpoint permission must not short-circuit to
-	// "*": enumeration narrows every workspace to endpoint_type=endpoint, while
-	// still folding in any workspace-scoped external grant (here ws2).
+	// A global grant on only the endpoint permission yields an unscoped
+	// endpoint_type clause (so retained traces of deleted workspaces stay
+	// visible), OR'd with any workspace-scoped external grant (here ws2). It must
+	// not narrow the global endpoint permission to current workspaces.
 	store := scopedPermMock(func(ws, perm string) bool {
 		if perm == permEndpointTraceRead {
 			return true // global endpoint grant
@@ -423,9 +424,49 @@ func TestRequireTracePermission_AllWorkspaces_GlobalEndpointOnly(t *testing.T) {
 
 	assert.False(t, c.IsAborted())
 	assert.Equal(t,
-		`((workspace:="ws1" endpoint_type:="endpoint") OR (workspace:="ws2"))`,
+		`(endpoint_type:="endpoint" OR (workspace:="ws2" endpoint_type:="external-endpoint"))`,
 		c.GetString(traceScopeFilterKey),
 	)
+}
+
+func TestRequireTracePermission_AllWorkspaces_GlobalExternalOnly(t *testing.T) {
+	// Symmetric to the endpoint-only case: a global external grant yields an
+	// unscoped external endpoint_type clause, OR'd with any workspace-scoped
+	// endpoint grant (here ws1).
+	store := scopedPermMock(func(ws, perm string) bool {
+		if perm == permExternalEndpointTraceRead {
+			return true // global external grant
+		}
+
+		return ws == "ws1" // workspace-scoped endpoint grant
+	})
+	mockWorkspaces(store, "ws1", "ws2")
+	deps := &Dependencies{Storage: store}
+	c, _ := traceCtx("user-1", "_all_")
+
+	requireTracePermission(deps)(c)
+
+	assert.False(t, c.IsAborted())
+	assert.Equal(t,
+		`(endpoint_type:="external-endpoint" OR (workspace:="ws1" endpoint_type:="endpoint"))`,
+		c.GetString(traceScopeFilterKey),
+	)
+}
+
+func TestRequireTracePermission_AllWorkspaces_GlobalEndpointOnlyNoWorkspaceGrants(t *testing.T) {
+	// Global endpoint permission with no extra external grants: a single unscoped
+	// endpoint_type clause, with no per-workspace clauses appended.
+	store := scopedPermMock(func(_, perm string) bool {
+		return perm == permEndpointTraceRead
+	})
+	mockWorkspaces(store, "ws1", "ws2")
+	deps := &Dependencies{Storage: store}
+	c, _ := traceCtx("user-1", "_all_")
+
+	requireTracePermission(deps)(c)
+
+	assert.False(t, c.IsAborted())
+	assert.Equal(t, `(endpoint_type:="endpoint")`, c.GetString(traceScopeFilterKey))
 }
 
 func TestTraceScopeClause_ConcreteWorkspace(t *testing.T) {

--- a/internal/routes/logs/ai_trace_test.go
+++ b/internal/routes/logs/ai_trace_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
@@ -321,6 +322,126 @@ func TestRequireTracePermission_BothGrantedUnrestricted(t *testing.T) {
 	assert.False(t, c.IsAborted())
 	// No single-type restriction recorded => handlers see both endpoint types.
 	assert.Equal(t, "", c.GetString(traceEndpointTypeKey))
+}
+
+// scopedPermMock returns a MockStorage whose has_permission resolves via the
+// given decision function, keyed on (workspace, permission). A nil workspace
+// param (the global check) is passed through as "".
+func scopedPermMock(decide func(workspace, perm string) bool) *mocks.MockStorage {
+	m := new(mocks.MockStorage)
+	m.On("CallDatabaseFunction", "has_permission", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			params := args.Get(1).(map[string]interface{})
+			perm, _ := params["required_permission"].(string)
+			ws, _ := params["workspace"].(string) // nil (global) → ""
+			out := args.Get(2).(*bool)
+			*out = decide(ws, perm)
+		}).Return(nil)
+
+	return m
+}
+
+// mockWorkspaces wires ListWorkspace to return workspaces with the given names.
+func mockWorkspaces(m *mocks.MockStorage, names ...string) {
+	wss := make([]v1.Workspace, 0, len(names))
+	for _, n := range names {
+		wss = append(wss, v1.Workspace{Metadata: &v1.Metadata{Name: n}})
+	}
+
+	m.On("ListWorkspace", mock.Anything).Return(wss, nil)
+}
+
+func TestRequireTracePermission_AllWorkspaces_GlobalBothUnrestricted(t *testing.T) {
+	// A global grant on both permissions skips workspace enumeration and imposes
+	// no workspace constraint (scope "*").
+	store := scopedPermMock(func(ws, _ string) bool { return ws == "" })
+	deps := &Dependencies{Storage: store}
+	c, _ := traceCtx("user-1", "_all_")
+
+	requireTracePermission(deps)(c)
+
+	assert.False(t, c.IsAborted())
+	assert.Equal(t, "*", c.GetString(traceScopeFilterKey))
+	store.AssertNotCalled(t, "ListWorkspace", mock.Anything)
+}
+
+func TestRequireTracePermission_AllWorkspaces_NoGrantsForbidden(t *testing.T) {
+	// No global grant and no per-workspace grant => 403, not an empty result.
+	store := scopedPermMock(func(_, _ string) bool { return false })
+	mockWorkspaces(store, "ws1", "ws2")
+	deps := &Dependencies{Storage: store}
+	c, w := traceCtx("user-1", "_all_")
+
+	requireTracePermission(deps)(c)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.True(t, c.IsAborted())
+}
+
+func TestRequireTracePermission_AllWorkspaces_ScopedBuildsFilter(t *testing.T) {
+	// No global grant; the caller holds both permissions in ws1, endpoint-only in
+	// ws2, and nothing in ws3. The scope OR-expression must reflect exactly that.
+	store := scopedPermMock(func(ws, perm string) bool {
+		switch ws {
+		case "ws1":
+			return true
+		case "ws2":
+			return perm == permEndpointTraceRead
+		default: // "" (global) and ws3
+			return false
+		}
+	})
+	mockWorkspaces(store, "ws1", "ws2", "ws3")
+	deps := &Dependencies{Storage: store}
+	c, _ := traceCtx("user-1", "_all_")
+
+	requireTracePermission(deps)(c)
+
+	assert.False(t, c.IsAborted())
+	assert.Equal(t,
+		`((workspace:="ws1") OR (workspace:="ws2" endpoint_type:="endpoint"))`,
+		c.GetString(traceScopeFilterKey),
+	)
+}
+
+func TestRequireTracePermission_AllWorkspaces_GlobalEndpointOnly(t *testing.T) {
+	// A global grant on only the endpoint permission must not short-circuit to
+	// "*": enumeration narrows every workspace to endpoint_type=endpoint, while
+	// still folding in any workspace-scoped external grant (here ws2).
+	store := scopedPermMock(func(ws, perm string) bool {
+		if perm == permEndpointTraceRead {
+			return true // global endpoint grant
+		}
+
+		return ws == "ws2" // workspace-scoped external grant
+	})
+	mockWorkspaces(store, "ws1", "ws2")
+	deps := &Dependencies{Storage: store}
+	c, _ := traceCtx("user-1", "_all_")
+
+	requireTracePermission(deps)(c)
+
+	assert.False(t, c.IsAborted())
+	assert.Equal(t,
+		`((workspace:="ws1" endpoint_type:="endpoint") OR (workspace:="ws2"))`,
+		c.GetString(traceScopeFilterKey),
+	)
+}
+
+func TestTraceScopeClause_ConcreteWorkspace(t *testing.T) {
+	// Concrete workspace, both endpoint types: bare workspace clause.
+	c, _ := traceCtx("user-1", "ws1")
+	assert.Equal(t, `workspace:="ws1"`, traceScopeClause(c))
+
+	// Concrete workspace restricted to one endpoint type folds the type in.
+	c.Set(traceEndpointTypeKey, "endpoint")
+	assert.Equal(t, `workspace:="ws1" endpoint_type:="endpoint"`, traceScopeClause(c))
+}
+
+func TestTraceScopeClause_AllWorkspacesUsesPrecomputedFilter(t *testing.T) {
+	c, _ := traceCtx("user-1", "_all_")
+	c.Set(traceScopeFilterKey, `((workspace:="ws1"))`)
+	assert.Equal(t, `((workspace:="ws1"))`, traceScopeClause(c))
 }
 
 func TestAITraceHandlers_StoreNotConfigured(t *testing.T) {


### PR DESCRIPTION
## Problem

On the Inference Trace page, selecting **All workspaces** sends the UI-only sentinel `_all_` (`ALL_WORKSPACES`, `foundation/hooks/use-workspace.ts`) as a literal workspace to `GET /api/v1/ai-traces/:workspace`. The handler built an exact-match LogsQL filter `workspace:="_all_"`, which matches no record:

- Community / enterprise **global** roles → list + stats silently empty.
- Enterprise **workspace-scoped** users → `has_permission(.., "_all_")` matches nothing → **403**.

Standard PostgREST list resources already treat `_all_` as "drop the workspace filter" (`providers/data-provider`), so the trace page was the odd one out.

## Change

Treat `_all_` as a **cross-workspace aggregate scoped to the workspaces the caller may read**:

- New `resolveAllWorkspacesTraceScope` in the permission middleware:
  - A **global grant on both** trace permissions (`endpoint:trace-read` + `external_endpoint:trace-read`) → no workspace constraint (scope `*`), covering traces of since-deleted workspaces too.
  - Otherwise enumerate workspaces and OR together one clause per readable workspace, narrowed to a single `endpoint_type` where the caller holds only one of the two permissions. This correctly folds in mixed global/workspace grants.
  - No readable workspace → `403` (not a silent empty result).
- `traceScopeClause` unifies the leading LogsQL clause for all three handlers (list / stats / detail). The **detail** endpoint now reuses the same scope, so an `_all_` lookup by `request_id` cannot read a trace the caller has no permission for.
- A concrete workspace keeps its existing behaviour (`workspace:="<ws>"` plus any single-endpoint-type restriction); no behavioural change there.

## Testing

- `go test ./internal/routes/logs/...` — pass (added cases for global-both, no-grants-403, scoped OR filter, global-endpoint-only mixing, and `traceScopeClause`).
- `go vet ./internal/routes/logs/...` — clean.
- `make build-neutree-api` — builds.

Pairs with the UI change adding a workspace column to the All-workspaces view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)