### PR TITLE
NEU-324: mark Kubernetes rollout deadline failures as failed

### DIFF
--- a/internal/orchestrator/kubernetes_orchestrator.go
+++ b/internal/orchestrator/kubernetes_orchestrator.go
@@ -43,6 +43,8 @@ const (
 	k8sContainerReasonPodInitializing  = "PodInitializing"
 )
 
+const k8sDeploymentReasonProgressDeadlineExceeded = "ProgressDeadlineExceeded"
+
 var _ Orchestrator = &kubernetesOrchestrator{}
 
 type kubernetesOrchestrator struct {
@@ -600,6 +602,14 @@ func (k *kubernetesOrchestrator) getEndpointStats(
 		}, nil
 	}
 
+	if hasFailed, failedMsg := k.checkDeploymentFailures(dep); hasFailed {
+		return &v1.EndpointStatus{
+			Phase:        v1.EndpointPhaseFAILED,
+			ErrorMessage: "Endpoint failed: " + failedMsg,
+			Resources:    resources,
+		}, nil
+	}
+
 	if hasIncomplete, detail := hasIncompleteModelDownloaderInitContainer(pods); hasIncomplete {
 		return &v1.EndpointStatus{
 			Phase:        v1.EndpointPhaseMODELDOWNLOADING,
@@ -771,6 +781,19 @@ func (k *kubernetesOrchestrator) checkPodFailures(pods []corev1.Pod) (bool, stri
 	}
 
 	return failed, strings.Join(errorMsg, "; ")
+}
+
+func (k *kubernetesOrchestrator) checkDeploymentFailures(dep *appsv1.Deployment) (bool, string) {
+	for _, condition := range dep.Status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == k8sDeploymentReasonProgressDeadlineExceeded {
+			return true, fmt.Sprintf("Deployment rollout failed: Type: %s, Reason: %s, Message: %s",
+				condition.Type, condition.Reason, condition.Message)
+		}
+	}
+
+	return false, ""
 }
 
 // buildDeploymentErrorMessage builds a descriptive error message from deployment conditions

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -2879,6 +2879,27 @@ func TestKubernetesOrchestrator_getEndpointStats(t *testing.T) {
 			expectError:    false,
 		},
 		{
+			name: "return Failed when deployment rollout exceeds progress deadline",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(t *testing.T) *FakeK8sClient {
+				return NewFakeK8sClient(t).
+					WithDeploymentWithCondition(
+						newEndpoint().Metadata.Name,
+						1,
+						0,
+						0,
+						string(appsv1.DeploymentProgressing),
+						k8sDeploymentReasonProgressDeadlineExceeded,
+						"ReplicaSet has timed out progressing",
+					)
+			},
+			expectedPhase:  v1.EndpointPhaseFAILED,
+			expectErrorMsg: k8sDeploymentReasonProgressDeadlineExceeded,
+			expectError:    false,
+		},
+		{
 			name: "return Failed for init container in CrashLoopBackOff with high restart count",
 			inputEndpoint: func() *v1.Endpoint {
 				return newEndpoint()


### PR DESCRIPTION
## Summary
- mark Kubernetes endpoint Deployments with ProgressDeadlineExceeded as Failed instead of Deploying
- include the deployment condition in the endpoint error message
- add a regression test for the rollout deadline failure status

## Validation
- go test ./internal/orchestrator -run TestKubernetesOrchestrator_getEndpointStats -count=1