### PR TITLE
fix: prevent deleting models used by endpoints

### DIFF
--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -27,6 +27,8 @@ type Dependencies struct {
 	AuthConfig  middleware.AuthConfig
 }
 
+const modelReferencedByEndpointCode = "10131"
+
 // progressWriter implements io.Writer for progress reporting via HTTP chunked encoding
 type progressWriter struct {
 	writer    io.Writer
@@ -448,14 +450,80 @@ func downloadModel(deps *Dependencies) gin.HandlerFunc {
 	}
 }
 
+func validateModelDeletion(deps *Dependencies, workspace, registryName, modelName, version string) (int, error) {
+	endpoints, err := deps.Storage.ListEndpoint(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->workspace",
+				Operator: "eq",
+				Value:    strconv.Quote(workspace),
+			},
+			{
+				Column:   "spec->model->>registry",
+				Operator: "eq",
+				Value:    registryName,
+			},
+			{
+				Column:   "spec->model->>name",
+				Operator: "eq",
+				Value:    modelName,
+			},
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list endpoints: %w", err)
+	}
+
+	references := 0
+
+	for _, endpoint := range endpoints {
+		if endpoint.Spec == nil || endpoint.Spec.Model == nil {
+			continue
+		}
+
+		endpointVersion := endpoint.Spec.Model.Version
+		if endpointVersion == "" {
+			endpointVersion = v1.LatestVersion
+		}
+
+		if version == v1.LatestVersion || endpointVersion == v1.LatestVersion || endpointVersion == version {
+			references++
+		}
+	}
+
+	return references, nil
+}
+
 // deleteModel handles deleting a model
 func deleteModel(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		workspace := c.Param("workspace")
+		registryName := c.Param("registry")
 		modelName := c.Param("model")
 
 		version := c.Query("version")
 		if version == "" {
 			version = v1.LatestVersion
+		}
+
+		references, err := validateModelDeletion(deps, workspace, registryName, modelName, version)
+		if err != nil {
+			klog.Errorf("Failed to validate model deletion %s/%s/%s:%s: %v", workspace, registryName, modelName, version, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": fmt.Sprintf("Failed to validate model deletion: %v", err),
+			})
+
+			return
+		}
+
+		if references > 0 {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"code":    modelReferencedByEndpointCode,
+				"message": fmt.Sprintf("cannot delete model '%s/%s/%s:%s'", workspace, registryName, modelName, version),
+				"hint":    fmt.Sprintf("%d endpoint(s) still reference this model", references),
+			})
+
+			return
 		}
 
 		// Get and connect to the model registry

--- a/internal/routes/models/models_test.go
+++ b/internal/routes/models/models_test.go
@@ -82,6 +82,53 @@ func setupMocks(t *testing.T) (*mocks.MockStorage, *model_registry_mocks.MockMod
 	return mockStorage, mockModelRegistry
 }
 
