### PR TITLE
ci: use nightly tag for UI nightly build

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -2,7 +2,7 @@ name: Daily Build
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
 
 jobs:
@@ -21,24 +21,25 @@ jobs:
         id: create_nightly_tag
         run: |
           DATE=$(date +'%Y%m%d')
-          git tag v1.1.0-nightly-$DATE -m v1.1.0-nightly-$DATE
-          git push origin v1.1.0-nightly-$DATE
-          echo "tag=v1.1.0-nightly-$DATE" >> $GITHUB_OUTPUT
+          NIGHTLY_TAG="v1.1.0-nightly-${DATE}"
+          git tag "${NIGHTLY_TAG}" -m "${NIGHTLY_TAG}"
+          git push origin "${NIGHTLY_TAG}"
+          echo "tag=${NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
       - name: Trigger Workflow
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
-          NIGHTLY_UI_VERSION: ${{ secrets.NIGHTLY_UI_VERSION }}
           NIGHTLY_CLUSTER_VERSION: ${{ secrets.NIGHTLY_CLUSTER_VERSION }}
         with:
           script: |
-            github.rest.actions.createWorkflowDispatch({
+            const nightlyTag = '${{ steps.create_nightly_tag.outputs.tag }}';
+            await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'release.yaml',
               ref: 'main',
               inputs: {
-                tag: '${{ steps.create_nightly_tag.outputs.tag }}',
-                ui_version: '${{ env.NIGHTLY_UI_VERSION }}',
-                cluster_version:'${{ env.NIGHTLY_CLUSTER_VERSION }}'
+                tag: nightlyTag,
+                ui_version: nightlyTag,
+                cluster_version: process.env.NIGHTLY_CLUSTER_VERSION
               },
             })


### PR DESCRIPTION
## Issue

n/a

## Summary

Daily Build now runs at `0 1 * * *` and dispatches `release.yaml` with the same nightly tag as the UI version. The API image build clones `neutree-ai/ui` using the `ui_version` input, so nightly builds should pass the generated nightly tag instead of the old UI ref from `NIGHTLY_UI_VERSION`.

## Changes

- Change the Daily Build schedule from `0 0 * * *` to `0 1 * * *`.
- Reuse the generated nightly tag as both the release `tag` input and the UI `ui_version` input.
- Await the `release.yaml` workflow dispatch so dispatch failures fail the daily build step.
- Update `actions/github-script` to v7, quote nightly tag shell variables, and read `NIGHTLY_CLUSTER_VERSION` from `process.env` inside the script.
- Stop reading `NIGHTLY_UI_VERSION` in the daily build dispatch path.

## Test Plan

### Unit test

- Not affected: workflow-only change, no Go/Python production code changed.
- `git diff --check` passed.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/daily-build.yaml"); puts "yaml ok"'` passed.
- `awk ... .github/workflows/daily-build.yaml | bash -n` passed for the tag creation shell block.
- `awk ... .github/workflows/daily-build.yaml | node --check` passed for the embedded GitHub Script wrapped in an async function.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/daily-build.yaml` passed.
- `gh workflow view daily-build.yaml --ref ops-nightly-ui-tag --yaml` returned the updated workflow from the remote branch, including cron `0 1 * * *`.

### DB test

- Not affected: no database migrations or storage behavior changed.

### E2E test

- Not affected: isolated GitHub Actions workflow dispatch change. Manual testing is not required because there is no deployed runtime behavior to cover.

## Risk & Rollback

Risk is limited to the nightly release automation. The daily build now assumes the matching UI nightly tag is available when `release.yaml` builds the API image. Rollback is to restore the previous schedule and `NIGHTLY_UI_VERSION` input wiring.

## Change Classification

Trivial: isolated `.github/workflows/*.yaml` build-infra change. Docs MR, TestRail sync, E2E green validation, and E2E regression are skipped per workflow policy.