### PR TITLE
fix: reject invalid vGPU endpoint requests

### DIFF
--- a/internal/routes/proxies/endpoint_proxy.go
+++ b/internal/routes/proxies/endpoint_proxy.go
@@ -19,7 +19,7 @@ func RegisterEndpointRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFun
 	proxyGroup.Use(middlewares...)
 
 	handler := CreateStructProxyHandler[v1.Endpoint](deps, storage.ENDPOINT_TABLE)
-	acceleratorVirtualizationValidation := validateEndpointAcceleratorVirtualization()
+	acceleratorVirtualizationValidation := validateEndpointAcceleratorVirtualization(deps.Storage)
 
 	// Only register allowed methods
 	proxyGroup.GET("", handler)

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -6,14 +6,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
-func validateEndpointAcceleratorVirtualization() gin.HandlerFunc {
+func validateEndpointAcceleratorVirtualization(store storage.Storage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -39,8 +43,13 @@ func validateEndpointAcceleratorVirtualization() gin.HandlerFunc {
 			return
 		}
 
-		if validationErr := validateEndpointAcceleratorVirtualizationBody(body); validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
+		if validationErr := validateEndpointAcceleratorVirtualizationRequest(
+			store,
+			c.Request.Method,
+			c.Request.URL.Query(),
+			body,
+		); validationErr != nil {
+			c.JSON(validationErrStatus(validationErr), validationErr)
 			c.Abort()
 
 			return
@@ -50,10 +59,45 @@ func validateEndpointAcceleratorVirtualization() gin.HandlerFunc {
 	}
 }
 
-func validateEndpointAcceleratorVirtualizationBody(body []byte) *validationError {
+func validateEndpointAcceleratorVirtualizationRequest(
+	store storage.Storage,
+	method string,
+	queryParams url.Values,
+	body []byte,
+) *validationError {
+	endpoint, validationErr := decodeEndpointAcceleratorVirtualizationBody(body)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	if validationErr := validateEndpointAcceleratorVirtualizationEndpoint(endpoint); validationErr != nil {
+		return validationErr
+	}
+
+	return validateEndpointAcceleratorVirtualizationPreflight(store, method, queryParams, endpoint)
+}
+
+func decodeEndpointAcceleratorVirtualizationBody(body []byte) (*v1.Endpoint, *validationError) {
 	var endpoint v1.Endpoint
 	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&endpoint); err != nil {
-		return invalidEndpointPayloadError(err)
+		return nil, invalidEndpointPayloadError(err)
+	}
+
+	return &endpoint, nil
+}
+
+func validateEndpointAcceleratorVirtualizationBody(body []byte) *validationError {
+	endpoint, validationErr := decodeEndpointAcceleratorVirtualizationBody(body)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	return validateEndpointAcceleratorVirtualizationEndpoint(endpoint)
+}
+
+func validateEndpointAcceleratorVirtualizationEndpoint(endpoint *v1.Endpoint) *validationError {
+	if endpoint == nil {
+		return nil
 	}
 
 	if endpoint.GetDeletionTimestamp() != "" {
@@ -69,6 +113,339 @@ func validateEndpointAcceleratorVirtualizationBody(body []byte) *validationError
 	resources := endpoint.Spec.Resources
 	if err := validateEndpointAcceleratorVirtualizationResourceShape(resources); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func validateEndpointAcceleratorVirtualizationPreflight(
+	store storage.Storage,
+	method string,
+	queryParams url.Values,
+	endpoint *v1.Endpoint,
+) *validationError {
+	if endpoint == nil {
+		return nil
+	}
+
+	if endpoint.GetDeletionTimestamp() != "" {
+		return nil
+	}
+
+	if method == http.MethodPatch &&
+		(endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization()) {
+		return nil
+	}
+
+	if method != http.MethodPatch &&
+		(endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization()) {
+		return nil
+	}
+
+	if store == nil {
+		return endpointAcceleratorVirtualizationLookupError("storage is required to validate endpoint accelerator virtualization")
+	}
+
+	if method == http.MethodPatch && endpointPatchNeedsExistingEndpoint(endpoint, queryParams) {
+		existing, validationErr := resolveEndpointAcceleratorVirtualizationPatchEndpoint(store, queryParams)
+		if validationErr != nil {
+			return validationErr
+		}
+
+		merged := mergeEndpointAcceleratorVirtualizationPatch(existing, endpoint)
+		endpoint = &merged
+	}
+
+	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
+	}
+
+	target, validationErr := resolveEndpointAcceleratorVirtualizationTarget(method, queryParams, endpoint)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	clusters, err := store.ListCluster(storage.ListOption{
+		Filters: endpointClusterLookupFilters(target.cluster, target.workspace),
+	})
+	if err != nil {
+		klog.Warningf("failed to look up endpoint accelerator virtualization cluster %s/%s: %v", target.workspace, target.cluster, err)
+
+		return endpointAcceleratorVirtualizationLookupError("failed to look up cluster for endpoint accelerator virtualization")
+	}
+
+	if len(clusters) == 0 {
+		return endpointAcceleratorVirtualizationTargetError(fmt.Sprintf("cluster %s/%s not found", target.workspace, target.cluster))
+	}
+
+	if len(clusters) > 1 {
+		return endpointAcceleratorVirtualizationTargetError(fmt.Sprintf("multiple clusters matched %s/%s", target.workspace, target.cluster))
+	}
+
+	if validationErr := validateEndpointClusterAcceleratorVirtualizationReady(&clusters[0]); validationErr != nil {
+		return validationErr
+	}
+
+	return nil
+}
+
+type endpointAcceleratorVirtualizationTarget struct {
+	cluster   string
+	workspace string
+}
+
+func resolveEndpointAcceleratorVirtualizationTarget(
+	method string,
+	queryParams url.Values,
+	endpoint *v1.Endpoint,
+) (endpointAcceleratorVirtualizationTarget, *validationError) {
+	target := endpointAcceleratorVirtualizationTarget{
+		workspace: endpointTargetWorkspace(method, queryParams, endpoint),
+	}
+
+	if endpoint.Spec != nil {
+		target.cluster = endpoint.Spec.Cluster
+	}
+
+	return validateEndpointAcceleratorVirtualizationTarget(target)
+}
+
+func resolveEndpointAcceleratorVirtualizationPatchEndpoint(
+	store storage.Storage,
+	queryParams url.Values,
+) (*v1.Endpoint, *validationError) {
+	filters := queryParamsToFilters(queryParams)
+	if len(filters) == 0 {
+		return nil, endpointAcceleratorVirtualizationTargetError("endpoint lookup filters are required for vGPU resource PATCH")
+	}
+
+	endpoints, err := store.ListEndpoint(storage.ListOption{Filters: filters})
+	if err != nil {
+		klog.Warningf("failed to look up endpoint for vGPU resource PATCH: %v", err)
+
+		return nil, endpointAcceleratorVirtualizationLookupError("failed to look up endpoint for vGPU resource PATCH")
+	}
+
+	if len(endpoints) == 0 {
+		return nil, endpointAcceleratorVirtualizationTargetError("endpoint not found for vGPU resource PATCH")
+	}
+
+	if len(endpoints) > 1 {
+		return nil, endpointAcceleratorVirtualizationTargetError("multiple endpoints matched vGPU resource PATCH filters")
+	}
+
+	return &endpoints[0], nil
+}
+
+func endpointPatchNeedsExistingEndpoint(endpoint *v1.Endpoint, queryParams url.Values) bool {
+	return endpoint != nil &&
+		endpoint.Spec != nil &&
+		endpoint.Spec.Resources != nil &&
+		endpoint.Spec.Resources.HasAcceleratorVirtualization() &&
+		(endpoint.Spec.Cluster == "" || endpointTargetWorkspace(http.MethodPatch, queryParams, endpoint) == "")
+}
+
+func mergeEndpointAcceleratorVirtualizationPatch(existing *v1.Endpoint, patch *v1.Endpoint) v1.Endpoint {
+	if existing == nil {
+		if patch == nil {
+			return v1.Endpoint{}
+		}
+
+		return *patch
+	}
+
+	merged := *existing
+
+	if existing.Metadata != nil {
+		metadata := *existing.Metadata
+		merged.Metadata = &metadata
+	}
+
+	if existing.Spec != nil {
+		spec := *existing.Spec
+		if existing.Spec.Resources != nil {
+			spec.Resources = copyEndpointResourceSpec(existing.Spec.Resources)
+		}
+
+		merged.Spec = &spec
+	}
+
+	if patch == nil {
+		return merged
+	}
+
+	if patch.Metadata != nil {
+		if merged.Metadata == nil {
+			merged.Metadata = &v1.Metadata{}
+		}
+
+		if patch.Metadata.Name != "" {
+			merged.Metadata.Name = patch.Metadata.Name
+		}
+
+		if patch.Metadata.Workspace != "" {
+			merged.Metadata.Workspace = patch.Metadata.Workspace
+		}
+	}
+
+	if patch.Spec != nil {
+		if merged.Spec == nil {
+			merged.Spec = &v1.EndpointSpec{}
+		}
+
+		if patch.Spec.Cluster != "" {
+			merged.Spec.Cluster = patch.Spec.Cluster
+		}
+
+		if patch.Spec.Resources != nil {
+			merged.Spec.Resources = mergeEndpointResourceSpec(merged.Spec.Resources, patch.Spec.Resources)
+		}
+	}
+
+	return merged
+}
+
+func mergeEndpointResourceSpec(existing *v1.ResourceSpec, patch *v1.ResourceSpec) *v1.ResourceSpec {
+	if existing == nil {
+		return copyEndpointResourceSpec(patch)
+	}
+
+	merged := copyEndpointResourceSpec(existing)
+	if patch.CPU != nil {
+		merged.CPU = patch.CPU
+	}
+
+	if patch.GPU != nil {
+		merged.GPU = patch.GPU
+	}
+
+	if patch.Memory != nil {
+		merged.Memory = patch.Memory
+	}
+
+	if patch.Accelerator != nil {
+		if merged.Accelerator == nil {
+			merged.Accelerator = make(map[string]string, len(patch.Accelerator))
+		}
+
+		for key, value := range patch.Accelerator {
+			merged.Accelerator[key] = value
+		}
+	}
+
+	return merged
+}
+
+func copyEndpointResourceSpec(resources *v1.ResourceSpec) *v1.ResourceSpec {
+	if resources == nil {
+		return nil
+	}
+
+	copied := *resources
+	if resources.Accelerator != nil {
+		copied.Accelerator = make(map[string]string, len(resources.Accelerator))
+		for key, value := range resources.Accelerator {
+			copied.Accelerator[key] = value
+		}
+	}
+
+	return &copied
+}
+
+func validateEndpointAcceleratorVirtualizationTarget(
+	target endpointAcceleratorVirtualizationTarget,
+) (endpointAcceleratorVirtualizationTarget, *validationError) {
+	if target.workspace == "" {
+		target.workspace = defaultWorkspace
+	}
+
+	if target.cluster == "" {
+		return target, endpointAcceleratorVirtualizationTargetError("spec.cluster is required for endpoint accelerator virtualization")
+	}
+
+	return target, nil
+}
+
+func endpointTargetWorkspace(method string, queryParams url.Values, endpoint *v1.Endpoint) string {
+	if workspace := endpointWorkspace(endpoint); workspace != "" {
+		return workspace
+	}
+
+	if method == http.MethodPatch {
+		return endpointWorkspaceFromQuery(queryParams)
+	}
+
+	return ""
+}
+
+func endpointWorkspace(endpoint *v1.Endpoint) string {
+	if endpoint == nil || endpoint.Metadata == nil {
+		return ""
+	}
+
+	return endpoint.Metadata.Workspace
+}
+
+func endpointWorkspaceFromQuery(queryParams url.Values) string {
+	for _, key := range []string{"metadata->>workspace", "metadata->workspace"} {
+		values, ok := queryParams[key]
+		if !ok || len(values) == 0 {
+			continue
+		}
+
+		workspace := values[0]
+
+		parts := strings.SplitN(workspace, ".", 2)
+		if len(parts) == 2 {
+			if parts[0] != "eq" {
+				continue
+			}
+
+			workspace = parts[1]
+		}
+
+		if unquoted, err := strconv.Unquote(workspace); err == nil {
+			workspace = unquoted
+		}
+
+		return workspace
+	}
+
+	return ""
+}
+
+func endpointClusterLookupFilters(cluster, workspace string) []storage.Filter {
+	return []storage.Filter{
+		{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(cluster)},
+		{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
+	}
+}
+
+func validateEndpointClusterAcceleratorVirtualizationReady(cluster *v1.Cluster) *validationError {
+	if cluster == nil || cluster.Spec == nil || !cluster.Spec.AcceleratorVirtualizationEnabled() {
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization is not enabled")
+	}
+
+	if cluster.Spec.Type != v1.KubernetesClusterType {
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, "endpoint accelerator virtualization is only supported for kubernetes clusters")
+	}
+
+	if cluster.Status == nil || cluster.Status.ComponentStatus == nil {
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization component status is missing")
+	}
+
+	component := cluster.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey]
+	if component == nil {
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, "cluster accelerator virtualization component status is missing")
+	}
+
+	if component.Phase != v1.ComponentPhaseReady {
+		hint := "cluster accelerator virtualization is not ready"
+		if component.Reason != "" || component.Message != "" {
+			hint = fmt.Sprintf("%s: %s %s", hint, component.Reason, component.Message)
+		}
+
+		return endpointAcceleratorVirtualizationNotReadyError(cluster, hint)
 	}
 
 	return nil
@@ -177,5 +554,40 @@ func endpointResourceValueError(err error) *validationError {
 		Code:    "10216",
 		Message: "invalid endpoint accelerator virtualization resources",
 		Hint:    err.Error(),
+	}
+}
+
+func endpointAcceleratorVirtualizationTargetError(hint string) *validationError {
+	return &validationError{
+		Code:    "10221",
+		Message: "invalid endpoint accelerator virtualization target",
+		Hint:    hint,
+	}
+}
+
+func endpointAcceleratorVirtualizationLookupError(hint string) *validationError {
+	err := endpointAcceleratorVirtualizationTargetError(hint)
+	err.HTTPStatus = http.StatusServiceUnavailable
+
+	return err
+}
+
+func validationErrStatus(err *validationError) int {
+	if err != nil && err.HTTPStatus != 0 {
+		return err.HTTPStatus
+	}
+
+	return http.StatusBadRequest
+}
+
+func endpointAcceleratorVirtualizationNotReadyError(cluster *v1.Cluster, hint string) *validationError {
+	if cluster != nil && cluster.Metadata != nil {
+		hint = fmt.Sprintf("cluster %s/%s accelerator virtualization is not ready: %s", cluster.Metadata.Workspace, cluster.Metadata.Name, hint)
+	}
+
+	return &validationError{
+		Code:    "10222",
+		Message: "cluster accelerator virtualization is not ready",
+		Hint:    hint,
 	}
 }

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -1,9 +1,23 @@
 package proxies
 
 import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
 func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
@@ -181,4 +195,680 @@ func TestValidateEndpointAcceleratorVirtualizationBody(t *testing.T) {
 
 		assert.Nil(t, err)
 	})
