### PR TITLE
NEU-476 reject unready vGPU endpoint requests

### DIFF
--- a/internal/orchestrator/kubernetes_orchestrator.go
+++ b/internal/orchestrator/kubernetes_orchestrator.go
@@ -135,15 +135,28 @@ func validateAcceleratorVirtualizationDependencies(ctx *OrchestratorContext) err
 		return nil
 	}
 
-	if ctx.Cluster.Spec == nil || !ctx.Cluster.Spec.AcceleratorVirtualizationEnabled() {
+	return ValidateAcceleratorVirtualizationEndpointDependencies(ctx.Endpoint, ctx.Cluster)
+}
+
+func ValidateAcceleratorVirtualizationEndpointDependencies(endpoint *v1.Endpoint, cluster *v1.Cluster) error {
+	if endpoint == nil ||
+		endpoint.Spec == nil ||
+		endpoint.Spec.Resources == nil ||
+		!endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
+	}
+	if cluster == nil || cluster.Metadata == nil {
+		return errors.Errorf("endpoint %s requests accelerator virtualization, but deploy cluster is not found", endpoint.Metadata.WorkspaceName())
+	}
+	if cluster.Spec == nil || !cluster.Spec.AcceleratorVirtualizationEnabled() {
 		return errors.Errorf(
 			"endpoint %s requests accelerator virtualization, but deploy cluster %s accelerator virtualization is not enabled",
-			ctx.Endpoint.Metadata.WorkspaceName(),
-			ctx.Cluster.Metadata.WorkspaceName(),
+			endpoint.Metadata.WorkspaceName(),
+			cluster.Metadata.WorkspaceName(),
 		)
 	}
 
