### PR TITLE
fix: validate model upload names

### DIFF
--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -1,8 +1,18 @@
 package v1
 
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
 const (
 	LatestVersion = "latest"
+
+	maxModelNameLength = 63
 )
+
+var modelNameRegex = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$`)
 
 type ModelVersion struct {
 	Name         string            `json:"name"`
@@ -16,4 +26,30 @@ type ModelVersion struct {
 type GeneralModel struct {
 	Name     string         `json:"name"`
 	Versions []ModelVersion `json:"versions"`
+}
+
+// ValidateModelName enforces BentoML v1.4.6 tag name rules without BentoML's
+// implicit lowercasing, so API/CLI input stays consistent with stored names.
+func ValidateModelName(name string) error {
+	if name != strings.TrimSpace(name) {
+		return fmt.Errorf("model name must not contain leading or trailing whitespace")
+	}
+
+	if len(name) == 0 {
+		return fmt.Errorf("model name is required")
+	}
+
+	if len(name) > maxModelNameLength {
+		return fmt.Errorf("model name must be at most %d characters", maxModelNameLength)
+	}
+
+	if strings.ToLower(name) != name {
+		return fmt.Errorf("model name must be lowercase")
+	}
+
+	if !modelNameRegex.MatchString(name) {
+		return fmt.Errorf("model name must consist of lowercase alphanumeric characters, '_', '-', or '.', and must start and end with an alphanumeric character")
+	}
+
+	return nil
 }

--- a/api/v1/model_types_test.go
+++ b/api/v1/model_types_test.go
@@ -1,0 +1,49 @@
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateModelName(t *testing.T) {
+	validNames := []string{
+		"a",
+		"model-1",
+		"e2e-model_test.v2",
+		strings.Repeat("a", 63),
+	}
+
+	for _, name := range validNames {
+		t.Run("valid_"+name, func(t *testing.T) {
+			assert.NoError(t, ValidateModelName(name))
+		})
+	}
+
+	invalidNames := []string{
+		"",
+		" Model",
+		"model ",
+		"Invalid_Name",
+		"bad/name",
+		`bad\name`,
+		".",
+		"..",
+		"-bad",
+		"bad-",
+		"_bad",
+		"bad_",
+		"bad name",
+		"bad:name",
+		strings.Repeat("a", 64),
+	}
+
+	for _, name := range invalidNames {
+		t.Run("invalid_"+name, func(t *testing.T) {
+			err := ValidateModelName(name)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "model name")
+		})
+	}
+}

--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -42,6 +42,10 @@ func NewPushCmd() *cobra.Command {
 				modelName = filepath.Base(modelPath)
 			}
 
+			if err := v1.ValidateModelName(modelName); err != nil {
+				return fmt.Errorf("invalid model name: %w", err)
+			}
+
 			if version == v1.LatestVersion {
 				return fmt.Errorf("cannot use 'latest' as version, please specify a concrete version or leave it empty for auto-generation")
 			}

--- a/cmd/neutree-cli/app/cmd/model/push_test.go
+++ b/cmd/neutree-cli/app/cmd/model/push_test.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPushCmd_InvalidModelName(t *testing.T) {
+	modelDir := t.TempDir()
+	cmd := NewPushCmd()
+	cmd.SetArgs([]string{
+		modelDir,
+		"--name", "Invalid_Name",
+		"--version", "v1.0",
+	})
+
+	err := cmd.Execute()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid model name")
+	assert.Contains(t, err.Error(), "model name must be lowercase")
+}

--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -297,7 +297,7 @@ func uploadModel(deps *Dependencies) gin.HandlerFunc {
 			switch part.FormName() {
 			case "name":
 				value, _ := io.ReadAll(part)
-				name = strings.TrimSpace(string(value))
+				name = string(value)
 			case "version":
 				value, _ := io.ReadAll(part)
 				version = strings.TrimSpace(string(value))
@@ -319,6 +319,14 @@ func uploadModel(deps *Dependencies) gin.HandlerFunc {
 		if name == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"message": "Model name is required",
+			})
+
+			return
+		}
+
+		if err := v1.ValidateModelName(name); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"message": fmt.Sprintf("Invalid model name: %v", err),
 			})
 
 			return

--- a/internal/routes/models/models_test.go
+++ b/internal/routes/models/models_test.go
@@ -1,8 +1,10 @@
 package models
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -633,4 +635,47 @@ func TestDeleteModel_ValidationErrorSkipsRegistryDelete(t *testing.T) {
 	mockModelRegistry.AssertNotCalled(t, "DeleteModel", "test-model", v1.LatestVersion)
 	mockStorage.AssertExpectations(t)
 	mockModelRegistry.AssertExpectations(t)
+}
+
+func TestUploadModel_InvalidName(t *testing.T) {
+	mockStorage, mockModelRegistry := setupMocks(t)
+	deps := &Dependencies{
+		Storage: mockStorage,
+		TempDirFunc: func() (string, error) {
+			return t.TempDir(), nil
+		},
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	assert.NoError(t, writer.WriteField("name", "Invalid_Name"))
+	assert.NoError(t, writer.WriteField("version", "v1.0"))
+	part, err := writer.CreateFormFile("model", "model.bentomodel")
+	assert.NoError(t, err)
+	_, err = part.Write([]byte("model data"))
+	assert.NoError(t, err)
+	assert.NoError(t, writer.Close())
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/default/model_registries/test-registry/models", &body)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	c.Params = []gin.Param{
+		{Key: "workspace", Value: "default"},
+		{Key: "registry", Value: "test-registry"},
+	}
+
+	uploadModel(deps)(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]string
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Contains(t, response["message"], "Invalid model name")
+	assert.Contains(t, response["message"], "model name must be lowercase")
+
+	mockStorage.AssertNotCalled(t, "ListModelRegistry", mock.Anything)
+	mockModelRegistry.AssertNotCalled(t, "ImportModel", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -314,6 +314,13 @@ var _ = Describe("Model", Ordered, func() {
 			ExpectFailed(r)
 			Expect(r.Stdout + r.Stderr).To(ContainSubstring("latest"))
 		})
+
+		It("should reject model names that BentoML would lowercase", Label("C2723761", "validation"), func() {
+			r := pushModel("Invalid_Name", "v1.0", 64)
+			ExpectFailed(r)
+			Expect(r.Stdout + r.Stderr).To(ContainSubstring("invalid model name"))
+			Expect(r.Stdout + r.Stderr).To(ContainSubstring("model name must be lowercase"))
+		})
 	})
 
 	// --- Delete ---


### PR DESCRIPTION
## Issue

NEU-198

## Summary

Model uploads now validate model names before any upload side effects. The validation follows BentoML tag-name rules while rejecting inputs that BentoML would silently lowercase, keeping CLI/API input consistent with stored model names.

## Changes

- Add shared `api/v1` model name validation for BentoML-compatible names.
- Reject invalid names in `neutree-api` upload requests before registry lookup/import.
- Reject invalid names in `neutree-cli model push` before archive creation, registry lookup, or upload.
- Add focused unit tests and an E2E case for invalid uppercase model names while preserving the existing underscore/dot valid-name case.

## Test Plan

### Unit test

- [x] `go test -count=1 ./api/v1 ./internal/routes/models ./cmd/neutree-cli/app/cmd/model`
- [x] `go vet ./api/v1 ./internal/routes/models ./cmd/neutree-cli/app/cmd/model ./tests/e2e`
- [x] `./bin/golangci-lint run ./api/v1 ./internal/routes/models ./cmd/neutree-cli/app/cmd/model ./tests/e2e`
- Note: full `go vet ./...` and `go test ./...` are blocked in this worktree by missing prebuilt embed artifacts: `cmd/neutree-cli/app/cmd/launch/manifests/core.go:7:12: pattern neutree-core.tar: no matching files found`.

### DB test

- [x] Not affected. This change does not touch DB schema, migrations, storage queries, or RLS behavior.

### E2E test

- [x] Step 3 compile check: `go build ./tests/e2e/...`
- [x] Step 5 manual `C2612564`: valid `e2e-model_test.v2:v1.0` upload succeeded and `model get` returned `Name: e2e-model_test.v2`.
- [x] Step 5 manual `C2723761`: invalid `Invalid_Name:v1.0` push failed with `invalid model name: model name must be lowercase`.
- [x] Step 5 scoped code-backed E2E: `make e2e-test LABEL_FILTER='model && push' E2E_TIMEOUT=30m` reran after review feedback; 10 of 246 specs ran, 10 passed, 0 failed, 236 skipped.

## Risk & Rollback

Risk is limited to model upload paths. Existing stored models are not migrated or renamed, and model version validation is unchanged except for existing `latest` rejection. Rollback is reverting this commit, which restores previous API/CLI upload behavior.