+}
+
+func TestValidateEndpointAcceleratorVirtualizationRequestRunsBodyAndPreflight(t *testing.T) {
+	storageMock := storageMocks.NewMockStorage(t)
+	storageMock.EXPECT().
+		ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "default"))).
+		Return([]v1.Cluster{endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 200)}, nil)
+
+	err := validateEndpointAcceleratorVirtualizationRequest(
+		storageMock,
+		http.MethodPost,
+		nil,
+		[]byte(endpointValidationVGPUPayload("k8s-cluster")),
+	)
+
+	assert.Nil(t, err)
+}
+
+func TestRegisterEndpointRoutesRejectsVGPUCreateWhenClusterVirtualizationUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name          string
+		clusters      []v1.Cluster
+		expectedBody  string
+		expectedError string
+	}{
+		{
+			name: "cluster disabled",
+			clusters: []v1.Cluster{
+				endpointValidationCluster(false, v1.ComponentPhaseReady, 32768, 200),
+			},
+			expectedBody:  "accelerator virtualization",
+			expectedError: "not ready",
+		},
+		{
+			name: "component not ready",
+			clusters: []v1.Cluster{
+				endpointValidationCluster(true, v1.ComponentPhaseNotReady, 32768, 200),
+			},
+			expectedBody:  "accelerator virtualization",
+			expectedError: "not ready",
+		},
+		{
+			name: "component status missing",
+			clusters: []v1.Cluster{
+				endpointValidationClusterMissingComponentStatus(),
+			},
+			expectedBody:  "accelerator virtualization",
+			expectedError: "component status is missing",
+		},
+		{
+			name: "non Kubernetes cluster",
+			clusters: []v1.Cluster{
+				endpointValidationClusterWithType(v1.SSHClusterType, true, v1.ComponentPhaseReady),
+			},
+			expectedBody:  "accelerator virtualization",
+			expectedError: "only supported for kubernetes clusters",
+		},
+		{
+			name:          "cluster not found",
+			clusters:      []v1.Cluster{},
+			expectedBody:  "cluster",
+			expectedError: "not found",
+		},
+		{
+			name: "cluster lookup ambiguous",
+			clusters: []v1.Cluster{
+				endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 200),
+				endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 200),
+			},
+			expectedBody:  "cluster",
+			expectedError: "multiple",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storageMock := storageMocks.NewMockStorage(t)
+			storageMock.EXPECT().
+				ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "default"))).
+				Return(tt.clusters, nil)
+
+			router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusCreated)
+			recorder := performEndpointValidationRequest(router, http.MethodPost, "/api/v1/endpoints", endpointValidationVGPUPayload("k8s-cluster"))
+
+			assert.Equal(t, http.StatusBadRequest, recorder.ResponseRecorder.Code)
+			assert.Contains(t, recorder.ResponseRecorder.Body.String(), tt.expectedBody)
+			assert.Contains(t, recorder.ResponseRecorder.Body.String(), tt.expectedError)
+			assert.False(t, upstreamCalled.Load(), "invalid vGPU endpoint should not be forwarded to PostgREST")
+		})
+	}
+}
+
+func TestRegisterEndpointRoutesForwardsVGPUCreateWhenClusterVirtualizationReady(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name    string
+		cluster v1.Cluster
+		body    string
+	}{
+		{
+			name:    "different product is available",
+			cluster: endpointValidationClusterWithProduct("Other-GPU", true, v1.ComponentPhaseReady, 32768, 200),
+			body:    endpointValidationVGPUPayload("k8s-cluster"),
+		},
+		{
+			name:    "memory_mib availability is low",
+			cluster: endpointValidationCluster(true, v1.ComponentPhaseReady, 512, 200),
+			body:    endpointValidationVGPUPayload("k8s-cluster"),
+		},
+		{
+			name:    "core availability is low",
+			cluster: endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 5),
+			body:    endpointValidationVGPUPayload("k8s-cluster"),
+		},
+		{
+			name:    "product metadata is missing",
+			cluster: endpointValidationClusterWithoutProductMetadata(true, v1.ComponentPhaseReady, 32768, 200),
+			body:    endpointValidationVGPUPercentPayload("k8s-cluster"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storageMock := storageMocks.NewMockStorage(t)
+			storageMock.EXPECT().
+				ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "default"))).
+				Return([]v1.Cluster{tt.cluster}, nil)
+
+			router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusCreated)
+			recorder := performEndpointValidationRequest(router, http.MethodPost, "/api/v1/endpoints", tt.body)
+
+			assert.Equal(t, http.StatusCreated, recorder.ResponseRecorder.Code)
+			assert.True(t, upstreamCalled.Load(), "NEU-476 only checks cluster virtualization readiness, not capacity")
+		})
+	}
+}
+
+func TestRegisterEndpointRoutesHidesClusterLookupErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storageMock := storageMocks.NewMockStorage(t)
+	storageMock.EXPECT().
+		ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "default"))).
+		Return(nil, errors.New("postgres://internal-secret"))
+
+	router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusCreated)
+	recorder := performEndpointValidationRequest(router, http.MethodPost, "/api/v1/endpoints", endpointValidationVGPUPayload("k8s-cluster"))
+
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.ResponseRecorder.Code)
+	assert.Contains(t, recorder.ResponseRecorder.Body.String(), "failed to look up cluster")
+	assert.NotContains(t, recorder.ResponseRecorder.Body.String(), "internal-secret")
+	assert.False(t, upstreamCalled.Load(), "cluster lookup errors should not be forwarded to PostgREST")
+}
+
+func TestRegisterEndpointRoutesForwardsVGPUCreateWhenClusterVirtualizationIsReady(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storageMock := storageMocks.NewMockStorage(t)
+	storageMock.EXPECT().
+		ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "default"))).
+		Return([]v1.Cluster{endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 200)}, nil)
+
+	router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusCreated)
+	recorder := performEndpointValidationRequest(router, http.MethodPost, "/api/v1/endpoints", endpointValidationVGPUPayload("k8s-cluster"))
+
+	assert.Equal(t, http.StatusCreated, recorder.ResponseRecorder.Code)
+	assert.True(t, upstreamCalled.Load(), "valid vGPU endpoint should be forwarded to PostgREST")
+}
+
+func TestRegisterEndpointRoutesForwardsOriginalVGPURequestBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{
+			name:   "post",
+			method: http.MethodPost,
+			path:   "/api/v1/endpoints",
+			body:   endpointValidationVGPUPayload("k8s-cluster"),
+		},
+		{
+			name:   "patch",
+			method: http.MethodPatch,
+			path:   "/api/v1/endpoints?metadata->>workspace=eq.default&id=eq.118",
+			body:   endpointValidationVGPUResourcePatchPayloadWithCluster("k8s-cluster"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storageMock := storageMocks.NewMockStorage(t)
+			storageMock.EXPECT().
+				ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "default"))).
+				Return([]v1.Cluster{endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 200)}, nil)
+
+			router, upstreamCalled, upstreamBody := setupEndpointValidationRouteWithBodyCapture(t, storageMock, http.StatusCreated)
+			recorder := performEndpointValidationRequest(router, tt.method, tt.path, tt.body)
+
+			assert.Equal(t, http.StatusCreated, recorder.ResponseRecorder.Code)
+			assert.True(t, upstreamCalled.Load(), "valid vGPU request should be forwarded to PostgREST")
+			assert.JSONEq(t, tt.body, upstreamBody.Load().(string))
+		})
+	}
+}
+
+func TestRegisterEndpointRoutesResolvesExistingEndpointForVGPUResourcePatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storageMock := storageMocks.NewMockStorage(t)
+	storageMock.EXPECT().
+		ListEndpoint(matchListOption([]storage.Filter{
+			{Column: "metadata->>name", Operator: "eq", Value: "endpoint"},
+			{Column: "metadata->>workspace", Operator: "eq", Value: "default"},
+		})).
+		Return([]v1.Endpoint{
+			{
+				Metadata: &v1.Metadata{Name: "endpoint", Workspace: "default"},
+				Spec:     &v1.EndpointSpec{Cluster: "k8s-cluster"},
+			},
+		}, nil)
+	storageMock.EXPECT().
+		ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "default"))).
+		Return([]v1.Cluster{endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 200)}, nil)
+
+	router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusNoContent)
+	recorder := performEndpointValidationRequest(
+		router,
+		http.MethodPatch,
+		"/api/v1/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.default&select=*",
+		endpointValidationVGPUResourcePatchPayload(),
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+	assert.True(t, upstreamCalled.Load(), "valid vGPU patch should be forwarded to PostgREST")
+}
+
+func TestRegisterEndpointRoutesSkipsPreflightWhenPatchOmitsVGPUResourceKeys(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storageMock := storageMocks.NewMockStorage(t)
+
+	router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusNoContent)
+	recorder := performEndpointValidationRequest(
+		router,
+		http.MethodPatch,
+		"/api/v1/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.default",
+		`{"spec":{"cluster":"unsupported-cluster"}}`,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+	assert.True(t, upstreamCalled.Load(), "PATCH without vGPU resource keys should follow the design and skip preflight")
+}
+
+func TestRegisterEndpointRoutesRejectsVGPUResourcePatchWhenExistingEndpointLookupIsAmbiguous(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name      string
+		endpoints []v1.Endpoint
+		expected  string
+	}{
+		{
+			name:      "not found",
+			endpoints: nil,
+			expected:  "not found",
+		},
+		{
+			name: "multiple",
+			endpoints: []v1.Endpoint{
+				{Metadata: &v1.Metadata{Name: "endpoint", Workspace: "default"}, Spec: &v1.EndpointSpec{Cluster: "a"}},
+				{Metadata: &v1.Metadata{Name: "endpoint", Workspace: "default"}, Spec: &v1.EndpointSpec{Cluster: "b"}},
+			},
+			expected: "multiple",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storageMock := storageMocks.NewMockStorage(t)
+			storageMock.EXPECT().
+				ListEndpoint(matchListOption([]storage.Filter{
+					{Column: "metadata->>name", Operator: "eq", Value: "endpoint"},
+					{Column: "metadata->>workspace", Operator: "eq", Value: "default"},
+				})).
+				Return(tt.endpoints, nil)
+
+			router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusNoContent)
+			recorder := performEndpointValidationRequest(
+				router,
+				http.MethodPatch,
+				"/api/v1/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.default",
+				endpointValidationVGPUResourcePatchPayload(),
+			)
+
+			assert.Equal(t, http.StatusBadRequest, recorder.ResponseRecorder.Code)
+			assert.Contains(t, recorder.ResponseRecorder.Body.String(), tt.expected)
+			assert.False(t, upstreamCalled.Load(), "ambiguous vGPU patch should not be forwarded to PostgREST")
+		})
+	}
+}
+
+func TestRegisterEndpointRoutesHidesEndpointLookupErrors(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storageMock := storageMocks.NewMockStorage(t)
+	storageMock.EXPECT().
+		ListEndpoint(matchListOption([]storage.Filter{
+			{Column: "metadata->>name", Operator: "eq", Value: "endpoint"},
+			{Column: "metadata->>workspace", Operator: "eq", Value: "default"},
+		})).
+		Return(nil, errors.New("postgres://endpoint-secret"))
+
+	router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusNoContent)
+	recorder := performEndpointValidationRequest(
+		router,
+		http.MethodPatch,
+		"/api/v1/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.default",
+		endpointValidationVGPUResourcePatchPayload(),
+	)
+
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.ResponseRecorder.Code)
+	assert.Contains(t, recorder.ResponseRecorder.Body.String(), "failed to look up endpoint")
+	assert.NotContains(t, recorder.ResponseRecorder.Body.String(), "endpoint-secret")
+	assert.False(t, upstreamCalled.Load(), "endpoint lookup errors should not be forwarded to PostgREST")
+}
+
+func TestRegisterEndpointRoutesResolvesExistingEndpointForVGPUResourcePatchWithIDFilter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storageMock := storageMocks.NewMockStorage(t)
+	storageMock.EXPECT().
+		ListEndpoint(matchListOption([]storage.Filter{
+			{Column: "id", Operator: "eq", Value: "118"},
+		})).
+		Return([]v1.Endpoint{
+			{
+				Metadata: &v1.Metadata{Name: "endpoint", Workspace: "default"},
+				Spec:     &v1.EndpointSpec{Cluster: "k8s-cluster"},
+			},
+		}, nil)
+	storageMock.EXPECT().
+		ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "default"))).
+		Return([]v1.Cluster{endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 200)}, nil)
+
+	router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusNoContent)
+	recorder := performEndpointValidationRequest(
+		router,
+		http.MethodPatch,
+		"/api/v1/endpoints?id=eq.118",
+		endpointValidationVGPUResourcePatchPayload(),
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+	assert.True(t, upstreamCalled.Load(), "vGPU resource PATCH can resolve existing endpoint from regular query filters")
+}
+
+func TestRegisterEndpointRoutesUsesExistingEndpointWorkspaceForVGPUResourcePatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	storageMock := storageMocks.NewMockStorage(t)
+	storageMock.EXPECT().
+		ListEndpoint(matchListOption([]storage.Filter{
+			{Column: "id", Operator: "eq", Value: "118"},
+		})).
+		Return([]v1.Endpoint{
+			{
+				Metadata: &v1.Metadata{Name: "endpoint", Workspace: "workspace-a"},
+				Spec:     &v1.EndpointSpec{Cluster: "old-cluster"},
+			},
+		}, nil)
+	storageMock.EXPECT().
+		ListCluster(matchListOption(clusterLookupFilters("k8s-cluster", "workspace-a"))).
+		Return([]v1.Cluster{endpointValidationClusterInWorkspace("workspace-a", true, v1.ComponentPhaseReady, 32768, 200)}, nil)
+
+	router, upstreamCalled := setupEndpointValidationRoute(t, storageMock, http.StatusNoContent)
+	recorder := performEndpointValidationRequest(
+		router,
+		http.MethodPatch,
+		"/api/v1/endpoints?id=eq.118",
+		endpointValidationVGPUResourcePatchPayloadWithCluster("k8s-cluster"),
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+	assert.True(t, upstreamCalled.Load(), "vGPU resource PATCH should use existing endpoint workspace when patch omits metadata.workspace")
+}
+
+func TestRegisterEndpointRoutesSkipsClusterPreflightForNonVGPUAndSoftDeletePatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "non vGPU patch",
+			body: `{"spec":{"replicas":{"num":2}}}`,
+		},
+		{
+			name: "soft delete patch",
+			body: `{"metadata":{"name":"endpoint","workspace":"default","deletion_timestamp":"2026-06-23T08:00:00Z"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router, upstreamCalled := setupEndpointValidationRoute(t, nil, http.StatusNoContent)
+			recorder := performEndpointValidationRequest(router, http.MethodPatch, "/api/v1/endpoints?id=eq.118", tt.body)
+
+			assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+			assert.True(t, upstreamCalled.Load(), "non-vGPU and soft-delete patches should be forwarded")
+		})
+	}
+}
+
+func setupEndpointValidationRoute(t *testing.T, store storage.Storage, upstreamStatus int) (*gin.Engine, *atomic.Bool) {
+	return setupEndpointValidationRouteWithUser(t, store, upstreamStatus, "test-user-uuid")
+}
+
+func setupEndpointValidationRouteWithoutUser(t *testing.T, store storage.Storage, upstreamStatus int) (*gin.Engine, *atomic.Bool) {
+	return setupEndpointValidationRouteWithUser(t, store, upstreamStatus, "")
+}
+
+func setupEndpointValidationRouteWithUser(t *testing.T, store storage.Storage, upstreamStatus int, userID string) (*gin.Engine, *atomic.Bool) {
+	t.Helper()
+
+	router, upstreamCalled, _ := setupEndpointValidationRouteWithBodyCaptureAndUser(t, store, upstreamStatus, userID)
+
+	return router, upstreamCalled
+}
+
+func setupEndpointValidationRouteWithBodyCapture(t *testing.T, store storage.Storage, upstreamStatus int) (*gin.Engine, *atomic.Bool, *atomic.Value) {
+	t.Helper()
+
+	return setupEndpointValidationRouteWithBodyCaptureAndUser(t, store, upstreamStatus, "test-user-uuid")
+}
+
+func setupEndpointValidationRouteWithBodyCaptureAndUser(t *testing.T, store storage.Storage, upstreamStatus int, userID string) (*gin.Engine, *atomic.Bool, *atomic.Value) {
+	t.Helper()
+
+	var upstreamCalled atomic.Bool
+	var upstreamBody atomic.Value
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled.Store(true)
+		assert.Equal(t, "/endpoints", r.URL.Path)
+		if r.Method == http.MethodPost || r.Method == http.MethodPatch {
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			upstreamBody.Store(string(body))
+		}
+		w.WriteHeader(upstreamStatus)
+	}))
+	t.Cleanup(upstream.Close)
+
+	router := gin.New()
+	middlewares := []gin.HandlerFunc{}
+	if userID != "" {
+		middlewares = append(middlewares, func(c *gin.Context) {
+			c.Set("user_id", userID)
+			c.Next()
+		})
+	}
+
+	RegisterEndpointRoutes(router.Group("/api/v1"), middlewares, &Dependencies{
+		StorageAccessURL: upstream.URL,
+		Storage:          store,
+	})
+
+	return router, &upstreamCalled, &upstreamBody
+}
+
+func performEndpointValidationRequest(router *gin.Engine, method, path, body string) *closeNotifyRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	return recorder
+}
+
+func endpointValidationVGPUPayload(cluster string) string {
+	return `{
+		"api_version": "v1",
+		"kind": "Endpoint",
+		"metadata": {"name": "endpoint", "workspace": "default"},
+		"spec": {
+			"cluster": "` + cluster + `",
+			"model": {"registry": "dummy", "name": "dummy", "version": "v0"},
+			"engine": {"engine": "vllm", "version": "v0.12.0"},
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "1024",
+					"virtualization.core_percent": "10"
+				}
+			},
+			"replicas": {"num": 1}
+		}
+	}`
+}
+
+func endpointValidationVGPUPercentPayload(cluster string) string {
+	return `{
+		"api_version": "v1",
+		"kind": "Endpoint",
+		"metadata": {"name": "endpoint", "workspace": "default"},
+		"spec": {
+			"cluster": "` + cluster + `",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_percent": "50",
+					"virtualization.core_percent": "10"
+				}
+			}
+		}
+	}`
+}
+
+func endpointValidationVGPUResourcePatchPayload() string {
+	return `{
+		"spec": {
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "1024",
+					"virtualization.core_percent": "10"
+				}
+			}
+		}
+	}`
+}
+
+func endpointValidationVGPUResourcePatchPayloadWithCluster(cluster string) string {
+	return `{
+		"spec": {
+			"cluster": "` + cluster + `",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "1024",
+					"virtualization.core_percent": "10"
+				}
+			}
+		}
+	}`
+}
+
+func endpointValidationCluster(enabled bool, phase v1.ComponentPhase, memoryMiB, coreUnits float64) v1.Cluster {
+	return endpointValidationClusterInWorkspace("default", enabled, phase, memoryMiB, coreUnits)
+}
+
+func endpointValidationClusterInWorkspace(workspace string, enabled bool, phase v1.ComponentPhase, memoryMiB, coreUnits float64) v1.Cluster {
+	cluster := endpointValidationClusterWithProduct("Tesla-T4", enabled, phase, memoryMiB, coreUnits)
+	cluster.Metadata.Workspace = workspace
+
+	return cluster
+}
+
+func endpointValidationClusterWithoutProductMetadata(enabled bool, phase v1.ComponentPhase, memoryMiB, coreUnits float64) v1.Cluster {
+	cluster := endpointValidationCluster(enabled, phase, memoryMiB, coreUnits)
+	cluster.Status.ResourceInfo.AcceleratorMetadata = nil
+
+	return cluster
+}
+
+func endpointValidationClusterWithProduct(product string, enabled bool, phase v1.ComponentPhase, memoryMiB, coreUnits float64) v1.Cluster {
+	return v1.Cluster{
+		Metadata: &v1.Metadata{Name: "k8s-cluster", Workspace: "default"},
+		Spec: &v1.ClusterSpec{
+			Type:                      v1.KubernetesClusterType,
+			AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: enabled},
+		},
+		Status: &v1.ClusterStatus{
+			ComponentStatus: map[string]*v1.ComponentStatus{
+				v1.ComponentStatusAcceleratorVirtualizationKey: {
+					Phase:   phase,
+					Reason:  "HAMiNotReady",
+					Message: "HAMi device plugin is not ready",
+				},
+			},
+			ResourceInfo: &v1.ClusterResources{
+				AcceleratorMetadata: map[v1.AcceleratorType]*v1.AcceleratorMetadata{
+					v1.AcceleratorTypeNVIDIAGPU: {
+						Products: map[v1.AcceleratorProduct]*v1.AcceleratorProductMetadata{
+							v1.AcceleratorProduct(product): {MemoryTotalMiB: 16384},
+						},
+					},
+				},
+				ResourceStatus: v1.ResourceStatus{
+					Available: &v1.ResourceInfo{
+						AcceleratorGroups: map[v1.AcceleratorType]*v1.AcceleratorGroup{
+							v1.AcceleratorTypeNVIDIAGPU: {
+								Products: map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{
+									v1.AcceleratorProduct(product): {
+										Quantity: 1,
+										Virtualization: &v1.AcceleratorVirtualizationResource{
+											MemoryMiB: memoryMiB,
+											CoreUnits: coreUnits,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func endpointValidationClusterMissingComponentStatus() v1.Cluster {
+	cluster := endpointValidationCluster(true, v1.ComponentPhaseReady, 32768, 200)
+	cluster.Status.ComponentStatus = nil
+
+	return cluster
+}
+
+func endpointValidationClusterWithType(clusterType string, enabled bool, phase v1.ComponentPhase) v1.Cluster {
+	cluster := endpointValidationCluster(enabled, phase, 32768, 200)
+	cluster.Spec.Type = clusterType
+
+	return cluster
+}
+
+func clusterLookupFilters(cluster, workspace string) []storage.Filter {
+	return []storage.Filter{
+		{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(cluster)},
+		{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
+	}
+}
+
+func matchListOption(filters []storage.Filter) interface{} {
+	return mock.MatchedBy(func(option storage.ListOption) bool {
+		return filtersEqualUnordered(filters, option.Filters)
+	})
+}
+
+func filtersEqualUnordered(expected, actual []storage.Filter) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+
+	unmatched := make([]storage.Filter, len(actual))
+	copy(unmatched, actual)
+
+	for _, expectedFilter := range expected {
+		found := false
+		for i, actualFilter := range unmatched {
+			if reflect.DeepEqual(expectedFilter, actualFilter) {
+				unmatched = append(unmatched[:i], unmatched[i+1:]...)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return len(unmatched) == 0
 }

--- a/internal/routes/proxies/validation_error.go
+++ b/internal/routes/proxies/validation_error.go
@@ -1,7 +1,8 @@
 package proxies
 
 type validationError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Hint    string `json:"hint"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+	Hint       string `json:"hint"`
