### PR TITLE
Reject invalid image registry URL hosts

### DIFF
--- a/internal/routes/proxies/image_registry_proxy.go
+++ b/internal/routes/proxies/image_registry_proxy.go
@@ -1,12 +1,17 @@
 package proxies
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/middleware"
+	"github.com/neutree-ai/neutree/internal/util"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
@@ -34,6 +39,44 @@ func validateImageRegistryDeletion(s storage.Storage) middleware.DeletionValidat
 	}
 }
 
+func validateImageRegistryURL() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to read request body: %v", err)})
+			c.Abort()
+
+			return
+		}
+
+		c.Request.Body.Close()
+		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+		c.Request.ContentLength = int64(len(body))
+		c.Request.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
+
+		var imageRegistry v1.ImageRegistry
+		if err := json.Unmarshal(body, &imageRegistry); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to parse image registry: %v", err)})
+			c.Abort()
+
+			return
+		}
+
+		if imageRegistry.Spec != nil && imageRegistry.Spec.URL != "" {
+			if _, err := util.GetImageRegistryHost(&imageRegistry); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": fmt.Sprintf("invalid image registry url: %v", err),
+				})
+				c.Abort()
+
+				return
+			}
+		}
+
+		c.Next()
+	}
+}
+
 func RegisterImageRegistryRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc, deps *Dependencies) {
 	proxyGroup := group.Group("/image_registries")
 	proxyGroup.Use(middlewares...)
@@ -45,6 +88,6 @@ func RegisterImageRegistryRoutes(group *gin.RouterGroup, middlewares []gin.Handl
 	handler := CreateStructProxyHandler[v1.ImageRegistry](deps, storage.IMAGE_REGISTRY_TABLE)
 
 	proxyGroup.GET("", handler)
-	proxyGroup.POST("", handler)
-	proxyGroup.PATCH("", deletionValidation, handler)
+	proxyGroup.POST("", validateImageRegistryURL(), handler)
+	proxyGroup.PATCH("", deletionValidation, validateImageRegistryURL(), handler)
 }

--- a/internal/routes/proxies/image_registry_proxy_test.go
+++ b/internal/routes/proxies/image_registry_proxy_test.go
@@ -2,14 +2,166 @@ package proxies
 
 import (
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/neutree-ai/neutree/internal/middleware"
 	"github.com/neutree-ai/neutree/pkg/storage"
 	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
+
+func TestRegisterImageRegistryRoutesRejectsInvalidURLHostOnCreate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var upstreamCalled atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled.Store(true)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	RegisterImageRegistryRoutes(router.Group("/api/v1"), nil, &Dependencies{
+		StorageAccessURL: upstream.URL,
+	})
+
+	body := strings.NewReader(`{
+		"api_version":"v1",
+		"kind":"ImageRegistry",
+		"metadata":{"name":"invalid-registry","workspace":"default"},
+		"spec":{"url":"https://index.docker<>.io","repository":"neutree"}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/image_registries", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.ResponseRecorder.Code)
+	assert.Contains(t, recorder.ResponseRecorder.Body.String(), "invalid image registry url")
+	assert.False(t, upstreamCalled.Load(), "invalid image registry should not be forwarded to PostgREST")
+}
+
+func TestRegisterImageRegistryRoutesForwardsValidURLOnCreate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var upstreamCalled atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled.Store(true)
+		assert.Equal(t, "/image_registries", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	RegisterImageRegistryRoutes(router.Group("/api/v1"), nil, &Dependencies{
+		StorageAccessURL: upstream.URL,
+	})
+
+	body := strings.NewReader(`{
+		"api_version":"v1",
+		"kind":"ImageRegistry",
+		"metadata":{"name":"valid-registry","workspace":"default"},
+		"spec":{"url":"https://registry.example.com:5000","repository":"neutree"}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/image_registries", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusCreated, recorder.ResponseRecorder.Code)
+	assert.True(t, upstreamCalled.Load(), "valid image registry should be forwarded to PostgREST")
+}
+
+func TestRegisterImageRegistryRoutesRejectsInvalidURLHostOnPatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var upstreamCalled atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled.Store(true)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	RegisterImageRegistryRoutes(router.Group("/api/v1"), nil, &Dependencies{
+		StorageAccessURL: upstream.URL,
+	})
+
+	body := strings.NewReader(`{"spec":{"url":"https://index.docker<>.io"}}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/image_registries?id=eq.118", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.ResponseRecorder.Code)
+	assert.Contains(t, recorder.ResponseRecorder.Body.String(), "invalid image registry url")
+	assert.False(t, upstreamCalled.Load(), "invalid image registry patch should not be forwarded to PostgREST")
+}
+
+func TestRegisterImageRegistryRoutesForwardsValidURLOnPatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storageMock := storageMocks.NewMockStorage(t)
+	storageMock.EXPECT().
+		GenericQuery(storage.IMAGE_REGISTRY_TABLE, "spec", mock.Anything, mock.Anything).
+		Run(func(_ string, _ string, _ []storage.Filter, result interface{}) {
+			resources := result.(*[]map[string]interface{})
+			*resources = []map[string]interface{}{
+				{
+					"spec": map[string]interface{}{
+						"authconfig": map[string]interface{}{
+							"username": "existing-user",
+							"password": "existing-password",
+						},
+					},
+				},
+			}
+		}).
+		Return(nil)
+
+	var upstreamCalled atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled.Store(true)
+		assert.Equal(t, "/image_registries", r.URL.Path)
+		assert.Equal(t, "id=eq.118", r.URL.RawQuery)
+		assert.Equal(t, http.MethodPatch, r.Method)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Contains(t, string(body), `"url":"https://registry.example.com:5000"`)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	RegisterImageRegistryRoutes(router.Group("/api/v1"), nil, &Dependencies{
+		StorageAccessURL: upstream.URL,
+		Storage:          storageMock,
+	})
+
+	body := strings.NewReader(`{"spec":{"url":"https://registry.example.com:5000"}}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/image_registries?id=eq.118", body)
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+	assert.True(t, upstreamCalled.Load(), "valid image registry patch should be forwarded to PostgREST")
+}
 
 func TestValidateImageRegistryDeletion(t *testing.T) {
 	tests := []struct {

--- a/internal/util/image_registry.go
+++ b/internal/util/image_registry.go
@@ -3,12 +3,15 @@ package util
 import (
 	"encoding/base64"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
+
+var invalidRegistryHostnameChar = regexp.MustCompile(`[^A-Za-z0-9.:-]`)
 
 // GetImageRegistryAuthInfo extracts the username and password from the given image registry auth config.
 // If both username and password are provided, they are returned directly.
@@ -67,7 +70,23 @@ func parseRegistryHost(rawURL string) (string, error) {
 		return "", errors.New("invalid registry url: " + rawURL)
 	}
 
+	if err := validateRegistryHostname(parsed.Hostname()); err != nil {
+		return "", err
+	}
+
 	return parsed.Host, nil
+}
+
+func validateRegistryHostname(hostname string) error {
+	if hostname == "" {
+		return errors.New("empty registry host")
+	}
+
+	if char := invalidRegistryHostnameChar.FindString(hostname); char != "" {
+		return errors.Errorf("invalid registry host %q: contains invalid character %q", hostname, char)
+	}
+
+	return nil
 }
 
 // StripRegistryScheme removes the http:// or https:// scheme prefix from a

--- a/internal/util/image_registry_test.go
+++ b/internal/util/image_registry_test.go
@@ -123,6 +123,17 @@ func TestGetImagePrefix(t *testing.T) {
 			want:    "registry.example.com:5000/repo",
 			wantErr: false,
 		},
+		{
+			name: "URL with invalid host characters",
+			imageRegistry: &v1.ImageRegistry{
+				Spec: &v1.ImageRegistrySpec{
+					URL:        "https://index.docker<>.io",
+					Repository: "repo",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -352,10 +363,40 @@ func TestGetImageRegistryHost(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "URL with IPv6 literal host and port",
+			imageRegistry: &v1.ImageRegistry{
+				Spec: &v1.ImageRegistrySpec{
+					URL: "https://[2001:db8::1]:5000",
+				},
+			},
+			want:    "[2001:db8::1]:5000",
+			wantErr: false,
+		},
+		{
 			name: "empty URL",
 			imageRegistry: &v1.ImageRegistry{
 				Spec: &v1.ImageRegistrySpec{
 					URL: "",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "URL with invalid host characters",
+			imageRegistry: &v1.ImageRegistry{
+				Spec: &v1.ImageRegistrySpec{
+					URL: "https://index.docker<>.io",
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "URL with invalid port characters",
+			imageRegistry: &v1.ImageRegistry{
+				Spec: &v1.ImageRegistrySpec{
+					URL: "registry.example.com:5<00",
 				},
 			},
 			want:    "",

--- a/tests/e2e/image_registry_test.go
+++ b/tests/e2e/image_registry_test.go
@@ -10,6 +10,36 @@ import (
 
 var _ = Describe("Image Registry", Label("image-registry"), func() {
 
+	Describe("URL validation", Label("validation"), func() {
+		It("should reject URL with invalid host characters", Label("C2711809"), func() {
+			name := "e2e-ir-invalid-host-" + Cfg.RunID
+
+			yamlPath, err := renderTemplateToTempFile("testdata/image-registry.yaml", map[string]any{
+				"E2E_IMAGE_REGISTRY":          name,
+				"E2E_IMAGE_REGISTRY_URL":      "https://index.docker<>.io",
+				"E2E_IMAGE_REGISTRY_REPO":     "neutree",
+				"E2E_IMAGE_REGISTRY_USERNAME": "",
+				"E2E_IMAGE_REGISTRY_PASSWORD": "",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer os.Remove(yamlPath)
+
+			DeferCleanup(func() {
+				RunCLI("delete", "imageregistry", name,
+					"-w", profileWorkspace(), "--force", "--ignore-not-found")
+			})
+
+			By("Applying image registry with invalid host characters")
+			r := RunCLI("apply", "-f", yamlPath)
+			ExpectFailed(r)
+			Expect(r.Stderr + r.Stdout).To(ContainSubstring("invalid image registry url"))
+
+			By("Verifying invalid image registry was not persisted")
+			r = RunCLI("get", "imageregistry", name, "-w", profileWorkspace())
+			ExpectFailed(r)
+		})
+	})
+
 	Describe("No-Protocol URL", Label("no-protocol"), func() {
 		It("should create image registry with URL without protocol prefix", Label("C2642281"), func() {
 			requireImageRegistryProfile()


### PR DESCRIPTION
## Issue

NEU-232

## Summary

Reject image registry URLs whose parsed host contains invalid characters before proxying create/update requests to PostgREST, so malformed registry hosts are not persisted.

## Changes

- Add image registry URL host validation on create and patch requests using a precompiled invalid-character regexp after URL parsing.
- Tighten image registry host parsing so invalid characters such as `<` and `>` are rejected after URL normalization while preserving valid IPv6 literal registry hosts.
- Keep request body reset behavior aligned with existing proxy backfill middleware by closing and re-wrapping the body with a correct content length.
- Add unit coverage for create/patch rejection, valid create/patch forwarding, invalid port parsing, IPv6 literal hosts, and host parsing behavior.
- Add E2E case `image-registry && validation` / `C2711809` for the invalid-host regression scenario.

## Test Plan

Unit test

- [x] `go test ./internal/util ./internal/routes/proxies`
- [x] `go test -race ./internal/routes/proxies`
- [x] `go build ./tests/e2e/...`
- [x] `go vet ./internal/util/... ./internal/routes/proxies/...`
- [x] `go vet ./...`
- [x] `packages=$(go list ./... | grep -v 'e2e\|mocks\|db/dbtest'); go test -coverprofile coverage.out -covermode=atomic $packages`
- [x] `./bin/golangci-lint run ./internal/routes/proxies/... ./internal/util/...`
- [x] CI `pr-check` passed on `fbb684fa` in 3m25s.

DB test

- [x] Not affected; no DB schema or storage contract changes.

E2E test

- [x] Manual-first validation: after hot-updating `neutree-api`/`neutree-core` to `fbb684fa`, posting `https://index.docker<>.io` to `/api/v1/image_registries` returned HTTP 400 with `invalid image registry url`, and follow-up query returned 0 persisted resources.
- [x] Code-backed E2E after manual validation: `E2E_PROFILE_PATH=/tmp/neutree-neu-232-profile.yaml TESTRAIL_RUN_ID= LABEL_FILTER='image-registry && validation' E2E_TIMEOUT=30m make e2e-test` passed: 1 passed, 0 failed, 241 skipped, 5.613s.

## Risk & Rollback

No DB schema change. Runtime risk is limited to image registry create/update validation. Roll back by reverting this commit to restore the previous proxy behavior.

