### PR TITLE
fix: clarify model download status messages

### DIFF
--- a/internal/orchestrator/kubernetes_orchestrator.go
+++ b/internal/orchestrator/kubernetes_orchestrator.go
@@ -670,7 +670,27 @@ func hasIncompleteModelDownloaderInitContainer(pods []corev1.Pod) (bool, string)
 				return true, modelDownloaderInitContainerName + " init container is running"
 			}
 
-			return true, modelDownloaderInitContainerName + " init container has not completed"
+			if initStatus.State.Waiting != nil {
+				message := fmt.Sprintf("%s init container is waiting (reason=%s)",
+					modelDownloaderInitContainerName, initStatus.State.Waiting.Reason)
+				if initStatus.State.Waiting.Message != "" {
+					message += ": " + initStatus.State.Waiting.Message
+				}
+
+				return true, message
+			}
+
+			if initStatus.State.Terminated != nil {
+				message := fmt.Sprintf("%s init container terminated with exit code %d after %d restart(s), retrying model download",
+					modelDownloaderInitContainerName, initStatus.State.Terminated.ExitCode, initStatus.RestartCount)
+				if initStatus.State.Terminated.Message != "" {
+					message += ": " + initStatus.State.Terminated.Message
+				}
+
+				return true, message
+			}
+
+			return true, modelDownloaderInitContainerName + " init container has not started; waiting for model download to start"
 		}
 	}
 

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -2931,7 +2931,7 @@ func TestKubernetesOrchestrator_getEndpointStats(t *testing.T) {
 					WithTerminatedInitContainer(modelDownloaderInitContainerName, 1, 1)
 			},
 			expectedPhase:  v1.EndpointPhaseMODELDOWNLOADING,
-			expectErrorMsg: modelDownloaderInitContainerName + " init container has not completed",
+			expectErrorMsg: modelDownloaderInitContainerName + " init container terminated with exit code 1 after 1 restart(s), retrying model download",
 			expectError:    false,
 		},
 		{
@@ -2973,7 +2973,7 @@ func TestKubernetesOrchestrator_getEndpointStats(t *testing.T) {
 					WithWaitingInitContainer(modelDownloaderInitContainerName, k8sContainerReasonPodInitializing)
 			},
 			expectedPhase:  v1.EndpointPhaseMODELDOWNLOADING,
-			expectErrorMsg: modelDownloaderInitContainerName + " init container has not completed",
+			expectErrorMsg: modelDownloaderInitContainerName + " init container is waiting (reason=PodInitializing)",
 			expectError:    false,
 		},
 		{

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -472,7 +472,9 @@ func inspectRayModelDownloadLogs(svc dashboard.DashboardService, appStatus dashb
 		firstErr         error
 		doneDetail       string
 		inProgressDetail string
+		noReplicaDetail  string
 		unknownActorSeen bool
+		unknownActorMsg  string
 	)
 
 	for deploymentKey, deployment := range appStatus.Deployments {
@@ -485,8 +487,24 @@ func inspectRayModelDownloadLogs(svc dashboard.DashboardService, appStatus dashb
 			continue
 		}
 
+		if len(deployment.Replicas) == 0 {
+			noReplicaDetail = fmt.Sprintf("Backend deployment %s has no replica actors yet; waiting for model download to start", deploymentName)
+			continue
+		}
+
 		for _, replica := range deployment.Replicas {
 			if replica.ActorID == "" {
+				unknownActorSeen = true
+
+				if unknownActorMsg == "" {
+					replicaID := replica.ReplicaID
+					if replicaID == "" {
+						replicaID = "unknown"
+					}
+
+					unknownActorMsg = fmt.Sprintf("Deployment %s replica %s has no actor ID yet; waiting for model download logs", deploymentName, replicaID)
+				}
+
 				continue
 			}
 
@@ -528,6 +546,10 @@ func inspectRayModelDownloadLogs(svc dashboard.DashboardService, appStatus dashb
 				inProgressDetail = fmt.Sprintf("Deployment %s replica %s model download in progress", deploymentName, replicaID)
 			case modelDownloadMarkerNone:
 				unknownActorSeen = true
+
+				if unknownActorMsg == "" {
+					unknownActorMsg = fmt.Sprintf("Deployment %s replica %s has no model download marker yet", deploymentName, replicaID)
+				}
 			}
 		}
 	}
@@ -537,7 +559,11 @@ func inspectRayModelDownloadLogs(svc dashboard.DashboardService, appStatus dashb
 	}
 
 	if unknownActorSeen {
-		return modelDownloadMarkerNone, "", firstErr
+		return modelDownloadMarkerNone, unknownActorMsg, firstErr
+	}
+
+	if noReplicaDetail != "" {
+		return modelDownloadMarkerNone, noReplicaDetail, firstErr
 	}
 
 	if doneDetail != "" {
@@ -545,6 +571,26 @@ func inspectRayModelDownloadLogs(svc dashboard.DashboardService, appStatus dashb
 	}
 
 	return modelDownloadMarkerNone, "", firstErr
+}
+
+func pendingRayModelDownloadMessage(
+	appStatus dashboard.RayServeApplicationStatus,
+	markerMsg string,
+	markerErr error,
+) string {
+	if markerMsg != "" {
+		if markerErr != nil {
+			return markerMsg + "; failed to inspect backend actor logs: " + markerErr.Error()
+		}
+
+		return markerMsg
+	}
+
+	if markerErr != nil {
+		return "failed to inspect backend actor logs: " + markerErr.Error()
+	}
+
+	return fmt.Sprintf("Ray Serve application status=%s has no backend replicas yet; waiting for model download to start", appStatus.Status)
 }
 
 func currentModelDownloadHashMatches(endpoint *v1.Endpoint, currentModelHash string) bool {
@@ -603,7 +649,7 @@ func resolveRayStartupModelDownloadStatus(
 			phase = v1.EndpointPhaseMODELDOWNLOADING
 			modelDownloadIncomplete = true
 
-			errorMessages = append(errorMessages, "current model download is not completed")
+			errorMessages = append(errorMessages, pendingRayModelDownloadMessage(appStatus, markerMsg, markerErr))
 		}
 	}
 

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2338,7 +2338,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 				}, nil)
 			},
 			expectedPhase:  v1.EndpointPhaseMODELDOWNLOADING,