+	HTTPStatus int    `json:"-"`
 }


### PR DESCRIPTION
## Issue

NEU-476

## Summary

Add API-side preflight validation for Endpoint vGPU create requests and vGPU resource PATCH requests so requests are rejected before PostgREST persistence when the associated target cluster is missing, ambiguous, or does not have accelerator virtualization enabled and Ready.

Capacity validation, product availability, and vGPU virtualization configuration rationality are intentionally out of scope for this PR and are tracked by NEU-467.

## Changes

- Use control-plane `deps.Storage` reads for Endpoint/Cluster preflight; PostgREST proxying still handles final persistence.
- Add a request-level validation wrapper that decodes the Endpoint payload once, then runs body shape validation and cluster readiness preflight.
- Keep existing vGPU resource shape validation before proxying Endpoint POST/PATCH requests.
- Resolve the target cluster/workspace for vGPU POST requests, and for PATCH requests that include vGPU `spec.resources` but omit `spec.cluster` or target workspace, by looking up the existing Endpoint from the request filters through `deps.Storage`.
- Reject vGPU requests when the target cluster is missing, ambiguous, not Kubernetes, or has accelerator virtualization disabled/not ready.
- Return sanitized HTTP 503 for Endpoint/Cluster lookup execution failures.
- Do not reject based on `status.resource_info.available`, product capacity, product metadata, or vGPU capacity calculations; those checks belong to NEU-467.
- Preserve non-vGPU requests, soft-delete PATCH requests, and PATCH requests that do not include vGPU `spec.resources`.
- Add route-level regression tests for invalid create, invalid PATCH, existing Endpoint lookup, valid forwarding, non-vGPU bypass, soft-delete bypass, cluster-only PATCH bypass, lookup error sanitization, and the NEU-467 boundary.