+func endpointModelReferenceFilterMatcher(workspace, registryName, modelName string) interface{} {
+	return mock.MatchedBy(func(option storage.ListOption) bool {
+		expected := map[string]string{
+			"metadata->workspace":    strconvQuote(workspace),
+			"spec->model->>registry": registryName,
+			"spec->model->>name":     modelName,
+		}
+
+		if len(option.Filters) != len(expected) {
+			return false
+		}
+
+		for _, filter := range option.Filters {
+			if filter.Operator != "eq" {
+				return false
+			}
+
+			value, ok := expected[filter.Column]
+			if !ok || filter.Value != value {
+				return false
+			}
+		}
+
+		return true
+	})
+}
+
+func strconvQuote(value string) string {
+	return "\"" + value + "\""
+}
+
+func setVersionQuery(c *gin.Context, version string) {
+	c.Request.URL.RawQuery = "version=" + version
+}
+
+func endpointWithModel(registryName, modelName, version string) v1.Endpoint {
+	return v1.Endpoint{
+		Spec: &v1.EndpointSpec{
+			Model: &v1.ModelSpec{
+				Registry: registryName,
+				Name:     modelName,
+				Version:  version,
+			},
+		},
+	}
+}
+
 func TestListModels_Success(t *testing.T) {
 	// Setup mocks
 	mockStorage, mockModelRegistry := setupMocks(t)
@@ -386,6 +433,8 @@ func TestDeleteModel_Success(t *testing.T) {
 
 	// Configure mock behaviors
 	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{modelRegistry}, nil)
+	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
+		Return([]v1.Endpoint{}, nil)
 	mockModelRegistry.On("Connect").Return(nil)
 	mockModelRegistry.On("Disconnect").Return(nil)
 	mockModelRegistry.On("DeleteModel", "test-model", v1.LatestVersion).Return(nil)
@@ -398,6 +447,190 @@ func TestDeleteModel_Success(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
 
 	// Verify mock expectations
+	mockStorage.AssertExpectations(t)
+	mockModelRegistry.AssertExpectations(t)
+}
+
+func TestDeleteModel_BlockedWhenEndpointReferencesExactVersion(t *testing.T) {
+	mockStorage, mockModelRegistry := setupMocks(t)
+
+	deps := &Dependencies{
+		Storage: mockStorage,
+		TempDirFunc: func() (string, error) {
+			return t.TempDir(), nil
+		},
+	}
+
+	c, w := createMockContext("default", "test-registry", "test-model", "")
+	setVersionQuery(c, "v1.0.0")
+
+	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
+		Return([]v1.Endpoint{endpointWithModel("test-registry", "test-model", "v1.0.0")}, nil)
+	mockModelRegistry.On("DeleteModel", "test-model", "v1.0.0").Return(nil).Maybe()
+
+	handlerFunc := deleteModel(deps)
+	handlerFunc(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "10131", response["code"])
+	assert.Contains(t, response["message"], "cannot delete model 'default/test-registry/test-model:v1.0.0'")
+	assert.Contains(t, response["hint"], "1 endpoint(s) still reference this model")
+
+	mockModelRegistry.AssertNotCalled(t, "DeleteModel", "test-model", "v1.0.0")
+	mockStorage.AssertExpectations(t)
+	mockModelRegistry.AssertExpectations(t)
+}
+
+func TestDeleteModel_BlockedWhenEndpointReferencesLatestVersion(t *testing.T) {
+	testCases := []struct {
+		name            string
+		endpointVersion string
+	}{
+		{
+			name:            "latest",
+			endpointVersion: v1.LatestVersion,
+		},
+		{
+			name:            "empty",
+			endpointVersion: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStorage, mockModelRegistry := setupMocks(t)
+
+			deps := &Dependencies{
+				Storage: mockStorage,
+				TempDirFunc: func() (string, error) {
+					return t.TempDir(), nil
+				},
+			}
+
+			c, w := createMockContext("default", "test-registry", "test-model", "")
+			setVersionQuery(c, "v1.0.0")
+
+			mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
+				Return([]v1.Endpoint{endpointWithModel("test-registry", "test-model", tc.endpointVersion)}, nil)
+			mockModelRegistry.On("DeleteModel", "test-model", "v1.0.0").Return(nil).Maybe()
+
+			handlerFunc := deleteModel(deps)
+			handlerFunc(c)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+
+			var response map[string]string
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, "10131", response["code"])
+			assert.Contains(t, response["hint"], "1 endpoint(s) still reference this model")
+
+			mockModelRegistry.AssertNotCalled(t, "DeleteModel", "test-model", "v1.0.0")
+			mockStorage.AssertExpectations(t)
+			mockModelRegistry.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDeleteModel_BlockedWhenDeletingLatestAndEndpointReferencesConcreteVersion(t *testing.T) {
+	mockStorage, mockModelRegistry := setupMocks(t)
+
+	deps := &Dependencies{
+		Storage: mockStorage,
+		TempDirFunc: func() (string, error) {
+			return t.TempDir(), nil
+		},
+	}
+
+	c, w := createMockContext("default", "test-registry", "test-model", "")
+
+	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
+		Return([]v1.Endpoint{endpointWithModel("test-registry", "test-model", "v1.0.0")}, nil)
+	mockModelRegistry.On("DeleteModel", "test-model", v1.LatestVersion).Return(nil).Maybe()
+
+	handlerFunc := deleteModel(deps)
+	handlerFunc(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "10131", response["code"])
+	assert.Contains(t, response["message"], "cannot delete model 'default/test-registry/test-model:latest'")
+	assert.Contains(t, response["hint"], "1 endpoint(s) still reference this model")
+
+	mockModelRegistry.AssertNotCalled(t, "DeleteModel", "test-model", v1.LatestVersion)
+	mockStorage.AssertExpectations(t)
+	mockModelRegistry.AssertExpectations(t)
+}
+
+func TestDeleteModel_AllowsUnrelatedEndpointVersion(t *testing.T) {
+	mockStorage, mockModelRegistry := setupMocks(t)
+
+	deps := &Dependencies{
+		Storage: mockStorage,
+		TempDirFunc: func() (string, error) {
+			return t.TempDir(), nil
+		},
+	}
+
+	c, _ := createMockContext("default", "test-registry", "test-model", "")
+	setVersionQuery(c, "v1.0.0")
+
+	modelRegistry := v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: "bentoml",
+		},
+	}
+
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{modelRegistry}, nil)
+	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
+		Return([]v1.Endpoint{endpointWithModel("test-registry", "test-model", "v2.0.0")}, nil)
+	mockModelRegistry.On("Connect").Return(nil)
+	mockModelRegistry.On("Disconnect").Return(nil)
+	mockModelRegistry.On("DeleteModel", "test-model", "v1.0.0").Return(nil)
+
+	handlerFunc := deleteModel(deps)
+	handlerFunc(c)
+
+	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
+
+	mockStorage.AssertExpectations(t)
+	mockModelRegistry.AssertExpectations(t)
+}
+
+func TestDeleteModel_ValidationErrorSkipsRegistryDelete(t *testing.T) {
+	mockStorage, mockModelRegistry := setupMocks(t)
+
+	deps := &Dependencies{
+		Storage: mockStorage,
+		TempDirFunc: func() (string, error) {
+			return t.TempDir(), nil
+		},
+	}
+
+	c, w := createMockContext("default", "test-registry", "test-model", "")
+
+	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
+		Return([]v1.Endpoint{}, errors.New("list endpoint error"))
+	mockModelRegistry.On("DeleteModel", "test-model", v1.LatestVersion).Return(nil).Maybe()
+
+	handlerFunc := deleteModel(deps)
+	handlerFunc(c)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	var response map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Contains(t, response["message"], "Failed to validate model deletion")
+
+	mockModelRegistry.AssertNotCalled(t, "DeleteModel", "test-model", v1.LatestVersion)
 	mockStorage.AssertExpectations(t)
 	mockModelRegistry.AssertExpectations(t)
 }

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -117,6 +117,35 @@ func pushModel(name, version string, fileSize int, extraArgs ...string) CLIResul
 	return Model.Push(modelDir, name, version, extraArgs...)
 }
 
