### PR TITLE
fix: reject virtualization disable with vGPU endpoints

### DIFF
--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -77,6 +77,7 @@ func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc
 
 				return
 			}
+
 			if !disableRequested {
 				c.Next()
 				return
@@ -152,6 +153,7 @@ func validateClusterAcceleratorVirtualizationDisable(
 	}
 
 	vGPUEndpointCount := 0
+
 	for _, endpoint := range endpoints {
 		if endpoint.Spec != nil &&
 			endpoint.Spec.Resources != nil &&

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -202,19 +202,38 @@ func validateClusterAcceleratorVirtualizationDisable(
 func resolveClusterIdentityForAcceleratorVirtualizationDisable(
 	s storage.Storage, cluster v1.Cluster, queryParams url.Values,
 ) (string, string, *validationError) {
+	filters := queryParamsToFilters(queryParams)
+	if len(filters) > 0 {
+		workspace, name, validationErr := resolveClusterIdentityFromPatchFilters(s, filters)
+		if validationErr != nil {
+			return "", "", validationErr
+		}
+
+		if cluster.Metadata != nil &&
+			((cluster.Metadata.Workspace != "" && cluster.Metadata.Workspace != workspace) ||
+				(cluster.Metadata.Name != "" && cluster.Metadata.Name != name)) {
+			return "", "", &validationError{
+				Code:    "10209",
+				Message: "failed to validate cluster accelerator virtualization",
+				Hint:    "cluster metadata in patch body does not match patch target",
+			}
+		}
+
+		return workspace, name, nil
+	}
+
 	if cluster.Metadata != nil && cluster.Metadata.Workspace != "" && cluster.Metadata.Name != "" {
 		return cluster.Metadata.Workspace, cluster.Metadata.Name, nil
 	}
 
-	filters := queryParamsToFilters(queryParams)
-	if len(filters) == 0 {
-		return "", "", &validationError{
-			Code:    "10209",
-			Message: "failed to validate cluster accelerator virtualization",
-			Hint:    "cluster identity is required when disabling accelerator virtualization",
-		}
+	return "", "", &validationError{
+		Code:    "10209",
+		Message: "failed to validate cluster accelerator virtualization",
+		Hint:    "cluster identity is required when disabling accelerator virtualization",
 	}
+}
 
+func resolveClusterIdentityFromPatchFilters(s storage.Storage, filters []storage.Filter) (string, string, *validationError) {
 	clusters, err := s.ListCluster(storage.ListOption{Filters: filters})
 	if err != nil {
 		return "", "", &validationError{

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 
@@ -18,10 +19,7 @@ import (
 
 func validateClusterDeletion(s storage.Storage) middleware.DeletionValidatorFunc {
 	return func(workspace, name string) error {
-		count, err := s.Count(storage.ENDPOINT_TABLE, []storage.Filter{
-			{Column: "metadata->>workspace", Operator: "eq", Value: workspace},
-			{Column: "spec->>cluster", Operator: "eq", Value: name},
-		})
+		count, err := s.Count(storage.ENDPOINT_TABLE, clusterEndpointReferenceFilters(workspace, name))
 		if err != nil {
 			return fmt.Errorf("failed to count endpoints: %w", err)
 		}
@@ -38,7 +36,7 @@ func validateClusterDeletion(s storage.Storage) middleware.DeletionValidatorFunc
 	}
 }
 
-func validateClusterAcceleratorVirtualization() gin.HandlerFunc {
+func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -71,8 +69,160 @@ func validateClusterAcceleratorVirtualization() gin.HandlerFunc {
 			return
 		}
 
+		if c.Request.Method == http.MethodPatch {
+			disableRequested, err := clusterAcceleratorVirtualizationDisableRequested(body)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+				c.Abort()
+
+				return
+			}
+			if !disableRequested {
+				c.Next()
+				return
+			}
+
+			var cluster v1.Cluster
+			if err := json.Unmarshal(body, &cluster); err != nil {
+				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+				c.Abort()
+
+				return
+			}
+
+			if validationErr := validateClusterAcceleratorVirtualizationDisable(
+				s, cluster, c.Request.URL.Query()); validationErr != nil {
+				c.JSON(http.StatusBadRequest, validationErr)
+				c.Abort()
+
+				return
+			}
+		}
+
 		c.Next()
 	}
+}
+
+func clusterAcceleratorVirtualizationDisableRequested(body []byte) (bool, error) {
+	var payload struct {
+		Spec *struct {
+			AcceleratorVirtualization *struct {
+				Enabled *bool `json:"enabled"`
+			} `json:"accelerator_virtualization"`
+		} `json:"spec"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false, err
+	}
+
+	return payload.Spec != nil &&
+		payload.Spec.AcceleratorVirtualization != nil &&
+		payload.Spec.AcceleratorVirtualization.Enabled != nil &&
+		!*payload.Spec.AcceleratorVirtualization.Enabled, nil
+}
+
+func clusterEndpointReferenceFilters(workspace, name string) []storage.Filter {
+	return []storage.Filter{
+		{Column: "metadata->>workspace", Operator: "eq", Value: workspace},
+		{Column: "spec->>cluster", Operator: "eq", Value: name},
+	}
+}
+
+func validateClusterAcceleratorVirtualizationDisable(
+	s storage.Storage, cluster v1.Cluster, queryParams url.Values,
+) *validationError {
+	if cluster.GetDeletionTimestamp() != "" || !isDisablingAcceleratorVirtualization(cluster) {
+		return nil
+	}
+
+	workspace, name, validationErr := resolveClusterIdentityForAcceleratorVirtualizationDisable(
+		s, cluster, queryParams)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	endpoints, err := s.ListEndpoint(storage.ListOption{Filters: clusterEndpointReferenceFilters(workspace, name)})
+	if err != nil {
+		return &validationError{
+			Code:    "10209",
+			Message: "failed to validate cluster accelerator virtualization",
+			Hint:    err.Error(),
+		}
+	}
+
+	vGPUEndpointCount := 0
+	for _, endpoint := range endpoints {
+		if endpoint.Spec != nil &&
+			endpoint.Spec.Resources != nil &&
+			endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+			vGPUEndpointCount++
+		}
+	}
+
+	if vGPUEndpointCount > 0 {
+		return &validationError{
+			Code:    "10211",
+			Message: fmt.Sprintf("cannot disable accelerator virtualization for cluster '%s/%s'", workspace, name),
+			Hint: fmt.Sprintf(
+				"%d vGPU endpoint(s) still reference this cluster; delete the vGPU endpoints before disabling accelerator virtualization",
+				vGPUEndpointCount,
+			),
+		}
+	}
+
+	return nil
+}
+
+func isDisablingAcceleratorVirtualization(cluster v1.Cluster) bool {
+	return cluster.Spec != nil &&
+		cluster.Spec.AcceleratorVirtualization != nil &&
+		!cluster.Spec.AcceleratorVirtualization.Enabled
+}
+
+func resolveClusterIdentityForAcceleratorVirtualizationDisable(
+	s storage.Storage, cluster v1.Cluster, queryParams url.Values,
+) (string, string, *validationError) {
+	if cluster.Metadata != nil && cluster.Metadata.Workspace != "" && cluster.Metadata.Name != "" {
+		return cluster.Metadata.Workspace, cluster.Metadata.Name, nil
+	}
+
+	filters := queryParamsToFilters(queryParams)
+	if len(filters) == 0 {
+		return "", "", &validationError{
+			Code:    "10209",
+			Message: "failed to validate cluster accelerator virtualization",
+			Hint:    "cluster identity is required when disabling accelerator virtualization",
+		}
+	}
+
+	clusters, err := s.ListCluster(storage.ListOption{Filters: filters})
+	if err != nil {
+		return "", "", &validationError{
+			Code:    "10209",
+			Message: "failed to validate cluster accelerator virtualization",
+			Hint:    err.Error(),
+		}
+	}
+
+	if len(clusters) != 1 {
+		return "", "", &validationError{
+			Code:    "10209",
+			Message: "failed to validate cluster accelerator virtualization",
+			Hint:    fmt.Sprintf("expected exactly one cluster from patch filters, got %d", len(clusters)),
+		}
+	}
+
+	resolved := clusters[0]
+	if resolved.Metadata == nil || resolved.Metadata.Workspace == "" || resolved.Metadata.Name == "" {
+		return "", "", &validationError{
+			Code:    "10209",
+			Message: "failed to validate cluster accelerator virtualization",
+			Hint:    "cluster identity is required when disabling accelerator virtualization",
+		}
+	}
+
+	return resolved.Metadata.Workspace, resolved.Metadata.Name, nil
 }
 
 func validateClusterAcceleratorVirtualizationBody(body []byte) *validationError {
@@ -160,7 +310,7 @@ func RegisterClusterRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc
 		validateClusterDeletion(deps.Storage),
 	)
 	handler := CreateStructProxyHandler[v1.Cluster](deps, storage.CLUSTERS_TABLE)
-	acceleratorVirtualizationValidation := validateClusterAcceleratorVirtualization()
+	acceleratorVirtualizationValidation := validateClusterAcceleratorVirtualization(deps.Storage)
 
 	proxyGroup.GET("", handler)
 	proxyGroup.POST("", acceleratorVirtualizationValidation, handler)

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -105,22 +105,45 @@ func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc
 }
 
 func clusterAcceleratorVirtualizationDisableRequested(body []byte) (bool, error) {
-	var payload struct {
-		Spec *struct {
-			AcceleratorVirtualization *struct {
-				Enabled *bool `json:"enabled"`
-			} `json:"accelerator_virtualization"`
-		} `json:"spec"`
-	}
-
+	var payload map[string]json.RawMessage
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return false, err
 	}
 
-	return payload.Spec != nil &&
-		payload.Spec.AcceleratorVirtualization != nil &&
-		payload.Spec.AcceleratorVirtualization.Enabled != nil &&
-		!*payload.Spec.AcceleratorVirtualization.Enabled, nil
+	specRaw, ok := payload["spec"]
+	if !ok {
+		return false, nil
+	}
+
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
+		return false, err
+	}
+
+	acceleratorVirtualizationRaw, ok := spec["accelerator_virtualization"]
+	if !ok {
+		return false, nil
+	}
+
+	var acceleratorVirtualization map[string]json.RawMessage
+	if err := json.Unmarshal(acceleratorVirtualizationRaw, &acceleratorVirtualization); err != nil {
+		return false, err
+	}
+
+	enabledRaw, ok := acceleratorVirtualization["enabled"]
+	if !ok {
+		// The CLI decodes YAML into Cluster and re-marshals JSON before PATCH.
+		// enabled:false is omitted by the API struct tag, yielding
+		// "accelerator_virtualization": {}, which still clears the enabled flag.
+		return true, nil
+	}
+
+	var enabled bool
+	if err := json.Unmarshal(enabledRaw, &enabled); err != nil {
+		return false, err
+	}
+
+	return !enabled, nil
 }
 
 func clusterEndpointReferenceFilters(workspace, name string) []storage.Filter {

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -156,7 +156,7 @@ func clusterEndpointReferenceFilters(workspace, name string) []storage.Filter {
 func validateClusterAcceleratorVirtualizationDisable(
 	s storage.Storage, cluster v1.Cluster, queryParams url.Values,
 ) *validationError {
-	if cluster.GetDeletionTimestamp() != "" || !isDisablingAcceleratorVirtualization(cluster) {
+	if cluster.GetDeletionTimestamp() != "" {
 		return nil
 	}
 
@@ -197,12 +197,6 @@ func validateClusterAcceleratorVirtualizationDisable(
 	}
 
 	return nil
-}
-
-func isDisablingAcceleratorVirtualization(cluster v1.Cluster) bool {
-	return cluster.Spec != nil &&
-		cluster.Spec.AcceleratorVirtualization != nil &&
-		!cluster.Spec.AcceleratorVirtualization.Enabled
 }
 
 func resolveClusterIdentityForAcceleratorVirtualizationDisable(

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -2,10 +2,13 @@ package proxies
 
 import (
 	"errors"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/middleware"
 	"github.com/neutree-ai/neutree/pkg/storage"
 	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
@@ -270,4 +273,163 @@ func TestValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
 		assert.Equal(t, "10208", err.Code)
 		assert.Contains(t, err.Message, "requires cluster version >= v1.1.0")
 	})
+}
+
+func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
+	vGPUEndpoint := v1.Endpoint{
+		Spec: &v1.EndpointSpec{
+			Resources: &v1.ResourceSpec{
+				Accelerator: map[string]string{
+					v1.AcceleratorVirtualizationMemoryMiBKey: "8192",
+				},
+			},
+		},
+	}
+	nonVGPUEndpoint := v1.Endpoint{
+		Spec: &v1.EndpointSpec{
+			Resources: &v1.ResourceSpec{
+				Accelerator: map[string]string{
+					v1.AcceleratorTypeKey: "nvidia_gpu",
+				},
+			},
+		},
+	}
+
+	t.Run("rejects disabling when vGPU endpoint references cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		cluster := v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec: &v1.ClusterSpec{
+				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
+			},
+		}
+		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
+
+		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
+			Return([]v1.Endpoint{vGPUEndpoint}, nil)
+
+		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, cluster, nil)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10211", err.Code)
+		assert.Contains(t, err.Message, "cannot disable accelerator virtualization")
+		assert.Contains(t, err.Hint, "1 vGPU endpoint(s) still reference this cluster")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("allows disabling when only non-vGPU endpoint references cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		cluster := v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec: &v1.ClusterSpec{
+				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
+			},
+		}
+		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
+
+		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
+			Return([]v1.Endpoint{nonVGPUEndpoint}, nil)
+
+		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, cluster, nil)
+
+		assert.Nil(t, err)
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("resolves cluster identity from patch query filters", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		clusterPatch := v1.Cluster{
+			Spec: &v1.ClusterSpec{
+				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
+			},
+		}
+		query := url.Values{
+			"metadata->>workspace": []string{"eq.default"},
+			"metadata->>name":      []string{"eq.gpu-cluster"},
+		}
+		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
+
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{
+			{Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"}},
+		}, nil)
+		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
+			Return([]v1.Endpoint{vGPUEndpoint}, nil)
+
+		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, clusterPatch, query)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10211", err.Code)
+		assert.Contains(t, err.Hint, "1 vGPU endpoint(s) still reference this cluster")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("returns validation error when endpoint lookup fails", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		cluster := v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec: &v1.ClusterSpec{
+				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
+			},
+		}
+		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
+
+		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
+			Return(nil, errors.New("database error"))
+
+		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, cluster, nil)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10209", err.Code)
+		assert.Contains(t, err.Hint, "database error")
+		mockStorage.AssertExpectations(t)
+	})
+}
+
+func TestClusterAcceleratorVirtualizationDisableRequested(t *testing.T) {
+	t.Run("true when payload explicitly sets enabled false", func(t *testing.T) {
+		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
+			"spec": {
+				"accelerator_virtualization": {"enabled": false}
+			}
+		}`))
+
+		assert.NoError(t, err)
+		assert.True(t, requested)
+	})
+
+	t.Run("false when enabled is omitted", func(t *testing.T) {
+		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
+			"spec": {
+				"accelerator_virtualization": {"config_patch": {"devicePlugin": {}}}
+			}
+		}`))
+
+		assert.NoError(t, err)
+		assert.False(t, requested)
+	})
+}
+
+func sameFilters(actual, expected []storage.Filter) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+
+	unmatched := append([]storage.Filter(nil), actual...)
+	for _, expectedFilter := range expected {
+		matched := false
+		for i, actualFilter := range unmatched {
+			if actualFilter == expectedFilter {
+				unmatched = append(unmatched[:i], unmatched[i+1:]...)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -369,6 +369,34 @@ func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 	})
 
+	t.Run("rejects mismatched patch body identity and query target", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		clusterPatch := v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "body-cluster"},
+			Spec: &v1.ClusterSpec{
+				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
+			},
+		}
+		query := url.Values{
+			"id": []string{"eq.1"},
+		}
+
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{
+			{Metadata: &v1.Metadata{Workspace: "default", Name: "query-cluster"}},
+		}, nil)
+
+		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, clusterPatch, query)
+
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "10209", err.Code)
+			assert.Contains(t, err.Hint, "does not match patch target")
+		}
+		mockStorage.AssertExpectations(t)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
 	t.Run("returns validation error when endpoint lookup fails", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		cluster := v1.Cluster{

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -385,6 +385,26 @@ func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
 		assert.Contains(t, err.Hint, "database error")
 		mockStorage.AssertExpectations(t)
 	})
+
+	t.Run("rejects clearing accelerator virtualization with null while vGPU endpoint references cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		cluster := v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec:     &v1.ClusterSpec{AcceleratorVirtualization: nil},
+		}
+		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
+
+		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
+			Return([]v1.Endpoint{vGPUEndpoint}, nil)
+
+		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, cluster, nil)
+
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "10211", err.Code)
+			assert.Contains(t, err.Hint, "1 vGPU endpoint(s) still reference this cluster")
+		}
+		mockStorage.AssertExpectations(t)
+	})
 }
 
 func TestClusterAcceleratorVirtualizationDisableRequested(t *testing.T) {
@@ -414,6 +434,17 @@ func TestClusterAcceleratorVirtualizationDisableRequested(t *testing.T) {
 		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
 			"spec": {
 				"accelerator_virtualization": {}
+			}
+		}`))
+
+		assert.NoError(t, err)
+		assert.True(t, requested)
+	})
+
+	t.Run("true when accelerator virtualization patch is null", func(t *testing.T) {
+		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
+			"spec": {
+				"accelerator_virtualization": null
 			}
 		}`))
 

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -399,7 +399,7 @@ func TestClusterAcceleratorVirtualizationDisableRequested(t *testing.T) {
 		assert.True(t, requested)
 	})
 
-	t.Run("false when enabled is omitted", func(t *testing.T) {
+	t.Run("true when enabled is omitted from accelerator virtualization patch", func(t *testing.T) {
 		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
 			"spec": {
 				"accelerator_virtualization": {"config_patch": {"devicePlugin": {}}}
@@ -407,7 +407,18 @@ func TestClusterAcceleratorVirtualizationDisableRequested(t *testing.T) {
 		}`))
 
 		assert.NoError(t, err)
