### PR TITLE
fix: validate vGPU endpoint requests

### DIFF
--- a/internal/routes/proxies/endpoint_proxy.go
+++ b/internal/routes/proxies/endpoint_proxy.go
@@ -19,7 +19,7 @@ func RegisterEndpointRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFun
 	proxyGroup.Use(middlewares...)
 
 	handler := CreateStructProxyHandler[v1.Endpoint](deps, storage.ENDPOINT_TABLE)
-	acceleratorVirtualizationValidation := validateEndpointAcceleratorVirtualization()
+	acceleratorVirtualizationValidation := validateEndpointAcceleratorVirtualization(deps.Storage)
 
 	// Only register allowed methods
 	proxyGroup.GET("", handler)

--- a/internal/routes/proxies/endpoint_proxy.go
+++ b/internal/routes/proxies/endpoint_proxy.go
@@ -19,10 +19,10 @@ func RegisterEndpointRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFun
 	proxyGroup.Use(middlewares...)
 
 	handler := CreateStructProxyHandler[v1.Endpoint](deps, storage.ENDPOINT_TABLE)
-	acceleratorVirtualizationValidation := validateEndpointAcceleratorVirtualization(deps.Storage)
+	vgpuValidation := validateEndpointVGPU(deps.Storage)
 
 	// Only register allowed methods
 	proxyGroup.GET("", handler)
