### PR TITLE
fix: reject duplicate vGPU deployment on same underlying Kubernetes cluster

### DIFF
--- a/internal/cluster/component/hami/preflight.go
+++ b/internal/cluster/component/hami/preflight.go
@@ -120,25 +120,27 @@ func objectKind(obj client.Object) string {
 	return "Object"
 }
 
-// validateNoExistingVirtualization checks whether another Neutree cluster
-// already manages accelerator virtualization on the underlying Kubernetes
-// cluster. The check only runs on the initial deploy; restarts (where the
-// cluster already has a HAMi component status) are allowed through.
+// validateNoExistingVirtualization checks whether accelerator virtualization
+// is already active on the underlying Kubernetes cluster. The check only runs
+// on the initial deploy; restarts (where the cluster already has a HAMi
+// component status) are allowed through.
 func (h *HAMiComponent) validateNoExistingVirtualization(ctx context.Context) error {
 	if h.hasStatus() {
 		return nil
 	}
 
 	nodeList := &corev1.NodeList{}
-	if err := h.ctrlClient.List(ctx, nodeList); err != nil {
+	if err := h.ctrlClient.List(ctx, nodeList,
+		client.MatchingLabels{plugin.NvidiaGPUVirtualizationLabelKey: "true"},
+	); err != nil {
 		return errors.Wrap(err, "failed to list nodes for virtualization conflict check")
 	}
 
-	for _, node := range nodeList.Items {
-		if node.Labels[plugin.NvidiaGPUVirtualizationLabelKey] == "true" {
-			return errors.New(
-				"another Neutree cluster already manages accelerator virtualization on this Kubernetes cluster")
-		}
+	if len(nodeList.Items) > 0 {
+		return errors.New(
+			"accelerator virtualization is already active on the " +
+				"underlying Kubernetes cluster; remove existing vGPU node " +
+				"labels before re-creating the Neutree cluster")
 	}
 
 	return nil

--- a/internal/cluster/component/hami/preflight.go
+++ b/internal/cluster/component/hami/preflight.go
@@ -4,13 +4,12 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	clustervalidation "github.com/neutree-ai/neutree/internal/cluster/validation"
 )
 
@@ -30,10 +29,6 @@ func (h *HAMiComponent) Preflight(ctx context.Context) error {
 	}
 
 	if err := h.validateUnmanagedHAMi(ctx); err != nil {
-		return err
-	}
-
-	if err := h.validateNoExistingVirtualization(ctx); err != nil {
 		return err
 	}
 
@@ -109,6 +104,19 @@ func (h *HAMiComponent) validateManagedObject(ctx context.Context, obj client.Ob
 		return errors.Errorf("found existing unmanaged HAMi resource %s/%s", kind, key.Name)
 	}
 
+	// The HAMi webhook is cluster-scoped and can only be owned by one
+	// Neutree cluster. If it already carries the managed label but belongs
+	// to a different Neutree cluster, reject to prevent duplicate HAMi
+	// deployments on the same underlying Kubernetes cluster.
+	if kind == "MutatingWebhookConfiguration" && key.Name == WebhookName {
+		labels := obj.GetLabels()
+		if labels[v1.NeutreeClusterWorkspaceLabelKey] != h.cluster.Metadata.Workspace ||
+			labels[v1.NeutreeClusterLabelKey] != h.cluster.Metadata.Name {
+			return errors.New(
+				"found existing HAMi webhook managed by another Neutree cluster")
+		}
+	}
+
 	return nil
 }
 
@@ -118,32 +126,6 @@ func objectKind(obj client.Object) string {
 	}
 
 	return "Object"
-}
-
-// validateNoExistingVirtualization checks whether accelerator virtualization
-// is already active on the underlying Kubernetes cluster. The check only runs
-// on the initial deploy; restarts (where the cluster already has a HAMi
-// component status) are allowed through.
-func (h *HAMiComponent) validateNoExistingVirtualization(ctx context.Context) error {
-	if h.hasStatus() {
-		return nil
-	}
-
-	nodeList := &corev1.NodeList{}
-	if err := h.ctrlClient.List(ctx, nodeList,
-		client.MatchingLabels{plugin.NvidiaGPUVirtualizationLabelKey: "true"},
-	); err != nil {
-		return errors.Wrap(err, "failed to list nodes for virtualization conflict check")
-	}
-
-	if len(nodeList.Items) > 0 {
-		return errors.New(
-			"accelerator virtualization is already active on the " +
-				"underlying Kubernetes cluster; remove existing vGPU node " +
-				"labels before re-creating the Neutree cluster")
-	}
-
-	return nil
 }
 
 func clientIgnoreNotFound(err error) error {

--- a/internal/cluster/component/hami/preflight.go
+++ b/internal/cluster/component/hami/preflight.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
 	clustervalidation "github.com/neutree-ai/neutree/internal/cluster/validation"
 )
 
