### PR TITLE
fix: report NotReady when no NVIDIA GPU nodes available for vGPU

### DIFF
--- a/internal/accelerator/plugin/gpu_virtualization.go
+++ b/internal/accelerator/plugin/gpu_virtualization.go
@@ -72,10 +72,16 @@ func (p *GPUAcceleratorPlugin) ResolveVirtualizationConfig(
 		}
 	}
 
+	candidateNodes := NvidiaVirtualizationCandidateNodes(input.Nodes)
+	if len(candidateNodes) == 0 {
+		blockingReasons = append(blockingReasons,
+			"No NVIDIA GPU nodes available for vGPU virtualization")
+	}
+
 	return &VirtualizationConfig{
 		Supported:       true,
 		BlockingReasons: blockingReasons,
-		CandidateNodes:  NvidiaVirtualizationCandidateNodes(input.Nodes),
+		CandidateNodes:  candidateNodes,
 		NodeScopeLabel: VirtualizationNodeScopeLabel{
 			Key:           NvidiaGPUVirtualizationLabelKey,
 			EnabledValue:  "true",

--- a/internal/accelerator/plugin/gpu_virtualization_test.go
+++ b/internal/accelerator/plugin/gpu_virtualization_test.go
@@ -69,6 +69,31 @@ func TestNVIDIAGPU_ResolveVirtualizationConfig(t *testing.T) {
 	assert.Contains(t, config.BlockingReasons[0], "NVIDIA GPU Operator devicePlugin is enabled")
 }
 
+func TestNVIDIAGPU_ResolveVirtualizationConfigWithNoGPUNodes(t *testing.T) {
+	gpuPlugin := &GPUAcceleratorPlugin{}
+
+	config, err := gpuPlugin.ResolveVirtualizationConfig(context.Background(), VirtualizationConfigInput{
+		Nodes: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cpu-only-1",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cpu-only-2",
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, config.Supported)
+	assert.Empty(t, config.CandidateNodes)
+	assert.NotEmpty(t, config.BlockingReasons, "expected blocking reason when no GPU nodes are available")
+	assert.Contains(t, config.BlockingReasons[0], "No NVIDIA GPU")
+}
+
 func TestNVIDIAGPU_ResolveVirtualizationConfigIgnoresGlobalMIGStrategy(t *testing.T) {
 	gpuPlugin := &GPUAcceleratorPlugin{}
 


### PR DESCRIPTION
## Issue

NEU-474

## Summary

When a cluster has no virtualizable NVIDIA GPU nodes and vGPU is enabled, the HAMi component incorrectly reports Ready even though no accelerator groups or GPU resources exist. The virtualization config returned `Supported=true` with empty `CandidateNodes` and no `BlockingReasons`, allowing the status check to treat "no daemonset needed" as ready.

## Changes

- `internal/accelerator/plugin/gpu_virtualization.go`: add blocking reason `"No NVIDIA GPU nodes available for vGPU virtualization"` when `CandidateNodes` is empty
- `internal/accelerator/plugin/gpu_virtualization_test.go`: add `TestNVIDIAGPU_ResolveVirtualizationConfigWithNoGPUNodes` covering the no-GPU-node case

## Test Plan

- [x] Unit tests: all 43 tests pass across `internal/accelerator/plugin` and `internal/cluster/component/hami`
- [ ] E2E: not affected (trivial fix — single check addition, no new control flow)
- [ ] DB integration (`make db-test`): not affected

## Risk & Rollback

Minimal — adds a single error message to an existing blocking-reasons path. The HAMi `virtualizationConfigBlocked()` already rejects any config with non-empty `BlockingReasons`. Rollback: revert the 3 added lines in `gpu_virtualization.go`.

---
Change-level: Trivial (per user override — internal/ Go code but simplified path)