### PR TITLE
feat: add non-TTY download progress logs

### DIFF
--- a/python/neutree/downloader/__init__.py
+++ b/python/neutree/downloader/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "huggingface",
     "local",
     "entity",
+    "progress",
     "utils",
     "get_downloader",
     "build_request_from_model_args",

--- a/python/neutree/downloader/__main__.py
+++ b/python/neutree/downloader/__main__.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 
-from .utils import build_request_from_model_args
+from .utils import build_request_from_model_args, download_with_markers
 
 
 def _build_parser():
@@ -45,9 +45,9 @@ def main(argv=None):
 
     print(f"Performing download backend={backend} source={dl_req.source} dest={dl_req.dest}")
     downloader = get_downloader(backend)
-    downloader.download(dl_req.source, dl_req.dest, credentials=dl_req.credentials,
-                        recursive=dl_req.recursive, overwrite=dl_req.overwrite,
-                        retries=dl_req.retries, timeout=dl_req.timeout, metadata=dl_req.metadata)
+    download_with_markers(downloader, dl_req.source, dl_req.dest, credentials=dl_req.credentials,
+                          recursive=dl_req.recursive, overwrite=dl_req.overwrite,
+                          retries=dl_req.retries, timeout=dl_req.timeout, metadata=dl_req.metadata)
     print("Download finished")
 
 

--- a/python/neutree/downloader/huggingface.py
+++ b/python/neutree/downloader/huggingface.py
@@ -1,6 +1,7 @@
 import os
 import time
 import logging
+from contextlib import contextmanager
 from typing import Optional, Dict, Any
 
 from .base import Downloader
@@ -39,6 +40,41 @@ if not logger.handlers:
     logger.addHandler(_handler)
 
 
+@contextmanager
+def _hf_progress_bars_disabled(hf, interactive: bool):
+    if interactive:
+        yield
+        return
+
+    hf_utils = getattr(hf, "utils", None)
+    disable_progress_bars = getattr(hf_utils, "disable_progress_bars", None)
+    if not callable(disable_progress_bars):
+        yield
+        return
+
+    are_progress_bars_disabled = getattr(hf_utils, "are_progress_bars_disabled", None)
+    enable_progress_bars = getattr(hf_utils, "enable_progress_bars", None)
+
+    was_disabled = None
+    if callable(are_progress_bars_disabled):
+        try:
+            was_disabled = bool(are_progress_bars_disabled())
+        except Exception:
+            was_disabled = None
+
+    progress_context = disable_progress_bars()
+    if hasattr(progress_context, "__enter__") and hasattr(progress_context, "__exit__"):
+        with progress_context:
+            yield
+        return
+
+    try:
+        yield
+    finally:
+        if was_disabled is False and callable(enable_progress_bars):
+            enable_progress_bars()
+
+
 class HuggingFaceDownloader(Downloader):
     """Downloader for Hugging Face repositories.
 
@@ -75,23 +111,19 @@ class HuggingFaceDownloader(Downloader):
         version = metadata.get("version") or None if metadata else None
 
         interactive = is_interactive()
-        if not interactive:
-            disable_progress_bars = getattr(getattr(hf, "utils", None), "disable_progress_bars", None)
-            if callable(disable_progress_bars):
-                disable_progress_bars()
+        with _hf_progress_bars_disabled(hf, interactive):
+            with ProgressReporter(dest, logger, label="HuggingFace download", interactive=interactive):
+                hf.snapshot_download(
+                    repo_id=repo_id,
+                    allow_patterns=allow_pattern,
+                    local_dir=dest,
+                    token=token,
+                    revision=version,
+                )
 
-        with ProgressReporter(dest, logger, label="HuggingFace download", interactive=interactive):
-            hf.snapshot_download(
-                repo_id=repo_id,
-                allow_patterns=allow_pattern,
-                local_dir=dest,
-                token=token,
-                revision=version,
-            )
-
-            # Verify downloaded files if not skipped
-            if not should_skip_verification():
-                self._verify_downloaded_files(repo_id, dest, revision=version, token=token)
+                # Verify downloaded files if not skipped
+                if not should_skip_verification():
+                    self._verify_downloaded_files(repo_id, dest, revision=version, token=token)
 
     def _verify_downloaded_files(self, repo_id: str, dest: str, revision: Optional[str] = None, token: Optional[str] = None) -> None:
         """Verify downloaded files against HF repository checksums.

--- a/python/neutree/downloader/huggingface.py
+++ b/python/neutree/downloader/huggingface.py
@@ -5,6 +5,7 @@ from typing import Optional, Dict, Any
 
 from .base import Downloader
 from huggingface_hub.hf_api import RepoFile