@@ -28,6 +30,10 @@ func (h *HAMiComponent) Preflight(ctx context.Context) error {
 	}
 
 	if err := h.validateUnmanagedHAMi(ctx); err != nil {
+		return err
+	}
+
+	if err := h.validateNoExistingVirtualization(ctx); err != nil {
 		return err
 	}
 
@@ -112,6 +118,30 @@ func objectKind(obj client.Object) string {
 	}
 
 	return "Object"
+}
+
+// validateNoExistingVirtualization checks whether another Neutree cluster
+// already manages accelerator virtualization on the underlying Kubernetes
+// cluster. The check only runs on the initial deploy; restarts (where the
+// cluster already has a HAMi component status) are allowed through.
+func (h *HAMiComponent) validateNoExistingVirtualization(ctx context.Context) error {
+	if h.hasStatus() {
+		return nil
+	}
+
+	nodeList := &corev1.NodeList{}
+	if err := h.ctrlClient.List(ctx, nodeList); err != nil {
+		return errors.Wrap(err, "failed to list nodes for virtualization conflict check")
+	}
+
+	for _, node := range nodeList.Items {
+		if node.Labels[plugin.NvidiaGPUVirtualizationLabelKey] == "true" {
+			return errors.New(
+				"another Neutree cluster already manages accelerator virtualization on this Kubernetes cluster")
+		}
+	}
+
+	return nil
 }
 
 func clientIgnoreNotFound(err error) error {

--- a/internal/cluster/component/hami/preflight_test.go
+++ b/internal/cluster/component/hami/preflight_test.go
@@ -1,0 +1,100 @@
+package hami
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
+)
+
+func TestPreflightRejectsWhenNodesAlreadyLabeledByAnotherCluster(t *testing.T) {
+	// Simulate a first-time deploy (no existing HAMi status) against a K8s cluster
+	// whose nodes already carry the vGPU label from another Neutree cluster.
+	cluster := newTestCluster()
+	// Confirm no HAMi status exists (first deploy, not a restart).
+	require.False(t, hasHAMiStatus(cluster))
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node-1",
+			Labels: map[string]string{
+				plugin.NvidiaGPUVirtualizationLabelKey: "true",
+			},
+		},
+	}
+	ctrlClient := newHAMiFakeClient(t, node)
+
+	component := NewHAMiComponent(cluster, "neutree-system", "registry.example.com/neutree/",
+		"image-pull-secret", v1.KubernetesClusterConfig{}, ctrlClient)
+
+	err := component.Preflight(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "another Neutree cluster already manages")
+}
+
+func TestPreflightAllowsRestartWhenNodesAlreadyLabeledBySelf(t *testing.T) {
+	// Simulate a restart: the cluster already owns HAMi and the node labels
+	// were written by this same cluster.
+	cluster := newTestCluster()
+	markHAMiOwned(cluster)
+	require.True(t, hasHAMiStatus(cluster))
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node-1",
+			Labels: map[string]string{
+				plugin.NvidiaGPUVirtualizationLabelKey: "true",
+			},
+		},
+	}
+	ctrlClient := newHAMiFakeClient(t, node)
+
+	component := NewHAMiComponent(cluster, "neutree-system", "registry.example.com/neutree/",
+		"image-pull-secret", v1.KubernetesClusterConfig{}, ctrlClient)
+
+	// Preflight should succeed — this is a restart of the owner cluster.
+	err := component.Preflight(context.Background())
+	require.NoError(t, err)
+}
+
+func TestPreflightAllowsFirstDeployWhenNoExistingLabels(t *testing.T) {
+	// Simulate a first-time deploy on a clean K8s cluster with no vGPU labels.
+	cluster := newTestCluster()
+	require.False(t, hasHAMiStatus(cluster))
+
+	// Node without the vGPU label.
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node-1",
+		},
+	}
+	ctrlClient := newHAMiFakeClient(t, node)
+
+	component := NewHAMiComponent(cluster, "neutree-system", "registry.example.com/neutree/",
+		"image-pull-secret", v1.KubernetesClusterConfig{}, ctrlClient)
+
+	// Without unmanaged HAMi resources, the only blocking factor is the
+	// virtualization label check. We expect it to pass.
+	err := component.Preflight(context.Background())
+	// This may fail because there are no managed HAMi resources rendered;
+	// we only care that it does NOT fail with the duplicate-owner message.
+	if err != nil {
+		assert.NotContains(t, err.Error(), "already manages")
+	}
+}
+
+// hasHAMiStatus returns true when the cluster already carries a HAMi
+// component status written by a prior reconcile.
+func hasHAMiStatus(cluster *v1.Cluster) bool {
+	if cluster.Status == nil || cluster.Status.ComponentStatus == nil {
+		return false
+	}
+	_, ok := cluster.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey]
+	return ok
+}