## Test Plan

### Unit test

- [x] `git diff --check`
- [x] `go test ./internal/routes/proxies -run TestValidateEndpointAcceleratorVirtualizationRequestRunsBodyAndPreflight -count=1 -v`
- [x] `go test ./internal/routes/proxies -run 'TestValidateEndpointAcceleratorVirtualizationRequestRunsBodyAndPreflight|TestRegisterEndpointRoutesUsesExistingEndpointWorkspaceForVGPUResourcePatch|TestRegisterEndpointRoutesHides(Cluster|Endpoint)LookupErrors' -count=1 -v`
- [x] `go test ./internal/routes/proxies -run 'TestRegisterEndpointRoutesForwardsVGPUCreateWhenClusterVirtualizationReady|TestRegisterEndpointRoutesForwardsVGPUCreateWhenClusterVirtualizationIsReady' -v -count=1`
- [x] `go test ./internal/routes/proxies -count=1`
- [x] `go vet ./internal/routes/proxies`
- [x] `/tmp/neutree-codex-tools/golangci-lint run ./internal/routes/proxies/...`
- [x] `go vet ./...`
- [x] `go test ./...` checked; it failed only in `github.com/neutree-ai/neutree/db/dbtest` because local PostgreSQL at `127.0.0.1:5432` refused connections. Other packages shown in the output, including `internal/routes/proxies` and `tests/e2e`, passed.
- [x] TDD RED observed before implementation: focused vGPU route tests failed because invalid POST/PATCH requests were forwarded and storage expectations were unmet.
- [x] Scope-correction RED observed before removing the capacity gate: Ready-cluster cases with missing product, low availability, or missing metadata returned HTTP 400; after the fix they return HTTP 201 and forward upstream.
- [x] Wrapper RED observed before refactor: `TestValidateEndpointAcceleratorVirtualizationRequestRunsBodyAndPreflight` failed to compile before the request-level wrapper existed, then passed after implementation.
- [x] Step 7 design correction: rejected the extra request-scoped PostgREST reader direction after confirming API/control-plane should use `deps.Storage`; route tests cover direct storage lookup, request wrapper, existing Endpoint lookup, and sanitized 503 lookup errors.
- [x] PR CI for current head `c43aa5a6d7230216b99d8b0e5df61b92b1a29e81` passed: `codecov/patch` and `pr-check`; job https://github.com/neutree-ai/neutree/actions/runs/28039115520/job/83000397940.