+func applyPausedEndpointReferencingModel(endpointName, modelName, modelVersion string) {
+	endpointYAML := fmt.Sprintf(`apiVersion: v1
+kind: Endpoint
+metadata:
+  name: %s
+  workspace: %s
+spec:
+  cluster: e2e-missing-cluster-%s
+  engine:
+    engine: %s
+    version: %s
+  model:
+    registry: %s
+    name: %s
+    version: %s
+    task: %s
+  resources:
+    gpu: "0"
+  replicas:
+    num: 0
+`, endpointName, profileWorkspace(), Cfg.RunID, profileEngineName(), profileEngineVersion(), testRegistry(), modelName, modelVersion, profileModelTask())
+
+	yamlPath := filepath.Join(GinkgoT().TempDir(), endpointName+".yaml")
+	Expect(os.WriteFile(yamlPath, []byte(endpointYAML), 0644)).To(Succeed())
+
+	r := RunCLI("apply", "-f", yamlPath)
+	ExpectSuccess(r)
+}
+
 // --- Tests ---
 
 var _ = Describe("Model", Ordered, func() {
@@ -344,6 +373,39 @@ var _ = Describe("Model", Ordered, func() {
 			r = Model.List()
 			ExpectSuccess(r)
 			Expect(ParseTable(r.Stdout)).NotTo(ContainElement(HaveKeyWithValue("NAME", name)))
+		})
+
+		// TestRail: C2723579
+		It("should reject deleting a model referenced by an endpoint", Label("C2723579"), func() {
+			name := "e2e-delete-ref-" + Cfg.RunID
+			version := "v1.0"
+			endpointName := "e2e-model-ref-" + Cfg.RunID
+
+			DeferCleanup(func() {
+				deleteEndpoint(endpointName)
+				Model.EnsureDeleted(name, version)
+			})
+
+			r := pushModel(name, version, 64)
+			ExpectSuccess(r)
+
+			applyPausedEndpointReferencingModel(endpointName, name, version)
+
+			r = Model.Delete(name)
+			ExpectFailed(r)
+			Expect(r.Stdout + r.Stderr).To(ContainSubstring("10131"))
+			Expect(r.Stdout + r.Stderr).To(ContainSubstring("still reference this model"))
+
+			r = Model.Delete(name + ":" + version)
+			ExpectFailed(r)
+			Expect(r.Stdout + r.Stderr).To(ContainSubstring("10131"))
+			Expect(r.Stdout + r.Stderr).To(ContainSubstring("still reference this model"))
+
+			deleteEndpoint(endpointName)
+
+			r = Model.Delete(name + ":" + version)
+			ExpectSuccess(r)
+			ExpectStdoutContains(r, "deleted successfully")
 		})
 	})
 


