### PR TITLE
Filter list-model requests from AI access logs

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -224,6 +224,7 @@ local function maybe_return_model_list(conf, suffix)
     end
 
     if is_models_path(suffix) and kong.request.get_method() == "GET" then
+        kong.ctx.plugin.skip = true
         local models = {}
         for _, entry in ipairs(conf.upstreams) do
             for model_name, _ in pairs(entry.model_mapping) do
@@ -243,6 +244,7 @@ local function maybe_return_model_list(conf, suffix)
     end
 
     if is_anthropic_models_path(suffix) and kong.request.get_method() == "GET" then
+        kong.ctx.plugin.skip = true
         local models = {}
         for _, entry in ipairs(conf.upstreams) do
             for model_name, _ in pairs(entry.model_mapping) do


### PR DESCRIPTION
## Summary
- Mark OpenAI-compatible and Anthropic-compatible list-model responses as skipped in the Kong AI gateway plugin.
- Prevent model listing requests from emitting `ai.trace` / `ai.statistics` fields, so access logs only include inference requests.

## Runtime Verification
- Verified in a freshly provisioned test control-plane environment with a temporary OpenAI-compatible upstream.
- Sent a successful `GET /v1/models` request through Kong:
  - response status was `200`
  - captured Kong structured log did not contain `ai`, `ai.trace`, or `ai.statistics`
- Sent a successful `POST /v1/chat/completions` request through Kong:
  - response status was `200`
  - response included token usage
  - captured Kong structured log included `ai.statistics.usage`
  - usage was recorded in `api.api_usage_records`
- Cleaned up temporary verification routes, plugins, and helper processes after testing.

## Verification
- `git diff --check`
- Runtime Kong/Vector usage-log verification described above

Heavyweight hooks/tests were not run in WS per repository agent instructions.