-	acceleratorVirtualizationStatus := acceleratorVirtualizationComponentStatus(ctx.Cluster)
+	acceleratorVirtualizationStatus := acceleratorVirtualizationComponentStatus(cluster)
 	if acceleratorVirtualizationStatus == nil || acceleratorVirtualizationStatus.Phase != v1.ComponentPhaseReady {
 		statusDetails := ""
 		if acceleratorVirtualizationStatus != nil {
@@ -152,13 +165,34 @@ func validateAcceleratorVirtualizationDependencies(ctx *OrchestratorContext) err
 
 		return errors.Errorf(
 			"endpoint %s requests accelerator virtualization, but deploy cluster %s accelerator virtualization component is not ready%s",
-			ctx.Endpoint.Metadata.WorkspaceName(),
-			ctx.Cluster.Metadata.WorkspaceName(),
+			endpoint.Metadata.WorkspaceName(),
+			cluster.Metadata.WorkspaceName(),
 			statusDetails,
 		)
 	}
 
+	if !hasAvailableAcceleratorVirtualizationResource(endpoint.Spec.Resources, cluster) {
+		return errors.Errorf(
+			"endpoint %s requests accelerator virtualization, but deploy cluster %s has no available vGPU resource for %s",
+			endpoint.Metadata.WorkspaceName(),
+			cluster.Metadata.WorkspaceName(),
+			endpoint.Spec.Resources.GetAcceleratorProduct(),
+		)
+	}
+
 	return nil
+}
+
+func hasAvailableAcceleratorVirtualizationResource(resources *v1.ResourceSpec, cluster *v1.Cluster) bool {
+	if resources == nil || cluster == nil || cluster.Status == nil || cluster.Status.ResourceInfo == nil || cluster.Status.ResourceInfo.Available == nil {
+		return false
+	}
+	acceleratorGroup := cluster.Status.ResourceInfo.Available.AcceleratorGroups[v1.AcceleratorType(resources.GetAcceleratorType())]
+	if acceleratorGroup == nil || acceleratorGroup.Products == nil {
+		return false
+	}
+	productResource := acceleratorGroup.Products[v1.AcceleratorProduct(resources.GetAcceleratorProduct())]
+	return productResource != nil && productResource.Virtualization != nil && productResource.Virtualization.MemoryMiB > 0 && productResource.Virtualization.CoreUnits > 0
 }
 
 func acceleratorVirtualizationComponentStatus(cluster *v1.Cluster) *v1.ComponentStatus {

--- a/internal/routes/proxies/endpoint_proxy.go
+++ b/internal/routes/proxies/endpoint_proxy.go
@@ -19,7 +19,7 @@ func RegisterEndpointRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFun
 	proxyGroup.Use(middlewares...)
 
 	handler := CreateStructProxyHandler[v1.Endpoint](deps, storage.ENDPOINT_TABLE)
-	acceleratorVirtualizationValidation := validateEndpointAcceleratorVirtualization()
+	acceleratorVirtualizationValidation := validateEndpointAcceleratorVirtualization(deps)
 
 	// Only register allowed methods
 	proxyGroup.GET("", handler)

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -11,9 +11,11 @@ import (
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/orchestrator"
+	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
-func validateEndpointAcceleratorVirtualization() gin.HandlerFunc {
+func validateEndpointAcceleratorVirtualization(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -45,6 +47,12 @@ func validateEndpointAcceleratorVirtualization() gin.HandlerFunc {
 
 			return
 		}
+		if validationErr := validateEndpointAcceleratorVirtualizationClusterReadiness(body, deps); validationErr != nil {
+			c.JSON(http.StatusBadRequest, validationErr)
+			c.Abort()
+
+			return
+		}
 
 		c.Next()
 	}
@@ -69,6 +77,64 @@ func validateEndpointAcceleratorVirtualizationBody(body []byte) *validationError
 	resources := endpoint.Spec.Resources
 	if err := validateEndpointAcceleratorVirtualizationResourceShape(resources); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func validateEndpointAcceleratorVirtualizationClusterReadiness(body []byte, deps *Dependencies) *validationError {
+	if deps == nil || deps.Storage == nil {
+		return nil
+	}
+
+	var endpoint v1.Endpoint
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&endpoint); err != nil {
+		return invalidEndpointPayloadError(err)
+	}
+
+	if endpoint.GetDeletionTimestamp() != "" ||
+		endpoint.Spec == nil ||
+		endpoint.Spec.Resources == nil ||
+		!endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
+	}
+
+	if endpoint.Spec.Cluster == "" {
+		return &validationError{
+			Code:    "10220",
+			Message: "endpoint accelerator virtualization requires deploy cluster",
+			Hint:    "Set spec.cluster to the target Kubernetes cluster",
+		}
+	}
+
+	clusters, err := deps.Storage.ListCluster(storage.ListOption{
+		Filters: []storage.Filter{
+			{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(endpoint.Spec.Cluster)},
+			{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(endpoint.Metadata.Workspace)},
+		},
+	})
+	if err != nil {
+		return &validationError{
+			Code:    "10221",
+			Message: "failed to validate endpoint accelerator virtualization dependencies",
+			Hint:    err.Error(),
+		}
+	}
+
+	if len(clusters) == 0 {
+		return &validationError{
+			Code:    "10220",
+			Message: "deploy cluster not found for endpoint accelerator virtualization",
+			Hint:    fmt.Sprintf("Cluster %s was not found in workspace %s", endpoint.Spec.Cluster, endpoint.Metadata.Workspace),
+		}
+	}
+
+	if err := orchestrator.ValidateAcceleratorVirtualizationEndpointDependencies(&endpoint, &clusters[0]); err != nil {
+		return &validationError{
+			Code:    "10221",
+			Message: "endpoint accelerator virtualization dependencies are not ready",
+			Hint:    err.Error(),
+		}
 	}
 
 	return nil

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -1,9 +1,14 @@
 package proxies
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
 func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
@@ -181,4 +186,109 @@ func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
 
 		assert.Nil(t, err)
 	})