-	proxyGroup.POST("", acceleratorVirtualizationValidation, handler)
-	proxyGroup.PATCH("", acceleratorVirtualizationValidation, handler)
+	proxyGroup.POST("", vgpuValidation, handler)
+	proxyGroup.PATCH("", vgpuValidation, handler)
 }

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -15,7 +17,12 @@ import (
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
-func validateEndpointAcceleratorVirtualization(clusterStorage storage.ClusterStorage) gin.HandlerFunc {
+type endpointAcceleratorVirtualizationStorage interface {
+	ListCluster(option storage.ListOption) ([]v1.Cluster, error)
+	ListEndpoint(option storage.ListOption) ([]v1.Endpoint, error)
+}
+
+func validateEndpointAcceleratorVirtualization(store endpointAcceleratorVirtualizationStorage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -41,20 +48,14 @@ func validateEndpointAcceleratorVirtualization(clusterStorage storage.ClusterSto
 			return
 		}
 
-		endpoint, validationErr := parseEndpointAcceleratorVirtualizationBody(body)
+		validationErr := validateEndpointAcceleratorVirtualizationRequest(
+			store,
+			c.Request.Method,
+			c.Request.URL.Query(),
+			body,
+		)
 		if validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
-			c.Abort()
-
-			return
-		}
-
-		if c.Request.Method == http.MethodPost {
-			validationErr = validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
-		}
-
-		if validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
+			c.JSON(validationErrStatus(validationErr), validationErr)
 			c.Abort()
 
 			return
@@ -62,6 +63,20 @@ func validateEndpointAcceleratorVirtualization(clusterStorage storage.ClusterSto
 
 		c.Next()
 	}
+}
+
+func validateEndpointAcceleratorVirtualizationRequest(
+	store endpointAcceleratorVirtualizationStorage,
+	method string,
+	queryParams url.Values,
+	body []byte,
+) *validationError {
+	endpoint, validationErr := parseEndpointAcceleratorVirtualizationBody(body)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	return validateEndpointAcceleratorVirtualizationPreflight(store, method, queryParams, endpoint)
 }
 
 func validateEndpointAcceleratorVirtualizationBody(body []byte) *validationError {
@@ -92,6 +107,327 @@ func parseEndpointAcceleratorVirtualizationBody(body []byte) (*v1.Endpoint, *val
 	}
 
 	return &endpoint, nil
+}
+
+func validateEndpointAcceleratorVirtualizationPreflight(
+	store endpointAcceleratorVirtualizationStorage,
+	method string,
+	queryParams url.Values,
+	endpoint *v1.Endpoint,
+) *validationError {
+	if endpoint == nil || endpoint.GetDeletionTimestamp() != "" {
+		return nil
+	}
+
+	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
+	}
+
+	if store == nil {
+		return endpointAcceleratorVirtualizationLookupError("storage is required to validate endpoint accelerator virtualization")
+	}
+
+	var existing *v1.Endpoint
+	if method == http.MethodPatch {
+		resolved, validationErr := resolveEndpointAcceleratorVirtualizationPatchEndpoint(store, queryParams)
+		if validationErr != nil {
+			return validationErr
+		}
+		existing = resolved
+		merged := mergeEndpointAcceleratorVirtualizationPatch(existing, endpoint)
+		endpoint = &merged
+	}
+
+	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
+	}
+
+	target, validationErr := resolveEndpointAcceleratorVirtualizationTarget(method, queryParams, endpoint)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	clusters, err := store.ListCluster(storage.ListOption{
+		Filters: endpointClusterLookupFilters(target.cluster, target.workspace),
+	})
+	if err != nil {
+		return endpointAcceleratorVirtualizationLookupError("failed to look up cluster for endpoint accelerator virtualization")
+	}
+
+	if len(clusters) == 0 {
+		return endpointAcceleratorVirtualizationTargetError(fmt.Sprintf("cluster %s/%s not found", target.workspace, target.cluster))
+	}
+
+	if len(clusters) > 1 {
+		return endpointAcceleratorVirtualizationTargetError(fmt.Sprintf("multiple clusters matched %s/%s", target.workspace, target.cluster))
+	}
+
+	cluster := &clusters[0]
+	if validationErr := validateEndpointClusterAcceleratorVirtualizationReady(cluster); validationErr != nil {
+		return validationErr
+	}
+
+	if method == http.MethodPatch && endpointAcceleratorVirtualizationAllocationCanBeAddedBack(existing, target) {
+		cluster = clusterWithEndpointAcceleratorVirtualizationAllocationAddedBack(cluster, existing)
+	}
+
+	return validateEndpointAcceleratorVirtualizationCapacity(endpoint.Spec.Resources, cluster)
+}
+
+type endpointAcceleratorVirtualizationTarget struct {
+	cluster   string
+	workspace string
+}
+
+func resolveEndpointAcceleratorVirtualizationTarget(
+	method string,
+	queryParams url.Values,
+	endpoint *v1.Endpoint,
+) (endpointAcceleratorVirtualizationTarget, *validationError) {
+	target := endpointAcceleratorVirtualizationTarget{
+		workspace: endpointTargetWorkspace(method, queryParams, endpoint),
+	}
+
+	if endpoint.Spec != nil {
+		target.cluster = endpoint.Spec.Cluster
+	}
+
+	return validateEndpointAcceleratorVirtualizationTarget(target)
+}
+
+func resolveEndpointAcceleratorVirtualizationPatchEndpoint(
+	store endpointAcceleratorVirtualizationStorage,
+	queryParams url.Values,
+) (*v1.Endpoint, *validationError) {
+	filters := queryParamsToFilters(queryParams)
+	if len(filters) == 0 {
+		return nil, endpointAcceleratorVirtualizationTargetError("endpoint lookup filters are required for vGPU resource PATCH")
+	}
+
+	endpoints, err := store.ListEndpoint(storage.ListOption{Filters: filters})
+	if err != nil {
+		return nil, endpointAcceleratorVirtualizationLookupError("failed to look up endpoint for vGPU resource PATCH")
+	}
+
+	if len(endpoints) == 0 {
+		return nil, endpointAcceleratorVirtualizationTargetError("endpoint not found for vGPU resource PATCH")
+	}
+
+	if len(endpoints) > 1 {
+		return nil, endpointAcceleratorVirtualizationTargetError("multiple endpoints matched vGPU resource PATCH filters")
+	}
+
+	return &endpoints[0], nil
+}
+
+func mergeEndpointAcceleratorVirtualizationPatch(existing *v1.Endpoint, patch *v1.Endpoint) v1.Endpoint {
+	if existing == nil {
+		if patch == nil {
+			return v1.Endpoint{}
+		}
+
+		return *patch
+	}
+
+	merged := *existing
+
+	if existing.Metadata != nil {
+		metadata := *existing.Metadata
+		merged.Metadata = &metadata
+	}
+
+	if existing.Spec != nil {
+		spec := *existing.Spec
+		if existing.Spec.Resources != nil {
+			spec.Resources = copyEndpointResourceSpec(existing.Spec.Resources)
+		}
+		merged.Spec = &spec
+	}
+
+	if patch == nil {
+		return merged
+	}
+
+	if patch.Metadata != nil {
+		if merged.Metadata == nil {
+			merged.Metadata = &v1.Metadata{}
+		}
+		if patch.Metadata.Name != "" {
+			merged.Metadata.Name = patch.Metadata.Name
+		}
+		if patch.Metadata.Workspace != "" {
+			merged.Metadata.Workspace = patch.Metadata.Workspace
+		}
+	}
+
+	if patch.Spec != nil {
+		if merged.Spec == nil {
+			merged.Spec = &v1.EndpointSpec{}
+		}
+		if patch.Spec.Cluster != "" {
+			merged.Spec.Cluster = patch.Spec.Cluster
+		}
+		if patch.Spec.Resources != nil {
+			merged.Spec.Resources = mergeEndpointResourceSpec(merged.Spec.Resources, patch.Spec.Resources)
+		}
+	}
+
+	return merged
+}
+
+func mergeEndpointResourceSpec(existing *v1.ResourceSpec, patch *v1.ResourceSpec) *v1.ResourceSpec {
+	if existing == nil {
+		return copyEndpointResourceSpec(patch)
+	}
+
+	merged := copyEndpointResourceSpec(existing)
+	if patch.CPU != nil {
+		merged.CPU = patch.CPU
+	}
+	if patch.GPU != nil {
+		merged.GPU = patch.GPU
+	}
+	if patch.Memory != nil {
+		merged.Memory = patch.Memory
+	}
+	if patch.Accelerator != nil {
+		if merged.Accelerator == nil {
+			merged.Accelerator = make(map[string]string, len(patch.Accelerator))
+		}
+		for key, value := range patch.Accelerator {
+			merged.Accelerator[key] = value
+		}
+	}
+
+	return merged
+}
+
+func copyEndpointResourceSpec(resources *v1.ResourceSpec) *v1.ResourceSpec {
+	if resources == nil {
+		return nil
+	}
+
+	copied := *resources
+	if resources.Accelerator != nil {
+		copied.Accelerator = make(map[string]string, len(resources.Accelerator))
+		for key, value := range resources.Accelerator {
+			copied.Accelerator[key] = value
+		}
+	}
+
+	return &copied
+}
+
+func validateEndpointAcceleratorVirtualizationTarget(
+	target endpointAcceleratorVirtualizationTarget,
+) (endpointAcceleratorVirtualizationTarget, *validationError) {
+	if target.workspace == "" {
+		target.workspace = defaultWorkspace
+	}
+
+	if target.cluster == "" {
+		return target, endpointAcceleratorVirtualizationTargetError("spec.cluster is required for endpoint accelerator virtualization")
+	}
+
+	return target, nil
+}
+
+func endpointTargetWorkspace(method string, queryParams url.Values, endpoint *v1.Endpoint) string {
+	if workspace := endpointWorkspace(endpoint); workspace != "" {
+		return workspace
+	}
+
+	if method == http.MethodPatch {
+		return endpointWorkspaceFromQuery(queryParams)
+	}
+
+	return ""
+}
+
+func endpointWorkspace(endpoint *v1.Endpoint) string {
+	if endpoint == nil || endpoint.Metadata == nil {
+		return ""
+	}
+
+	return endpoint.Metadata.Workspace
+}
+
+func endpointWorkspaceFromQuery(queryParams url.Values) string {
+	for _, key := range []string{"metadata->>workspace", "metadata->workspace"} {
+		values, ok := queryParams[key]
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		workspace := values[0]
+		parts := strings.SplitN(workspace, ".", 2)
+		if len(parts) == 2 {
+			if parts[0] != "eq" {
+				continue
+			}
+			workspace = parts[1]
+		}
+
+		if unquoted, err := strconv.Unquote(workspace); err == nil {
+			workspace = unquoted
+		}
+
+		return workspace
+	}
+
+	return ""
+}
+
+func endpointClusterLookupFilters(cluster, workspace string) []storage.Filter {
+	return []storage.Filter{
+		{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(cluster)},
+		{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
+	}
+}
+
+func endpointAcceleratorVirtualizationAllocationCanBeAddedBack(
+	endpoint *v1.Endpoint,
+	target endpointAcceleratorVirtualizationTarget,
+) bool {
+	if endpoint == nil || endpoint.Spec == nil {
+		return false
+	}
+
+	workspace := endpointWorkspace(endpoint)
+	if workspace == "" {
+		workspace = defaultWorkspace
+	}
+
+	return endpoint.Spec.Cluster == target.cluster && workspace == target.workspace
+}
+
+func validateEndpointClusterAcceleratorVirtualizationReady(cluster *v1.Cluster) *validationError {
+	if cluster == nil || cluster.Spec == nil || !cluster.Spec.AcceleratorVirtualizationEnabled() {
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization is not enabled")
+	}
+
+	if cluster.Spec.Type != v1.KubernetesClusterType {
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, "endpoint accelerator virtualization is only supported for kubernetes clusters")
+	}
+
+	if cluster.Status == nil || cluster.Status.ComponentStatus == nil {
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization component status is missing")
+	}
+
+	component := cluster.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey]
+	if component == nil {
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization component status is missing")
+	}
+
+	if component.Phase != v1.ComponentPhaseReady {
+		hint := "cluster accelerator virtualization is not ready"
+		if component.Reason != "" || component.Message != "" {
+			hint = fmt.Sprintf("%s: %s %s", hint, component.Reason, component.Message)
+		}
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, hint)
+	}
+
+	return nil
 }
 
 func validateEndpointAcceleratorVirtualizationResourceShape(resources *v1.ResourceSpec) *validationError {
@@ -140,45 +476,6 @@ func validateEndpointAcceleratorVirtualizationResourceShape(resources *v1.Resour
 	}
 
 	return nil
-}
-
-func validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage storage.ClusterStorage, endpoint *v1.Endpoint) *validationError {
-	if endpoint == nil || endpoint.GetDeletionTimestamp() != "" || endpoint.Spec == nil || endpoint.Spec.Resources == nil ||
-		!endpoint.Spec.Resources.HasAcceleratorVirtualization() {
-		return nil
-	}
-
-	// Capacity precheck is best effort; leave lookup/schema failures to the
-	// existing persistence and reconcile paths.
-	if clusterStorage == nil {
-		return nil
-	}
-
-	clusterName := endpoint.Spec.Cluster
-	if clusterName == "" {
-		return nil
-	}
-
-	workspace := endpoint.GetWorkspace()
-	if workspace == "" {
-		return nil
-	}
-
-	clusters, err := clusterStorage.ListCluster(storage.ListOption{
-		Filters: []storage.Filter{
-			{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(clusterName)},
-			{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
-		},
-	})
-	if err != nil {
-		return nil
-	}
-
-	if len(clusters) == 0 {
-		return nil
-	}
-
-	return validateEndpointAcceleratorVirtualizationCapacity(endpoint.Spec.Resources, &clusters[0])
 }
 
 func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpec, cluster *v1.Cluster) *validationError {
@@ -262,6 +559,113 @@ func clusterResourceInfo(cluster *v1.Cluster) *v1.ClusterResources {
 	return cluster.Status.ResourceInfo
 }
 
+func clusterWithEndpointAcceleratorVirtualizationAllocationAddedBack(cluster *v1.Cluster, endpoint *v1.Endpoint) *v1.Cluster {
+	if cluster == nil || endpoint == nil || endpoint.Status == nil || endpoint.Status.Resources == nil {
+		return cluster
+	}
+
+	resourceInfo := clusterResourceInfo(cluster)
+	if resourceInfo == nil {
+		return cluster
+	}
+
+	for _, replica := range endpoint.Status.Resources.Replicas {
+		for _, allocation := range replica.Devices {
+			addEndpointAcceleratorVirtualizationAllocation(resourceInfo, replica, allocation)
+		}
+	}
+
+	return cluster
+}
+
+func addEndpointAcceleratorVirtualizationAllocation(
+	resourceInfo *v1.ClusterResources,
+	replica v1.ReplicaDeviceAllocation,
+	allocation v1.DeviceAllocation,
+) {
+	if resourceInfo == nil || allocation.UUID == "" || allocation.Product == "" {
+		return
+	}
+
+	nodeID := allocation.NodeID
+	if nodeID == "" {
+		nodeID = replica.NodeID
+	}
+
+	if nodeID != "" {
+		if node := resourceInfo.NodeResources[nodeID]; addAllocationToMatchingDevice(node, allocation) {
+			addAvailableAcceleratorVirtualizationProductResource(resourceInfo, allocation)
+			return
+		}
+	}
+
+	for _, node := range resourceInfo.NodeResources {
+		if addAllocationToMatchingDevice(node, allocation) {
+			addAvailableAcceleratorVirtualizationProductResource(resourceInfo, allocation)
+			return
+		}
+	}
+}
+
+func addAllocationToMatchingDevice(node *v1.NodeResourceStatus, allocation v1.DeviceAllocation) bool {
+	if node == nil {
+		return false
+	}
+
+	for _, device := range node.Devices {
+		if device == nil || device.UUID != allocation.UUID || device.Product != allocation.Product {
+			continue
+		}
+
+		if device.Available == nil {
+			device.Available = &v1.DeviceResourcePool{}
+		}
+		device.Available.MemoryMiB += allocation.MemoryMiB
+		device.Available.CoreUnits += allocation.CoreUnits
+
+		return true
+	}
+
+	return false
+}
+
+func addAvailableAcceleratorVirtualizationProductResource(
+	resourceInfo *v1.ClusterResources,
+	allocation v1.DeviceAllocation,
+) {
+	if resourceInfo.Available == nil {
+		resourceInfo.Available = &v1.ResourceInfo{}
+	}
+	if resourceInfo.Available.AcceleratorGroups == nil {
+		resourceInfo.Available.AcceleratorGroups = map[v1.AcceleratorType]*v1.AcceleratorGroup{}
+	}
+
+	group := resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
+	if group == nil {
+		group = &v1.AcceleratorGroup{}
+		resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU] = group
+	}
+	if group.Products == nil {
+		group.Products = map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{}
+	}
+
+	product := v1.AcceleratorProduct(allocation.Product)
+	productResource := group.Products[product]
+	if productResource == nil {
+		productResource = &v1.AcceleratorProductResource{}
+		group.Products[product] = productResource
+	}
+	if productResource.Virtualization == nil {
+		productResource.Virtualization = &v1.AcceleratorVirtualizationResource{}
+	}
+
+	productResource.Virtualization.MemoryMiB += float64(allocation.MemoryMiB)
+	productResource.Virtualization.CoreUnits += float64(allocation.CoreUnits)
+	if productResource.Quantity < 1 {
+		productResource.Quantity = 1
+	}
+}
+
 func acceleratorVirtualizationProductResources(resourceInfo *v1.ClusterResources) (map[v1.AcceleratorProduct]*v1.AcceleratorProductResource, bool) {
 	if resourceInfo == nil || resourceInfo.Available == nil || resourceInfo.Available.AcceleratorGroups == nil {
 		return nil, false
@@ -269,7 +673,7 @@ func acceleratorVirtualizationProductResources(resourceInfo *v1.ClusterResources
 
 	group := resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
 	if group == nil || group.Products == nil {
-		return nil, false
+		return map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{}, true
 	}
 
 	return group.Products, true
@@ -437,6 +841,41 @@ func endpointAcceleratorVirtualizationCapacityError(hint string) *validationErro
 	return &validationError{
 		Code:    "10220",
 		Message: "endpoint accelerator virtualization resources exceed cluster availability",
+		Hint:    hint,
+	}
+}
+
+func endpointAcceleratorVirtualizationTargetError(hint string) *validationError {
+	return &validationError{
+		Code:    "10221",
+		Message: "invalid endpoint accelerator virtualization target",
+		Hint:    hint,
+	}
+}
+
+func endpointAcceleratorVirtualizationLookupError(hint string) *validationError {
+	err := endpointAcceleratorVirtualizationTargetError(hint)
+	err.HTTPStatus = http.StatusServiceUnavailable
+
+	return err
+}
+
+func validationErrStatus(err *validationError) int {
+	if err != nil && err.HTTPStatus != 0 {
+		return err.HTTPStatus
+	}
+
+	return http.StatusBadRequest
+}
+
+func endpointAcceleratorVirtualizationNotReadyError(cluster *v1.Cluster, hint string) *validationError {
+	if cluster != nil && cluster.Metadata != nil {
+		hint = fmt.Sprintf("cluster %s/%s accelerator virtualization is not ready: %s", cluster.Metadata.Workspace, cluster.Metadata.Name, hint)
+	}
+
+	return &validationError{
+		Code:    "10222",
+		Message: "cluster accelerator virtualization is not ready",
 		Hint:    hint,
 	}
 }

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -92,13 +92,13 @@ func validateEndpointVGPUPreflight(
 		return nil
 	}
 
-	// Only validate writes that directly touch vGPU resources.
-	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+	// Only validate writes that directly touch endpoint resources.
+	if endpoint.Spec == nil || endpoint.Spec.Resources == nil {
 		return nil
 	}
 
-	if validationErr := validateEndpointVGPUResourceShape(endpoint.Spec.Resources); validationErr != nil {
-		return validationErr
+	if method != http.MethodPatch && !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
 	}
 
 	if store == nil {
@@ -116,6 +116,14 @@ func validateEndpointVGPUPreflight(
 		existing = resolved
 		merged := mergeEndpointPatch(existing, endpoint)
 		endpoint = &merged
+	}
+
+	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
+	}
+
+	if validationErr := validateEndpointVGPUResourceShape(endpoint.Spec.Resources); validationErr != nil {
+		return validationErr
 	}
 
 	target, validationErr := resolveEndpointVGPUTarget(endpoint)

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -200,8 +200,12 @@ func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpe
 	}
 
 	productResource := productResources[v1.AcceleratorProduct(product)]
-	if productResource == nil || productResource.Virtualization == nil {
+	if productResource == nil {
 		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf("product=%s has no available accelerator virtualization capacity", product))
+	}
+
+	if productResource.Virtualization == nil {
+		return nil
 	}
 
 	requestedMemoryMiB, memoryTelemetryReady, err := requestedAcceleratorVirtualizationMemoryMiB(resources, resourceInfo, product)

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -128,11 +128,13 @@ func validateEndpointAcceleratorVirtualizationPreflight(
 	}
 
 	var existing *v1.Endpoint
+
 	if method == http.MethodPatch {
 		resolved, validationErr := resolveEndpointAcceleratorVirtualizationPatchEndpoint(store, queryParams)
 		if validationErr != nil {
 			return validationErr
 		}
+
 		existing = resolved
 		merged := mergeEndpointAcceleratorVirtualizationPatch(existing, endpoint)
 		endpoint = &merged
@@ -241,6 +243,7 @@ func mergeEndpointAcceleratorVirtualizationPatch(existing *v1.Endpoint, patch *v
 		if existing.Spec.Resources != nil {
 			spec.Resources = copyEndpointResourceSpec(existing.Spec.Resources)
 		}
+
 		merged.Spec = &spec
 	}
 
@@ -252,9 +255,11 @@ func mergeEndpointAcceleratorVirtualizationPatch(existing *v1.Endpoint, patch *v
 		if merged.Metadata == nil {
 			merged.Metadata = &v1.Metadata{}
 		}
+
 		if patch.Metadata.Name != "" {
 			merged.Metadata.Name = patch.Metadata.Name
 		}
+
 		if patch.Metadata.Workspace != "" {
 			merged.Metadata.Workspace = patch.Metadata.Workspace
 		}
@@ -264,9 +269,11 @@ func mergeEndpointAcceleratorVirtualizationPatch(existing *v1.Endpoint, patch *v
 		if merged.Spec == nil {
 			merged.Spec = &v1.EndpointSpec{}
 		}
+
 		if patch.Spec.Cluster != "" {
 			merged.Spec.Cluster = patch.Spec.Cluster
 		}
+
 		if patch.Spec.Resources != nil {
 			merged.Spec.Resources = mergeEndpointResourceSpec(merged.Spec.Resources, patch.Spec.Resources)
 		}
@@ -281,19 +288,24 @@ func mergeEndpointResourceSpec(existing *v1.ResourceSpec, patch *v1.ResourceSpec
 	}
 
 	merged := copyEndpointResourceSpec(existing)
+
 	if patch.CPU != nil {
 		merged.CPU = patch.CPU
 	}
+
 	if patch.GPU != nil {
 		merged.GPU = patch.GPU
 	}
+
 	if patch.Memory != nil {
 		merged.Memory = patch.Memory
 	}
+
 	if patch.Accelerator != nil {
 		if merged.Accelerator == nil {
 			merged.Accelerator = make(map[string]string, len(patch.Accelerator))
 		}
+
 		for key, value := range patch.Accelerator {
 			merged.Accelerator[key] = value
 		}
@@ -361,10 +373,12 @@ func endpointWorkspaceFromQuery(queryParams url.Values) string {
 
 		workspace := values[0]
 		parts := strings.SplitN(workspace, ".", 2)
+
 		if len(parts) == 2 {
 			if parts[0] != "eq" {
 				continue
 			}
+
 			workspace = parts[1]
 		}
 
@@ -424,6 +438,7 @@ func validateEndpointClusterAcceleratorVirtualizationReady(cluster *v1.Cluster) 
 		if component.Reason != "" || component.Message != "" {
 			hint = fmt.Sprintf("%s: %s %s", hint, component.Reason, component.Message)
 		}
+
 		return endpointAcceleratorVirtualizationNotReadyError(cluster, hint)
 	}
 
@@ -620,6 +635,7 @@ func addAllocationToMatchingDevice(node *v1.NodeResourceStatus, allocation v1.De
 		if device.Available == nil {
 			device.Available = &v1.DeviceResourcePool{}
 		}
+
 		device.Available.MemoryMiB += allocation.MemoryMiB
 		device.Available.CoreUnits += allocation.CoreUnits
 
@@ -636,6 +652,7 @@ func addAvailableAcceleratorVirtualizationProductResource(
 	if resourceInfo.Available == nil {
 		resourceInfo.Available = &v1.ResourceInfo{}
 	}
+
 	if resourceInfo.Available.AcceleratorGroups == nil {
 		resourceInfo.Available.AcceleratorGroups = map[v1.AcceleratorType]*v1.AcceleratorGroup{}
 	}
@@ -645,22 +662,26 @@ func addAvailableAcceleratorVirtualizationProductResource(
 		group = &v1.AcceleratorGroup{}
 		resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU] = group
 	}
+
 	if group.Products == nil {
 		group.Products = map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{}
 	}
 
 	product := v1.AcceleratorProduct(allocation.Product)
+
 	productResource := group.Products[product]
 	if productResource == nil {
 		productResource = &v1.AcceleratorProductResource{}
 		group.Products[product] = productResource
 	}
+
 	if productResource.Virtualization == nil {
 		productResource.Virtualization = &v1.AcceleratorVirtualizationResource{}
 	}
 
 	productResource.Virtualization.MemoryMiB += float64(allocation.MemoryMiB)
 	productResource.Virtualization.CoreUnits += float64(allocation.CoreUnits)
+
 	if productResource.Quantity < 1 {
 		productResource.Quantity = 1
 	}

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -131,9 +131,9 @@ func validateEndpointVGPUPreflight(
 		return endpointVGPUTargetError("spec.cluster is required for endpoint accelerator virtualization")
 	}
 
-	workspace := endpointWorkspace(endpoint)
-	if workspace == "" {
-		workspace = defaultWorkspace
+	workspace := defaultWorkspace
+	if endpoint.Metadata != nil && endpoint.Metadata.Workspace != "" {
+		workspace = endpoint.Metadata.Workspace
 	}
 
 	clusters, err := store.ListCluster(storage.ListOption{
@@ -296,14 +296,6 @@ func copyEndpointResourceSpec(resources *v1.ResourceSpec) *v1.ResourceSpec {
 	return &copied
 }
 
-func endpointWorkspace(endpoint *v1.Endpoint) string {
-	if endpoint == nil || endpoint.Metadata == nil {
-		return ""
-	}
-
-	return endpoint.Metadata.Workspace
-}
-
 func endpointClusterLookupFilters(cluster, workspace string) []storage.Filter {
 	return []storage.Filter{
 		{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(cluster)},
@@ -320,9 +312,9 @@ func canAddBackEndpointVGPUAllocation(
 		return false
 	}
 
-	endpointWorkspace := endpointWorkspace(endpoint)
-	if endpointWorkspace == "" {
-		endpointWorkspace = defaultWorkspace
+	endpointWorkspace := defaultWorkspace
+	if endpoint.Metadata != nil && endpoint.Metadata.Workspace != "" {
+		endpointWorkspace = endpoint.Metadata.Workspace
 	}
 
 	return endpoint.Spec.Cluster == cluster && endpointWorkspace == targetWorkspace

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -161,7 +161,7 @@ func validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage stor
 
 	workspace := endpoint.GetWorkspace()
 	if workspace == "" {
-		workspace = defaultWorkspace
+		return nil
 	}
 
 	clusters, err := clusterStorage.ListCluster(storage.ListOption{

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -5,15 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
-func validateEndpointAcceleratorVirtualization() gin.HandlerFunc {
+func validateEndpointAcceleratorVirtualization(clusterStorage storage.ClusterStorage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -39,7 +41,19 @@ func validateEndpointAcceleratorVirtualization() gin.HandlerFunc {
 			return
 		}
 
-		if validationErr := validateEndpointAcceleratorVirtualizationBody(body); validationErr != nil {
+		endpoint, validationErr := parseEndpointAcceleratorVirtualizationBody(body)
+		if validationErr != nil {
+			c.JSON(http.StatusBadRequest, validationErr)
+			c.Abort()
+
+			return
+		}
+
+		if c.Request.Method == http.MethodPost {
+			validationErr = validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
+		}
+
+		if validationErr != nil {
 			c.JSON(http.StatusBadRequest, validationErr)
 			c.Abort()
 
@@ -51,27 +65,33 @@ func validateEndpointAcceleratorVirtualization() gin.HandlerFunc {
 }
 
 func validateEndpointAcceleratorVirtualizationBody(body []byte) *validationError {
+	_, err := parseEndpointAcceleratorVirtualizationBody(body)
+
+	return err
+}
+
+func parseEndpointAcceleratorVirtualizationBody(body []byte) (*v1.Endpoint, *validationError) {
 	var endpoint v1.Endpoint
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&endpoint); err != nil {
-		return invalidEndpointPayloadError(err)
+		return nil, invalidEndpointPayloadError(err)
 	}
 
 	if endpoint.GetDeletionTimestamp() != "" {
 		// Soft delete PATCH reuses the same route but should not be blocked by
 		// endpoint resource validation.
-		return nil
+		return &endpoint, nil
 	}
 
 	if endpoint.Spec == nil || endpoint.Spec.Resources == nil {
-		return nil
+		return &endpoint, nil
 	}
 
 	resources := endpoint.Spec.Resources
 	if err := validateEndpointAcceleratorVirtualizationResourceShape(resources); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return &endpoint, nil
 }
 
 func validateEndpointAcceleratorVirtualizationResourceShape(resources *v1.ResourceSpec) *validationError {
@@ -120,6 +140,189 @@ func validateEndpointAcceleratorVirtualizationResourceShape(resources *v1.Resour
 	}
 
 	return nil
+}
+
+func validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage storage.ClusterStorage, endpoint *v1.Endpoint) *validationError {
+	if endpoint == nil || endpoint.GetDeletionTimestamp() != "" || endpoint.Spec == nil || endpoint.Spec.Resources == nil ||
+		!endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
+	}
+
+	if clusterStorage == nil {
+		return endpointAcceleratorVirtualizationCapacityError("cluster storage is unavailable")
+	}
+
+	clusterName := endpoint.Spec.Cluster
+	if clusterName == "" {
+		return endpointAcceleratorVirtualizationCapacityError("spec.cluster is required for accelerator virtualization capacity validation")
+	}
+
+	workspace := endpoint.GetWorkspace()
+	if workspace == "" {
+		workspace = defaultWorkspace
+	}
+
+	clusters, err := clusterStorage.ListCluster(storage.ListOption{
+		Filters: []storage.Filter{
+			{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(clusterName)},
+			{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
+		},
+	})
+	if err != nil {
+		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf("failed to look up cluster %s in workspace %s: %v", clusterName, workspace, err))
+	}
+
+	if len(clusters) == 0 {
+		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf("cluster %s not found in workspace %s", clusterName, workspace))
+	}
+
+	return validateEndpointAcceleratorVirtualizationCapacity(endpoint.Spec.Resources, &clusters[0])
+}
+
+func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpec, cluster *v1.Cluster) *validationError {
+	if resources == nil || !resources.HasAcceleratorVirtualization() {
+		return nil
+	}
+
+	requestedGPU, err := parsePositiveIntegerResource(resources.GPU, "spec.resources.gpu")
+	if err != nil {
+		return endpointResourceValueError(err)
+	}
+
+	product := resources.GetAcceleratorProduct()
+	resourceInfo := clusterResourceInfo(cluster)
+
+	productResource := acceleratorVirtualizationProductResource(resourceInfo, product)
+	if productResource == nil || productResource.Virtualization == nil {
+		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf("product=%s has no available accelerator virtualization capacity", product))
+	}
+
+	requestedMemoryMiB, err := requestedAcceleratorVirtualizationMemoryMiB(resources, resourceInfo, product)
+	if err != nil {
+		return endpointAcceleratorVirtualizationCapacityError(err.Error())
+	}
+
+	requestedCoreUnits, err := requestedAcceleratorVirtualizationCoreUnits(resources)
+	if err != nil {
+		return endpointAcceleratorVirtualizationCapacityError(err.Error())
+	}
+
+	satisfiableDevices := countSatisfiableAcceleratorVirtualizationDevices(resourceInfo, product, requestedMemoryMiB, requestedCoreUnits)
+	if satisfiableDevices < requestedGPU {
+		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf(
+			"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d satisfiable_devices=%d",
+			product,
+			requestedGPU,
+			requestedMemoryMiB,
+			requestedCoreUnits,
+			satisfiableDevices,
+		))
+	}
+
+	return nil
+}
+
+func clusterResourceInfo(cluster *v1.Cluster) *v1.ClusterResources {
+	if cluster == nil || cluster.Status == nil {
+		return nil
+	}
+
+	return cluster.Status.ResourceInfo
+}
+
+func acceleratorVirtualizationProductResource(resourceInfo *v1.ClusterResources, product string) *v1.AcceleratorProductResource {
+	if resourceInfo == nil || resourceInfo.Available == nil || resourceInfo.Available.AcceleratorGroups == nil {
+		return nil
+	}
+
+	group := resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
+	if group == nil || group.Products == nil {
+		return nil
+	}
+
+	return group.Products[v1.AcceleratorProduct(product)]
+}
+
+func requestedAcceleratorVirtualizationMemoryMiB(resources *v1.ResourceSpec, resourceInfo *v1.ClusterResources, product string) (int64, error) {
+	if memoryMiB := resources.GetAcceleratorVirtualizationMemoryMiB(); memoryMiB != "" {
+		return parseRequiredPositiveInteger(memoryMiB, "virtualization.memory_mib")
+	}
+
+	memoryPercent := resources.GetAcceleratorVirtualizationMemoryPercent()
+	if memoryPercent == "" {
+		return 0, nil
+	}
+
+	percent, err := parseRequiredPositiveInteger(memoryPercent, "virtualization.memory_percent")
+	if err != nil {
+		return 0, err
+	}
+
+	totalMemoryMiB := productTotalMemoryMiB(resourceInfo, product)
+	if totalMemoryMiB <= 0 {
+		return 0, fmt.Errorf("product=%s missing accelerator memory metadata for virtualization.memory_percent", product)
+	}
+
+	return int64(math.Ceil(totalMemoryMiB * float64(percent) / 100)), nil
+}
+
+func productTotalMemoryMiB(resourceInfo *v1.ClusterResources, product string) float64 {
+	if resourceInfo == nil || resourceInfo.AcceleratorMetadata == nil {
+		return 0
+	}
+
+	metadata := resourceInfo.AcceleratorMetadata[v1.AcceleratorTypeNVIDIAGPU]
+	if metadata == nil || metadata.Products == nil {
+		return 0
+	}
+
+	productMetadata := metadata.Products[v1.AcceleratorProduct(product)]
+	if productMetadata == nil {
+		return 0
+	}
+
+	return productMetadata.MemoryTotalMiB
+}
+
+func requestedAcceleratorVirtualizationCoreUnits(resources *v1.ResourceSpec) (int64, error) {
+	corePercent := resources.GetAcceleratorVirtualizationCorePercent()
+	if corePercent == "" {
+		return 0, nil
+	}
+
+	return parseRequiredPositiveInteger(corePercent, "virtualization.core_percent")
+}
+
+func countSatisfiableAcceleratorVirtualizationDevices(resourceInfo *v1.ClusterResources, product string, requestedMemoryMiB int64, requestedCoreUnits int64) int64 {
+	if resourceInfo == nil {
+		return 0
+	}
+
+	var count int64
+
+	for _, node := range resourceInfo.NodeResources {
+		if node == nil {
+			continue
+		}
+
+		for _, device := range node.Devices {
+			if device == nil || !device.Health || device.Product != product || device.Available == nil {
+				continue
+			}
+
+			if requestedMemoryMiB > 0 && device.Available.MemoryMiB < requestedMemoryMiB {
+				continue
+			}
+
+			if requestedCoreUnits > 0 && device.Available.CoreUnits < requestedCoreUnits {
+				continue
+			}
+
+			count++
+		}
+	}
+
+	return count
 }
 
 func parsePositiveIntegerResource(value *string, field string) (int64, error) {
@@ -177,5 +380,13 @@ func endpointResourceValueError(err error) *validationError {
 		Code:    "10216",
 		Message: "invalid endpoint accelerator virtualization resources",
 		Hint:    err.Error(),
+	}
+}
+
+func endpointAcceleratorVirtualizationCapacityError(hint string) *validationError {
+	return &validationError{
+		Code:    "10220",
+		Message: "endpoint accelerator virtualization resources exceed cluster availability",
+		Hint:    hint,
 	}
 }

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -17,12 +17,7 @@ import (
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
-type endpointAcceleratorVirtualizationStorage interface {
-	ListCluster(option storage.ListOption) ([]v1.Cluster, error)
-	ListEndpoint(option storage.ListOption) ([]v1.Endpoint, error)
-}
-
-func validateEndpointAcceleratorVirtualization(store endpointAcceleratorVirtualizationStorage) gin.HandlerFunc {
+func validateEndpointAcceleratorVirtualization(store storage.Storage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -66,7 +61,7 @@ func validateEndpointAcceleratorVirtualization(store endpointAcceleratorVirtuali
 }
 
 func validateEndpointAcceleratorVirtualizationRequest(
-	store endpointAcceleratorVirtualizationStorage,
+	store storage.Storage,
 	method string,
 	queryParams url.Values,
 	body []byte,
@@ -110,7 +105,7 @@ func parseEndpointAcceleratorVirtualizationBody(body []byte) (*v1.Endpoint, *val
 }
 
 func validateEndpointAcceleratorVirtualizationPreflight(
-	store endpointAcceleratorVirtualizationStorage,
+	store storage.Storage,
 	method string,
 	queryParams url.Values,
 	endpoint *v1.Endpoint,
@@ -198,7 +193,7 @@ func resolveEndpointAcceleratorVirtualizationTarget(
 }
 
 func resolveEndpointAcceleratorVirtualizationPatchEndpoint(
-	store endpointAcceleratorVirtualizationStorage,
+	store storage.Storage,
 	queryParams url.Values,
 ) (*v1.Endpoint, *validationError) {
 	filters := queryParamsToFilters(queryParams)

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -474,6 +474,10 @@ func validateEndpointVGPUCapacity(resources *v1.ResourceSpec, cluster *v1.Cluste
 		return nil
 	}
 
+	if !deviceTelemetryReady {
+		return nil
+	}
+
 	if matchingDeviceCountReady && matchingDevices < requestedGPU {
 		return endpointVGPUCapacityError(fmt.Sprintf(
 			"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d matching_devices=%d satisfiable_devices=%d",
@@ -484,10 +488,6 @@ func validateEndpointVGPUCapacity(resources *v1.ResourceSpec, cluster *v1.Cluste
 			matchingDevices,
 			satisfiableDevices,
 		))
-	}
-
-	if !deviceTelemetryReady {
-		return nil
 	}
 
 	return endpointVGPUCapacityError(fmt.Sprintf(

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -148,13 +148,15 @@ func validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage stor
 		return nil
 	}
 
+	// Capacity precheck is best effort; leave lookup/schema failures to the
+	// existing persistence and reconcile paths.
 	if clusterStorage == nil {
-		return endpointAcceleratorVirtualizationCapacityError("cluster storage is unavailable")
+		return nil
 	}
 
 	clusterName := endpoint.Spec.Cluster
 	if clusterName == "" {
-		return endpointAcceleratorVirtualizationCapacityError("spec.cluster is required for accelerator virtualization capacity validation")
+		return nil
 	}
 
 	workspace := endpoint.GetWorkspace()
@@ -169,11 +171,11 @@ func validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage stor
 		},
 	})
 	if err != nil {
-		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf("failed to look up cluster %s in workspace %s: %v", clusterName, workspace, err))
+		return nil
 	}
 
 	if len(clusters) == 0 {
-		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf("cluster %s not found in workspace %s", clusterName, workspace))
+		return nil
 	}
 
 	return validateEndpointAcceleratorVirtualizationCapacity(endpoint.Spec.Resources, &clusters[0])

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -214,7 +214,7 @@ func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpe
 	}
 
 	if !memoryTelemetryReady {
-		return nil
+		requestedMemoryMiB = 0
 	}
 
 	requestedCoreUnits, err := requestedAcceleratorVirtualizationCoreUnits(resources)
@@ -222,9 +222,22 @@ func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpe
 		return endpointAcceleratorVirtualizationCapacityError(err.Error())
 	}
 
-	satisfiableDevices, deviceTelemetryReady := countSatisfiableAcceleratorVirtualizationDevices(resourceInfo, product, requestedMemoryMiB, requestedCoreUnits)
+	satisfiableDevices, matchingDevices, matchingDeviceCountReady, deviceTelemetryReady :=
+		countSatisfiableAcceleratorVirtualizationDevices(resourceInfo, product, requestedMemoryMiB, requestedCoreUnits)
 	if satisfiableDevices >= requestedGPU {
 		return nil
+	}
+
+	if matchingDeviceCountReady && matchingDevices < requestedGPU {
+		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf(
+			"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d matching_devices=%d satisfiable_devices=%d",
+			product,
+			requestedGPU,
+			requestedMemoryMiB,
+			requestedCoreUnits,
+			matchingDevices,
+			satisfiableDevices,
+		))
 	}
 
 	if !deviceTelemetryReady {
@@ -319,12 +332,15 @@ func countSatisfiableAcceleratorVirtualizationDevices(
 	product string,
 	requestedMemoryMiB int64,
 	requestedCoreUnits int64,
-) (int64, bool) {
+) (int64, int64, bool, bool) {
 	if resourceInfo == nil || resourceInfo.NodeResources == nil {
-		return 0, false
+		return 0, 0, false, false
 	}
 
-	var count int64
+	var (
+		satisfiableDevices int64
+		matchingDevices    int64
+	)
 	telemetryReady := true
 
 	for _, node := range resourceInfo.NodeResources {
@@ -336,6 +352,8 @@ func countSatisfiableAcceleratorVirtualizationDevices(
 			if device == nil || !device.Health || device.Product != product {
 				continue
 			}
+
+			matchingDevices++
 
 			if device.Available == nil {
 				telemetryReady = false
@@ -350,11 +368,11 @@ func countSatisfiableAcceleratorVirtualizationDevices(
 				continue
 			}
 
-			count++
+			satisfiableDevices++
 		}
 	}
 
-	return count, telemetryReady
+	return satisfiableDevices, matchingDevices, true, telemetryReady
 }
 
 func parsePositiveIntegerResource(value *string, field string) (int64, error) {

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -74,31 +74,10 @@ func validateEndpointAcceleratorVirtualizationRequest(
 	return validateEndpointAcceleratorVirtualizationPreflight(store, method, queryParams, endpoint)
 }
 
-func validateEndpointAcceleratorVirtualizationBody(body []byte) *validationError {
-	_, err := parseEndpointAcceleratorVirtualizationBody(body)
-
-	return err
-}
-
 func parseEndpointAcceleratorVirtualizationBody(body []byte) (*v1.Endpoint, *validationError) {
 	var endpoint v1.Endpoint
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&endpoint); err != nil {
 		return nil, invalidEndpointPayloadError(err)
-	}
-
-	if endpoint.GetDeletionTimestamp() != "" {
-		// Soft delete PATCH reuses the same route but should not be blocked by
-		// endpoint resource validation.
-		return &endpoint, nil
-	}
-
-	if endpoint.Spec == nil || endpoint.Spec.Resources == nil {
-		return &endpoint, nil
-	}
-
-	resources := endpoint.Spec.Resources
-	if err := validateEndpointAcceleratorVirtualizationResourceShape(resources); err != nil {
-		return nil, err
 	}
 
 	return &endpoint, nil
@@ -116,6 +95,10 @@ func validateEndpointAcceleratorVirtualizationPreflight(
 
 	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
 		return nil
+	}
+
+	if validationErr := validateEndpointAcceleratorVirtualizationResourceShape(endpoint.Spec.Resources); validationErr != nil {
+		return validationErr
 	}
 
 	if store == nil {

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -17,7 +16,7 @@ import (
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
-func validateEndpointAcceleratorVirtualization(store storage.Storage) gin.HandlerFunc {
+func validateEndpointVGPU(store storage.Storage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -43,7 +42,7 @@ func validateEndpointAcceleratorVirtualization(store storage.Storage) gin.Handle
 			return
 		}
 
-		validationErr := validateEndpointAcceleratorVirtualizationRequest(
+		validationErr := validateEndpointVGPURequest(
 			store,
 			c.Request.Method,
 			c.Request.URL.Query(),
@@ -60,21 +59,21 @@ func validateEndpointAcceleratorVirtualization(store storage.Storage) gin.Handle
 	}
 }
 
-func validateEndpointAcceleratorVirtualizationRequest(
+func validateEndpointVGPURequest(
 	store storage.Storage,
 	method string,
 	queryParams url.Values,
 	body []byte,
 ) *validationError {
-	endpoint, validationErr := parseEndpointAcceleratorVirtualizationBody(body)
+	endpoint, validationErr := parseEndpointBody(body)
 	if validationErr != nil {
 		return validationErr
 	}
 
-	return validateEndpointAcceleratorVirtualizationPreflight(store, method, queryParams, endpoint)
+	return validateEndpointVGPUPreflight(store, method, queryParams, endpoint)
 }
 
-func parseEndpointAcceleratorVirtualizationBody(body []byte) (*v1.Endpoint, *validationError) {
+func parseEndpointBody(body []byte) (*v1.Endpoint, *validationError) {
 	var endpoint v1.Endpoint
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&endpoint); err != nil {
 		return nil, invalidEndpointPayloadError(err)
@@ -83,7 +82,7 @@ func parseEndpointAcceleratorVirtualizationBody(body []byte) (*v1.Endpoint, *val
 	return &endpoint, nil
 }
 
-func validateEndpointAcceleratorVirtualizationPreflight(
+func validateEndpointVGPUPreflight(
 	store storage.Storage,
 	method string,
 	queryParams url.Values,
@@ -93,36 +92,33 @@ func validateEndpointAcceleratorVirtualizationPreflight(
 		return nil
 	}
 
+	// Only validate writes that directly touch vGPU resources.
 	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
 		return nil
 	}
 
-	if validationErr := validateEndpointAcceleratorVirtualizationResourceShape(endpoint.Spec.Resources); validationErr != nil {
+	if validationErr := validateEndpointVGPUResourceShape(endpoint.Spec.Resources); validationErr != nil {
 		return validationErr
 	}
 
 	if store == nil {
-		return endpointAcceleratorVirtualizationLookupError("storage is required to validate endpoint accelerator virtualization")
+		return endpointVGPULookupError("storage is required to validate endpoint accelerator virtualization")
 	}
 
 	var existing *v1.Endpoint
 
 	if method == http.MethodPatch {
-		resolved, validationErr := resolveEndpointAcceleratorVirtualizationPatchEndpoint(store, queryParams)
+		resolved, validationErr := resolveEndpointPatch(store, queryParams)
 		if validationErr != nil {
 			return validationErr
 		}
 
 		existing = resolved
-		merged := mergeEndpointAcceleratorVirtualizationPatch(existing, endpoint)
+		merged := mergeEndpointPatch(existing, endpoint)
 		endpoint = &merged
 	}
 
-	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
-		return nil
-	}
-
-	target, validationErr := resolveEndpointAcceleratorVirtualizationTarget(method, queryParams, endpoint)
+	target, validationErr := resolveEndpointVGPUTarget(endpoint)
 	if validationErr != nil {
 		return validationErr
 	}
@@ -131,76 +127,82 @@ func validateEndpointAcceleratorVirtualizationPreflight(
 		Filters: endpointClusterLookupFilters(target.cluster, target.workspace),
 	})
 	if err != nil {
-		return endpointAcceleratorVirtualizationLookupError("failed to look up cluster for endpoint accelerator virtualization")
+		return endpointVGPULookupError("failed to look up cluster for endpoint accelerator virtualization")
 	}
 
 	if len(clusters) == 0 {
-		return endpointAcceleratorVirtualizationTargetError(fmt.Sprintf("cluster %s/%s not found", target.workspace, target.cluster))
+		return endpointVGPUTargetError(fmt.Sprintf("cluster %s/%s not found", target.workspace, target.cluster))
 	}
 
 	if len(clusters) > 1 {
-		return endpointAcceleratorVirtualizationTargetError(fmt.Sprintf("multiple clusters matched %s/%s", target.workspace, target.cluster))
+		return endpointVGPUTargetError(fmt.Sprintf("multiple clusters matched %s/%s", target.workspace, target.cluster))
 	}
 
 	cluster := &clusters[0]
-	if validationErr := validateEndpointClusterAcceleratorVirtualizationReady(cluster); validationErr != nil {
+	if validationErr := validateEndpointVGPUCluster(cluster); validationErr != nil {
 		return validationErr
 	}
 
-	if method == http.MethodPatch && endpointAcceleratorVirtualizationAllocationCanBeAddedBack(existing, target) {
-		cluster = clusterWithEndpointAcceleratorVirtualizationAllocationAddedBack(cluster, existing)
+	if method == http.MethodPatch && canAddBackEndpointVGPUAllocation(existing, target) {
+		cluster = clusterWithEndpointVGPUAllocationAddedBack(cluster, existing)
 	}
 
-	return validateEndpointAcceleratorVirtualizationCapacity(endpoint.Spec.Resources, cluster)
+	return validateEndpointVGPUCapacity(endpoint.Spec.Resources, cluster)
 }
 
-type endpointAcceleratorVirtualizationTarget struct {
+type endpointVGPUTarget struct {
 	cluster   string
 	workspace string
 }
 
-func resolveEndpointAcceleratorVirtualizationTarget(
-	method string,
-	queryParams url.Values,
+func resolveEndpointVGPUTarget(
 	endpoint *v1.Endpoint,
-) (endpointAcceleratorVirtualizationTarget, *validationError) {
-	target := endpointAcceleratorVirtualizationTarget{
-		workspace: endpointTargetWorkspace(method, queryParams, endpoint),
+) (endpointVGPUTarget, *validationError) {
+	target := endpointVGPUTarget{
+		workspace: endpointWorkspace(endpoint),
 	}
 
 	if endpoint.Spec != nil {
 		target.cluster = endpoint.Spec.Cluster
 	}
 
-	return validateEndpointAcceleratorVirtualizationTarget(target)
+	if target.workspace == "" {
+		target.workspace = defaultWorkspace
+	}
+
+	if target.cluster == "" {
+		return target, endpointVGPUTargetError("spec.cluster is required for endpoint accelerator virtualization")
+	}
+
+	return target, nil
 }
 
-func resolveEndpointAcceleratorVirtualizationPatchEndpoint(
+func resolveEndpointPatch(
 	store storage.Storage,
 	queryParams url.Values,
 ) (*v1.Endpoint, *validationError) {
 	filters := queryParamsToFilters(queryParams)
 	if len(filters) == 0 {
-		return nil, endpointAcceleratorVirtualizationTargetError("endpoint lookup filters are required for vGPU resource PATCH")
+		return nil, endpointVGPUTargetError("endpoint lookup filters are required for vGPU resource PATCH")
 	}
 
 	endpoints, err := store.ListEndpoint(storage.ListOption{Filters: filters})
 	if err != nil {
-		return nil, endpointAcceleratorVirtualizationLookupError("failed to look up endpoint for vGPU resource PATCH")
+		return nil, endpointVGPULookupError("failed to look up endpoint for vGPU resource PATCH")
 	}
 
 	if len(endpoints) == 0 {
-		return nil, endpointAcceleratorVirtualizationTargetError("endpoint not found for vGPU resource PATCH")
+		return nil, endpointVGPUTargetError("endpoint not found for vGPU resource PATCH")
 	}
 
 	if len(endpoints) > 1 {
-		return nil, endpointAcceleratorVirtualizationTargetError("multiple endpoints matched vGPU resource PATCH filters")
+		return nil, endpointVGPUTargetError("multiple endpoints matched vGPU resource PATCH filters")
 	}
 
 	return &endpoints[0], nil
 }
 
-func mergeEndpointAcceleratorVirtualizationPatch(existing *v1.Endpoint, patch *v1.Endpoint) v1.Endpoint {
+func mergeEndpointPatch(existing *v1.Endpoint, patch *v1.Endpoint) v1.Endpoint {
 	if existing == nil {
 		if patch == nil {
 			return v1.Endpoint{}
@@ -308,66 +310,12 @@ func copyEndpointResourceSpec(resources *v1.ResourceSpec) *v1.ResourceSpec {
 	return &copied
 }
 
-func validateEndpointAcceleratorVirtualizationTarget(
-	target endpointAcceleratorVirtualizationTarget,
-) (endpointAcceleratorVirtualizationTarget, *validationError) {
-	if target.workspace == "" {
-		target.workspace = defaultWorkspace
-	}
-
-	if target.cluster == "" {
-		return target, endpointAcceleratorVirtualizationTargetError("spec.cluster is required for endpoint accelerator virtualization")
-	}
-
-	return target, nil
-}
-
-func endpointTargetWorkspace(method string, queryParams url.Values, endpoint *v1.Endpoint) string {
-	if workspace := endpointWorkspace(endpoint); workspace != "" {
-		return workspace
-	}
-
-	if method == http.MethodPatch {
-		return endpointWorkspaceFromQuery(queryParams)
-	}
-
-	return ""
-}
-
 func endpointWorkspace(endpoint *v1.Endpoint) string {
 	if endpoint == nil || endpoint.Metadata == nil {
 		return ""
 	}
 
 	return endpoint.Metadata.Workspace
-}
-
-func endpointWorkspaceFromQuery(queryParams url.Values) string {
-	for _, key := range []string{"metadata->>workspace", "metadata->workspace"} {
-		values, ok := queryParams[key]
-		if !ok || len(values) == 0 {
-			continue
-		}
-
-		workspace := values[0]
-		parts := strings.SplitN(workspace, ".", 2)
-
-		if len(parts) == 2 {
-			if parts[0] != "eq" {
-				continue
-			}
-
-			workspace = parts[1]
-		}
-
-		if unquoted, err := strconv.Unquote(workspace); err == nil {
-			workspace = unquoted
-		}
-
-		return workspace
-	}
-
-	return ""
 }
 
 func endpointClusterLookupFilters(cluster, workspace string) []storage.Filter {
@@ -377,9 +325,9 @@ func endpointClusterLookupFilters(cluster, workspace string) []storage.Filter {
 	}
 }
 
-func endpointAcceleratorVirtualizationAllocationCanBeAddedBack(
+func canAddBackEndpointVGPUAllocation(
 	endpoint *v1.Endpoint,
-	target endpointAcceleratorVirtualizationTarget,
+	target endpointVGPUTarget,
 ) bool {
 	if endpoint == nil || endpoint.Spec == nil {
 		return false
@@ -393,22 +341,22 @@ func endpointAcceleratorVirtualizationAllocationCanBeAddedBack(
 	return endpoint.Spec.Cluster == target.cluster && workspace == target.workspace
 }
 
-func validateEndpointClusterAcceleratorVirtualizationReady(cluster *v1.Cluster) *validationError {
+func validateEndpointVGPUCluster(cluster *v1.Cluster) *validationError {
 	if cluster == nil || cluster.Spec == nil || !cluster.Spec.AcceleratorVirtualizationEnabled() {
-		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization is not enabled")
+		return endpointVGPUNotReadyError(cluster, "cluster accelerator virtualization is not enabled")
 	}
 
 	if cluster.Spec.Type != v1.KubernetesClusterType {
-		return endpointAcceleratorVirtualizationNotReadyError(cluster, "endpoint accelerator virtualization is only supported for kubernetes clusters")
+		return endpointVGPUNotReadyError(cluster, "endpoint accelerator virtualization is only supported for kubernetes clusters")
 	}
 
 	if cluster.Status == nil || cluster.Status.ComponentStatus == nil {
-		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization component status is missing")
+		return endpointVGPUNotReadyError(cluster, "cluster accelerator virtualization component status is missing")
 	}
 
 	component := cluster.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey]
 	if component == nil {
-		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization component status is missing")
+		return endpointVGPUNotReadyError(cluster, "cluster accelerator virtualization component status is missing")
 	}
 
 	if component.Phase != v1.ComponentPhaseReady {
@@ -417,13 +365,13 @@ func validateEndpointClusterAcceleratorVirtualizationReady(cluster *v1.Cluster) 
 			hint = fmt.Sprintf("%s: %s %s", hint, component.Reason, component.Message)
 		}
 
-		return endpointAcceleratorVirtualizationNotReadyError(cluster, hint)
+		return endpointVGPUNotReadyError(cluster, hint)
 	}
 
 	return nil
 }
 
-func validateEndpointAcceleratorVirtualizationResourceShape(resources *v1.ResourceSpec) *validationError {
+func validateEndpointVGPUResourceShape(resources *v1.ResourceSpec) *validationError {
 	if !resources.HasAcceleratorVirtualization() {
 		return nil
 	}
@@ -471,7 +419,7 @@ func validateEndpointAcceleratorVirtualizationResourceShape(resources *v1.Resour
 	return nil
 }
 
-func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpec, cluster *v1.Cluster) *validationError {
+func validateEndpointVGPUCapacity(resources *v1.ResourceSpec, cluster *v1.Cluster) *validationError {
 	if resources == nil || !resources.HasAcceleratorVirtualization() {
 		return nil
 	}
@@ -484,42 +432,42 @@ func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpe
 	product := resources.GetAcceleratorProduct()
 	resourceInfo := clusterResourceInfo(cluster)
 
-	productResources, productTelemetryReady := acceleratorVirtualizationProductResources(resourceInfo)
+	productResources, productTelemetryReady := vgpuProductResources(resourceInfo)
 	if !productTelemetryReady {
 		return nil
 	}
 
 	productResource := productResources[v1.AcceleratorProduct(product)]
 	if productResource == nil {
-		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf("product=%s has no available accelerator virtualization capacity", product))
+		return endpointVGPUCapacityError(fmt.Sprintf("product=%s has no available accelerator virtualization capacity", product))
 	}
 
 	if productResource.Virtualization == nil {
 		return nil
 	}
 
-	requestedMemoryMiB, memoryTelemetryReady, err := requestedAcceleratorVirtualizationMemoryMiB(resources, resourceInfo, product)
+	requestedMemoryMiB, memoryTelemetryReady, err := requestedVGPUMemoryMiB(resources, resourceInfo, product)
 	if err != nil {
-		return endpointAcceleratorVirtualizationCapacityError(err.Error())
+		return endpointVGPUCapacityError(err.Error())
 	}
 
 	if !memoryTelemetryReady {
 		requestedMemoryMiB = 0
 	}
 
-	requestedCoreUnits, err := requestedAcceleratorVirtualizationCoreUnits(resources)
+	requestedCoreUnits, err := requestedVGPUCoreUnits(resources)
 	if err != nil {
-		return endpointAcceleratorVirtualizationCapacityError(err.Error())
+		return endpointVGPUCapacityError(err.Error())
 	}
 
 	satisfiableDevices, matchingDevices, matchingDeviceCountReady, deviceTelemetryReady :=
-		countSatisfiableAcceleratorVirtualizationDevices(resourceInfo, product, requestedMemoryMiB, requestedCoreUnits)
+		countSatisfiableVGPUDevices(resourceInfo, product, requestedMemoryMiB, requestedCoreUnits)
 	if satisfiableDevices >= requestedGPU {
 		return nil
 	}
 
 	if matchingDeviceCountReady && matchingDevices < requestedGPU {
-		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf(
+		return endpointVGPUCapacityError(fmt.Sprintf(
 			"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d matching_devices=%d satisfiable_devices=%d",
 			product,
 			requestedGPU,
@@ -534,7 +482,7 @@ func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpe
 		return nil
 	}
 
-	return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf(
+	return endpointVGPUCapacityError(fmt.Sprintf(
 		"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d satisfiable_devices=%d",
 		product,
 		requestedGPU,
@@ -552,7 +500,7 @@ func clusterResourceInfo(cluster *v1.Cluster) *v1.ClusterResources {
 	return cluster.Status.ResourceInfo
 }
 
-func clusterWithEndpointAcceleratorVirtualizationAllocationAddedBack(cluster *v1.Cluster, endpoint *v1.Endpoint) *v1.Cluster {
+func clusterWithEndpointVGPUAllocationAddedBack(cluster *v1.Cluster, endpoint *v1.Endpoint) *v1.Cluster {
 	if cluster == nil || endpoint == nil || endpoint.Status == nil || endpoint.Status.Resources == nil {
 		return cluster
 	}
@@ -564,14 +512,14 @@ func clusterWithEndpointAcceleratorVirtualizationAllocationAddedBack(cluster *v1
 
 	for _, replica := range endpoint.Status.Resources.Replicas {
 		for _, allocation := range replica.Devices {
-			addEndpointAcceleratorVirtualizationAllocation(resourceInfo, replica, allocation)
+			addEndpointVGPUAllocation(resourceInfo, replica, allocation)
 		}
 	}
 
 	return cluster
 }
 
-func addEndpointAcceleratorVirtualizationAllocation(
+func addEndpointVGPUAllocation(
 	resourceInfo *v1.ClusterResources,
 	replica v1.ReplicaDeviceAllocation,
 	allocation v1.DeviceAllocation,
@@ -587,14 +535,14 @@ func addEndpointAcceleratorVirtualizationAllocation(
 
 	if nodeID != "" {
 		if node := resourceInfo.NodeResources[nodeID]; addAllocationToMatchingDevice(node, allocation) {
-			addAvailableAcceleratorVirtualizationProductResource(resourceInfo, allocation)
+			addAvailableVGPUProductResource(resourceInfo, allocation)
 			return
 		}
 	}
 
 	for _, node := range resourceInfo.NodeResources {
 		if addAllocationToMatchingDevice(node, allocation) {
-			addAvailableAcceleratorVirtualizationProductResource(resourceInfo, allocation)
+			addAvailableVGPUProductResource(resourceInfo, allocation)
 			return
 		}
 	}
@@ -623,7 +571,7 @@ func addAllocationToMatchingDevice(node *v1.NodeResourceStatus, allocation v1.De
 	return false
 }
 
-func addAvailableAcceleratorVirtualizationProductResource(
+func addAvailableVGPUProductResource(
 	resourceInfo *v1.ClusterResources,
 	allocation v1.DeviceAllocation,
 ) {
@@ -665,7 +613,7 @@ func addAvailableAcceleratorVirtualizationProductResource(
 	}
 }
 
-func acceleratorVirtualizationProductResources(resourceInfo *v1.ClusterResources) (map[v1.AcceleratorProduct]*v1.AcceleratorProductResource, bool) {
+func vgpuProductResources(resourceInfo *v1.ClusterResources) (map[v1.AcceleratorProduct]*v1.AcceleratorProductResource, bool) {
 	if resourceInfo == nil || resourceInfo.Available == nil || resourceInfo.Available.AcceleratorGroups == nil {
 		return nil, false
 	}
@@ -678,7 +626,7 @@ func acceleratorVirtualizationProductResources(resourceInfo *v1.ClusterResources
 	return group.Products, true
 }
 
-func requestedAcceleratorVirtualizationMemoryMiB(resources *v1.ResourceSpec, resourceInfo *v1.ClusterResources, product string) (int64, bool, error) {
+func requestedVGPUMemoryMiB(resources *v1.ResourceSpec, resourceInfo *v1.ClusterResources, product string) (int64, bool, error) {
 	if memoryMiB := resources.GetAcceleratorVirtualizationMemoryMiB(); memoryMiB != "" {
 		parsed, err := parseRequiredPositiveInteger(memoryMiB, "virtualization.memory_mib")
 
@@ -721,7 +669,7 @@ func productTotalMemoryMiB(resourceInfo *v1.ClusterResources, product string) (f
 	return productMetadata.MemoryTotalMiB, true
 }
 
-func requestedAcceleratorVirtualizationCoreUnits(resources *v1.ResourceSpec) (int64, error) {
+func requestedVGPUCoreUnits(resources *v1.ResourceSpec) (int64, error) {
 	corePercent := resources.GetAcceleratorVirtualizationCorePercent()
 	if corePercent == "" {
 		return 0, nil
@@ -730,7 +678,7 @@ func requestedAcceleratorVirtualizationCoreUnits(resources *v1.ResourceSpec) (in
 	return parseRequiredPositiveInteger(corePercent, "virtualization.core_percent")
 }
 
-func countSatisfiableAcceleratorVirtualizationDevices(
+func countSatisfiableVGPUDevices(
 	resourceInfo *v1.ClusterResources,
 	product string,
 	requestedMemoryMiB int64,
@@ -836,7 +784,7 @@ func endpointResourceValueError(err error) *validationError {
 	}
 }
 
-func endpointAcceleratorVirtualizationCapacityError(hint string) *validationError {
+func endpointVGPUCapacityError(hint string) *validationError {
 	return &validationError{
 		Code:    "10220",
 		Message: "endpoint accelerator virtualization resources exceed cluster availability",
@@ -844,7 +792,7 @@ func endpointAcceleratorVirtualizationCapacityError(hint string) *validationErro
 	}
 }
 
-func endpointAcceleratorVirtualizationTargetError(hint string) *validationError {
+func endpointVGPUTargetError(hint string) *validationError {
 	return &validationError{
 		Code:    "10221",
 		Message: "invalid endpoint accelerator virtualization target",
@@ -852,8 +800,8 @@ func endpointAcceleratorVirtualizationTargetError(hint string) *validationError 
 	}
 }
 
-func endpointAcceleratorVirtualizationLookupError(hint string) *validationError {
-	err := endpointAcceleratorVirtualizationTargetError(hint)
+func endpointVGPULookupError(hint string) *validationError {
+	err := endpointVGPUTargetError(hint)
 	err.HTTPStatus = http.StatusServiceUnavailable
 
 	return err
@@ -867,7 +815,7 @@ func validationErrStatus(err *validationError) int {
 	return http.StatusBadRequest
 }
 
-func endpointAcceleratorVirtualizationNotReadyError(cluster *v1.Cluster, hint string) *validationError {
+func endpointVGPUNotReadyError(cluster *v1.Cluster, hint string) *validationError {
 	if cluster != nil && cluster.Metadata != nil {
 		hint = fmt.Sprintf("cluster %s/%s accelerator virtualization is not ready: %s", cluster.Metadata.Workspace, cluster.Metadata.Name, hint)
 	}

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -126,24 +126,29 @@ func validateEndpointVGPUPreflight(
 		return validationErr
 	}
 
-	target, validationErr := resolveEndpointVGPUTarget(endpoint)
-	if validationErr != nil {
-		return validationErr
+	clusterName := endpoint.Spec.Cluster
+	if clusterName == "" {
+		return endpointVGPUTargetError("spec.cluster is required for endpoint accelerator virtualization")
+	}
+
+	workspace := endpointWorkspace(endpoint)
+	if workspace == "" {
+		workspace = defaultWorkspace
 	}
 
 	clusters, err := store.ListCluster(storage.ListOption{
-		Filters: endpointClusterLookupFilters(target.cluster, target.workspace),
+		Filters: endpointClusterLookupFilters(clusterName, workspace),
 	})
 	if err != nil {
 		return endpointVGPULookupError("failed to look up cluster for endpoint accelerator virtualization")
 	}
 
 	if len(clusters) == 0 {
-		return endpointVGPUTargetError(fmt.Sprintf("cluster %s/%s not found", target.workspace, target.cluster))
+		return endpointVGPUTargetError(fmt.Sprintf("cluster %s/%s not found", workspace, clusterName))
 	}
 
 	if len(clusters) > 1 {
-		return endpointVGPUTargetError(fmt.Sprintf("multiple clusters matched %s/%s", target.workspace, target.cluster))
+		return endpointVGPUTargetError(fmt.Sprintf("multiple clusters matched %s/%s", workspace, clusterName))
 	}
 
 	cluster := &clusters[0]
@@ -151,38 +156,11 @@ func validateEndpointVGPUPreflight(
 		return validationErr
 	}
 
-	if method == http.MethodPatch && canAddBackEndpointVGPUAllocation(existing, target) {
+	if method == http.MethodPatch && canAddBackEndpointVGPUAllocation(existing, clusterName, workspace) {
 		cluster = clusterWithEndpointVGPUAllocationAddedBack(cluster, existing)
 	}
 
 	return validateEndpointVGPUCapacity(endpoint.Spec.Resources, cluster)
-}
-
-type endpointVGPUTarget struct {
-	cluster   string
-	workspace string
-}
-
-func resolveEndpointVGPUTarget(
-	endpoint *v1.Endpoint,
-) (endpointVGPUTarget, *validationError) {
-	target := endpointVGPUTarget{
-		workspace: endpointWorkspace(endpoint),
-	}
-
-	if endpoint.Spec != nil {
-		target.cluster = endpoint.Spec.Cluster
-	}
-
-	if target.workspace == "" {
-		target.workspace = defaultWorkspace
-	}
-
-	if target.cluster == "" {
-		return target, endpointVGPUTargetError("spec.cluster is required for endpoint accelerator virtualization")
-	}
-
-	return target, nil
 }
 
 func resolveEndpointPatch(
@@ -335,18 +313,19 @@ func endpointClusterLookupFilters(cluster, workspace string) []storage.Filter {
 
 func canAddBackEndpointVGPUAllocation(
 	endpoint *v1.Endpoint,
-	target endpointVGPUTarget,
+	cluster string,
+	targetWorkspace string,
 ) bool {
 	if endpoint == nil || endpoint.Spec == nil {
 		return false
 	}
 
-	workspace := endpointWorkspace(endpoint)
-	if workspace == "" {
-		workspace = defaultWorkspace
+	endpointWorkspace := endpointWorkspace(endpoint)
+	if endpointWorkspace == "" {
+		endpointWorkspace = defaultWorkspace
 	}
 
-	return endpoint.Spec.Cluster == target.cluster && workspace == target.workspace
+	return endpoint.Spec.Cluster == cluster && endpointWorkspace == targetWorkspace
 }
 
 func validateEndpointVGPUCluster(cluster *v1.Cluster) *validationError {

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -194,14 +194,23 @@ func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpe
 	product := resources.GetAcceleratorProduct()
 	resourceInfo := clusterResourceInfo(cluster)
 
-	productResource := acceleratorVirtualizationProductResource(resourceInfo, product)
+	productResources, productTelemetryReady := acceleratorVirtualizationProductResources(resourceInfo)
+	if !productTelemetryReady {
+		return nil
+	}
+
+	productResource := productResources[v1.AcceleratorProduct(product)]
 	if productResource == nil || productResource.Virtualization == nil {
 		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf("product=%s has no available accelerator virtualization capacity", product))
 	}
 
-	requestedMemoryMiB, err := requestedAcceleratorVirtualizationMemoryMiB(resources, resourceInfo, product)
+	requestedMemoryMiB, memoryTelemetryReady, err := requestedAcceleratorVirtualizationMemoryMiB(resources, resourceInfo, product)
 	if err != nil {
 		return endpointAcceleratorVirtualizationCapacityError(err.Error())
+	}
+
+	if !memoryTelemetryReady {
+		return nil
 	}
 
 	requestedCoreUnits, err := requestedAcceleratorVirtualizationCoreUnits(resources)
@@ -209,19 +218,23 @@ func validateEndpointAcceleratorVirtualizationCapacity(resources *v1.ResourceSpe
 		return endpointAcceleratorVirtualizationCapacityError(err.Error())
 	}
 
-	satisfiableDevices := countSatisfiableAcceleratorVirtualizationDevices(resourceInfo, product, requestedMemoryMiB, requestedCoreUnits)
-	if satisfiableDevices < requestedGPU {
-		return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf(
-			"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d satisfiable_devices=%d",
-			product,
-			requestedGPU,
-			requestedMemoryMiB,
-			requestedCoreUnits,
-			satisfiableDevices,
-		))
+	satisfiableDevices, deviceTelemetryReady := countSatisfiableAcceleratorVirtualizationDevices(resourceInfo, product, requestedMemoryMiB, requestedCoreUnits)
+	if satisfiableDevices >= requestedGPU {
+		return nil
 	}
 
-	return nil
+	if !deviceTelemetryReady {
+		return nil
+	}
+
+	return endpointAcceleratorVirtualizationCapacityError(fmt.Sprintf(
+		"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d satisfiable_devices=%d",
+		product,
+		requestedGPU,
+		requestedMemoryMiB,
+		requestedCoreUnits,
+		satisfiableDevices,
+	))
 }
 
 func clusterResourceInfo(cluster *v1.Cluster) *v1.ClusterResources {
@@ -232,58 +245,60 @@ func clusterResourceInfo(cluster *v1.Cluster) *v1.ClusterResources {
 	return cluster.Status.ResourceInfo
 }
 
-func acceleratorVirtualizationProductResource(resourceInfo *v1.ClusterResources, product string) *v1.AcceleratorProductResource {
+func acceleratorVirtualizationProductResources(resourceInfo *v1.ClusterResources) (map[v1.AcceleratorProduct]*v1.AcceleratorProductResource, bool) {
 	if resourceInfo == nil || resourceInfo.Available == nil || resourceInfo.Available.AcceleratorGroups == nil {
-		return nil
+		return nil, false
 	}
 
 	group := resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
 	if group == nil || group.Products == nil {
-		return nil
+		return nil, false
 	}
 
-	return group.Products[v1.AcceleratorProduct(product)]
+	return group.Products, true
 }
 
-func requestedAcceleratorVirtualizationMemoryMiB(resources *v1.ResourceSpec, resourceInfo *v1.ClusterResources, product string) (int64, error) {
+func requestedAcceleratorVirtualizationMemoryMiB(resources *v1.ResourceSpec, resourceInfo *v1.ClusterResources, product string) (int64, bool, error) {
 	if memoryMiB := resources.GetAcceleratorVirtualizationMemoryMiB(); memoryMiB != "" {
-		return parseRequiredPositiveInteger(memoryMiB, "virtualization.memory_mib")
+		parsed, err := parseRequiredPositiveInteger(memoryMiB, "virtualization.memory_mib")
+
+		return parsed, true, err
 	}
 
 	memoryPercent := resources.GetAcceleratorVirtualizationMemoryPercent()
 	if memoryPercent == "" {
-		return 0, nil
+		return 0, true, nil
 	}
 
 	percent, err := parseRequiredPositiveInteger(memoryPercent, "virtualization.memory_percent")
 	if err != nil {
-		return 0, err
+		return 0, true, err
 	}
 
-	totalMemoryMiB := productTotalMemoryMiB(resourceInfo, product)
-	if totalMemoryMiB <= 0 {
-		return 0, fmt.Errorf("product=%s missing accelerator memory metadata for virtualization.memory_percent", product)
+	totalMemoryMiB, ok := productTotalMemoryMiB(resourceInfo, product)
+	if !ok || totalMemoryMiB <= 0 {
+		return 0, false, nil
 	}
 
-	return int64(math.Ceil(totalMemoryMiB * float64(percent) / 100)), nil
+	return int64(math.Ceil(totalMemoryMiB * float64(percent) / 100)), true, nil
 }
 
-func productTotalMemoryMiB(resourceInfo *v1.ClusterResources, product string) float64 {
+func productTotalMemoryMiB(resourceInfo *v1.ClusterResources, product string) (float64, bool) {
 	if resourceInfo == nil || resourceInfo.AcceleratorMetadata == nil {
-		return 0
+		return 0, false
 	}
 
 	metadata := resourceInfo.AcceleratorMetadata[v1.AcceleratorTypeNVIDIAGPU]
 	if metadata == nil || metadata.Products == nil {
-		return 0
+		return 0, false
 	}
 
 	productMetadata := metadata.Products[v1.AcceleratorProduct(product)]
 	if productMetadata == nil {
-		return 0
+		return 0, false
 	}
 
-	return productMetadata.MemoryTotalMiB
+	return productMetadata.MemoryTotalMiB, true
 }
 
 func requestedAcceleratorVirtualizationCoreUnits(resources *v1.ResourceSpec) (int64, error) {
@@ -295,12 +310,18 @@ func requestedAcceleratorVirtualizationCoreUnits(resources *v1.ResourceSpec) (in
 	return parseRequiredPositiveInteger(corePercent, "virtualization.core_percent")
 }
 
-func countSatisfiableAcceleratorVirtualizationDevices(resourceInfo *v1.ClusterResources, product string, requestedMemoryMiB int64, requestedCoreUnits int64) int64 {
-	if resourceInfo == nil {
-		return 0
+func countSatisfiableAcceleratorVirtualizationDevices(
+	resourceInfo *v1.ClusterResources,
+	product string,
+	requestedMemoryMiB int64,
+	requestedCoreUnits int64,
+) (int64, bool) {
+	if resourceInfo == nil || resourceInfo.NodeResources == nil {
+		return 0, false
 	}
 
 	var count int64
+	telemetryReady := true
 
 	for _, node := range resourceInfo.NodeResources {
 		if node == nil {
@@ -308,7 +329,12 @@ func countSatisfiableAcceleratorVirtualizationDevices(resourceInfo *v1.ClusterRe
 		}
 
 		for _, device := range node.Devices {
-			if device == nil || !device.Health || device.Product != product || device.Available == nil {
+			if device == nil || !device.Health || device.Product != product {
+				continue
+			}
+
+			if device.Available == nil {
+				telemetryReady = false
 				continue
 			}
 
@@ -324,7 +350,7 @@ func countSatisfiableAcceleratorVirtualizationDevices(resourceInfo *v1.ClusterRe
 		}
 	}
 
-	return count
+	return count, telemetryReady
 }
 
 func parsePositiveIntegerResource(value *string, field string) (int64, error) {

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateEndpointAcceleratorVirtualizationResourceShape(t *testing.T) {
+func TestValidateEndpointVGPUResourceShape(t *testing.T) {
 	t.Run("allows non vGPU endpoint resources", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", nil)
+		resources := vgpuResources("1", "Tesla-T4", nil)
 
-		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
+		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.Nil(t, err)
 	})
@@ -35,41 +35,41 @@ func TestValidateEndpointAcceleratorVirtualizationResourceShape(t *testing.T) {
 			},
 		}
 
-		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
+		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("rejects vGPU endpoint without product", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "", map[string]string{
+		resources := vgpuResources("1", "", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey: "8192",
 		})
 
-		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
+		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10218", err.Code)
 	})
 
 	t.Run("rejects mutually exclusive memory fields", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:     "8192",
 			v1.AcceleratorVirtualizationMemoryPercentKey: "50",
 		})
 
-		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
+		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10219", err.Code)
 	})
 
 	t.Run("rejects invalid vGPU numeric resources", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192",
 			v1.AcceleratorVirtualizationCorePercentKey: "101",
 		})
 
-		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
+		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10216", err.Code)
@@ -77,12 +77,12 @@ func TestValidateEndpointAcceleratorVirtualizationResourceShape(t *testing.T) {
 	})
 
 	t.Run("rejects fractional vGPU memory resource", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192.5",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
 
-		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
+		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10216", err.Code)
@@ -91,12 +91,12 @@ func TestValidateEndpointAcceleratorVirtualizationResourceShape(t *testing.T) {
 	})
 
 	t.Run("rejects fractional vGPU core resource", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192",
 			v1.AcceleratorVirtualizationCorePercentKey: "50.5",
 		})
 
-		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
+		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10216", err.Code)
@@ -105,18 +105,18 @@ func TestValidateEndpointAcceleratorVirtualizationResourceShape(t *testing.T) {
 	})
 
 	t.Run("allows vGPU endpoint resource shape without cluster availability lookup", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
 
-		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
+		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("skips patch that does not touch resources", func(t *testing.T) {
-		endpoint, err := parseEndpointAcceleratorVirtualizationBody([]byte(`{
+		endpoint, err := parseEndpointBody([]byte(`{
 			"spec": {
 				"replicas": {"num": 2}
 			}
@@ -124,13 +124,13 @@ func TestValidateEndpointAcceleratorVirtualizationResourceShape(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.NotNil(t, endpoint)
-		assert.Nil(t, validateEndpointAcceleratorVirtualizationPreflight(nil, http.MethodPatch, nil, endpoint))
+		assert.Nil(t, validateEndpointVGPUPreflight(nil, http.MethodPatch, nil, endpoint))
 	})
 }
 
-func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
+func TestValidateEndpointVGPUCapacity(t *testing.T) {
 	t.Run("skips when cluster resource info is unavailable", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -138,13 +138,13 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			Status: &v1.ClusterStatus{},
 		}
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("skips when available accelerator telemetry is incomplete", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -154,13 +154,13 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			},
 		}
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("rejects request that exceeds per device memory availability", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "8193",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -168,7 +168,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10220", err.Code)
@@ -177,7 +177,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 
 	t.Run("rejects product absent from cluster resource info", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Missing-GPU", map[string]string{
+		resources := vgpuResources("1", "Missing-GPU", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -185,7 +185,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10220", err.Code)
@@ -193,7 +193,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 
 	t.Run("skips when product exists but virtualization telemetry is missing", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -203,13 +203,13 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 		cluster.Status.ResourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU].
 			Products[v1.AcceleratorProduct("Tesla-T4")].Virtualization = nil
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("rejects fragmented capacity that cannot satisfy each requested virtual card", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+		resources := vgpuResources("2", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "8193",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -218,7 +218,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			healthyDevice("gpu-1", "Tesla-T4", 8192, 100),
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10220", err.Code)
@@ -226,7 +226,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 
 	t.Run("rejects request that exceeds per device core availability", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "51",
 		})
@@ -234,7 +234,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			healthyDevice("gpu-0", "Tesla-T4", 8192, 50),
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		if assert.NotNil(t, err) {
 			assert.Equal(t, "10220", err.Code)
@@ -244,7 +244,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 
 	t.Run("rejects request that needs more healthy matching devices than available", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+		resources := vgpuResources("2", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -252,7 +252,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10220", err.Code)
@@ -261,7 +261,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 
 	t.Run("ignores unhealthy matching devices", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+		resources := vgpuResources("2", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -270,7 +270,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			unhealthyDevice("gpu-1", "Tesla-T4", 8192, 100),
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10220", err.Code)
@@ -278,7 +278,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 
 	t.Run("allows request when enough healthy matching devices fit", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+		resources := vgpuResources("2", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -287,13 +287,13 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			healthyDevice("gpu-1", "Tesla-T4", 8192, 50),
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("derives memory from memory percent using product metadata", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
 			v1.AcceleratorVirtualizationCorePercentKey:   "50",
 		})
@@ -301,13 +301,13 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			healthyDevice("gpu-0", "Tesla-T4", 5101, 100),
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("skips memory percent precheck when product memory metadata is missing", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
 			v1.AcceleratorVirtualizationCorePercentKey:   "50",
 		})
@@ -316,13 +316,13 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 		})
 		cluster.Status.ResourceInfo.AcceleratorMetadata = nil
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("rejects core overuse when memory percent metadata is missing", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
 			v1.AcceleratorVirtualizationCorePercentKey:   "51",
 		})
@@ -331,7 +331,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 		})
 		cluster.Status.ResourceInfo.AcceleratorMetadata = nil
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		if err == nil {
 			t.Fatal("expected capacity error")
@@ -342,7 +342,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 
 	t.Run("skips when matching device availability telemetry is incomplete", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -352,13 +352,13 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			device,
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("rejects when matching device count is insufficient despite incomplete availability telemetry", func(t *testing.T) {
-		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+		resources := vgpuResources("2", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
 		})
@@ -368,7 +368,7 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 			device,
 		})
 
-		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+		err := validateEndpointVGPUCapacity(resources, cluster)
 
 		if err == nil {
 			t.Fatal("expected capacity error")
@@ -379,11 +379,11 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 }
 
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsUnsatisfiablePost(t *testing.T) {
+func TestEndpointVGPUValidationRejectsUnsatisfiablePost(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
 	})
-	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
 	clusterStorage := &fakeClusterStorage{
 		clusters: []v1.Cluster{*cluster},
 	}
@@ -403,7 +403,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsUnsatisfiable
 		}
 	}`
 
-	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPost, body, clusterStorage)
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
 
 	var response validationError
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -412,9 +412,9 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsUnsatisfiable
 	assert.False(t, handlerCalled)
 }
 
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsNoGPUClusterPost(t *testing.T) {
+func TestEndpointVGPUValidationRejectsNoGPUClusterPost(t *testing.T) {
 	cluster := clusterWithoutNVIDIAGPUProducts()
-	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
 	clusterStorage := &fakeClusterStorage{
 		clusters: []v1.Cluster{*cluster},
 	}
@@ -434,7 +434,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsNoGPUClusterP
 		}
 	}`
 
-	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPost, body, clusterStorage)
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
 
 	var response validationError
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -444,7 +444,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsNoGPUClusterP
 	assert.False(t, handlerCalled)
 }
 
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareReturnsServiceUnavailableOnClusterLookupError(t *testing.T) {
+func TestEndpointVGPUValidationReturnsServiceUnavailableOnClusterLookupError(t *testing.T) {
 	clusterStorage := &fakeClusterStorage{
 		listError: errors.New("database is down"),
 	}
@@ -464,7 +464,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareReturnsServiceUnavai
 		}
 	}`
 
-	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPost, body, clusterStorage)
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
 
 	var response validationError
 	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
@@ -475,11 +475,11 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareReturnsServiceUnavai
 	assert.False(t, handlerCalled)
 }
 
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsNotReadyPost(t *testing.T) {
+func TestEndpointVGPUValidationRejectsNotReadyPost(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
 	})
-	markClusterAcceleratorVirtualizationNotReady(cluster, "cluster-a", "team-a")
+	markClusterVGPUNotReady(cluster, "cluster-a", "team-a")
 	clusterStorage := &fakeClusterStorage{
 		clusters: []v1.Cluster{*cluster},
 	}
@@ -499,7 +499,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsNotReadyPost(
 		}
 	}`
 
-	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPost, body, clusterStorage)
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
 
 	var response validationError
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -509,11 +509,11 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsNotReadyPost(
 	assert.False(t, handlerCalled)
 }
 
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsPatchWithoutEndpointFilters(t *testing.T) {
+func TestEndpointVGPUValidationRejectsPatchWithoutEndpointFilters(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
 	})
-	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
 	clusterStorage := &fakeClusterStorage{
 		clusters: []v1.Cluster{*cluster},
 	}
@@ -533,7 +533,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsPatchWithoutE
 		}
 	}`
 
-	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPatch, body, clusterStorage)
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPatch, body, clusterStorage)
 
 	var response validationError
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -543,15 +543,15 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsPatchWithoutE
 	assert.False(t, handlerCalled)
 }
 
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareResolvesEndpointAndRejectsUnsatisfiablePatch(t *testing.T) {
+func TestEndpointVGPUValidationResolvesEndpointAndRejectsUnsatisfiablePatch(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
 	})
-	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
 	clusterStorage := &fakeClusterStorage{
 		clusters: []v1.Cluster{*cluster},
 		endpoints: []v1.Endpoint{
-			*endpointWithAcceleratorVirtualization("cluster-a", "team-a"),
+			*endpointWithVGPU("cluster-a", "team-a"),
 		},
 	}
 	body := `{
@@ -568,7 +568,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareResolvesEndpointAndR
 		}
 	}`
 
-	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithPath(
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
 		http.MethodPatch,
 		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
 		body,
@@ -583,12 +583,12 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareResolvesEndpointAndR
 	assert.False(t, handlerCalled)
 }
 
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareAddsBackCurrentPatchAllocation(t *testing.T) {
+func TestEndpointVGPUValidationAddsBackCurrentPatchAllocation(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 0, 0),
 	})
-	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
-	endpoint := endpointWithAcceleratorVirtualization("cluster-a", "team-a")
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
+	endpoint := endpointWithVGPU("cluster-a", "team-a")
 	endpoint.Status = &v1.EndpointStatus{
 		Resources: &v1.EndpointResourceStatus{
 			Replicas: []v1.ReplicaDeviceAllocation{
@@ -625,7 +625,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareAddsBackCurrentPatch
 		}
 	}`
 
-	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithPath(
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
 		http.MethodPatch,
 		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
 		body,
@@ -637,12 +637,12 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareAddsBackCurrentPatch
 	assert.True(t, handlerCalled)
 }
 
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareDoesNotAddBackAllocationWhenPatchMovesCluster(t *testing.T) {
+func TestEndpointVGPUValidationDoesNotAddBackAllocationWhenPatchMovesCluster(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 0, 0),
 	})
-	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
-	endpoint := endpointWithAcceleratorVirtualization("old-cluster", "team-a")
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
+	endpoint := endpointWithVGPU("old-cluster", "team-a")
 	endpoint.Status = &v1.EndpointStatus{
 		Resources: &v1.EndpointResourceStatus{
 			Replicas: []v1.ReplicaDeviceAllocation{
@@ -680,7 +680,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareDoesNotAddBackAlloca
 		}
 	}`
 
-	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithPath(
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
 		http.MethodPatch,
 		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
 		body,
@@ -694,7 +694,7 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareDoesNotAddBackAlloca
 	assert.False(t, handlerCalled)
 }
 
-func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1.Endpoint {
+func endpointWithVGPU(cluster string, workspace string) *v1.Endpoint {
 	return &v1.Endpoint{
 		Metadata: &v1.Metadata{
 			Name:      "endpoint",
@@ -702,7 +702,7 @@ func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1
 		},
 		Spec: &v1.EndpointSpec{
 			Cluster: cluster,
-			Resources: acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			Resources: vgpuResources("1", "Tesla-T4", map[string]string{
 				v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 				v1.AcceleratorVirtualizationCorePercentKey: "50",
 			}),
@@ -710,30 +710,30 @@ func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1
 	}
 }
 
-func runEndpointAcceleratorVirtualizationValidation(method string, body string, clusterStorage storage.Storage) *httptest.ResponseRecorder {
-	recorder, _ := runEndpointAcceleratorVirtualizationValidationWithHandler(method, body, clusterStorage)
+func runEndpointVGPUValidation(method string, body string, clusterStorage storage.Storage) *httptest.ResponseRecorder {
+	recorder, _ := runEndpointVGPUValidationWithHandler(method, body, clusterStorage)
 
 	return recorder
 }
 
-func runEndpointAcceleratorVirtualizationValidationWithPath(
+func runEndpointVGPUValidationWithPath(
 	method string,
 	path string,
 	body string,
 	clusterStorage storage.Storage,
 ) (*httptest.ResponseRecorder, bool) {
-	return runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(method, path, body, clusterStorage)
+	return runEndpointVGPUValidationWithHandlerAndPath(method, path, body, clusterStorage)
 }
 
-func runEndpointAcceleratorVirtualizationValidationWithHandler(
+func runEndpointVGPUValidationWithHandler(
 	method string,
 	body string,
 	clusterStorage storage.Storage,
 ) (*httptest.ResponseRecorder, bool) {
-	return runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(method, "/endpoints", body, clusterStorage)
+	return runEndpointVGPUValidationWithHandlerAndPath(method, "/endpoints", body, clusterStorage)
 }
 
-func runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(
+func runEndpointVGPUValidationWithHandlerAndPath(
 	method string,
 	path string,
 	body string,
@@ -743,7 +743,7 @@ func runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(
 
 	router := gin.New()
 	handlerCalled := false
-	router.Handle(method, "/endpoints", validateEndpointAcceleratorVirtualization(clusterStorage), func(c *gin.Context) {
+	router.Handle(method, "/endpoints", validateEndpointVGPU(clusterStorage), func(c *gin.Context) {
 		handlerCalled = true
 		c.Status(http.StatusNoContent)
 	})
@@ -756,7 +756,7 @@ func runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(
 	return recorder, handlerCalled
 }
 
-func acceleratorVirtualizationResources(gpu string, product string, virtualization map[string]string) *v1.ResourceSpec {
+func vgpuResources(gpu string, product string, virtualization map[string]string) *v1.ResourceSpec {
 	accelerator := map[string]string{
 		v1.AcceleratorTypeKey:    string(v1.AcceleratorTypeNVIDIAGPU),
 		v1.AcceleratorProductKey: product,
@@ -826,7 +826,7 @@ func clusterWithoutNVIDIAGPUProducts() *v1.Cluster {
 	}
 }
 
-func markClusterAcceleratorVirtualizationReady(cluster *v1.Cluster, name string, workspace string) {
+func markClusterVGPUReady(cluster *v1.Cluster, name string, workspace string) {
 	if cluster.Metadata == nil {
 		cluster.Metadata = &v1.Metadata{}
 	}
@@ -848,8 +848,8 @@ func markClusterAcceleratorVirtualizationReady(cluster *v1.Cluster, name string,
 	}
 }
 
-func markClusterAcceleratorVirtualizationNotReady(cluster *v1.Cluster, name string, workspace string) {
-	markClusterAcceleratorVirtualizationReady(cluster, name, workspace)
+func markClusterVGPUNotReady(cluster *v1.Cluster, name string, workspace string) {
+	markClusterVGPUReady(cluster, name, workspace)
 	cluster.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey] = &v1.ComponentStatus{
 		Phase:   v1.ComponentPhaseNotReady,
 		Reason:  "HAMiNotReady",

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -357,7 +357,7 @@ func TestValidateEndpointVGPUCapacity(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("rejects when matching device count is insufficient despite incomplete availability telemetry", func(t *testing.T) {
+	t.Run("skips matching device count rejection when availability telemetry is incomplete", func(t *testing.T) {
 		resources := vgpuResources("2", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
@@ -370,12 +370,7 @@ func TestValidateEndpointVGPUCapacity(t *testing.T) {
 
 		err := validateEndpointVGPUCapacity(resources, cluster)
 
-		if err == nil {
-			t.Fatal("expected capacity error")
-		}
-		assert.Equal(t, "10220", err.Code)
-		assert.Contains(t, err.Hint, "requested_gpu=2")
-		assert.Contains(t, err.Hint, "matching_devices=1")
+		assert.Nil(t, err)
 	})
 }
 

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -1,6 +1,7 @@
 package proxies
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -420,6 +421,21 @@ func TestValidateEndpointAcceleratorVirtualizationCreateCapacitySkipsWhenCluster
 		assert.Equal(t, 0, clusterStorage.listCalls)
 	})
 
+	t.Run("skips when endpoint workspace is missing", func(t *testing.T) {
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
+		})
+		clusterStorage := &fakeClusterStorage{
+			clusters: []v1.Cluster{*cluster},
+		}
+		endpoint := endpointWithAcceleratorVirtualization("cluster-a", "")
+
+		err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
+
+		assert.Nil(t, err)
+		assert.Equal(t, 0, clusterStorage.listCalls)
+	})
+
 	t.Run("skips when cluster lookup fails", func(t *testing.T) {
 		clusterStorage := &fakeClusterStorage{
 			listError: errors.New("storage unavailable"),
@@ -500,6 +516,38 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareSkipsCapacityLookupO
 	assert.Equal(t, 0, clusterStorage.listCalls)
 }
 
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsUnsatisfiablePost(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
+	})
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPost, body, clusterStorage)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10220", response.Code)
+	assert.False(t, handlerCalled)
+}
+
 func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1.Endpoint {
 	return &v1.Endpoint{
 		Metadata: &v1.Metadata{
@@ -517,10 +565,22 @@ func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1
 }
 
 func runEndpointAcceleratorVirtualizationValidation(method string, body string, clusterStorage storage.ClusterStorage) *httptest.ResponseRecorder {
+	recorder, _ := runEndpointAcceleratorVirtualizationValidationWithHandler(method, body, clusterStorage)
+
+	return recorder
+}
+
+func runEndpointAcceleratorVirtualizationValidationWithHandler(
+	method string,
+	body string,
+	clusterStorage storage.ClusterStorage,
+) (*httptest.ResponseRecorder, bool) {
 	gin.SetMode(gin.TestMode)
 
 	router := gin.New()
+	handlerCalled := false
 	router.Handle(method, "/endpoints", validateEndpointAcceleratorVirtualization(clusterStorage), func(c *gin.Context) {
+		handlerCalled = true
 		c.Status(http.StatusNoContent)
 	})
 
@@ -529,7 +589,7 @@ func runEndpointAcceleratorVirtualizationValidation(method string, body string, 
 	request.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(recorder, request)
 
-	return recorder
+	return recorder, handlerCalled
 }
 
 func acceleratorVirtualizationResources(gpu string, product string, virtualization map[string]string) *v1.ResourceSpec {

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -1,8 +1,13 @@
 package proxies
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/pkg/storage"
 	"github.com/stretchr/testify/assert"
@@ -236,6 +241,40 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 		assert.Contains(t, err.Hint, "requested_gpu=2")
 	})
 
+	t.Run("rejects request that exceeds per device core availability", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "51",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 8192, 50),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10220", err.Code)
+		assert.Contains(t, err.Hint, "requested_core_units=51")
+		assert.Contains(t, err.Hint, "satisfiable_devices=0")
+	})
+
+	t.Run("rejects request that needs more healthy matching devices than available", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10220", err.Code)
+		assert.Contains(t, err.Hint, "requested_gpu=2")
+		assert.Contains(t, err.Hint, "satisfiable_devices=1")
+	})
+
 	t.Run("ignores unhealthy matching devices", func(t *testing.T) {
 		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
@@ -283,6 +322,50 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 }
 
+func TestValidateEndpointAcceleratorVirtualizationCreateCapacitySkipsWhenClusterCannotBePrevalidated(t *testing.T) {
+	t.Run("skips when cluster storage is unavailable", func(t *testing.T) {
+		endpoint := endpointWithAcceleratorVirtualization("cluster-a", "team-a")
+
+		err := validateEndpointAcceleratorVirtualizationCreateCapacity(nil, endpoint)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("skips when endpoint has no target cluster", func(t *testing.T) {
+		clusterStorage := &fakeClusterStorage{
+			listError: errors.New("unexpected lookup"),
+		}
+		endpoint := endpointWithAcceleratorVirtualization("", "team-a")
+
+		err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
+
+		assert.Nil(t, err)
+		assert.Equal(t, 0, clusterStorage.listCalls)
+	})
+
+	t.Run("skips when cluster lookup fails", func(t *testing.T) {
+		clusterStorage := &fakeClusterStorage{
+			listError: errors.New("storage unavailable"),
+		}
+		endpoint := endpointWithAcceleratorVirtualization("cluster-a", "team-a")
+
+		err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
+
+		assert.Nil(t, err)
+		assert.Equal(t, 1, clusterStorage.listCalls)
+	})
+
+	t.Run("skips when cluster is not found", func(t *testing.T) {
+		clusterStorage := &fakeClusterStorage{}
+		endpoint := endpointWithAcceleratorVirtualization("cluster-a", "team-a")
+
+		err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
+
+		assert.Nil(t, err)
+		assert.Equal(t, 1, clusterStorage.listCalls)
+	})
+}
+
 func TestValidateEndpointAcceleratorVirtualizationCreateCapacityLooksUpClusterByNameAndWorkspace(t *testing.T) {
 	resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
 		v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
@@ -312,6 +395,64 @@ func TestValidateEndpointAcceleratorVirtualizationCreateCapacityLooksUpClusterBy
 		{Column: "metadata->name", Operator: "eq", Value: `"cluster-a"`},
 		{Column: "metadata->workspace", Operator: "eq", Value: `"team-a"`},
 	}, clusterStorage.listOption.Filters)
+}
+
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareSkipsCapacityLookupOnPatch(t *testing.T) {
+	clusterStorage := &fakeClusterStorage{
+		listError: errors.New("patch must not look up cluster capacity"),
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder := runEndpointAcceleratorVirtualizationValidation(http.MethodPatch, body, clusterStorage)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, 0, clusterStorage.listCalls)
+}
+
+func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1.Endpoint {
+	return &v1.Endpoint{
+		Metadata: &v1.Metadata{
+			Name:      "endpoint",
+			Workspace: workspace,
+		},
+		Spec: &v1.EndpointSpec{
+			Cluster: cluster,
+			Resources: acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+				v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+				v1.AcceleratorVirtualizationCorePercentKey: "50",
+			}),
+		},
+	}
+}
+
+func runEndpointAcceleratorVirtualizationValidation(method string, body string, clusterStorage storage.ClusterStorage) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Handle(method, "/endpoints", validateEndpointAcceleratorVirtualization(clusterStorage), func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(method, "/endpoints", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, request)
+
+	return recorder
 }
 
 func acceleratorVirtualizationResources(gpu string, product string, virtualization map[string]string) *v1.ResourceSpec {
@@ -390,6 +531,8 @@ func unhealthyDevice(uuid string, product string, memoryMiB int64, coreUnits int
 
 type fakeClusterStorage struct {
 	clusters   []v1.Cluster
+	listCalls  int
+	listError  error
 	listOption storage.ListOption
 }
 
@@ -410,7 +553,12 @@ func (s *fakeClusterStorage) GetCluster(id string) (*v1.Cluster, error) {
 }
 
 func (s *fakeClusterStorage) ListCluster(option storage.ListOption) ([]v1.Cluster, error) {
+	s.listCalls++
 	s.listOption = option
+
+	if s.listError != nil {
+		return nil, s.listError
+	}
 
 	return s.clusters, nil
 }

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -191,6 +191,36 @@ func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
 }
 
 func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
+	t.Run("skips when cluster resource info is unavailable", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := &v1.Cluster{
+			Status: &v1.ClusterStatus{},
+		}
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("skips when available accelerator telemetry is incomplete", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := &v1.Cluster{
+			Status: &v1.ClusterStatus{
+				ResourceInfo: &v1.ClusterResources{},
+			},
+		}
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.Nil(t, err)
+	})
+
 	t.Run("rejects request that exceeds per device memory availability", func(t *testing.T) {
 		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "8193",
@@ -314,6 +344,37 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 		})
 		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 10001, []*v1.DeviceResource{
 			healthyDevice("gpu-0", "Tesla-T4", 5101, 100),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("skips memory percent precheck when product memory metadata is missing", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
+			v1.AcceleratorVirtualizationCorePercentKey:   "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 10001, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 5101, 100),
+		})
+		cluster.Status.ResourceInfo.AcceleratorMetadata = nil
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("skips when matching device availability telemetry is incomplete", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		device := healthyDevice("gpu-0", "Tesla-T4", 8192, 100)
+		device.Available = nil
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			device,
 		})
 
 		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -254,6 +254,22 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 		assert.Contains(t, err.Hint, "Missing-GPU")
 	})
 
+	t.Run("skips when product exists but virtualization telemetry is missing", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+		})
+		cluster.Status.ResourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU].
+			Products[v1.AcceleratorProduct("Tesla-T4")].Virtualization = nil
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.Nil(t, err)
+	})
+
 	t.Run("rejects fragmented capacity that cannot satisfy each requested virtual card", func(t *testing.T) {
 		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "8193",

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/pkg/storage"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -773,7 +774,7 @@ func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1
 	}
 }
 
-func runEndpointAcceleratorVirtualizationValidation(method string, body string, clusterStorage endpointAcceleratorVirtualizationStorage) *httptest.ResponseRecorder {
+func runEndpointAcceleratorVirtualizationValidation(method string, body string, clusterStorage storage.Storage) *httptest.ResponseRecorder {
 	recorder, _ := runEndpointAcceleratorVirtualizationValidationWithHandler(method, body, clusterStorage)
 
 	return recorder
@@ -783,7 +784,7 @@ func runEndpointAcceleratorVirtualizationValidationWithPath(
 	method string,
 	path string,
 	body string,
-	clusterStorage endpointAcceleratorVirtualizationStorage,
+	clusterStorage storage.Storage,
 ) (*httptest.ResponseRecorder, bool) {
 	return runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(method, path, body, clusterStorage)
 }
@@ -791,7 +792,7 @@ func runEndpointAcceleratorVirtualizationValidationWithPath(
 func runEndpointAcceleratorVirtualizationValidationWithHandler(
 	method string,
 	body string,
-	clusterStorage endpointAcceleratorVirtualizationStorage,
+	clusterStorage storage.Storage,
 ) (*httptest.ResponseRecorder, bool) {
 	return runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(method, "/endpoints", body, clusterStorage)
 }
@@ -800,7 +801,7 @@ func runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(
 	method string,
 	path string,
 	body string,
-	clusterStorage endpointAcceleratorVirtualizationStorage,
+	clusterStorage storage.Storage,
 ) (*httptest.ResponseRecorder, bool) {
 	gin.SetMode(gin.TestMode)
 
@@ -940,6 +941,8 @@ func unhealthyDevice(uuid string, product string, memoryMiB int64, coreUnits int
 }
 
 type fakeClusterStorage struct {
+	*storagemocks.MockStorage
+
 	clusters           []v1.Cluster
 	endpoints          []v1.Endpoint
 	listCalls          int

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -299,10 +299,11 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 
 		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
 
-		assert.NotNil(t, err)
-		assert.Equal(t, "10220", err.Code)
-		assert.Contains(t, err.Hint, "requested_core_units=51")
-		assert.Contains(t, err.Hint, "satisfiable_devices=0")
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "10220", err.Code)
+			assert.Contains(t, err.Hint, "requested_core_units=51")
+			assert.Contains(t, err.Hint, "satisfiable_devices=0")
+		}
 	})
 
 	t.Run("rejects request that needs more healthy matching devices than available", func(t *testing.T) {
@@ -383,6 +384,26 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
+	t.Run("rejects core overuse when memory percent metadata is missing", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
+			v1.AcceleratorVirtualizationCorePercentKey:   "51",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 10001, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 5101, 50),
+		})
+		cluster.Status.ResourceInfo.AcceleratorMetadata = nil
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		if err == nil {
+			t.Fatal("expected capacity error")
+		}
+		assert.Equal(t, "10220", err.Code)
+		assert.Contains(t, err.Hint, "requested_core_units=51")
+		assert.Contains(t, err.Hint, "satisfiable_devices=0")
+	})
+
 	t.Run("skips when matching device availability telemetry is incomplete", func(t *testing.T) {
 		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
@@ -397,6 +418,27 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
 
 		assert.Nil(t, err)
+	})
+
+	t.Run("rejects when matching device count is insufficient despite incomplete availability telemetry", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		device := healthyDevice("gpu-0", "Tesla-T4", 8192, 100)
+		device.Available = nil
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			device,
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		if err == nil {
+			t.Fatal("expected capacity error")
+		}
+		assert.Equal(t, "10220", err.Code)
+		assert.Contains(t, err.Hint, "requested_gpu=2")
+		assert.Contains(t, err.Hint, "matching_devices=1")
 	})
 }
 

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -442,126 +442,11 @@ func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
 	})
 }
 
-func TestValidateEndpointAcceleratorVirtualizationCreateCapacitySkipsWhenClusterCannotBePrevalidated(t *testing.T) {
-	t.Run("skips when cluster storage is unavailable", func(t *testing.T) {
-		endpoint := endpointWithAcceleratorVirtualization("cluster-a", "team-a")
-
-		err := validateEndpointAcceleratorVirtualizationCreateCapacity(nil, endpoint)
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("skips when endpoint has no target cluster", func(t *testing.T) {
-		clusterStorage := &fakeClusterStorage{
-			listError: errors.New("unexpected lookup"),
-		}
-		endpoint := endpointWithAcceleratorVirtualization("", "team-a")
-
-		err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
-
-		assert.Nil(t, err)
-		assert.Equal(t, 0, clusterStorage.listCalls)
-	})
-
-	t.Run("skips when endpoint workspace is missing", func(t *testing.T) {
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
-		})
-		clusterStorage := &fakeClusterStorage{
-			clusters: []v1.Cluster{*cluster},
-		}
-		endpoint := endpointWithAcceleratorVirtualization("cluster-a", "")
-
-		err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
-
-		assert.Nil(t, err)
-		assert.Equal(t, 0, clusterStorage.listCalls)
-	})
-
-	t.Run("skips when cluster lookup fails", func(t *testing.T) {
-		clusterStorage := &fakeClusterStorage{
-			listError: errors.New("storage unavailable"),
-		}
-		endpoint := endpointWithAcceleratorVirtualization("cluster-a", "team-a")
-
-		err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
-
-		assert.Nil(t, err)
-		assert.Equal(t, 1, clusterStorage.listCalls)
-	})
-
-	t.Run("skips when cluster is not found", func(t *testing.T) {
-		clusterStorage := &fakeClusterStorage{}
-		endpoint := endpointWithAcceleratorVirtualization("cluster-a", "team-a")
-
-		err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
-
-		assert.Nil(t, err)
-		assert.Equal(t, 1, clusterStorage.listCalls)
-	})
-}
-
-func TestValidateEndpointAcceleratorVirtualizationCreateCapacityLooksUpClusterByNameAndWorkspace(t *testing.T) {
-	resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
-		v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-		v1.AcceleratorVirtualizationCorePercentKey: "50",
-	})
-	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-		healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
-	})
-	clusterStorage := &fakeClusterStorage{
-		clusters: []v1.Cluster{*cluster},
-	}
-	endpoint := &v1.Endpoint{
-		Metadata: &v1.Metadata{
-			Name:      "endpoint",
-			Workspace: "team-a",
-		},
-		Spec: &v1.EndpointSpec{
-			Cluster:   "cluster-a",
-			Resources: resources,
-		},
-	}
-
-	err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
-
-	assert.Nil(t, err)
-	assert.Equal(t, []storage.Filter{
-		{Column: "metadata->name", Operator: "eq", Value: `"cluster-a"`},
-		{Column: "metadata->workspace", Operator: "eq", Value: `"team-a"`},
-	}, clusterStorage.listOption.Filters)
-}
-
-func TestValidateEndpointAcceleratorVirtualizationMiddlewareSkipsCapacityLookupOnPatch(t *testing.T) {
-	clusterStorage := &fakeClusterStorage{
-		listError: errors.New("patch must not look up cluster capacity"),
-	}
-	body := `{
-		"metadata": {"name": "endpoint", "workspace": "team-a"},
-		"spec": {
-			"cluster": "cluster-a",
-			"resources": {
-				"gpu": "1",
-				"accelerator": {
-					"type": "nvidia_gpu",
-					"product": "Tesla-T4",
-					"virtualization.memory_mib": "4096",
-					"virtualization.core_percent": "50"
-				}
-			}
-		}
-	}`
-
-	recorder := runEndpointAcceleratorVirtualizationValidation(http.MethodPatch, body, clusterStorage)
-
-	assert.Equal(t, http.StatusNoContent, recorder.Code)
-	assert.Equal(t, 0, clusterStorage.listCalls)
-}
-
 func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsUnsatisfiablePost(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
 	})
+	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
 	clusterStorage := &fakeClusterStorage{
 		clusters: []v1.Cluster{*cluster},
 	}
@@ -590,6 +475,288 @@ func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsUnsatisfiable
 	assert.False(t, handlerCalled)
 }
 
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsNoGPUClusterPost(t *testing.T) {
+	cluster := clusterWithoutNVIDIAGPUProducts()
+	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPost, body, clusterStorage)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10220", response.Code)
+	assert.Contains(t, response.Hint, "product=Tesla-T4 has no available")
+	assert.False(t, handlerCalled)
+}
+
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareReturnsServiceUnavailableOnClusterLookupError(t *testing.T) {
+	clusterStorage := &fakeClusterStorage{
+		listError: errors.New("database is down"),
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPost, body, clusterStorage)
+
+	var response validationError
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10221", response.Code)
+	assert.Contains(t, response.Hint, "failed to look up cluster")
+	assert.NotContains(t, response.Hint, "database is down")
+	assert.False(t, handlerCalled)
+}
+
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsNotReadyPost(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+	})
+	markClusterAcceleratorVirtualizationNotReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPost, body, clusterStorage)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10222", response.Code)
+	assert.Contains(t, response.Hint, "not ready")
+	assert.False(t, handlerCalled)
+}
+
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareRejectsPatchWithoutEndpointFilters(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
+	})
+	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithHandler(http.MethodPatch, body, clusterStorage)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10221", response.Code)
+	assert.Contains(t, response.Hint, "endpoint lookup filters")
+	assert.False(t, handlerCalled)
+}
+
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareResolvesEndpointAndRejectsUnsatisfiablePatch(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
+	})
+	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+		endpoints: []v1.Endpoint{
+			*endpointWithAcceleratorVirtualization("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10220", response.Code)
+	assert.Equal(t, 1, clusterStorage.endpointListCalls)
+	assert.False(t, handlerCalled)
+}
+
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareAddsBackCurrentPatchAllocation(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 0, 0),
+	})
+	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	endpoint := endpointWithAcceleratorVirtualization("cluster-a", "team-a")
+	endpoint.Status = &v1.EndpointStatus{
+		Resources: &v1.EndpointResourceStatus{
+			Replicas: []v1.ReplicaDeviceAllocation{
+				{
+					NodeID: "node-0",
+					Devices: []v1.DeviceAllocation{
+						{
+							UUID:      "gpu-0",
+							Product:   "Tesla-T4",
+							MemoryMiB: 4096,
+							CoreUnits: 50,
+							NodeID:    "node-0",
+						},
+					},
+				},
+			},
+		},
+	}
+	clusterStorage := &fakeClusterStorage{
+		clusters:  []v1.Cluster{*cluster},
+		endpoints: []v1.Endpoint{*endpoint},
+	}
+	body := `{
+		"spec": {
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, 1, clusterStorage.endpointListCalls)
+	assert.True(t, handlerCalled)
+}
+
+func TestValidateEndpointAcceleratorVirtualizationMiddlewareDoesNotAddBackAllocationWhenPatchMovesCluster(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 0, 0),
+	})
+	markClusterAcceleratorVirtualizationReady(cluster, "cluster-a", "team-a")
+	endpoint := endpointWithAcceleratorVirtualization("old-cluster", "team-a")
+	endpoint.Status = &v1.EndpointStatus{
+		Resources: &v1.EndpointResourceStatus{
+			Replicas: []v1.ReplicaDeviceAllocation{
+				{
+					NodeID: "node-0",
+					Devices: []v1.DeviceAllocation{
+						{
+							UUID:      "gpu-0",
+							Product:   "Tesla-T4",
+							MemoryMiB: 4096,
+							CoreUnits: 50,
+							NodeID:    "node-0",
+						},
+					},
+				},
+			},
+		},
+	}
+	clusterStorage := &fakeClusterStorage{
+		clusters:  []v1.Cluster{*cluster},
+		endpoints: []v1.Endpoint{*endpoint},
+	}
+	body := `{
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointAcceleratorVirtualizationValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10220", response.Code)
+	assert.False(t, handlerCalled)
+}
+
 func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1.Endpoint {
 	return &v1.Endpoint{
 		Metadata: &v1.Metadata{
@@ -606,16 +773,34 @@ func endpointWithAcceleratorVirtualization(cluster string, workspace string) *v1
 	}
 }
 
-func runEndpointAcceleratorVirtualizationValidation(method string, body string, clusterStorage storage.ClusterStorage) *httptest.ResponseRecorder {
+func runEndpointAcceleratorVirtualizationValidation(method string, body string, clusterStorage endpointAcceleratorVirtualizationStorage) *httptest.ResponseRecorder {
 	recorder, _ := runEndpointAcceleratorVirtualizationValidationWithHandler(method, body, clusterStorage)
 
 	return recorder
 }
 
+func runEndpointAcceleratorVirtualizationValidationWithPath(
+	method string,
+	path string,
+	body string,
+	clusterStorage endpointAcceleratorVirtualizationStorage,
+) (*httptest.ResponseRecorder, bool) {
+	return runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(method, path, body, clusterStorage)
+}
+
 func runEndpointAcceleratorVirtualizationValidationWithHandler(
 	method string,
 	body string,
-	clusterStorage storage.ClusterStorage,
+	clusterStorage endpointAcceleratorVirtualizationStorage,
+) (*httptest.ResponseRecorder, bool) {
+	return runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(method, "/endpoints", body, clusterStorage)
+}
+
+func runEndpointAcceleratorVirtualizationValidationWithHandlerAndPath(
+	method string,
+	path string,
+	body string,
+	clusterStorage endpointAcceleratorVirtualizationStorage,
 ) (*httptest.ResponseRecorder, bool) {
 	gin.SetMode(gin.TestMode)
 
@@ -627,7 +812,7 @@ func runEndpointAcceleratorVirtualizationValidationWithHandler(
 	})
 
 	recorder := httptest.NewRecorder()
-	request := httptest.NewRequest(method, "/endpoints", strings.NewReader(body))
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
 	request.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(recorder, request)
 
@@ -689,6 +874,52 @@ func clusterWithNVIDIAGPUProduct(product string, productMemoryMiB float64, devic
 	}
 }
 
+func clusterWithoutNVIDIAGPUProducts() *v1.Cluster {
+	return &v1.Cluster{
+		Status: &v1.ClusterStatus{
+			ResourceInfo: &v1.ClusterResources{
+				ResourceStatus: v1.ResourceStatus{
+					Available: &v1.ResourceInfo{
+						AcceleratorGroups: map[v1.AcceleratorType]*v1.AcceleratorGroup{},
+					},
+				},
+				NodeResources: map[string]*v1.NodeResourceStatus{},
+			},
+		},
+	}
+}
+
+func markClusterAcceleratorVirtualizationReady(cluster *v1.Cluster, name string, workspace string) {
+	if cluster.Metadata == nil {
+		cluster.Metadata = &v1.Metadata{}
+	}
+	cluster.Metadata.Name = name
+	cluster.Metadata.Workspace = workspace
+	cluster.Spec = &v1.ClusterSpec{
+		Type: v1.KubernetesClusterType,
+		AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{
+			Enabled: true,
+		},
+	}
+	if cluster.Status == nil {
+		cluster.Status = &v1.ClusterStatus{}
+	}
+	cluster.Status.ComponentStatus = map[string]*v1.ComponentStatus{
+		v1.ComponentStatusAcceleratorVirtualizationKey: {
+			Phase: v1.ComponentPhaseReady,
+		},
+	}
+}
+
+func markClusterAcceleratorVirtualizationNotReady(cluster *v1.Cluster, name string, workspace string) {
+	markClusterAcceleratorVirtualizationReady(cluster, name, workspace)
+	cluster.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey] = &v1.ComponentStatus{
+		Phase:   v1.ComponentPhaseNotReady,
+		Reason:  "HAMiNotReady",
+		Message: "HAMi device plugin is not ready",
+	}
+}
+
 func healthyDevice(uuid string, product string, memoryMiB int64, coreUnits int64) *v1.DeviceResource {
 	return &v1.DeviceResource{
 		UUID:    uuid,
@@ -709,10 +940,14 @@ func unhealthyDevice(uuid string, product string, memoryMiB int64, coreUnits int
 }
 
 type fakeClusterStorage struct {
-	clusters   []v1.Cluster
-	listCalls  int
-	listError  error
-	listOption storage.ListOption
+	clusters           []v1.Cluster
+	endpoints          []v1.Endpoint
+	listCalls          int
+	endpointListCalls  int
+	listError          error
+	endpointListError  error
+	listOption         storage.ListOption
+	endpointListOption storage.ListOption
 }
 
 func (s *fakeClusterStorage) CreateCluster(data *v1.Cluster) error {
@@ -740,4 +975,31 @@ func (s *fakeClusterStorage) ListCluster(option storage.ListOption) ([]v1.Cluste
 	}
 
 	return s.clusters, nil
+}
+
+func (s *fakeClusterStorage) CreateEndpoint(data *v1.Endpoint) error {
+	return nil
+}
+
+func (s *fakeClusterStorage) DeleteEndpoint(id string) error {
+	return nil
+}
+
+func (s *fakeClusterStorage) UpdateEndpoint(id string, data *v1.Endpoint) error {
+	return nil
+}
+
+func (s *fakeClusterStorage) GetEndpoint(id string) (*v1.Endpoint, error) {
+	return nil, nil
+}
+
+func (s *fakeClusterStorage) ListEndpoint(option storage.ListOption) ([]v1.Endpoint, error) {
+	s.endpointListCalls++
+	s.endpointListOption = option
+
+	if s.endpointListError != nil {
+		return nil, s.endpointListError
+	}
+
+	return s.endpoints, nil
 }

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -583,6 +583,76 @@ func TestEndpointVGPUValidationResolvesEndpointAndRejectsUnsatisfiablePatch(t *t
 	assert.False(t, handlerCalled)
 }
 
+func TestEndpointVGPUValidationRejectsMergedPatchWhenOnlyGPUChanges(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 4096, 50),
+	})
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+		endpoints: []v1.Endpoint{
+			*endpointWithVGPU("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"resources": {
+				"gpu": "2"
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10220", response.Code)
+	assert.Equal(t, 1, clusterStorage.endpointListCalls)
+	assert.False(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationRejectsMergedPatchWhenOnlyProductChanges(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 4096, 50),
+	})
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+		endpoints: []v1.Endpoint{
+			*endpointWithVGPU("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"resources": {
+				"accelerator": {
+					"product": "L4"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10220", response.Code)
+	assert.Equal(t, 1, clusterStorage.endpointListCalls)
+	assert.False(t, handlerCalled)
+}
+
 func TestEndpointVGPUValidationAddsBackCurrentPatchAllocation(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 0, 0),

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -15,100 +15,61 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
+func TestValidateEndpointAcceleratorVirtualizationResourceShape(t *testing.T) {
 	t.Run("allows non vGPU endpoint resources", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "endpoint", "workspace": "default"},
-			"spec": {
-				"cluster": "cluster",
-				"resources": {
-					"gpu": "1",
-					"accelerator": {
-						"type": "nvidia_gpu",
-						"product": "Tesla-T4"
-					}
-				}
-			}
-		}`))
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", nil)
+
+		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("allows raw accelerator keys without virtualization fields", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "endpoint", "workspace": "default"},
-			"spec": {
-				"cluster": "cluster",
-				"resources": {
-					"gpu": "1",
-					"accelerator": {
-						"type": "nvidia_gpu",
-						"product": "Tesla-T4",
-						"nvidia.com/gpucores": "50"
-					}
-				}
-			}
-		}`))
+		gpu := "1"
+		resources := &v1.ResourceSpec{
+			GPU: &gpu,
+			Accelerator: map[string]string{
+				v1.AcceleratorTypeKey:    string(v1.AcceleratorTypeNVIDIAGPU),
+				v1.AcceleratorProductKey: "Tesla-T4",
+				"nvidia.com/gpucores":    "50",
+			},
+		}
+
+		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("rejects vGPU endpoint without product", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "endpoint", "workspace": "default"},
-			"spec": {
-				"cluster": "cluster",
-				"resources": {
-					"gpu": "1",
-					"accelerator": {
-						"type": "nvidia_gpu",
-						"virtualization.memory_mib": "8192"
-					}
-				}
-			}
-		}`))
+		resources := acceleratorVirtualizationResources("1", "", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey: "8192",
+		})
+
+		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10218", err.Code)
 	})
 
 	t.Run("rejects mutually exclusive memory fields", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "endpoint", "workspace": "default"},
-			"spec": {
-				"cluster": "cluster",
-				"resources": {
-					"gpu": "1",
-					"accelerator": {
-						"type": "nvidia_gpu",
-						"product": "Tesla-T4",
-						"virtualization.memory_mib": "8192",
-						"virtualization.memory_percent": "50"
-					}
-				}
-			}
-		}`))
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:     "8192",
+			v1.AcceleratorVirtualizationMemoryPercentKey: "50",
+		})
+
+		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10219", err.Code)
 	})
 
 	t.Run("rejects invalid vGPU numeric resources", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "endpoint", "workspace": "default"},
-			"spec": {
-				"cluster": "cluster",
-				"resources": {
-					"gpu": "1",
-					"accelerator": {
-						"type": "nvidia_gpu",
-						"product": "Tesla-T4",
-						"virtualization.memory_mib": "8192",
-						"virtualization.core_percent": "101"
-					}
-				}
-			}
-		}`))
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192",
+			v1.AcceleratorVirtualizationCorePercentKey: "101",
+		})
+
+		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10216", err.Code)
@@ -116,21 +77,12 @@ func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
 	})
 
 	t.Run("rejects fractional vGPU memory resource", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "endpoint", "workspace": "default"},
-			"spec": {
-				"cluster": "cluster",
-				"resources": {
-					"gpu": "1",
-					"accelerator": {
-						"type": "nvidia_gpu",
-						"product": "Tesla-T4",
-						"virtualization.memory_mib": "8192.5",
-						"virtualization.core_percent": "50"
-					}
-				}
-			}
-		}`))
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192.5",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+
+		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10216", err.Code)
@@ -139,21 +91,12 @@ func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
 	})
 
 	t.Run("rejects fractional vGPU core resource", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "endpoint", "workspace": "default"},
-			"spec": {
-				"cluster": "cluster",
-				"resources": {
-					"gpu": "1",
-					"accelerator": {
-						"type": "nvidia_gpu",
-						"product": "Tesla-T4",
-						"virtualization.memory_mib": "8192",
-						"virtualization.core_percent": "50.5"
-					}
-				}
-			}
-		}`))
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192",
+			v1.AcceleratorVirtualizationCorePercentKey: "50.5",
+		})
+
+		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10216", err.Code)
@@ -162,33 +105,26 @@ func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
 	})
 
 	t.Run("allows vGPU endpoint resource shape without cluster availability lookup", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "endpoint", "workspace": "default"},
-			"spec": {
-				"cluster": "cluster",
-				"resources": {
-					"gpu": "1",
-					"accelerator": {
-						"type": "nvidia_gpu",
-						"product": "Tesla-T4",
-						"virtualization.memory_mib": "8192",
-						"virtualization.core_percent": "50"
-					}
-				}
-			}
-		}`))
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+
+		err := validateEndpointAcceleratorVirtualizationResourceShape(resources)
 
 		assert.Nil(t, err)
 	})
 
 	t.Run("skips patch that does not touch resources", func(t *testing.T) {
-		err := validateEndpointAcceleratorVirtualizationBody([]byte(`{
+		endpoint, err := parseEndpointAcceleratorVirtualizationBody([]byte(`{
 			"spec": {
 				"replicas": {"num": 2}
 			}
 		}`))
 
 		assert.Nil(t, err)
+		assert.NotNil(t, endpoint)
+		assert.Nil(t, validateEndpointAcceleratorVirtualizationPreflight(nil, http.MethodPatch, nil, endpoint))
 	})
 }
 

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -3,6 +3,8 @@ package proxies
 import (
 	"testing"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -181,4 +183,234 @@ func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
 
 		assert.Nil(t, err)
 	})
+}
+
+func TestValidateEndpointAcceleratorVirtualizationCapacity(t *testing.T) {
+	t.Run("rejects request that exceeds per device memory availability", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "8193",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10220", err.Code)
+		assert.Contains(t, err.Hint, "Tesla-T4")
+		assert.Contains(t, err.Hint, "satisfiable")
+	})
+
+	t.Run("rejects product absent from cluster resource info", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Missing-GPU", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10220", err.Code)
+		assert.Contains(t, err.Hint, "Missing-GPU")
+	})
+
+	t.Run("rejects fragmented capacity that cannot satisfy each requested virtual card", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "8193",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 32768, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+			healthyDevice("gpu-1", "Tesla-T4", 8192, 100),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10220", err.Code)
+		assert.Contains(t, err.Hint, "requested_gpu=2")
+	})
+
+	t.Run("ignores unhealthy matching devices", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 32768, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+			unhealthyDevice("gpu-1", "Tesla-T4", 8192, 100),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10220", err.Code)
+		assert.Contains(t, err.Hint, "satisfiable_devices=1")
+	})
+
+	t.Run("allows request when enough healthy matching devices fit", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("2", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 8192, 50),
+			healthyDevice("gpu-1", "Tesla-T4", 8192, 50),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("derives memory from memory percent using product metadata", func(t *testing.T) {
+		resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
+			v1.AcceleratorVirtualizationCorePercentKey:   "50",
+		})
+		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 10001, []*v1.DeviceResource{
+			healthyDevice("gpu-0", "Tesla-T4", 5101, 100),
+		})
+
+		err := validateEndpointAcceleratorVirtualizationCapacity(resources, cluster)
+
+		assert.Nil(t, err)
+	})
+}
+
+func TestValidateEndpointAcceleratorVirtualizationCreateCapacityLooksUpClusterByNameAndWorkspace(t *testing.T) {
+	resources := acceleratorVirtualizationResources("1", "Tesla-T4", map[string]string{
+		v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
+		v1.AcceleratorVirtualizationCorePercentKey: "50",
+	})
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+	})
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+	}
+	endpoint := &v1.Endpoint{
+		Metadata: &v1.Metadata{
+			Name:      "endpoint",
+			Workspace: "team-a",
+		},
+		Spec: &v1.EndpointSpec{
+			Cluster:   "cluster-a",
+			Resources: resources,
+		},
+	}
+
+	err := validateEndpointAcceleratorVirtualizationCreateCapacity(clusterStorage, endpoint)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []storage.Filter{
+		{Column: "metadata->name", Operator: "eq", Value: `"cluster-a"`},
+		{Column: "metadata->workspace", Operator: "eq", Value: `"team-a"`},
+	}, clusterStorage.listOption.Filters)
+}
+
+func acceleratorVirtualizationResources(gpu string, product string, virtualization map[string]string) *v1.ResourceSpec {
+	accelerator := map[string]string{
+		v1.AcceleratorTypeKey:    string(v1.AcceleratorTypeNVIDIAGPU),
+		v1.AcceleratorProductKey: product,
+	}
+	for key, value := range virtualization {
+		accelerator[key] = value
+	}
+
+	return &v1.ResourceSpec{
+		GPU:         &gpu,
+		Accelerator: accelerator,
+	}
+}
+
+func clusterWithNVIDIAGPUProduct(product string, productMemoryMiB float64, devices []*v1.DeviceResource) *v1.Cluster {
+	return &v1.Cluster{
+		Status: &v1.ClusterStatus{
+			ResourceInfo: &v1.ClusterResources{
+				ResourceStatus: v1.ResourceStatus{
+					Available: &v1.ResourceInfo{
+						AcceleratorGroups: map[v1.AcceleratorType]*v1.AcceleratorGroup{
+							v1.AcceleratorTypeNVIDIAGPU: {
+								Products: map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{
+									v1.AcceleratorProduct(product): {
+										Quantity: 1,
+										Virtualization: &v1.AcceleratorVirtualizationResource{
+											MemoryMiB: productMemoryMiB,
+											CoreUnits: 100,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				AcceleratorMetadata: map[v1.AcceleratorType]*v1.AcceleratorMetadata{
+					v1.AcceleratorTypeNVIDIAGPU: {
+						Products: map[v1.AcceleratorProduct]*v1.AcceleratorProductMetadata{
+							v1.AcceleratorProduct(product): {
+								MemoryTotalMiB: productMemoryMiB,
+							},
+						},
+					},
+				},
+				NodeResources: map[string]*v1.NodeResourceStatus{
+					"node-0": {
+						Devices: devices,
+					},
+				},
+			},
+		},
+	}
+}
+
+func healthyDevice(uuid string, product string, memoryMiB int64, coreUnits int64) *v1.DeviceResource {
+	return &v1.DeviceResource{
+		UUID:    uuid,
+		Product: product,
+		Health:  true,
+		Available: &v1.DeviceResourcePool{
+			MemoryMiB: memoryMiB,
+			CoreUnits: coreUnits,
+		},
+	}
+}
+
+func unhealthyDevice(uuid string, product string, memoryMiB int64, coreUnits int64) *v1.DeviceResource {
+	device := healthyDevice(uuid, product, memoryMiB, coreUnits)
+	device.Health = false
+
+	return device
+}
+
+type fakeClusterStorage struct {
+	clusters   []v1.Cluster
+	listOption storage.ListOption
+}
+
+func (s *fakeClusterStorage) CreateCluster(data *v1.Cluster) error {
+	return nil
+}
+
+func (s *fakeClusterStorage) DeleteCluster(id string) error {
+	return nil
+}
+
+func (s *fakeClusterStorage) UpdateCluster(id string, data *v1.Cluster) error {
+	return nil
+}
+
+func (s *fakeClusterStorage) GetCluster(id string) (*v1.Cluster, error) {
+	return nil, nil
+}
+
+func (s *fakeClusterStorage) ListCluster(option storage.ListOption) ([]v1.Cluster, error) {
+	s.listOption = option
+
+	return s.clusters, nil
 }

--- a/internal/routes/proxies/validation_error.go
+++ b/internal/routes/proxies/validation_error.go
@@ -1,7 +1,8 @@
 package proxies
 
 type validationError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Hint    string `json:"hint"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	Hint       string `json:"hint"`
+	HTTPStatus int    `json:"-"`
 }

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -370,7 +370,7 @@ func listEndpointsByName(endpointName string) ([]v1.Endpoint, []byte, int) {
 	query.Set("metadata->>name", "eq."+endpointName)
 	query.Set("metadata->>workspace", "eq."+profileWorkspace())
 
-	body, code := callNeutreeAPI(http.MethodGet, "/api/v1/endpoints?"+query.Encode())
+	body, code := callNeutreeAPIWithBody(http.MethodGet, "/api/v1/endpoints?"+query.Encode(), nil)
 	if code != http.StatusOK {
 		return nil, body, code
 	}

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -1,12 +1,8 @@
 package e2e
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
-	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -85,58 +81,6 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 			Expect(component.Version).NotTo(BeEmpty())
 
 			productName = expectNVIDIAVirtualizedClusterResources(cluster)
-		})
-
-		// TestRail: C2722839
-		It("should reject a vGPU endpoint when requested memory exceeds per-device availability", Label("C2722839", "negative"), func() {
-			var maxAvailableMemoryMiB int64
-			productName, maxAvailableMemoryMiB = eventuallyHealthyProductAvailableMemoryMiB(clusterName, productName)
-			requestedMemoryMiB := maxAvailableMemoryMiB + 1
-			endpointName := "e2e-vgpu-overmem-" + Cfg.RunID
-			DeferCleanup(func() {
-				endpoints, _, code := listEndpointsByName(endpointName)
-				if code == http.StatusOK && len(endpoints) > 0 {
-					deleteEndpoint(endpointName)
-				}
-			})
-
-			payload := map[string]any{
-				"metadata": map[string]any{
-					"name":      endpointName,
-					"workspace": profileWorkspace(),
-				},
-				"spec": map[string]any{
-					"cluster": clusterName,
-					"resources": map[string]any{
-						"gpu": "1",
-						"accelerator": map[string]any{
-							v1.AcceleratorTypeKey:                      string(v1.AcceleratorTypeNVIDIAGPU),
-							v1.AcceleratorProductKey:                   productName,
-							v1.AcceleratorVirtualizationMemoryMiBKey:   strconv.FormatInt(requestedMemoryMiB, 10),
-							v1.AcceleratorVirtualizationCorePercentKey: vgpuEndpointCorePercent,
-						},
-					},
-				},
-			}
-
-			By("Posting an over-capacity vGPU endpoint")
-			body, code := callNeutreeAPIWithJSON(http.MethodPost, "/api/v1/endpoints", payload)
-			Expect(code).To(Equal(http.StatusBadRequest), "POST response: %s", string(body))
-
-			var response struct {
-				Code    string `json:"code"`
-				Message string `json:"message"`
-				Hint    string `json:"hint"`
-			}
-			Expect(json.Unmarshal(body, &response)).To(Succeed(), "POST response: %s", string(body))
-			Expect(response.Code).To(Equal("10220"))
-			Expect(response.Message).To(Equal("endpoint accelerator virtualization resources exceed cluster availability"))
-			Expect(response.Hint).To(ContainSubstring(productName))
-
-			By("Confirming the rejected endpoint was not persisted")
-			endpoints, listBody, listCode := listEndpointsByName(endpointName)
-			Expect(listCode).To(Equal(http.StatusOK), "GET endpoint response: %s", string(listBody))
-			Expect(endpoints).To(BeEmpty())
 		})
 
 		It("should deploy a vGPU endpoint and expose endpoint resource allocation", func() {
@@ -333,94 +277,6 @@ func expectClusterProductDevices(nodes map[string]*v1.NodeResourceStatus, produc
 	ExpectWithOffset(1, count).To(BeNumerically(">", 0))
 
 	return count
-}
-
-func eventuallyHealthyProductAvailableMemoryMiB(clusterName string, preferredProduct string) (string, int64) {
-	var (
-		productName  string
-		maxMemoryMiB int64
-	)
-
-	Eventually(func(g Gomega) {
-		cluster := getClusterFullJSON(clusterName)
-
-		g.Expect(cluster.Status).NotTo(BeNil())
-		g.Expect(cluster.Status.ResourceInfo).NotTo(BeNil())
-
-		resources := cluster.Status.ResourceInfo
-		productName = preferredProduct
-		if productName == "" {
-			g.Expect(resources.Allocatable).NotTo(BeNil())
-
-			group := resources.Allocatable.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
-			g.Expect(group).NotTo(BeNil())
-
-			selectedProduct, productResource := firstVirtualizedProduct(group)
-			g.Expect(selectedProduct).NotTo(BeEmpty())
-			g.Expect(productResource).NotTo(BeNil())
-			g.Expect(productResource.Virtualization.MemoryMiB).To(BeNumerically(">", 0))
-			g.Expect(productResource.Virtualization.CoreUnits).To(BeNumerically(">", 0))
-			productName = selectedProduct
-		}
-
-		maxMemoryMiB = maxHealthyProductAvailableMemoryMiB(
-			resources.NodeResources,
-			productName,
-			vgpuEndpointCorePercentValue,
-		)
-		g.Expect(maxMemoryMiB).To(BeNumerically(">", 0),
-			"product %s should have healthy available devices with vGPU telemetry", productName)
-	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
-
-	return productName, maxMemoryMiB
-}
-
-func maxHealthyProductAvailableMemoryMiB(
-	nodes map[string]*v1.NodeResourceStatus,
-	productName string,
-	minCoreUnits int64,
-) int64 {
-	var maxMemoryMiB int64
-
-	for _, node := range nodes {
-		if node == nil {
-			continue
-		}
-
-		for _, device := range node.Devices {
-			if device == nil || !device.Health || device.Product != productName || device.Available == nil {
-				continue
-			}
-
-			if device.Available.CoreUnits < minCoreUnits {
-				continue
-			}
-
-			if device.Available.MemoryMiB > maxMemoryMiB {
-				maxMemoryMiB = device.Available.MemoryMiB
-			}
-		}
-	}
-
-	return maxMemoryMiB
-}
-
-func listEndpointsByName(endpointName string) ([]v1.Endpoint, []byte, int) {
-	GinkgoHelper()
-
-	query := url.Values{}
-	query.Set("metadata->>name", "eq."+endpointName)
-	query.Set("metadata->>workspace", "eq."+profileWorkspace())
-
-	body, code := callNeutreeAPIWithBody(http.MethodGet, "/api/v1/endpoints?"+query.Encode(), nil)
-	if code != http.StatusOK {
-		return nil, body, code
-	}
-
-	var endpoints []v1.Endpoint
-	ExpectWithOffset(1, json.Unmarshal(body, &endpoints)).To(Succeed(), "GET endpoint response: %s", string(body))
-
-	return endpoints, body, code
 }
 
 func expectNVIDIAProductMemoryMiB(cluster v1.Cluster, productName string) int64 {

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -89,12 +89,9 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 
 		// TestRail: C2722839
 		It("should reject a vGPU endpoint when requested memory exceeds per-device availability", Label("C2722839", "negative"), func() {
-			cluster := eventuallyVirtualizedClusterResourceInfo(clusterName)
-			if productName == "" {
-				productName = expectNVIDIAVirtualizedClusterResources(cluster)
-			}
-
-			requestedMemoryMiB := maxHealthyProductAvailableMemoryMiB(cluster, productName) + 1
+			var maxAvailableMemoryMiB int64
+			productName, maxAvailableMemoryMiB = eventuallyHealthyProductAvailableMemoryMiB(clusterName, productName)
+			requestedMemoryMiB := maxAvailableMemoryMiB + 1
 			endpointName := "e2e-vgpu-overmem-" + Cfg.RunID
 			DeferCleanup(func() {
 				endpoints, _, code := listEndpointsByName(endpointName)
@@ -338,27 +335,72 @@ func expectClusterProductDevices(nodes map[string]*v1.NodeResourceStatus, produc
 	return count
 }
 
-func maxHealthyProductAvailableMemoryMiB(cluster v1.Cluster, productName string) int64 {
-	ExpectWithOffset(1, cluster.Status).NotTo(BeNil())
-	ExpectWithOffset(1, cluster.Status.ResourceInfo).NotTo(BeNil())
+func eventuallyHealthyProductAvailableMemoryMiB(clusterName string, preferredProduct string) (string, int64) {
+	var (
+		productName  string
+		maxMemoryMiB int64
+	)
 
+	Eventually(func(g Gomega) {
+		cluster := getClusterFullJSON(clusterName)
+
+		g.Expect(cluster.Status).NotTo(BeNil())
+		g.Expect(cluster.Status.ResourceInfo).NotTo(BeNil())
+
+		resources := cluster.Status.ResourceInfo
+		productName = preferredProduct
+		if productName == "" {
+			g.Expect(resources.Allocatable).NotTo(BeNil())
+
+			group := resources.Allocatable.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
+			g.Expect(group).NotTo(BeNil())
+
+			selectedProduct, productResource := firstVirtualizedProduct(group)
+			g.Expect(selectedProduct).NotTo(BeEmpty())
+			g.Expect(productResource).NotTo(BeNil())
+			g.Expect(productResource.Virtualization.MemoryMiB).To(BeNumerically(">", 0))
+			g.Expect(productResource.Virtualization.CoreUnits).To(BeNumerically(">", 0))
+			productName = selectedProduct
+		}
+
+		maxMemoryMiB = maxHealthyProductAvailableMemoryMiB(
+			resources.NodeResources,
+			productName,
+			vgpuEndpointCorePercentValue,
+		)
+		g.Expect(maxMemoryMiB).To(BeNumerically(">", 0),
+			"product %s should have healthy available devices with vGPU telemetry", productName)
+	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
+
+	return productName, maxMemoryMiB
+}
+
+func maxHealthyProductAvailableMemoryMiB(
+	nodes map[string]*v1.NodeResourceStatus,
+	productName string,
+	minCoreUnits int64,
+) int64 {
 	var maxMemoryMiB int64
-	for nodeID, node := range cluster.Status.ResourceInfo.NodeResources {
-		ExpectWithOffset(1, node).NotTo(BeNil(), "node %s", nodeID)
+
+	for _, node := range nodes {
+		if node == nil {
+			continue
+		}
 
 		for _, device := range node.Devices {
-			if device == nil || !device.Health || device.Product != productName {
+			if device == nil || !device.Health || device.Product != productName || device.Available == nil {
 				continue
 			}
 
-			ExpectWithOffset(1, device.Available).NotTo(BeNil(), "node %s device %s", nodeID, device.UUID)
+			if device.Available.CoreUnits < minCoreUnits {
+				continue
+			}
+
 			if device.Available.MemoryMiB > maxMemoryMiB {
 				maxMemoryMiB = device.Available.MemoryMiB
 			}
 		}
 	}
-
-	ExpectWithOffset(1, maxMemoryMiB).To(BeNumerically(">", 0), "product %s should have healthy available devices", productName)
 
 	return maxMemoryMiB
 }

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -1,8 +1,12 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -81,6 +85,61 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 			Expect(component.Version).NotTo(BeEmpty())
 
 			productName = expectNVIDIAVirtualizedClusterResources(cluster)
+		})
+
+		// TestRail: C2722839
+		It("should reject a vGPU endpoint when requested memory exceeds per-device availability", Label("C2722839", "negative"), func() {
+			cluster := eventuallyVirtualizedClusterResourceInfo(clusterName)
+			if productName == "" {
+				productName = expectNVIDIAVirtualizedClusterResources(cluster)
+			}
+
+			requestedMemoryMiB := maxHealthyProductAvailableMemoryMiB(cluster, productName) + 1
+			endpointName := "e2e-vgpu-overmem-" + Cfg.RunID
+			DeferCleanup(func() {
+				endpoints, _, code := listEndpointsByName(endpointName)
+				if code == http.StatusOK && len(endpoints) > 0 {
+					deleteEndpoint(endpointName)
+				}
+			})
+
+			payload := map[string]any{
+				"metadata": map[string]any{
+					"name":      endpointName,
+					"workspace": profileWorkspace(),
+				},
+				"spec": map[string]any{
+					"cluster": clusterName,
+					"resources": map[string]any{
+						"gpu": "1",
+						"accelerator": map[string]any{
+							v1.AcceleratorTypeKey:                      string(v1.AcceleratorTypeNVIDIAGPU),
+							v1.AcceleratorProductKey:                   productName,
+							v1.AcceleratorVirtualizationMemoryMiBKey:   strconv.FormatInt(requestedMemoryMiB, 10),
+							v1.AcceleratorVirtualizationCorePercentKey: vgpuEndpointCorePercent,
+						},
+					},
+				},
+			}
+
+			By("Posting an over-capacity vGPU endpoint")
+			body, code := callNeutreeAPIWithJSON(http.MethodPost, "/api/v1/endpoints", payload)
+			Expect(code).To(Equal(http.StatusBadRequest), "POST response: %s", string(body))
+
+			var response struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+				Hint    string `json:"hint"`
+			}
+			Expect(json.Unmarshal(body, &response)).To(Succeed(), "POST response: %s", string(body))
+			Expect(response.Code).To(Equal("10220"))
+			Expect(response.Message).To(Equal("endpoint accelerator virtualization resources exceed cluster availability"))
+			Expect(response.Hint).To(ContainSubstring(productName))
+
+			By("Confirming the rejected endpoint was not persisted")
+			endpoints, listBody, listCode := listEndpointsByName(endpointName)
+			Expect(listCode).To(Equal(http.StatusOK), "GET endpoint response: %s", string(listBody))
+			Expect(endpoints).To(BeEmpty())
 		})
 
 		It("should deploy a vGPU endpoint and expose endpoint resource allocation", func() {
@@ -277,6 +336,49 @@ func expectClusterProductDevices(nodes map[string]*v1.NodeResourceStatus, produc
 	ExpectWithOffset(1, count).To(BeNumerically(">", 0))
 
 	return count
+}
+
+func maxHealthyProductAvailableMemoryMiB(cluster v1.Cluster, productName string) int64 {
+	ExpectWithOffset(1, cluster.Status).NotTo(BeNil())
+	ExpectWithOffset(1, cluster.Status.ResourceInfo).NotTo(BeNil())
+
+	var maxMemoryMiB int64
+	for nodeID, node := range cluster.Status.ResourceInfo.NodeResources {
+		ExpectWithOffset(1, node).NotTo(BeNil(), "node %s", nodeID)
+
+		for _, device := range node.Devices {
+			if device == nil || !device.Health || device.Product != productName {
+				continue
+			}
+
+			ExpectWithOffset(1, device.Available).NotTo(BeNil(), "node %s device %s", nodeID, device.UUID)
+			if device.Available.MemoryMiB > maxMemoryMiB {
+				maxMemoryMiB = device.Available.MemoryMiB
+			}
+		}
+	}
+
+	ExpectWithOffset(1, maxMemoryMiB).To(BeNumerically(">", 0), "product %s should have healthy available devices", productName)
+
+	return maxMemoryMiB
+}
+
+func listEndpointsByName(endpointName string) ([]v1.Endpoint, []byte, int) {
+	GinkgoHelper()
+
+	query := url.Values{}
+	query.Set("metadata->>name", "eq."+endpointName)
+	query.Set("metadata->>workspace", "eq."+profileWorkspace())
+
+	body, code := callNeutreeAPI(http.MethodGet, "/api/v1/endpoints?"+query.Encode())
+	if code != http.StatusOK {
+		return nil, body, code
+	}
+
+	var endpoints []v1.Endpoint
+	ExpectWithOffset(1, json.Unmarshal(body, &endpoints)).To(Succeed(), "GET endpoint response: %s", string(body))
+
+	return endpoints, body, code
 }
 
 func expectNVIDIAProductMemoryMiB(cluster v1.Cluster, productName string) int64 {


### PR DESCRIPTION
## Issue

NEU-467, NEU-469, NEU-476

## Summary

Unify Endpoint vGPU write-time validation so create and vGPU resource update requests are rejected before persistence when the target cluster is not vGPU-ready, has no NVIDIA vGPU capacity, or cannot satisfy the requested product/device/memory/core requirements.

## Changes

- Runs the vGPU validation middleware for Endpoint POST and PATCH requests that include or directly modify endpoint resources.
- Resolves PATCH targets from existing Endpoint records, merges partial resource updates over the current Endpoint, and validates the merged request when it remains a vGPU Endpoint.
- Keeps the current scope limited to resource writes; workspace-only or cluster-only Endpoint PATCH is not expanded here because those modifications are currently unsupported.
- Checks target cluster lookup, accelerator virtualization readiness, and Kubernetes cluster type before capacity validation.
- Adds old-allocation add-back for same-target PATCH capacity checks.
- Treats ready clusters with no NVIDIA GPU product capacity as unsatisfiable instead of allowing the request through.
- Skips capacity rejection when matching device availability telemetry is incomplete, after target/product readiness has been checked.
- Keeps target lookup minimal by using merged Endpoint cluster/workspace directly instead of separate vGPU target/workspace helpers.
- Returns stable validation JSON with 400 for target/readiness/capacity failures and 503 for storage lookup failures.
- Adds focused unit coverage for POST capacity, no-GPU/not-ready readiness, PATCH target merge, resource-only PATCH merge, PATCH capacity, PATCH allocation add-back, incomplete device telemetry, and sanitized lookup errors.

## Test Plan

### Unit test

- [x] `git diff --check`
- [x] `go test ./internal/routes/proxies -run 'TestValidateEndpointVGPUCapacity' -count=1 -v`
- [x] `go test ./internal/routes/proxies -run 'TestEndpointVGPUValidationRejectsMergedPatchWhenOnly(GPU|Product)Changes' -count=1 -v`
- [x] `go test ./internal/routes/proxies -run 'TestValidateEndpointVGPU|TestEndpointVGPUValidation' -count=1`
- [x] `go test ./internal/routes/proxies -count=1`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v '^github.com/neutree-ai/neutree/db/dbtest$') -count=1`
- [x] `./bin/golangci-lint run ./internal/routes/proxies/...`
- [x] `./bin/golangci-lint run`

### DB test

- [x] Not affected: no DB schema, migration, RLS, or storage-layer contract changes.
- [ ] `go test ./... -count=1` reaches only `db/dbtest` failures locally because PostgreSQL is not running on `127.0.0.1:5432`; all non-DB packages pass in the command above.

### E2E test

- [x] `go build ./tests/e2e/...`
- [x] Deployed runtime for behavioral validation: CP `10.255.1.136`, lease `fix-NEU-467-step5-cp136-202606241333`, `/api/v1/system/info` returned `v1.1.0-nightly-20260624-9-g9af6284`, matching behavioral head `9af6284c8159a2b236eaa29ca91a200011d933be`. Latest head `7ec5c4f1d76855d1700eb2f9c33b14455cd1e47e` contains validation-structure refactors, reviewer follow-ups for resource-only PATCH merge validation, incomplete device telemetry ordering, minimal target/workspace lookup, and removal of the temporary negative code E2E so the current code-backed E2E scope remains happy path only. These later changes are covered by unit tests and E2E package build; they were not redeployed.
- [x] Code-backed HAMi/vGPU happy-path regression on CP `10.255.1.136`: `make e2e-test LABEL_FILTER='cluster && endpoint && k8s && accelerator-virtualization && hami' E2E_TIMEOUT=60m` passed before the temporary negative code E2E was removed. Current head keeps the existing three happy-path specs in `tests/e2e/accelerator_virtualization_test.go` and has no negative validation code E2E.
- [x] Manual negative validation NEU-467 / C2722839: POST over-memory vGPU Endpoint on `Tesla-T4` with `virtualization.memory_mib=15361` returned HTTP 400, code `10220`, and persisted Endpoint count `0`.
- [x] Manual negative validation NEU-476 / C2723124: POST vGPU Endpoint to an accelerator-virtualization-disabled K8s cluster returned HTTP 400, code `10222`, and persisted Endpoint count `0`.
- [x] Manual negative validation NEU-469 / C2723469: PATCH an existing paused vGPU Endpoint from `4096` MiB to `15361` MiB returned HTTP 400, code `10220`; persisted Endpoint count stayed `1` and `virtualization.memory_mib` stayed `4096`.

## Risk & Rollback

Risk is limited to Endpoint write requests that include or directly modify endpoint resources. Rollback is reverting this PR, which restores the previous POST-focused capacity precheck and PATCH shape-only behavior.