-		assert.False(t, requested)
+		assert.True(t, requested)
+	})
+
+	t.Run("true when accelerator virtualization patch is empty after omitempty marshal", func(t *testing.T) {
+		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
+			"spec": {
+				"accelerator_virtualization": {}
+			}
+		}`))
+
+		assert.NoError(t, err)
+		assert.True(t, requested)
 	})
 }
 

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -2,9 +2,13 @@ package proxies
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -404,6 +408,69 @@ func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
 			assert.Contains(t, err.Hint, "1 vGPU endpoint(s) still reference this cluster")
 		}
 		mockStorage.AssertExpectations(t)
+	})
+}
+
+func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("rejects disable patch before proxy handler when vGPU endpoint references cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListEndpoint", storage.ListOption{
+			Filters: clusterEndpointReferenceFilters("default", "gpu-cluster"),
+		}).Return([]v1.Endpoint{
+			{
+				Spec: &v1.EndpointSpec{
+					Resources: &v1.ResourceSpec{
+						Accelerator: map[string]string{
+							v1.AcceleratorVirtualizationMemoryMiBKey: "8192",
+						},
+					},
+				},
+			},
+		}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterAcceleratorVirtualization(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		body := `{
+			"metadata": {"workspace": "default", "name": "gpu-cluster"},
+			"spec": {"accelerator_virtualization": {"enabled": false}}
+		}`
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(body))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10211"`)
+		assert.Contains(t, recorder.Body.String(), "vGPU endpoint(s) still reference this cluster")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("allows non-disable patch to continue to proxy handler", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterAcceleratorVirtualization(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		body := `{"metadata": {"workspace": "default", "name": "gpu-cluster"}}`
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(body))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 	})
 }
 

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -163,112 +162,6 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 			Expect(endpoint.Spec.Resources.Accelerator).NotTo(HaveKey(v1.AcceleratorVirtualizationCorePercentKey))
 
 			expectEndpointNVIDIAGPUResourcesWithExpected(endpoint, productName, memoryMiB, vgpuFullCardCoreUnits)