+}
+
+func TestValidateEndpointAcceleratorVirtualizationClusterReadiness(t *testing.T) {
+	body := []byte(`{
+		"metadata": {"name": "endpoint", "workspace": "default"},
+		"spec": {
+			"cluster": "cluster",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "1024",
+					"virtualization.core_percent": "10"
+				}
+			}
+		}
+	}`)
+
+	t.Run("rejects vGPU endpoint when cluster virtualization component is not ready", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListCluster", endpointClusterListOption()).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Name: "cluster", Workspace: "default"},
+			Spec: &v1.ClusterSpec{
+				Type:                      v1.KubernetesClusterType,
+				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: true},
+			},
+			Status: &v1.ClusterStatus{
+				ComponentStatus: map[string]*v1.ComponentStatus{
+					v1.ComponentStatusAcceleratorVirtualizationKey: {
+						Phase:   v1.ComponentPhaseNotReady,
+						Reason:  "DaemonSetNotReady",
+						Message: "waiting for device plugin",
+					},
+				},
+			},
+		}}, nil)
+
+		err := validateEndpointAcceleratorVirtualizationClusterReadiness(body, &Dependencies{Storage: mockStorage})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10221", err.Code)
+		assert.Contains(t, err.Hint, "accelerator virtualization component is not ready")
+	})
+
+	t.Run("rejects vGPU endpoint when cluster has no available vGPU resource", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListCluster", endpointClusterListOption()).Return([]v1.Cluster{readyVirtualizationCluster(nil)}, nil)
+
+		err := validateEndpointAcceleratorVirtualizationClusterReadiness(body, &Dependencies{Storage: mockStorage})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10221", err.Code)
+		assert.Contains(t, err.Hint, "has no available vGPU resource")
+	})
+
+	t.Run("allows vGPU endpoint when cluster virtualization is ready and available", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListCluster", endpointClusterListOption()).Return([]v1.Cluster{readyVirtualizationCluster(&v1.ClusterResources{
+			ResourceStatus: v1.ResourceStatus{
+				Available: &v1.ResourceInfo{
+					AcceleratorGroups: map[v1.AcceleratorType]*v1.AcceleratorGroup{
+						v1.AcceleratorTypeNVIDIAGPU: {
+							Products: map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{
+								"Tesla-T4": {
+									Quantity: 1,
+									Virtualization: &v1.AcceleratorVirtualizationResource{
+										MemoryMiB: 1024,
+										CoreUnits: 10,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})}, nil)
+
+		err := validateEndpointAcceleratorVirtualizationClusterReadiness(body, &Dependencies{Storage: mockStorage})
+
+		assert.Nil(t, err)
+	})
+}
+
+func endpointClusterListOption() storage.ListOption {
+	return storage.ListOption{Filters: []storage.Filter{
+		{Column: "metadata->name", Operator: "eq", Value: strconv.Quote("cluster")},
+		{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote("default")},
+	}}
+}
+
+func readyVirtualizationCluster(resources *v1.ClusterResources) v1.Cluster {
+	return v1.Cluster{
+		Metadata: &v1.Metadata{Name: "cluster", Workspace: "default"},
+		Spec: &v1.ClusterSpec{
+			Type:                      v1.KubernetesClusterType,
+			AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: true},
+		},
+		Status: &v1.ClusterStatus{
+			ComponentStatus: map[string]*v1.ComponentStatus{
+				v1.ComponentStatusAcceleratorVirtualizationKey: {Phase: v1.ComponentPhaseReady},
+			},
+			ResourceInfo: resources,
+		},
+	}
 }


### PR DESCRIPTION
## Summary
- validate vGPU endpoint create/update requests against target cluster state before forwarding to PostgREST
- reuse orchestrator dependency validation for API preflight checks
- reject unready virtualization components and clusters with no available vGPU resource

## Tests
- go test ./internal/routes/proxies ./internal/orchestrator