### DB test

- [x] Not affected. This change does not add or modify DB schema, migrations, or storage persistence behavior.
- [x] DB package execution was attempted via `go test ./...`; `db/dbtest` requires a local PostgreSQL instance and failed with `dial tcp 127.0.0.1:5432: connect: connection refused` in this workspace.

### E2E test

- [x] Previous runtime evidence for PR head `a49f984b8622cd58837fe96b72f8200ef933d66d`: manual `C2723124` returned HTTP 400 with code `10222` for a target cluster without `spec.accelerator_virtualization`, and follow-up Endpoint lookup returned `[]`.
- [x] Previous runtime evidence for PR head `a49f984b8622cd58837fe96b72f8200ef933d66d`: code-backed positive vGPU regression passed with `NEUTREE_SERVER_URL=http://192.168.20.158:3000 E2E_PROFILE_PATH=/tmp/neu476-refresh-e2e/profile.yaml make e2e-test LABEL_FILTER='accelerator-virtualization && happy-path' E2E_TIMEOUT=60m`; Ginkgo ran 3 of 245 specs in 688.587s: `3 Passed`, `0 Failed`, `242 Skipped`.
- [ ] Runtime E2E must be refreshed for current head `c43aa5a6d7230216b99d8b0e5df61b92b1a29e81` because Go runtime source changed after the previous E2E run.

## Risk & Rollback

No DB schema change. The main behavioral risk is rejecting a vGPU PATCH when the existing Endpoint cannot be uniquely resolved from the request filters; this intentionally fails closed only for PATCH payloads that include vGPU `spec.resources`. Capacity shortages and vGPU configuration rationality remain outside this PR and should be handled by NEU-467. Rollback is reverting this commit and redeploying the control plane.