--- a/internal/cluster/component/hami/preflight_test.go
+++ b/internal/cluster/component/hami/preflight_test.go
@@ -4,91 +4,83 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
-	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
 )
 
-func TestPreflightRejectsWhenNodesAlreadyLabeledByAnotherCluster(t *testing.T) {
-	// Simulate a first-time deploy (no existing HAMi status) against a K8s cluster
-	// whose nodes already carry the vGPU label from another Neutree cluster.
-	cluster := newTestCluster()
-	// Confirm no HAMi status exists (first deploy, not a restart).
-	require.False(t, hasHAMiStatus(cluster))
-
-	node := &corev1.Node{
+// newManagedHAMiWebhook creates a MutatingWebhookConfiguration with the HAMi managed
+// label and optional cluster identity labels.
+func newManagedHAMiWebhook(clusterName, workspace string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "gpu-node-1",
+			Name: WebhookName,
 			Labels: map[string]string{
-				plugin.NvidiaGPUVirtualizationLabelKey: "true",
+				ManagedComponentLabelKey:           ManagedComponentLabelValue,
+				v1.NeutreeClusterLabelKey:          clusterName,
+				v1.NeutreeClusterWorkspaceLabelKey: workspace,
 			},
 		},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
+			Name: "hami-webhook.projecthami.io",
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				CABundle: []byte("test"),
+			},
+		}},
 	}
-	ctrlClient := newHAMiFakeClient(t, node)
+}
+
+func TestPreflightRejectsWebhookManagedByAnotherCluster(t *testing.T) {
+	// A HAMi webhook already exists and is labelled as managed by another
+	// Neutree cluster (different workspace/name).
+	cluster := newTestCluster()
+	webhook := newManagedHAMiWebhook("other-cluster", "other-workspace")
+	ctrlClient := newHAMiFakeClient(t, webhook)
 
 	component := NewHAMiComponent(cluster, "neutree-system", "registry.example.com/neutree/",
 		"image-pull-secret", v1.KubernetesClusterConfig{}, ctrlClient)
 
 	err := component.Preflight(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "accelerator virtualization is already active")
+	require.Contains(t, err.Error(), "managed by another Neutree cluster")
 }
 
-func TestPreflightAllowsRestartWhenNodesAlreadyLabeledBySelf(t *testing.T) {
-	// Simulate a restart: the cluster already owns HAMi and the node labels
-	// were written by this same cluster.
+func TestPreflightAllowsWebhookManagedByThisCluster(t *testing.T) {
+	// Restart: the webhook already exists and is labelled as managed by
+	// THIS Neutree cluster.
 	cluster := newTestCluster()
-	markHAMiOwned(cluster)
-	require.True(t, hasHAMiStatus(cluster))
+	webhook := newManagedHAMiWebhook(cluster.Metadata.Name, cluster.Metadata.Workspace)
+	ctrlClient := newHAMiFakeClient(t, webhook)
 
-	node := &corev1.Node{
+	component := NewHAMiComponent(cluster, "neutree-system", "registry.example.com/neutree/",
+		"image-pull-secret", v1.KubernetesClusterConfig{}, ctrlClient)
+
+	err := component.Preflight(context.Background())
+	require.NoError(t, err)
+}
+
+func TestPreflightRejectsUnmanagedWebhook(t *testing.T) {
+	// A HAMi webhook exists without the Neutree managed label (user-installed).
+	cluster := newTestCluster()
+	webhook := &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "gpu-node-1",
-			Labels: map[string]string{
-				plugin.NvidiaGPUVirtualizationLabelKey: "true",
+			Name: WebhookName,
+		},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
+			Name: "hami-webhook.projecthami.io",
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				CABundle: []byte("test"),
 			},
-		},
+		}},
 	}