### PR DESCRIPTION
## Issue

NEU-199

## Summary

Prevent model deletion when an Endpoint still references the same workspace, model registry, model name, and relevant model version. The API now performs the dependency check before connecting to the model registry, and the CLI surfaces the existing server error body.

## Changes

- Add API-side Endpoint reference validation before model deletion.
- Return `10131` with a clear message and hint when Endpoint references block deletion.
- Treat default `latest` deletion conservatively so endpoints pinned to a concrete model version also block `model delete <name>`.
- Add model route unit coverage for exact version, empty/latest Endpoint version, default latest deletion, unrelated version, validation errors, and successful deletion.
- Add E2E regression case `C2723579` for delete failure while referenced and success after Endpoint removal.

## Test Plan

Unit test:
- [x] `go test ./internal/routes/models`
- [x] `go test ./tests/e2e -run TestDoesNotExist`
- [x] `git diff --check`
- [ ] `go test ./...` not used as blocking evidence; baseline fails before this change because `cmd/neutree-cli/app/cmd/launch/manifests/core.go` cannot find `neutree-core.tar`.

DB test:
- [x] Not affected. No DB schema, migration, RLS, or storage interface changes.

E2E test:
- [x] Manual C2723579 on CP `10.255.1.136` before Step 7 review fix: created NFS/BentoML model registry, pushed a model, created an Endpoint referencing it, confirmed model delete failed with `10131` and `still reference this model`, deleted the Endpoint, then confirmed model delete succeeded.
- [x] Code-backed scoped E2E before Step 7 review fix: `E2E_PROFILE_PATH=<step5-profile> NEUTREE_SERVER_URL=http://10.255.1.136:3000 NEUTREE_API_KEY=<masked> make e2e-test LABEL_FILTER='C2723579' E2E_TIMEOUT=20m` passed: 1/1 selected spec passed, 245 skipped.
- [x] Fresh Step 5 rerun for behavior head `114c00ef09dba3852e1aafa4d130990f2d1e111e`: rebuilt CP `10.255.1.136` on baseline `v1.1.0-nightly-20260622`, hot-updated `neutree-api`, created NFS/BentoML model registry, pushed `neu199-delete-ref-manual123500:v1.0`, created a paused Endpoint reference, confirmed both default `model delete <name>` and explicit `model delete <name>:v1.0` failed with `10131` and `still reference this model`, deleted the Endpoint, then confirmed model delete succeeded.
- [x] Code-backed scoped E2E for current head: `E2E_PROFILE_PATH=/tmp/neutree-step5-rerun.QwTjQv/profile.yaml NEUTREE_SERVER_URL=http://10.255.1.136:3000 NEUTREE_API_KEY=<masked> make e2e-test LABEL_FILTER='C2723579' E2E_TIMEOUT=20m` passed: 1/1 selected spec passed, 245 skipped, package ok in `51.820s`.
- [x] Runtime under test: baseline CP image set `v1.1.0-nightly-20260622`, then hot-updated `neutree-api` from behavior head `114c00ef09dba3852e1aafa4d130990f2d1e111e`. Current PR head is `87f6fd9995a38e5ab46a02092395687d9ec00de7`; the only post-E2E delta is a lint-required blank line in `internal/routes/models/models.go`, so no E2E rerun is required. The latest `v1.1.0-nightly-20260624` artifact index exists, but prior Step 5 deployment found its registry image set incomplete, so `20260622` remains the deployable baseline used for this validation.

## Risk & Rollback

Risk is limited to model deletion requests. Rollback by reverting this commit to restore the previous delete path. No DB migration or data backfill is required.