-		})
-	})
-
-var _ = Describe("K8s Accelerator Virtualization Disable Guard", Ordered,
-	Label("cluster", "endpoint", "k8s", "accelerator-virtualization", "hami", "negative"), func() {
-		var (
-			clusterName  string
-			endpointName string
-			kubeconfig   string
-		)
-
-		BeforeAll(func() {
-			requireAcceleratorVirtualizationProfile()
-			kubeconfig = requireK8sProfile()
-
-			By("Setting up image registry")
-			SetupImageRegistry()
-
-			clusterName = "e2e-vgpu-guard-" + Cfg.RunID
-
-			yaml := renderK8sClusterYAML(map[string]any{
-				"name":                               clusterName,
-				"kubeconfig":                         kubeconfig,
-				"accelerator_virtualization_enabled": true,
-			})
-
-			ch := NewClusterHelper()
-
-			By("Applying K8s cluster with accelerator virtualization enabled: " + clusterName)
-			r := ch.Apply(yaml)
-			ExpectSuccess(r)
-
-			By("Waiting for virtualized cluster Running")
-			ch.EventuallyInPhase(clusterName, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
-		})
-
-		AfterAll(func() {
-			if endpointName != "" {
-				deleteEndpoint(endpointName)
-			}
-
-			if clusterName != "" {
-				teardownCluster(clusterName)
-			}
-		})
-
-		// TestRail: C2722691.
-		It("should reject disabling accelerator virtualization while a vGPU endpoint references the cluster", Label("C2722691"), func() {
-			if profileModelName() == "" {
-				Skip("Model name not configured in profile, skipping vGPU endpoint negative path")
-			}
-
-			cluster := eventuallyVirtualizedClusterResourceInfo(clusterName)
-			productName := expectNVIDIAVirtualizedClusterResources(cluster)
-
-			By("Setting up model registry")
-			SetupModelRegistry()
-			DeferCleanup(TeardownModelRegistry)
-
-			endpointName = "e2e-vgpu-guard-ep-" + Cfg.RunID
-
-			yamlPath := applyEndpoint(endpointName, clusterName,
-				withAccelerator(string(v1.AcceleratorTypeNVIDIAGPU), productName),
-				withAcceleratorVirtualization(vgpuEndpointMemoryMiB, "", vgpuEndpointCorePercent))
-			DeferCleanup(func() {
-				if endpointName != "" {
-					deleteEndpoint(endpointName)
-					endpointName = ""
-				}
-			})
-			DeferCleanup(removeFileIfExists, yamlPath)
-
-			By("Waiting for vGPU endpoint Running")
-			waitEndpointRunning(endpointName)
-
-			endpoint := getEndpoint(endpointName)
-			Expect(endpoint.Spec).NotTo(BeNil())
-			Expect(endpoint.Spec.Resources).NotTo(BeNil())
-			Expect(endpoint.Spec.Resources.HasAcceleratorVirtualization()).To(BeTrue())
-
-			disablePath := renderClusterAcceleratorVirtualizationUpdateJSON(clusterName, kubeconfig, false)
-			DeferCleanup(removeFileIfExists, disablePath)
-
-			By("Rejecting accelerator virtualization disable while vGPU endpoint exists")
-			r := RunCLI("apply", "-f", disablePath, "--force-update")
-			ExpectFailed(r)
-			combinedOutput := r.Stdout + r.Stderr
-			Expect(combinedOutput).To(ContainSubstring("10211"))
-			Expect(combinedOutput).To(ContainSubstring("cannot disable accelerator virtualization"))
-			Expect(combinedOutput).To(ContainSubstring("vGPU endpoint(s) still reference this cluster"))
-
-			cluster = getClusterFullJSON(clusterName)
-			Expect(cluster.Spec).NotTo(BeNil())
-			Expect(cluster.Spec.AcceleratorVirtualizationEnabled()).To(BeTrue())
-
-			By("Deleting vGPU endpoint")
-			deleteEndpoint(endpointName)
-			endpointName = ""
-
-			By("Allowing accelerator virtualization disable after vGPU endpoint is deleted")
-			r = RunCLI("apply", "-f", disablePath, "--force-update")
-			ExpectSuccess(r)
-
-			cluster = getClusterFullJSON(clusterName)
-			Expect(cluster.Spec).NotTo(BeNil())
-			Expect(cluster.Spec.AcceleratorVirtualizationEnabled()).To(BeFalse())
 		})
 	})
 
@@ -455,36 +348,6 @@ func expectEndpointNVIDIAGPUResourcesWithExpected(
 
 	ExpectWithOffset(1, memoryMiB).To(Equal(usage.MemoryMiB))
 	ExpectWithOffset(1, coreUnits).To(Equal(usage.CoreUnits))
-}
-
-func renderClusterAcceleratorVirtualizationUpdateJSON(clusterName, kubeconfig string, enabled bool) string {
-	cluster := getClusterFullJSON(clusterName)
-	ExpectWithOffset(1, cluster.Metadata).NotTo(BeNil())
-	ExpectWithOffset(1, cluster.Spec).NotTo(BeNil())
-	ExpectWithOffset(1, cluster.Spec.Config).NotTo(BeNil())
-	ExpectWithOffset(1, cluster.Spec.Config.KubernetesConfig).NotTo(BeNil())
-
-	cluster.ID = 0
-	cluster.APIVersion = "v1"
-	cluster.Kind = "Cluster"
-	cluster.Status = nil
-	cluster.Metadata.CreationTimestamp = ""
-	cluster.Metadata.UpdateTimestamp = ""
-	cluster.Metadata.DeletionTimestamp = ""
-	cluster.Spec.Config.KubernetesConfig.Kubeconfig = kubeconfig
-	cluster.Spec.AcceleratorVirtualization = &v1.AcceleratorVirtualizationSpec{Enabled: enabled}
-
-	data, err := json.MarshalIndent(cluster, "", "  ")
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	tmpFile, err := os.CreateTemp("", "e2e-cluster-accelerator-virtualization-*.json")
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	_, err = tmpFile.Write(data)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, tmpFile.Close()).To(Succeed())
-
-	return tmpFile.Name()
 }
 
 func removeFileIfExists(path string) {

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -162,6 +163,112 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 			Expect(endpoint.Spec.Resources.Accelerator).NotTo(HaveKey(v1.AcceleratorVirtualizationCorePercentKey))
 
 			expectEndpointNVIDIAGPUResourcesWithExpected(endpoint, productName, memoryMiB, vgpuFullCardCoreUnits)
+		})
+	})
+
+var _ = Describe("K8s Accelerator Virtualization Disable Guard", Ordered,
+	Label("cluster", "endpoint", "k8s", "accelerator-virtualization", "hami", "negative"), func() {
+		var (
+			clusterName  string
+			endpointName string
+			kubeconfig   string
+		)
+
+		BeforeAll(func() {
+			requireAcceleratorVirtualizationProfile()
+			kubeconfig = requireK8sProfile()
+
+			By("Setting up image registry")
+			SetupImageRegistry()
+
+			clusterName = "e2e-vgpu-guard-" + Cfg.RunID
+
+			yaml := renderK8sClusterYAML(map[string]any{
+				"name":                               clusterName,
+				"kubeconfig":                         kubeconfig,
+				"accelerator_virtualization_enabled": true,
+			})
+
+			ch := NewClusterHelper()
+
+			By("Applying K8s cluster with accelerator virtualization enabled: " + clusterName)
+			r := ch.Apply(yaml)
+			ExpectSuccess(r)
+
+			By("Waiting for virtualized cluster Running")
+			ch.EventuallyInPhase(clusterName, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
+		})
+
+		AfterAll(func() {
+			if endpointName != "" {
+				deleteEndpoint(endpointName)
+			}
+
+			if clusterName != "" {
+				teardownCluster(clusterName)
+			}
+		})
+
+		// TestRail: C2722691.
+		It("should reject disabling accelerator virtualization while a vGPU endpoint references the cluster", Label("C2722691"), func() {
+			if profileModelName() == "" {
+				Skip("Model name not configured in profile, skipping vGPU endpoint negative path")
+			}
+
+			cluster := eventuallyVirtualizedClusterResourceInfo(clusterName)
+			productName := expectNVIDIAVirtualizedClusterResources(cluster)
+
+			By("Setting up model registry")
+			SetupModelRegistry()
+			DeferCleanup(TeardownModelRegistry)
+
+			endpointName = "e2e-vgpu-guard-ep-" + Cfg.RunID
+
+			yamlPath := applyEndpoint(endpointName, clusterName,
+				withAccelerator(string(v1.AcceleratorTypeNVIDIAGPU), productName),
+				withAcceleratorVirtualization(vgpuEndpointMemoryMiB, "", vgpuEndpointCorePercent))
+			DeferCleanup(func() {
+				if endpointName != "" {
+					deleteEndpoint(endpointName)
+					endpointName = ""
+				}
+			})
+			DeferCleanup(removeFileIfExists, yamlPath)
+
+			By("Waiting for vGPU endpoint Running")
+			waitEndpointRunning(endpointName)
+
+			endpoint := getEndpoint(endpointName)
+			Expect(endpoint.Spec).NotTo(BeNil())
+			Expect(endpoint.Spec.Resources).NotTo(BeNil())
+			Expect(endpoint.Spec.Resources.HasAcceleratorVirtualization()).To(BeTrue())
+
+			disablePath := renderClusterAcceleratorVirtualizationUpdateJSON(clusterName, kubeconfig, false)
+			DeferCleanup(removeFileIfExists, disablePath)
+
+			By("Rejecting accelerator virtualization disable while vGPU endpoint exists")
+			r := RunCLI("apply", "-f", disablePath, "--force-update")
+			ExpectFailed(r)
+			combinedOutput := r.Stdout + r.Stderr
+			Expect(combinedOutput).To(ContainSubstring("10211"))
+			Expect(combinedOutput).To(ContainSubstring("cannot disable accelerator virtualization"))
+			Expect(combinedOutput).To(ContainSubstring("vGPU endpoint(s) still reference this cluster"))
+
+			cluster = getClusterFullJSON(clusterName)
+			Expect(cluster.Spec).NotTo(BeNil())
+			Expect(cluster.Spec.AcceleratorVirtualizationEnabled()).To(BeTrue())
+
+			By("Deleting vGPU endpoint")
+			deleteEndpoint(endpointName)
+			endpointName = ""
+
+			By("Allowing accelerator virtualization disable after vGPU endpoint is deleted")
+			r = RunCLI("apply", "-f", disablePath, "--force-update")
+			ExpectSuccess(r)
+
+			cluster = getClusterFullJSON(clusterName)
+			Expect(cluster.Spec).NotTo(BeNil())
+			Expect(cluster.Spec.AcceleratorVirtualizationEnabled()).To(BeFalse())
 		})
 	})
 
@@ -348,6 +455,36 @@ func expectEndpointNVIDIAGPUResourcesWithExpected(
 
 	ExpectWithOffset(1, memoryMiB).To(Equal(usage.MemoryMiB))
 	ExpectWithOffset(1, coreUnits).To(Equal(usage.CoreUnits))
+}
+
+func renderClusterAcceleratorVirtualizationUpdateJSON(clusterName, kubeconfig string, enabled bool) string {
+	cluster := getClusterFullJSON(clusterName)
+	ExpectWithOffset(1, cluster.Metadata).NotTo(BeNil())
+	ExpectWithOffset(1, cluster.Spec).NotTo(BeNil())
+	ExpectWithOffset(1, cluster.Spec.Config).NotTo(BeNil())
+	ExpectWithOffset(1, cluster.Spec.Config.KubernetesConfig).NotTo(BeNil())
+
+	cluster.ID = 0
+	cluster.APIVersion = "v1"
+	cluster.Kind = "Cluster"
+	cluster.Status = nil
+	cluster.Metadata.CreationTimestamp = ""
+	cluster.Metadata.UpdateTimestamp = ""
+	cluster.Metadata.DeletionTimestamp = ""
+	cluster.Spec.Config.KubernetesConfig.Kubeconfig = kubeconfig
+	cluster.Spec.AcceleratorVirtualization = &v1.AcceleratorVirtualizationSpec{Enabled: enabled}
+
+	data, err := json.MarshalIndent(cluster, "", "  ")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	tmpFile, err := os.CreateTemp("", "e2e-cluster-accelerator-virtualization-*.json")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	_, err = tmpFile.Write(data)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, tmpFile.Close()).To(Succeed())
+
+	return tmpFile.Name()
 }
 
 func removeFileIfExists(path string) {


### PR DESCRIPTION
## Issue

NEU-466

## Summary

Reject cluster accelerator virtualization disable requests while vGPU Endpoints still reference the target cluster. The guard is scoped to Endpoints whose accelerator resource includes `virtualization.*` keys, so non-vGPU Endpoints do not block the update.

## Changes

- Add cluster proxy validation for PATCH requests that disable or clear `spec.accelerator_virtualization.enabled`.
- Treat `spec.accelerator_virtualization: {}` and `spec.accelerator_virtualization: null` as disable/clear requests to cover CLI YAML decode + JSON `omitempty` behavior and direct clear payloads.
- Resolve partial PATCH targets from request filters and reject only when vGPU Endpoints reference the cluster.
- Cover vGPU block, non-vGPU allow, query fallback, body/query target mismatch, lookup error, explicit false detection, omitted false detection, null clear detection, and middleware HTTP response behavior with unit tests.
- Keep C2722691 as manual E2E coverage; code-backed E2E was intentionally removed after scope review because this is an API proxy guard and the deterministic behavior is covered by unit and middleware tests.

## Test Plan

Unit test:
- [x] `go vet ./internal/routes/proxies ./tests/e2e`
- [x] `go test ./internal/routes/proxies -count=1`
- [x] `go test ./internal/routes/proxies -coverprofile=/tmp/neu466-proxy-review-fix.cover -count=1` showed local proxy package coverage at 69.2%; `validateClusterAcceleratorVirtualization` coverage remains covered by middleware tests.
- [x] `go test ./tests/e2e -run TestNonExistent -count=0`
- [x] `go build ./tests/e2e/...`
- [x] `git diff --check`
- [x] Enterprise compatibility: `GOPROXY=direct GOPRIVATE='github.com/neutree-ai/*' GONOSUMDB='github.com/neutree-ai/*' COMMUNITY_VERSION=fix-NEU-466 make build-neutree-api` passed against community pseudo-version `v1.1.0-nightly-20260622.0.20260623092617-96fba58dd494` with build flag `communityCommit=96fba58`.
- [x] `gh pr checks 430 --repo neutree-ai/neutree`: `pr-check` and `codecov/patch` passed at head `96fba58dd49411ba8a8e50b12c246fb0be106eb5`.
- [ ] `go vet ./...` and `go test ./...` are blocked locally by missing embedded `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`.
- [ ] `golangci-lint run ./internal/routes/proxies ./tests/e2e` is blocked locally because golangci-lint v1.53.3 was built with Go 1.20.6 and reports typecheck errors for the current Go 1.23 toolchain and existing packages. CI `pr-check` covers the repository lint environment.

DB test:
- [x] Not required. No DB schema, migration, or storage schema changes.

E2E test:
- [x] Manual C2722691 on leased community K8s GPU/HAMi environment: with a Running vGPU Endpoint, disabling cluster accelerator virtualization was rejected with HTTP 400 code `10211`, message `cannot disable accelerator virtualization`, and hint `vGPU endpoint(s) still reference this cluster`; after deleting the vGPU Endpoint, the same disable update succeeded.
- [x] Validated runtime/artifacts: community CP baseline `v1.1.0-nightly-20260622`; branch `neutree-api` hot-updated from the PR fix; E2E profile used `neutree-test` artifacts with cluster version `v1.1.0-alpha.1` and vLLM `v0.11.2`.
- [x] Rerun rule satisfied for latest review fix: `96fba58dd49411ba8a8e50b12c246fb0be106eb5` changes API proxy target-identity validation and is covered by the added route/middleware unit regression `rejects_mismatched_patch_body_identity_and_query_target`; no live GPU/HAMi E2E rerun is required because the final E2E scope is manual-only and this artificial body/query mismatch is not a deployment behavior.
- [x] Code-backed E2E intentionally not included: this negative path is an API proxy validation guard already covered by unit and middleware tests; keeping a full K8s GPU/HAMi/model deployment E2E case would be disproportionate and more brittle than the behavior under test.

## Risk & Rollback

Risk is limited to cluster PATCH validation. The change does not modify DB schema, controllers, orchestrators, HAMi teardown, UI, or enterprise source. Rollback is reverting this PR, which restores the previous validation behavior.