+from .progress import ProgressReporter, is_interactive
 from .utils import (
     ensure_dir,
     resolve_allow_pattern,
@@ -73,11 +74,24 @@ class HuggingFaceDownloader(Downloader):
         # Empty string would be treated as an invalid branch name
         version = metadata.get("version") or None if metadata else None
 
-        hf.snapshot_download(repo_id=repo_id, allow_patterns=allow_pattern, local_dir=dest, token=token, revision=version)
+        interactive = is_interactive()
+        if not interactive:
+            disable_progress_bars = getattr(getattr(hf, "utils", None), "disable_progress_bars", None)
+            if callable(disable_progress_bars):
+                disable_progress_bars()
 
-        # Verify downloaded files if not skipped
-        if not should_skip_verification():
-            self._verify_downloaded_files(repo_id, dest, revision=version, token=token)
+        with ProgressReporter(dest, logger, label="HuggingFace download", interactive=interactive):
+            hf.snapshot_download(
+                repo_id=repo_id,
+                allow_patterns=allow_pattern,
+                local_dir=dest,
+                token=token,
+                revision=version,
+            )
+
+            # Verify downloaded files if not skipped
+            if not should_skip_verification():
+                self._verify_downloaded_files(repo_id, dest, revision=version, token=token)
 
     def _verify_downloaded_files(self, repo_id: str, dest: str, revision: Optional[str] = None, token: Optional[str] = None) -> None:
         """Verify downloaded files against HF repository checksums.

--- a/python/neutree/downloader/local.py
+++ b/python/neutree/downloader/local.py
@@ -7,6 +7,7 @@ import shutil
 import fnmatch
 
 from .base import Downloader
+from .progress import ProgressReporter, get_dir_size, is_interactive
 from .utils import (
     ensure_dir,
     resolve_allow_pattern,
@@ -53,7 +54,24 @@ class LocalDownloader(Downloader):
         ensure_dir(dest)
 
         allow_pattern = resolve_allow_pattern(metadata)
+        interactive = is_interactive()
+        total_size = None if interactive else get_dir_size(src)
 
+        with ProgressReporter(
+                dest,
+                logger,
+                label="Local download",
+                total_size=total_size,
+                interactive=interactive):
+            self._copy_files(src, dest, allow_pattern=allow_pattern,
+                             recursive=recursive, overwrite=overwrite)
+
+            # Verify copied files against source-of-truth checksums
+            if not should_skip_verification():
+                self._verify_copied_files(dest)
+
+    def _copy_files(self, src: str, dest: str, *, allow_pattern: Optional[str],
+                    recursive: bool, overwrite: bool) -> None:
         if recursive:
             # copy all files; skip existing unless overwrite
             for root, dirs, files in os.walk(src):
@@ -84,10 +102,6 @@ class LocalDownloader(Downloader):
                     if os.path.exists(t) and not overwrite:
                         continue
                     shutil.copy2(s, t)
-
-        # Verify copied files against source-of-truth checksums
-        if not should_skip_verification():
-            self._verify_copied_files(dest)
 
     def _verify_copied_files(self, dest: str) -> None:
         """Verify copied files against .neutree/checksums/ (source of truth).

--- a/python/neutree/downloader/local.py
+++ b/python/neutree/downloader/local.py
@@ -7,7 +7,7 @@ import shutil
 import fnmatch
 
 from .base import Downloader
-from .progress import ProgressReporter, get_dir_size, is_interactive
+from .progress import ProgressReporter, is_interactive
 from .utils import (
     ensure_dir,
     resolve_allow_pattern,
@@ -55,7 +55,14 @@ class LocalDownloader(Downloader):
 
         allow_pattern = resolve_allow_pattern(metadata)
         interactive = is_interactive()
-        total_size = None if interactive else get_dir_size(src)
+        total_size = None
+        if not interactive:
+            total_size = self._planned_copy_size(
+                src,
+                dest,
+                allow_pattern=allow_pattern,
+                recursive=recursive,
+                overwrite=overwrite)
 
         with ProgressReporter(
                 dest,
@@ -102,6 +109,54 @@ class LocalDownloader(Downloader):
                     if os.path.exists(t) and not overwrite:
                         continue
                     shutil.copy2(s, t)
+
+    def _planned_copy_size(self, src: str, dest: str, *, allow_pattern: Optional[str],
+                           recursive: bool, overwrite: bool) -> int:
+        total = 0
+
+        for source_path, _target_path in self._copy_candidates(
+                src,
+                dest,
+                allow_pattern=allow_pattern,
+                recursive=recursive,
+                overwrite=overwrite):
+            try:
+                total += os.path.getsize(source_path)
+            except OSError:
+                continue
+
+        return total
+
+    def _copy_candidates(self, src: str, dest: str, *, allow_pattern: Optional[str],
+                         recursive: bool, overwrite: bool):
+        if recursive:
+            for root, _, files in os.walk(src):
+                rel = os.path.relpath(root, src)
+                target_root = os.path.join(dest, rel) if rel != os.curdir else dest
+
+                for f in files:
+                    if allow_pattern and not rel.startswith(".neutree"):
+                        file_relpath = os.path.join(rel, f) if rel != os.curdir else f
+                        if not fnmatch.fnmatch(f, allow_pattern) and not fnmatch.fnmatch(file_relpath, allow_pattern):
+                            continue
+
+                    source_path = os.path.join(root, f)
+                    target_path = os.path.join(target_root, f)
+                    if os.path.exists(target_path) and not overwrite:
+                        continue
+                    yield source_path, target_path
+            return
+
+        for entry in os.listdir(src):
+            source_path = os.path.join(src, entry)
+            target_path = os.path.join(dest, entry)
+            if not os.path.isfile(source_path):
+                continue
+            if allow_pattern and not fnmatch.fnmatch(entry, allow_pattern):
+                continue
+            if os.path.exists(target_path) and not overwrite:
+                continue
+            yield source_path, target_path
 
     def _verify_copied_files(self, dest: str) -> None:
         """Verify copied files against .neutree/checksums/ (source of truth).

--- a/python/neutree/downloader/progress.py
+++ b/python/neutree/downloader/progress.py
@@ -36,8 +36,6 @@ def format_size(size: int) -> str:
         if value < 1024.0 or unit == "TiB":
             return f"{value:.1f} {unit}"
 
-    return f"{value:.1f} TiB"
-
 
 def get_dir_size(path: str) -> int:
     """Return total file size for a file or directory, ignoring transient races."""
@@ -136,10 +134,17 @@ class ProgressReporter:
             self._log_progress()
 
     def _log_progress(self) -> None:
+        if self._stop.is_set():
+            return
+
         try:
             size = self._downloaded_size()
         except Exception as exc:
-            self.logger.debug(f"{self.label} progress unavailable: {exc}")
+            if not self._stop.is_set():
+                self.logger.debug(f"{self.label} progress unavailable: {exc}")
+            return
+
+        if self._stop.is_set():
             return
 
         if self.total_size:

--- a/python/neutree/downloader/progress.py
+++ b/python/neutree/downloader/progress.py
@@ -1,0 +1,150 @@
+"""Log-based progress reporting for non-interactive model downloads."""
+
+import math
+import os
+import sys
+import threading
+import time
+from typing import Optional
+
+DEFAULT_PROGRESS_INTERVAL = 30.0
+MIN_PROGRESS_INTERVAL = 1.0
+PROGRESS_INTERVAL_ENV = "NEUTREE_DL_PROGRESS_INTERVAL"
+
+
+def is_interactive() -> bool:
+    """Return true when either stdout or stderr is attached to a terminal."""
+    for stream in (sys.stdout, sys.stderr):
+        isatty = getattr(stream, "isatty", None)
+        try:
+            if callable(isatty) and isatty():
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def format_size(size: int) -> str:
+    """Format a byte count using binary units."""
+    size = max(0, int(size))
+    if size < 1024:
+        return f"{size} B"
+
+    value = float(size)
+    for unit in ("KiB", "MiB", "GiB", "TiB"):
+        value /= 1024.0
+        if value < 1024.0 or unit == "TiB":
+            return f"{value:.1f} {unit}"
+
+    return f"{value:.1f} TiB"
+
+
+def get_dir_size(path: str) -> int:
+    """Return total file size for a file or directory, ignoring transient races."""
+    try:
+        if os.path.isfile(path):
+            return os.path.getsize(path)
+    except OSError:
+        return 0
+
+    total = 0
+    if not os.path.isdir(path):
+        return total
+
+    for root, _, files in os.walk(path):
+        for name in files:
+            file_path = os.path.join(root, name)
+            try:
+                total += os.path.getsize(file_path)
+            except OSError:
+                continue
+    return total
+
+
+def _valid_interval(value: object) -> Optional[float]:
+    try:
+        interval = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if not math.isfinite(interval) or interval <= 0:
+        return None
+    return max(MIN_PROGRESS_INTERVAL, interval)
+
+
+def _resolve_interval(interval: Optional[float]) -> float:
+    if interval is not None:
+        return _valid_interval(interval) or DEFAULT_PROGRESS_INTERVAL
+
+    env_value = os.environ.get(PROGRESS_INTERVAL_ENV)
+    if env_value is None:
+        return DEFAULT_PROGRESS_INTERVAL
+    return _valid_interval(env_value) or DEFAULT_PROGRESS_INTERVAL
+
+
+class ProgressReporter:
+    """Periodically log destination size for non-TTY downloads."""
+
+    def __init__(
+            self,
+            path: str,
+            logger,
+            *,
+            label: str = "Download",
+            total_size: Optional[int] = None,
+            interval: Optional[float] = None,
+            interactive: Optional[bool] = None):
+        self.path = path
+        self.logger = logger
+        self.label = label
+        self.total_size = total_size if total_size and total_size > 0 else None
+        self.interval = _resolve_interval(interval)
+        self.interactive = is_interactive() if interactive is None else interactive
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._started_at: Optional[float] = None
+
+    def __enter__(self):
+        if self.interactive:
+            return self
+
+        self._started_at = time.time()
+        self._log_progress()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, _tb):
+        if self.interactive:
+            return False
+
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+        elapsed = time.time() - self._started_at if self._started_at else 0.0
+        size = get_dir_size(self.path)
+        status = "aborted" if exc_type else "completed"
+        self.logger.info(
+            f"{self.label} {status}: {format_size(size)} downloaded in {elapsed:.1f}s")
+        return False
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.interval):
+            self._log_progress()
+
+    def _log_progress(self) -> None:
+        try:
+            size = get_dir_size(self.path)
+        except Exception as exc:
+            self.logger.debug(f"{self.label} progress unavailable: {exc}")
+            return
+
+        if self.total_size:
+            pct = min(100.0, (size / self.total_size) * 100.0)
+            self.logger.info(
+                f"{self.label} progress: {format_size(size)} / "
+                f"{format_size(self.total_size)} ({pct:.1f}%)")
+            return
+
+        self.logger.info(f"{self.label} progress: {format_size(size)} downloaded")

--- a/python/neutree/downloader/progress.py
+++ b/python/neutree/downloader/progress.py
@@ -103,12 +103,14 @@ class ProgressReporter:
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._started_at: Optional[float] = None
+        self._baseline_size = 0
 
     def __enter__(self):
         if self.interactive:
             return self
 
         self._started_at = time.time()
+        self._baseline_size = get_dir_size(self.path)
         self._log_progress()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -123,7 +125,7 @@ class ProgressReporter:
             self._thread.join(timeout=1.0)
 
         elapsed = time.time() - self._started_at if self._started_at else 0.0
-        size = get_dir_size(self.path)
+        size = self._downloaded_size()
         status = "aborted" if exc_type else "completed"
         self.logger.info(
             f"{self.label} {status}: {format_size(size)} downloaded in {elapsed:.1f}s")
@@ -135,7 +137,7 @@ class ProgressReporter:
 
     def _log_progress(self) -> None:
         try:
-            size = get_dir_size(self.path)
+            size = self._downloaded_size()
         except Exception as exc:
             self.logger.debug(f"{self.label} progress unavailable: {exc}")
             return
@@ -148,3 +150,6 @@ class ProgressReporter:
             return
 
         self.logger.info(f"{self.label} progress: {format_size(size)} downloaded")
+
+    def _downloaded_size(self) -> int:
+        return max(0, get_dir_size(self.path) - self._baseline_size)

--- a/python/neutree/downloader/test_huggingface.py
+++ b/python/neutree/downloader/test_huggingface.py
@@ -31,8 +31,11 @@ class TestHuggingFaceDownloaderGGUFFilter(unittest.TestCase):
 
     def setUp(self):
         self.dest_dir = tempfile.mkdtemp()
+        self.interactive_patcher = mock.patch("neutree.downloader.huggingface.is_interactive", return_value=True)
+        self.interactive_patcher.start()
 
     def tearDown(self):
+        self.interactive_patcher.stop()
         import shutil
         shutil.rmtree(self.dest_dir, ignore_errors=True)
 
@@ -71,6 +74,40 @@ class TestHuggingFaceDownloaderGGUFFilter(unittest.TestCase):
         fake_hf.snapshot_download.assert_called_once()
         _, kwargs = fake_hf.snapshot_download.call_args
         self.assertIsNone(kwargs.get("allow_patterns"))
+
+    @mock.patch("neutree.downloader.huggingface.should_skip_verification", return_value=True)
+    @mock.patch("neutree.downloader.huggingface.is_interactive", return_value=False)
+    @mock.patch("neutree.downloader.huggingface.ProgressReporter")
+    def test_non_tty_disables_hf_progress_bars_and_wraps_download(self, mock_reporter, _mock_interactive, _mock_skip):
+        """Non-TTY downloads should disable HF bars and use log-based progress."""
+        dl = HuggingFaceDownloader()
+        fake_hf = mock.MagicMock()
+        reporter_context = mock_reporter.return_value
+        reporter_context.__enter__.return_value = reporter_context
+        reporter_context.__exit__.return_value = False
+
+        with mock.patch.object(dl, "_ensure_hf", return_value=fake_hf):
+            dl.download("org/model", self.dest_dir, metadata={"file": ""})
+
+        fake_hf.utils.disable_progress_bars.assert_called_once()
+        mock_reporter.assert_called_once()
+        args, kwargs = mock_reporter.call_args
+        self.assertEqual(args[0], self.dest_dir)
+        self.assertEqual(kwargs["label"], "HuggingFace download")
+        reporter_context.__enter__.assert_called_once()
+        reporter_context.__exit__.assert_called_once()
+
+    @mock.patch("neutree.downloader.huggingface.should_skip_verification", return_value=True)
+    @mock.patch("neutree.downloader.huggingface.is_interactive", return_value=True)
+    def test_tty_keeps_hf_progress_bars_enabled(self, _mock_interactive, _mock_skip):
+        """Interactive downloads should leave upstream HF progress behavior intact."""
+        dl = HuggingFaceDownloader()
+        fake_hf = mock.MagicMock()
+
+        with mock.patch.object(dl, "_ensure_hf", return_value=fake_hf):
+            dl.download("org/model", self.dest_dir, metadata={"file": ""})
+
+        fake_hf.utils.disable_progress_bars.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/python/neutree/downloader/test_huggingface.py
+++ b/python/neutree/downloader/test_huggingface.py
@@ -82,6 +82,8 @@ class TestHuggingFaceDownloaderGGUFFilter(unittest.TestCase):
         """Non-TTY downloads should disable HF bars and use log-based progress."""
         dl = HuggingFaceDownloader()
         fake_hf = mock.MagicMock()
+        fake_hf.utils.disable_progress_bars.return_value = None
+        fake_hf.utils.are_progress_bars_disabled.return_value = False
         reporter_context = mock_reporter.return_value
         reporter_context.__enter__.return_value = reporter_context
         reporter_context.__exit__.return_value = False
@@ -90,12 +92,29 @@ class TestHuggingFaceDownloaderGGUFFilter(unittest.TestCase):
             dl.download("org/model", self.dest_dir, metadata={"file": ""})
 
         fake_hf.utils.disable_progress_bars.assert_called_once()
+        fake_hf.utils.enable_progress_bars.assert_called_once()
         mock_reporter.assert_called_once()
         args, kwargs = mock_reporter.call_args
         self.assertEqual(args[0], self.dest_dir)
         self.assertEqual(kwargs["label"], "HuggingFace download")
         reporter_context.__enter__.assert_called_once()
         reporter_context.__exit__.assert_called_once()
+
+    @mock.patch("neutree.downloader.huggingface.should_skip_verification", return_value=True)
+    @mock.patch("neutree.downloader.huggingface.is_interactive", return_value=False)
+    def test_non_tty_keeps_previously_disabled_hf_progress_bars_disabled(
+            self, _mock_interactive, _mock_skip):
+        """A non-TTY download should not re-enable bars that were already disabled."""
+        dl = HuggingFaceDownloader()
+        fake_hf = mock.MagicMock()
+        fake_hf.utils.disable_progress_bars.return_value = None
+        fake_hf.utils.are_progress_bars_disabled.return_value = True
+
+        with mock.patch.object(dl, "_ensure_hf", return_value=fake_hf):
+            dl.download("org/model", self.dest_dir, metadata={"file": ""})
+
+        fake_hf.utils.disable_progress_bars.assert_called_once()
+        fake_hf.utils.enable_progress_bars.assert_not_called()
 
     @mock.patch("neutree.downloader.huggingface.should_skip_verification", return_value=True)
     @mock.patch("neutree.downloader.huggingface.is_interactive", return_value=True)

--- a/python/neutree/downloader/test_local.py
+++ b/python/neutree/downloader/test_local.py
@@ -260,11 +260,10 @@ class TestLocalDownloaderVerification(unittest.TestCase):
 
     @mock.patch("neutree.downloader.local.should_skip_verification", return_value=True)
     @mock.patch("neutree.downloader.local.is_interactive", return_value=False)
-    @mock.patch("neutree.downloader.local.get_dir_size", return_value=123)
     @mock.patch("neutree.downloader.local.ProgressReporter")
     def test_non_tty_prescans_source_size_and_reports_progress(
-            self, mock_reporter, mock_size, _mock_interactive, _mock_skip):
-        """Non-TTY local copies should precompute total size for percentage logs."""
+            self, mock_reporter, _mock_interactive, _mock_skip):
+        """Non-TTY local copies should precompute the planned copy size."""
         reporter_context = mock_reporter.return_value
         reporter_context.__enter__.return_value = reporter_context
         reporter_context.__exit__.return_value = False
@@ -272,18 +271,48 @@ class TestLocalDownloaderVerification(unittest.TestCase):
         dl = LocalDownloader()
         dl.download(self.src_dir, self.dest_dir, metadata={"file": ""})
 
-        mock_size.assert_called_once_with(self.src_dir)
         mock_reporter.assert_called_once()
         args, kwargs = mock_reporter.call_args
         self.assertEqual(args[0], self.dest_dir)
         self.assertEqual(kwargs["label"], "Local download")
-        self.assertEqual(kwargs["total_size"], 123)
+        self.assertEqual(kwargs["total_size"], len(self.model_content) + len(self.config_content))
+
+    @mock.patch("neutree.downloader.local.should_skip_verification", return_value=True)
+    @mock.patch("neutree.downloader.local.is_interactive", return_value=False)
+    @mock.patch("neutree.downloader.local.ProgressReporter")
+    def test_non_tty_planned_size_respects_filter_recursive_and_existing_files(
+            self, mock_reporter, _mock_interactive, _mock_skip):
+        """Planned size should match files that will actually be copied."""
+        reporter_context = mock_reporter.return_value
+        reporter_context.__enter__.return_value = reporter_context
+        reporter_context.__exit__.return_value = False
+
+        with open(os.path.join(self.src_dir, "model-q4_0.gguf"), "wb") as f:
+            f.write(b"q4")
+        with open(os.path.join(self.src_dir, "model-q8_0.gguf"), "wb") as f:
+            f.write(b"q8")
+        nested = os.path.join(self.src_dir, "nested")
+        os.makedirs(nested)
+        with open(os.path.join(nested, "ignored.gguf"), "wb") as f:
+            f.write(b"nested")
+        with open(os.path.join(self.dest_dir, "model-q4_0.gguf"), "wb") as f:
+            f.write(b"already")
+
+        dl = LocalDownloader()
+        dl.download(
+            self.src_dir,
+            self.dest_dir,
+            recursive=False,
+            metadata={"file": "*.gguf"})
+
+        args, kwargs = mock_reporter.call_args
+        self.assertEqual(args[0], self.dest_dir)
+        self.assertEqual(kwargs["total_size"], len(b"q8"))
 
     @mock.patch("neutree.downloader.local.should_skip_verification", return_value=True)
     @mock.patch("neutree.downloader.local.is_interactive", return_value=True)
-    @mock.patch("neutree.downloader.local.get_dir_size")
     @mock.patch("neutree.downloader.local.ProgressReporter")
-    def test_tty_skips_source_size_prescan(self, mock_reporter, mock_size, _mock_interactive, _mock_skip):
+    def test_tty_skips_source_size_prescan(self, mock_reporter, _mock_interactive, _mock_skip):
         """Interactive local copies should not pay the source pre-scan cost."""
         reporter_context = mock_reporter.return_value
         reporter_context.__enter__.return_value = reporter_context
@@ -292,7 +321,6 @@ class TestLocalDownloaderVerification(unittest.TestCase):
         dl = LocalDownloader()
         dl.download(self.src_dir, self.dest_dir, metadata={"file": ""})
 
-        mock_size.assert_not_called()
         args, kwargs = mock_reporter.call_args
         self.assertEqual(args[0], self.dest_dir)
         self.assertIsNone(kwargs["total_size"])

--- a/python/neutree/downloader/test_local.py
+++ b/python/neutree/downloader/test_local.py
@@ -61,6 +61,8 @@ class TestLocalDownloaderVerification(unittest.TestCase):
     def setUp(self):
         self.src_dir = tempfile.mkdtemp()
         self.dest_dir = tempfile.mkdtemp()
+        self.interactive_patcher = mock.patch("neutree.downloader.local.is_interactive", return_value=True)
+        self.interactive_patcher.start()
 
         # Create source files
         self.model_content = b"fake model weights data"
@@ -71,6 +73,7 @@ class TestLocalDownloaderVerification(unittest.TestCase):
             f.write(self.config_content)
 
     def tearDown(self):
+        self.interactive_patcher.stop()
         shutil.rmtree(self.src_dir, ignore_errors=True)
         shutil.rmtree(self.dest_dir, ignore_errors=True)
 
@@ -254,6 +257,45 @@ class TestLocalDownloaderVerification(unittest.TestCase):
 
         self.assertTrue(os.path.exists(os.path.join(self.dest_dir, "model.bin")))
         self.assertTrue(os.path.exists(os.path.join(self.dest_dir, "config.json")))
+
+    @mock.patch("neutree.downloader.local.should_skip_verification", return_value=True)
+    @mock.patch("neutree.downloader.local.is_interactive", return_value=False)
+    @mock.patch("neutree.downloader.local.get_dir_size", return_value=123)
+    @mock.patch("neutree.downloader.local.ProgressReporter")
+    def test_non_tty_prescans_source_size_and_reports_progress(
+            self, mock_reporter, mock_size, _mock_interactive, _mock_skip):
+        """Non-TTY local copies should precompute total size for percentage logs."""
+        reporter_context = mock_reporter.return_value
+        reporter_context.__enter__.return_value = reporter_context
+        reporter_context.__exit__.return_value = False
+
+        dl = LocalDownloader()
+        dl.download(self.src_dir, self.dest_dir, metadata={"file": ""})
+
+        mock_size.assert_called_once_with(self.src_dir)
+        mock_reporter.assert_called_once()
+        args, kwargs = mock_reporter.call_args
+        self.assertEqual(args[0], self.dest_dir)
+        self.assertEqual(kwargs["label"], "Local download")
+        self.assertEqual(kwargs["total_size"], 123)
+
+    @mock.patch("neutree.downloader.local.should_skip_verification", return_value=True)
+    @mock.patch("neutree.downloader.local.is_interactive", return_value=True)
+    @mock.patch("neutree.downloader.local.get_dir_size")
+    @mock.patch("neutree.downloader.local.ProgressReporter")
+    def test_tty_skips_source_size_prescan(self, mock_reporter, mock_size, _mock_interactive, _mock_skip):
+        """Interactive local copies should not pay the source pre-scan cost."""
+        reporter_context = mock_reporter.return_value
+        reporter_context.__enter__.return_value = reporter_context
+        reporter_context.__exit__.return_value = False
+
+        dl = LocalDownloader()
+        dl.download(self.src_dir, self.dest_dir, metadata={"file": ""})
+
+        mock_size.assert_not_called()
+        args, kwargs = mock_reporter.call_args
+        self.assertEqual(args[0], self.dest_dir)
+        self.assertIsNone(kwargs["total_size"])
 
 
 if __name__ == "__main__":

--- a/python/neutree/downloader/test_markers.py
+++ b/python/neutree/downloader/test_markers.py
@@ -6,6 +6,7 @@ import io
 import sys
 import types
 import unittest
+from unittest import mock
 
 _fake_sha = types.ModuleType("huggingface_hub.utils.sha")
 _fake_sha.git_hash = lambda data: ""
@@ -18,6 +19,8 @@ _fake_hf_api.RepoFile = type("RepoFile", (), {})
 sys.modules.setdefault("huggingface_hub.hf_api", _fake_hf_api)
 
 from neutree.downloader import download_with_markers  # noqa: E402
+from neutree.downloader import __main__ as downloader_main  # noqa: E402
+from neutree.downloader.entity import DownloadRequest  # noqa: E402
 
 
 class FakeDownloader:
@@ -74,6 +77,40 @@ class TestDownloadMarkers(unittest.TestCase):
         self.assertEqual(
             output.getvalue().splitlines(),
             ["NEUTREE_MODEL_DOWNLOAD_START", "NEUTREE_MODEL_DOWNLOAD_FAILED"],
+        )
+
+    def test_cli_main_uses_download_with_markers(self):
+        downloader = FakeDownloader()
+        request = DownloadRequest(
+            source="source",
+            dest="/dest",
+            credentials={"token": "secret"},
+            recursive=False,
+            overwrite=True,
+            retries=2,
+            timeout=1.5,
+            metadata={"name": "model"},
+        )
+
+        with mock.patch.object(
+                downloader_main,
+                "build_request_from_model_args",
+                return_value=("local", request)), \
+                mock.patch("neutree.downloader.dispatcher.get_downloader", return_value=downloader), \
+                mock.patch.object(downloader_main, "download_with_markers") as mock_markers, \
+                contextlib.redirect_stdout(io.StringIO()):
+            downloader_main.main(["--name", "model", "--registry_type", "local"])
+
+        mock_markers.assert_called_once_with(
+            downloader,
+            "source",
+            "/dest",
+            credentials={"token": "secret"},
+            recursive=False,
+            overwrite=True,
+            retries=2,
+            timeout=1.5,
+            metadata={"name": "model"},
         )
 
 

--- a/python/neutree/downloader/test_progress.py
+++ b/python/neutree/downloader/test_progress.py
@@ -127,6 +127,19 @@ class TestProgressReporter(unittest.TestCase):
         self.assertTrue(any("Test download completed: 7 B downloaded" in message for message in messages))
         self.assertFalse(any("15 B downloaded" in message for message in messages))
 
+    def test_log_progress_suppressed_after_stop_requested(self):
+        reporter = ProgressReporter(
+            self.tmpdir,
+            self.logger,
+            label="Test download",
+            interactive=False)
+        reporter._baseline_size = 0
+
+        with mock.patch.object(reporter, "_downloaded_size", side_effect=lambda: reporter._stop.set() or 7):
+            reporter._log_progress()
+
+        self.logger.info.assert_not_called()
+
     def test_reporter_logs_aborted_on_exception(self):
         with self.assertRaisesRegex(RuntimeError, "boom"):
             with ProgressReporter(self.tmpdir, self.logger, label="Test download", interactive=False):

--- a/python/neutree/downloader/test_progress.py
+++ b/python/neutree/downloader/test_progress.py
@@ -1,0 +1,123 @@
+"""Tests for non-TTY downloader progress reporting."""
+
+import hashlib
+import os
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+_fake_sha = types.ModuleType("huggingface_hub.utils.sha")
+_fake_sha.git_hash = lambda data: ""
+_fake_sha.sha_fileobj = lambda stream, bufsize=0: hashlib.sha256(stream.read()).digest()
+sys.modules.setdefault("huggingface_hub", types.ModuleType("huggingface_hub"))
+sys.modules.setdefault("huggingface_hub.utils", types.ModuleType("huggingface_hub.utils"))
+sys.modules.setdefault("huggingface_hub.utils.sha", _fake_sha)
+_fake_hf_api = types.ModuleType("huggingface_hub.hf_api")
+_fake_hf_api.RepoFile = type("RepoFile", (), {})
+sys.modules.setdefault("huggingface_hub.hf_api", _fake_hf_api)
+
+from neutree.downloader.progress import (  # noqa: E402
+    ProgressReporter,
+    format_size,
+    get_dir_size,
+    is_interactive,
+)
+
+
+class _Stream:
+    def __init__(self, tty):
+        self._tty = tty
+
+    def isatty(self):
+        return self._tty
+
+
+class TestProgressHelpers(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_is_interactive_uses_stdout_or_stderr_tty(self):
+        with mock.patch.object(sys, "stdout", _Stream(True)), mock.patch.object(sys, "stderr", _Stream(False)):
+            self.assertTrue(is_interactive())
+
+        with mock.patch.object(sys, "stdout", _Stream(False)), mock.patch.object(sys, "stderr", _Stream(False)):
+            self.assertFalse(is_interactive())
+
+    def test_format_size(self):
+        self.assertEqual(format_size(0), "0 B")
+        self.assertEqual(format_size(512), "512 B")
+        self.assertEqual(format_size(1024), "1.0 KiB")
+        self.assertEqual(format_size(1536), "1.5 KiB")
+        self.assertEqual(format_size(1024 * 1024), "1.0 MiB")
+
+    def test_get_dir_size_handles_files_directories_and_missing_paths(self):
+        os.makedirs(os.path.join(self.tmpdir, "nested"))
+        with open(os.path.join(self.tmpdir, "a.bin"), "wb") as f:
+            f.write(b"a" * 3)
+        with open(os.path.join(self.tmpdir, "nested", "b.bin"), "wb") as f:
+            f.write(b"b" * 5)
+
+        self.assertEqual(get_dir_size(os.path.join(self.tmpdir, "a.bin")), 3)
+        self.assertEqual(get_dir_size(self.tmpdir), 8)
+        self.assertEqual(get_dir_size(os.path.join(self.tmpdir, "missing")), 0)
+
+    def test_interval_defaults_and_validation(self):
+        logger = mock.Mock()
+
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(ProgressReporter(self.tmpdir, logger, interactive=False).interval, 30.0)
+
+        with mock.patch.dict(os.environ, {"NEUTREE_DL_PROGRESS_INTERVAL": "0.2"}, clear=True):
+            self.assertEqual(ProgressReporter(self.tmpdir, logger, interactive=False).interval, 1.0)
+
+        for value in ("0", "-5", "nan", "inf", "bad"):
+            with mock.patch.dict(os.environ, {"NEUTREE_DL_PROGRESS_INTERVAL": value}, clear=True):
+                self.assertEqual(ProgressReporter(self.tmpdir, logger, interactive=False).interval, 30.0)
+
+        self.assertEqual(ProgressReporter(self.tmpdir, logger, interval=float("inf"), interactive=False).interval, 30.0)
+
+
+class TestProgressReporter(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.logger = mock.Mock()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_reporter_noops_in_interactive_shell(self):
+        reporter = ProgressReporter(self.tmpdir, self.logger, label="Test download", interactive=True)
+
+        with reporter:
+            with open(os.path.join(self.tmpdir, "model.bin"), "wb") as f:
+                f.write(b"content")
+
+        self.logger.info.assert_not_called()
+
+    def test_reporter_logs_completion_on_normal_exit(self):
+        with ProgressReporter(self.tmpdir, self.logger, label="Test download", interactive=False):
+            with open(os.path.join(self.tmpdir, "model.bin"), "wb") as f:
+                f.write(b"content")
+
+        messages = [call.args[0] for call in self.logger.info.call_args_list]
+        self.assertTrue(any("Test download progress" in message for message in messages))
+        self.assertTrue(any("Test download completed" in message for message in messages))
+
+    def test_reporter_logs_aborted_on_exception(self):
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            with ProgressReporter(self.tmpdir, self.logger, label="Test download", interactive=False):
+                raise RuntimeError("boom")
+
+        messages = [call.args[0] for call in self.logger.info.call_args_list]
+        self.assertTrue(any("Test download aborted" in message for message in messages))
+        self.assertFalse(any("Test download completed" in message for message in messages))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/neutree/downloader/test_progress.py
+++ b/python/neutree/downloader/test_progress.py
@@ -109,6 +109,24 @@ class TestProgressReporter(unittest.TestCase):
         self.assertTrue(any("Test download progress" in message for message in messages))
         self.assertTrue(any("Test download completed" in message for message in messages))
 
+    def test_reporter_logs_download_delta_for_prepopulated_destination(self):
+        with open(os.path.join(self.tmpdir, "existing.bin"), "wb") as f:
+            f.write(b"old data")
+
+        with ProgressReporter(
+                self.tmpdir,
+                self.logger,
+                label="Test download",
+                total_size=7,
+                interactive=False):
+            with open(os.path.join(self.tmpdir, "new.bin"), "wb") as f:
+                f.write(b"content")
+
+        messages = [call.args[0] for call in self.logger.info.call_args_list]
+        self.assertTrue(any("Test download progress: 0 B / 7 B" in message for message in messages))
+        self.assertTrue(any("Test download completed: 7 B downloaded" in message for message in messages))
+        self.assertFalse(any("15 B downloaded" in message for message in messages))
+
     def test_reporter_logs_aborted_on_exception(self):
         with self.assertRaisesRegex(RuntimeError, "boom"):
             with ProgressReporter(self.tmpdir, self.logger, label="Test download", interactive=False):


### PR DESCRIPTION
## Issue

NEU-202

## Summary

Add log-based model download progress for non-interactive environments so container and actor logs show long-running downloader activity. Keep interactive terminal behavior unchanged, and align the downloader CLI with the existing model download marker helper.

## Changes

- Add a downloader `ProgressReporter` with interval validation, TTY detection, size formatting, and completed/aborted terminal logs.
- Wrap HuggingFace downloads with non-TTY progress logging and scoped upstream HF progress-bar suppression when supported.
- Wrap Local downloads with non-TTY progress logging and compute planned copy bytes outside interactive terminals.
- Route `python -m neutree.downloader` through `download_with_markers(...)`.
- Add co-located Python unit tests for progress behavior, backend integration, review-fix edge cases, and CLI marker routing.

## Test Plan

### Unit test

- [x] RED: new tests failed before implementation because `progress.py`, backend progress hooks, and CLI marker routing were missing.
- [x] RED after local review: new tests failed for pre-populated destination delta accounting, Local planned-copy byte totals, and HuggingFace progress-bar restoration.
- [x] RED after Copilot review: `test_log_progress_suppressed_after_stop_requested` failed before implementation because `_log_progress()` still emitted `Test download progress: 7 B downloaded` after `_stop` was set.
- [x] `PYTHONPATH=python python3 python/neutree/downloader/test_progress.py -v` — 9 tests passed.
- [x] `PYTHONPATH=python python3 python/neutree/downloader/test_huggingface.py -v` — 6 tests passed.
- [x] `PYTHONPATH=python python3 python/neutree/downloader/test_local.py -v` — 14 tests passed.
- [x] `PYTHONPATH=python python3 python/neutree/downloader/test_markers.py -v` — 3 tests passed.
- [x] Aggregate unittest runner for the four downloader modules — 32 tests passed.
- [x] `PYTHONPATH=python python3 -m compileall -q python/neutree/downloader`.
- [x] `git diff --check`.
- [x] Local CLI smoke with `NEUTREE_DL_BACKEND=local`, `NEUTREE_DL_PROGRESS_INTERVAL=1`, and `NEUTREE_VERIFY_SKIP=1` showed start/done markers and progress/completed logs.
- [ ] `PYTHONPATH=python python3 -m pytest python/neutree/downloader/ -v` — not run locally because `pytest` is not installed in this environment.

### DB test

- [x] Not required. This change does not touch DB schema, migrations, SQL, RLS, or persistence behavior.

### E2E test

- [x] Step 5 validated head `ddb2ada62e6eb573c52fd934151457e13df743bc` on the E2E lease `lease-NEU-202-step5-20260618142011`.
- [x] Runtime artifact: `neutree-runtime:v1.1.0-neu202.20260618`; serve artifact: `neutree-serve:v1.1.0-neu202.20260618`; engine artifact: `engine-vllm:v0.11.2-neutree202-ray2.53.0`; imported engine package `vllm v0.11.2-neutree202`.
- [x] C2722599 K8s endpoint log observation: endpoint `neu202-k8s-ep-06190026` reached `Running`; cluster `neu202-k8s-06190026`; `model-downloader` initContainer log evidence by marker type:
  - `NEUTREE_MODEL_DOWNLOAD_START`: 1 line.
  - `Local download progress:`: 26 lines, from `0 B / 953.3 MiB (0.0%)` through `918.0 MiB / 953.3 MiB (96.3%)`.
  - `Local download completed:`: 1 line, `953.3 MiB downloaded in 26.0s`.
  - `NEUTREE_MODEL_DOWNLOAD_DONE`: 1 line.
- [x] C2722600 Ray/SSH endpoint log observation: endpoint `neu202-ssh-ep-06190026` reached `Running`; cluster `neu202-ssh-06190026`; backend replica `int7ysn6` log evidence by stream:
  - stdout: `NEUTREE_MODEL_DOWNLOAD_START` 1 line and `NEUTREE_MODEL_DOWNLOAD_DONE` 1 line.
  - stderr: `Local download progress:` 14 lines, from `0 B / 953.3 MiB (0.0%)` through `866.1 MiB / 953.3 MiB (90.8%)`.
  - stderr: `Local download completed:` 2 lines, including `953.3 MiB downloaded in 6.4s`.
- [x] Code E2E not added because the approved NEU-202 design classifies this revision as manual/environment log observation. Unit tests cover reporter/backend/CLI contracts; manual Step 5 covers K8s and Ray/SSH runtime log visibility.
- [x] Additional HuggingFace SSH/vLLM live validation used engine package `vllm v0.11.2-neutree202` and image `engine-vllm:v0.11.2-neutree202-ray2.53.0`; endpoint `e2e-ep-ssh-chat-486558`; cluster `e2e-ep-ssh-486558`; model `Qwen/Qwen2.5-0.5B-Instruct:main`; model registry type `hugging-face`.
  - Ray Serve config confirmed `runtime_env.container.image=192.168.22.100/neutree-e2e-test/neutree/engine-vllm:v0.11.2-neutree202-ray2.53.0`, `model.registry_type=hugging-face`, and `model.registry_path=Qwen/Qwen2.5-0.5B-Instruct`.
  - stdout: `NEUTREE_MODEL_DOWNLOAD_START` and `NEUTREE_MODEL_DOWNLOAD_DONE`; backend also printed `[Backend] Model download completed.`
  - stderr: `HuggingFace download progress:` lines at `0 B`, `918.9 MiB`, and `953.3 MiB`; terminal log `HuggingFace download completed: 953.3 MiB downloaded in 172.0s`.
  - vLLM SSH HuggingFace chat specs passed for deploy/reach Running, normal inference, and wrong model-name error handling.
  - The broad label filter also matched an unrelated SGLang chat spec; it was stopped after the vLLM HuggingFace target specs passed, and the `486558` endpoint/cluster/modelregistry/imageregistry resources were cleaned up.
- [ ] A fresh engine rebuild from final PR head `d165502a8e6e65018e3086f661a9f58f1f054198` was not run before merge. The additional HuggingFace live validation above used the existing NEU-202 engine artifact built earlier for Step 5; current-head review fixes are covered by unit tests and compile checks.

## Risk & Rollback

No DB or API compatibility risk. Rollback is reverting this PR; existing downloader behavior will continue without periodic non-TTY progress logs and the CLI marker routing change.