### PR TITLE
fix: parse all HAMi vGPU allocation devices

### DIFF
--- a/internal/accelerator/plugin/gpu_hami_parser.go
+++ b/internal/accelerator/plugin/gpu_hami_parser.go
@@ -217,11 +217,12 @@ func parseHAMiNvidiaDeviceAllocations(value string) ([]hamiNvidiaDeviceAllocatio
 	// Empty fields are common because the annotation keeps slots for each
 	// container/device position. Example:
 	//
-	//	;;GPU-5ad72eb2,NVIDIA,15360,100:;GPU-cd4432b1,NVIDIA,15360,100:;
+	//	;;GPU-5ad72eb2,NVIDIA,15360,100:GPU-cd4432b1,NVIDIA,15360,100:;
 	//
-	// Each non-empty record is parsed as:
+	// The semicolon entry can contain multiple colon-separated allocation
+	// segments. Each non-empty segment is parsed as:
 	//
-	//	<device_uuid>,<vendor>,<memory_mib>,<core_units>[:optional_suffix]
+	//	<device_uuid>,<vendor>,<memory_mib>,<core_units>
 	//
 	// Neutree only needs the UUID plus the memory/core allocation. The vendor
 	// is kept as Product only as a fallback when node registration metadata is
@@ -229,36 +230,34 @@ func parseHAMiNvidiaDeviceAllocations(value string) ([]hamiNvidiaDeviceAllocatio
 	var allocations []hamiNvidiaDeviceAllocation
 
 	for _, entry := range strings.Split(value, ";") {
-		entry = strings.TrimSpace(entry)
-		if entry == "" {
-			continue
-		}
+		for _, segment := range strings.Split(entry, ":") {
+			segment = strings.TrimSpace(segment)
+			if segment == "" {
+				continue
+			}
 
-		if colon := strings.Index(entry, ":"); colon >= 0 {
-			entry = entry[:colon]
-		}
+			fields := strings.Split(segment, ",")
+			if len(fields) < hamiNvidiaDeviceAllocationFieldCount {
+				continue
+			}
 
-		fields := strings.Split(entry, ",")
-		if len(fields) < hamiNvidiaDeviceAllocationFieldCount {
-			continue
-		}
+			memoryMiB, err := strconv.ParseInt(strings.TrimSpace(fields[2]), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid memory value %q: %w", fields[2], err)
+			}
 
-		memoryMiB, err := strconv.ParseInt(strings.TrimSpace(fields[2]), 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid memory value %q: %w", fields[2], err)
-		}
+			coreUnits, err := strconv.ParseInt(strings.TrimSpace(fields[3]), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid core value %q: %w", fields[3], err)
+			}
 
-		coreUnits, err := strconv.ParseInt(strings.TrimSpace(fields[3]), 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid core value %q: %w", fields[3], err)
+			allocations = append(allocations, hamiNvidiaDeviceAllocation{
+				DeviceID:  strings.TrimSpace(fields[0]),
+				Product:   strings.TrimSpace(fields[1]),
+				MemoryMiB: memoryMiB,
+				CoreUnits: coreUnits,
+			})
 		}
-
-		allocations = append(allocations, hamiNvidiaDeviceAllocation{
-			DeviceID:  strings.TrimSpace(fields[0]),
-			Product:   strings.TrimSpace(fields[1]),
-			MemoryMiB: memoryMiB,
-			CoreUnits: coreUnits,
-		})
 	}
 
 	return allocations, nil

--- a/internal/accelerator/plugin/gpu_hami_parser_test.go
+++ b/internal/accelerator/plugin/gpu_hami_parser_test.go
@@ -59,6 +59,48 @@ func TestGPUResourceParser_ParseKubernetesVirtualizationNodeWithUsage(t *testing
 	require.Equal(t, float64(15360), metadata.Products["Tesla-T4"].MemoryTotalMiB)
 }
 
+func TestGPUResourceParser_ParseKubernetesVirtualizationNodeCountsColonSeparatedAllocations(t *testing.T) {
+	parser := &GPUResourceParser{}
+	input := resourceparser.KubernetesNodeResourceContext{
+		NodeName: "gpu-node",
+		Labels: map[string]string{
+			NvidiaGPUKubernetesNodeSelectorKey: "Tesla-T4",
+			NvidiaGPUVirtualizationLabelKey:    "true",
+			NvidiaGPUCountResource:             "2",
+		},
+		Annotations: map[string]string{
+			HAMiNodeNvidiaRegisterAnnotation: `[
+				{"id":"GPU-1","count":100,"devmem":15360,"devcore":100,"type":"NVIDIA-Tesla T4","health":true},
+				{"id":"GPU-2","count":100,"devmem":15360,"devcore":100,"type":"NVIDIA-Tesla T4","health":true}
+			]`,
+		},
+		Pods: []resourceparser.KubernetesPodResourceContext{
+			{
+				Namespace: "default",
+				Name:      "infer-1",
+				Annotations: map[string]string{
+					HAMiVGPUDevicesAllocatedAnnotation: ";GPU-1,NVIDIA,15360,100:GPU-2,NVIDIA,7680,50:;",
+				},
+			},
+		},
+	}
+
+	result, matched, err := parser.ParseKubernetesVirtualizationNode(input)
+
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Len(t, result.Devices, 2)
+	require.Equal(t, int64(0), result.Devices[0].Available.MemoryMiB)
+	require.Equal(t, int64(0), result.Devices[0].Available.CoreUnits)
+	require.Equal(t, int64(7680), result.Devices[1].Available.MemoryMiB)
+	require.Equal(t, int64(50), result.Devices[1].Available.CoreUnits)
+
+	available := result.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
+	require.Equal(t, float64(1), available.Quantity)
+	require.Equal(t, float64(7680), available.Products["Tesla-T4"].Virtualization.MemoryMiB)
+	require.Equal(t, float64(50), available.Products["Tesla-T4"].Virtualization.CoreUnits)
+}
+
 func TestGPUResourceParser_ParseKubernetesVirtualizationNode(t *testing.T) {
 	parser := &GPUResourceParser{}
 	input := resourceparser.KubernetesNodeResourceContext{
@@ -166,5 +208,52 @@ func TestGPUResourceParser_ParseKubernetesVirtualizationEndpoint(t *testing.T) {
 	require.Equal(t, "gpu-node", instances[0].Devices[0].NodeID)
 	require.Equal(t, "GPU-2", instances[0].Devices[1].UUID)
 	require.Equal(t, int64(7680), instances[0].Devices[1].MemoryMiB)
+	require.Equal(t, int64(50), instances[0].Devices[1].CoreUnits)
+}
+
+func TestGPUResourceParser_ParseKubernetesVirtualizationEndpointWithColonSeparatedAllocations(t *testing.T) {
+	parser := &GPUResourceParser{}
+	input := resourceparser.KubernetesEndpointResourceContext{
+		EndpointName: "chat",
+		Namespace:    "default",
+		Nodes: map[string]resourceparser.KubernetesEndpointNodeResourceContext{
+			"gpu-node": {
+				Name: "gpu-node",
+				Labels: map[string]string{
+					NvidiaGPUKubernetesNodeSelectorKey: "Tesla-T4",
+					NvidiaGPUVirtualizationLabelKey:    "true",
+				},
+				Annotations: map[string]string{
+					HAMiNodeNvidiaRegisterAnnotation: `[
+						{"id":"GPU-1","count":100,"devmem":15360,"devcore":100,"type":"NVIDIA-Tesla T4","health":true},
+						{"id":"GPU-2","count":100,"devmem":15360,"devcore":100,"type":"NVIDIA-Tesla T4","health":true}
+					]`,
+				},
+			},
+		},
+		Pods: []resourceparser.KubernetesPodResourceContext{
+			{
+				Namespace: "default",
+				Name:      "chat-abc",
+				UID:       "uid-1",
+				NodeName:  "gpu-node",
+				Annotations: map[string]string{
+					HAMiVGPUDevicesAllocatedAnnotation: ";GPU-1,NVIDIA,8192,50:GPU-2,NVIDIA,8192,50:;",
+				},
+			},
+		},
+	}
+
+	instances, matched, err := parser.ParseKubernetesVirtualizationEndpoint(input)
+
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Devices, 2)
+	require.Equal(t, "GPU-1", instances[0].Devices[0].UUID)
+	require.Equal(t, int64(8192), instances[0].Devices[0].MemoryMiB)
+	require.Equal(t, int64(50), instances[0].Devices[0].CoreUnits)
+	require.Equal(t, "GPU-2", instances[0].Devices[1].UUID)
+	require.Equal(t, int64(8192), instances[0].Devices[1].MemoryMiB)
 	require.Equal(t, int64(50), instances[0].Devices[1].CoreUnits)
 }

--- a/internal/resource/resource_client_test.go
+++ b/internal/resource/resource_client_test.go
@@ -98,6 +98,86 @@ func TestK8sResourceClientListEndpointInstancesWithHAMiAllocation(t *testing.T) 
 	require.Equal(t, "gpu-node", instances[0].Devices[0].NodeID)
 }
 
+func TestK8sResourceClientListEndpointInstancesWithColonSeparatedHAMiAllocations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node",
+			Labels: map[string]string{
+				plugin.NvidiaGPUKubernetesNodeSelectorKey: "Tesla-T4",
+				plugin.NvidiaGPUVirtualizationLabelKey:    "true",
+			},
+			Annotations: map[string]string{
+				plugin.HAMiNodeNvidiaRegisterAnnotation: `[
+					{"id":"GPU-1","count":100,"devmem":15360,"devcore":100,"type":"NVIDIA-Tesla T4","health":true},
+					{"id":"GPU-2","count":100,"devmem":15360,"devcore":100,"type":"NVIDIA-Tesla T4","health":true}
+				]`,
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chat-abc",
+			Namespace: "default",
+			UID:       types.UID("uid-1"),
+			Labels: map[string]string{
+				"app":      "inference",
+				"endpoint": "chat",
+			},
+			Annotations: map[string]string{
+				plugin.HAMiVGPUDevicesAllocatedAnnotation: ";GPU-1,NVIDIA,8192,50:GPU-2,NVIDIA,8192,50:;",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "gpu-node",
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							plugin.NvidiaGPUKubernetesResource: k8sresource.MustParse("2"),
+							plugin.NvidiaGPUCoreResource:       k8sresource.MustParse("100"),
+						},
+						Requests: corev1.ResourceList{
+							plugin.NvidiaGPUKubernetesResource: k8sresource.MustParse("2"),
+							plugin.NvidiaGPUCoreResource:       k8sresource.MustParse("100"),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	ctrClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node, pod).
+		Build()
+	client := resourceview.NewK8sResourceClient(ctrClient, map[string]resourceparser.ResourceParser{
+		string(v1.AcceleratorTypeNVIDIAGPU): &plugin.GPUResourceParser{},
+	})
+
+	instances, err := client.ListEndpointInstances(context.Background(), resourceview.ListEndpointInstancesOptions{
+		EndpointName:                     "chat",
+		Namespace:                        "default",
+		AcceleratorVirtualizationEnabled: true,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Devices, 2)
+	require.Equal(t, "GPU-1", instances[0].Devices[0].UUID)
+	require.Equal(t, int64(8192), instances[0].Devices[0].MemoryMiB)
+	require.Equal(t, int64(50), instances[0].Devices[0].CoreUnits)
+	require.Equal(t, "GPU-2", instances[0].Devices[1].UUID)
+	require.Equal(t, int64(8192), instances[0].Devices[1].MemoryMiB)
+	require.Equal(t, int64(50), instances[0].Devices[1].CoreUnits)
+}
+
 func TestK8sResourceClientListNodesFallsBackToStandardParserWhenVirtualizationEnabled(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))


### PR DESCRIPTION
## Issue

NEU-465

## Summary

Fix HAMi vGPU allocation parsing so a single annotation entry containing multiple colon-separated devices contributes every allocated device to Endpoint resource details and node usage accounting.

## Changes

- Parse each colon-separated allocation segment inside a HAMi semicolon entry.
- Preserve existing semicolon-separated allocation behavior and invalid memory/core error handling.
- Add regression coverage for Endpoint resource devices, node usage deduction, and the K8s resource-client path.

## Test Plan

### Unit test

- [x] `go test ./internal/accelerator/plugin -run 'TestGPUResourceParser_ParseKubernetesVirtualization(NodeCountsColonSeparatedAllocations|EndpointWithColonSeparatedAllocations)' -count=1 -v`
- [x] `go test ./internal/resource -run TestK8sResourceClientListEndpointInstancesWithColonSeparatedHAMiAllocations -count=1 -v`
- [x] `go test ./internal/accelerator/plugin ./internal/resource -count=1`
- [x] `go test ./internal/orchestrator -run TestKubernetes -count=1`
- [x] `make vet`
- [x] `make lint`
- [x] `make test`

### DB test

- [x] Not affected. No DB schema, migration, storage query, RLS, or seed change.

### E2E test

- [x] Skipped for user-approved Trivial parser-only fix. The regression is covered by targeted unit and resource-client tests; no deployed-system E2E code or environment lease is required.

## Risk & Rollback

No schema or API field changes. Rollback is reverting this parser-only commit; old behavior would again ignore additional colon-separated HAMi devices in the same annotation entry.