-	ctrlClient := newHAMiFakeClient(t, node)
-
-	component := NewHAMiComponent(cluster, "neutree-system", "registry.example.com/neutree/",
-		"image-pull-secret", v1.KubernetesClusterConfig{}, ctrlClient)
-
-	// Preflight should succeed — this is a restart of the owner cluster.
-	err := component.Preflight(context.Background())
-	require.NoError(t, err)
-}
-
-func TestPreflightAllowsFirstDeployWhenNoExistingLabels(t *testing.T) {
-	// Simulate a first-time deploy on a clean K8s cluster with no vGPU labels.
-	cluster := newTestCluster()
-	require.False(t, hasHAMiStatus(cluster))
-
-	// Node without the vGPU label.
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "gpu-node-1",
-		},
-	}
-	ctrlClient := newHAMiFakeClient(t, node)
+	ctrlClient := newHAMiFakeClient(t, webhook)
 
 	component := NewHAMiComponent(cluster, "neutree-system", "registry.example.com/neutree/",
 		"image-pull-secret", v1.KubernetesClusterConfig{}, ctrlClient)
 
 	err := component.Preflight(context.Background())
-	require.NoError(t, err)
-}
-
-// hasHAMiStatus returns true when the cluster already carries a HAMi
-// component status written by a prior reconcile.
-func hasHAMiStatus(cluster *v1.Cluster) bool {
-	if cluster.Status == nil || cluster.Status.ComponentStatus == nil {
-		return false
-	}
-	_, ok := cluster.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey]
-	return ok
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "found existing unmanaged HAMi webhook")
 }

--- a/internal/cluster/component/hami/preflight_test.go
+++ b/internal/cluster/component/hami/preflight_test.go
@@ -35,7 +35,7 @@ func TestPreflightRejectsWhenNodesAlreadyLabeledByAnotherCluster(t *testing.T) {
 
 	err := component.Preflight(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "another Neutree cluster already manages")
+	assert.Contains(t, err.Error(), "accelerator virtualization is already active")
 }
 
 func TestPreflightAllowsRestartWhenNodesAlreadyLabeledBySelf(t *testing.T) {
@@ -79,14 +79,8 @@ func TestPreflightAllowsFirstDeployWhenNoExistingLabels(t *testing.T) {
 	component := NewHAMiComponent(cluster, "neutree-system", "registry.example.com/neutree/",
 		"image-pull-secret", v1.KubernetesClusterConfig{}, ctrlClient)
 
-	// Without unmanaged HAMi resources, the only blocking factor is the
-	// virtualization label check. We expect it to pass.
 	err := component.Preflight(context.Background())
-	// This may fail because there are no managed HAMi resources rendered;
-	// we only care that it does NOT fail with the duplicate-owner message.
-	if err != nil {
-		assert.NotContains(t, err.Error(), "already manages")
-	}
+	require.NoError(t, err)
 }
 
 // hasHAMiStatus returns true when the cluster already carries a HAMi


### PR DESCRIPTION
## Issue

NEU-473

## Summary

When a Kubernetes cluster already has HAMi/vGPU managed by one Neutree cluster, creating a second Neutree cluster with the same kubeconfig and `accelerator_virtualization.enabled=true` should detect the conflict and reject the deployment. Previously the second cluster would deploy a second HAMi namespace and converge to Ready, causing two Neutree clusters to compete for the same underlying GPU resources.

## Changes

- Extend `validateManagedObject` to check cluster ownership of the HAMi webhook (`MutatingWebhookConfiguration`). The webhook is cluster-scoped — only one Neutree cluster can own it on a given Kubernetes cluster.
- When the webhook already exists with the `neutree.ai/component=hami` label, compare its `neutree.ai/neutree-workspace` and `neutree.ai/neutree-cluster` labels against the current cluster. If they differ, reject with a clear error: "found existing HAMi webhook managed by another Neutree cluster."
- On restart, the webhook already carries this cluster's identity labels, so the check passes through correctly.

## Test Plan

- [ ] E2E: not affected (Trivial change)
- [ ] DB integration: not affected

Unit tests in `preflight_test.go` (3 cases):
1. Rejects webhook managed by another cluster (different workspace/name)
2. Allows webhook managed by this cluster (restart)
3. Rejects unmanaged webhook (user-installed, existing behaviour preserved)

## Risk and Rollback

- No DB schema changes. Backward-compatible. Rollback: revert commit.
- Classification: Trivial (single-file logic change, ~10 lines added to existing validation method)