-			expectErrorMsg: "model download is not completed",
+			expectErrorMsg: "Ray Serve application status=DEPLOYING has no backend replicas yet; waiting for model download to start",
 			expectError:    false,
 		},
 		{
@@ -2364,7 +2364,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 				}, nil)
 			},
 			expectedPhase:  v1.EndpointPhaseMODELDOWNLOADING,
-			expectErrorMsg: "model download is not completed",
+			expectErrorMsg: "Ray Serve application status=NOT_STARTED has no backend replicas yet; waiting for model download to start",
 			expectError:    false,
 		},
 		{
@@ -2626,7 +2626,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			},
 			expectedPhase:                v1.EndpointPhaseMODELDOWNLOADING,
 			expectModelDownloadHashEmpty: true,
-			expectErrorMsg:               "model download is not completed",
+			expectErrorMsg:               "Backend deployment BACKEND has no replica actors yet; waiting for model download to start",
 			expectError:                  false,
 		},
 		{
@@ -2901,7 +2901,51 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			},
 			expectedPhase:                v1.EndpointPhaseMODELDOWNLOADING,
 			expectModelDownloadHashEmpty: true,
-			expectErrorMsg:               "model download is not completed",
+			expectErrorMsg:               "Deployment BACKEND replica backend-replica-1 has no model download marker yet",
+			expectError:                  false,
+		},
+		{
+			name: "prefer missing backend actor ID message over unrelated log probe failure",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {
+									Name:   "BACKEND",
+									Status: "UPDATING",
+									Replicas: []dashboard.Replica{
+										{
+											ReplicaID: "backend-replica-no-actor",
+										},
+										{
+											ActorID:   "actor-log-error",
+											ReplicaID: "backend-replica-log-error",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+				mockDashboard.On("GetActorLog", "actor-log-error", "out", 200).Return("", assert.AnError)
+				mockDashboard.On("GetActorLog", "actor-log-error", "err", 200).Return("", assert.AnError)
+			},
+			expectedPhase:                v1.EndpointPhaseMODELDOWNLOADING,
+			expectModelDownloadHashEmpty: true,
+			expectErrorMsg:               "Deployment BACKEND replica backend-replica-no-actor has no actor ID yet",
 			expectError:                  false,
 		},
 		{
@@ -2983,7 +3027,7 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			},
 			expectedPhase:                v1.EndpointPhaseMODELDOWNLOADING,
 			expectModelDownloadHashEmpty: true,
-			expectErrorMsg:               "model download is not completed",
+			expectErrorMsg:               "failed to inspect backend actor logs",
 			expectError:                  false,
 		},
 		{


### PR DESCRIPTION
## Issue

n/a

## Summary

Clarify `ModelDownloading` endpoint status messages so operators can distinguish download startup, missing backend replica evidence, missing Ray actor log markers, log probe failures, and Kubernetes init container retry state without adding a new phase or changing the API schema.

## Changes

- Include Kubernetes `model-downloader` init container waiting reason, termination exit code, restart count, and retry context in `status.error_message`.
- Include Ray Serve backend deployment, replica actor, log marker, and log probe details when the current model download is not yet confirmed.
- Preserve the most specific missing backend actor evidence when another replica has an unrelated log probe failure.
- Update orchestrator unit tests to lock the more specific diagnostic messages.

## Test Plan

- [x] Unit test
  - RED: `go test ./internal/orchestrator -run 'Test(KubernetesOrchestrator_getEndpointStats|RayOrchestrator_GetEndpointStatus)$' -count=1 -v` failed on the new expected `error_message` assertions before implementation.
  - RED: the new Ray subtest `prefer missing backend actor ID message over unrelated log probe failure` failed before changing `pendingRayModelDownloadMessage()` precedence.
  - GREEN: `go test ./internal/orchestrator -run 'Test(KubernetesOrchestrator_getEndpointStats|RayOrchestrator_GetEndpointStatus)$' -count=1 -v` passed.
  - `go test ./internal/orchestrator -count=1` passed.
  - `go vet ./internal/orchestrator` passed.
  - `git diff --check` passed.
  - `git diff --name-status origin/main...HEAD` now contains only the four orchestrator files changed by this PR.
  - `go test ./...` was attempted but blocked by a pre-existing local artifact requirement: `cmd/neutree-cli/app/cmd/launch/manifests/core.go:7:12: pattern neutree-core.tar: no matching files found`.
  - `golangci-lint run ./internal/orchestrator/...` was attempted locally but the installed `golangci-lint v1.53.3` built with Go 1.20.6 failed typecheck against the Go 1.23.7 workspace and generated mocks/stdlib; not used as passing evidence. GitHub CI uses `golangci-lint v1.64.6`.
- [x] DB test
  - Not affected; no database schema, storage, migration, or RLS changes.
- [x] E2E test
  - Not required for this Trivial status-message-only change; endpoint phases, deployment flow, Ray/Kubernetes control flow, and API schema are unchanged. Manual testing is not required.

## Risk & Rollback

Low risk. The change only enriches controller-owned status text for existing `ModelDownloading` cases. Roll back by reverting this PR; no migration or compatibility action is required.
