### PR TITLE
feat: support direct NFS model push

### DIFF
--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -121,7 +121,12 @@ func NewPushCmd() *cobra.Command {
 					return err
 				}
 
-				if _, err := c.Models.FinalizePush(workspace, registry, modelName, version); err != nil {
+				modelVersion, err := cliModel.ReadImportedModelVersion(localNFSPath, modelName, version)
+				if err != nil {
+					return err
+				}
+
+				if err := c.Models.FinalizePush(workspace, registry, modelName, modelVersion); err != nil {
 					return fmt.Errorf("failed to finalize direct model push: %w", err)
 				}
 

--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -12,6 +12,7 @@ import (
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
+	cliModel "github.com/neutree-ai/neutree/internal/cli/model"
 	"github.com/neutree-ai/neutree/internal/model_registry/bentoml"
 	"github.com/neutree-ai/neutree/pkg/client"
 )
@@ -21,6 +22,7 @@ func NewPushCmd() *cobra.Command {
 	var version string
 	var description string
 	var labelsFlag []string
+	var localNFSPath string
 
 	cmd := &cobra.Command{
 		Use:          "push [local_model_path]",
@@ -104,9 +106,28 @@ func NewPushCmd() *cobra.Command {
 
 			// Create client
 			c := client.NewClient(global.ServerURL, clientOptions...)
-			_, err = c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
+			modelRegistry, err := c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
 			if err != nil {
 				return fmt.Errorf("failed to get model registry %s: %w", registry, err)
+			}
+
+			if localNFSPath != "" {
+				if err := cliModel.ValidateDirectPushTarget(modelRegistry, localNFSPath); err != nil {
+					return err
+				}
+
+				fmt.Println("Importing model...")
+				if err := cliModel.ImportArchiveToLocalNFS(localNFSPath, modelPath, modelName, version, nil); err != nil {
+					return err
+				}
+
+				if _, err := c.Models.FinalizePush(workspace, registry, modelName, version); err != nil {
+					return fmt.Errorf("failed to finalize direct model push: %w", err)
+				}
+
+				fmt.Println("Model pushed successfully!")
+
+				return nil
 			}
 
 			// Get file size for progress bar
@@ -147,6 +168,7 @@ func NewPushCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&version, "version", "v", "", "Version of the model, (default: auto‑generated)")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Description of the model")
 	cmd.Flags().StringSliceVarP(&labelsFlag, "label", "l", nil, "Labels in the format key=value")
+	cmd.Flags().StringVar(&localNFSPath, "local-nfs-path", "", "Path to a pre-mounted NFS ModelRegistry root for direct local import")
 
 	if err := cmd.MarkFlagRequired("name"); err != nil {
 		panic(fmt.Sprintf("Failed to mark flag 'name' as required: %v", err))

--- a/internal/cli/model/direct_push.go
+++ b/internal/cli/model/direct_push.go
@@ -5,11 +5,16 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/model_registry/bentoml"
 )
+
+var getMountSource = defaultGetMountSource
 
 func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) error {
 	if registry == nil || registry.Spec == nil {
@@ -24,6 +29,8 @@ func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) e
 	if registry.Spec.Type != v1.BentoMLModelRegistryType || parsedURL.Scheme != "nfs" {
 		return fmt.Errorf("direct model push only supports bentoml registries backed by nfs://")
 	}
+
+	expectedSource := normalizeNFSSource(parsedURL.Host + parsedURL.Path)
 
 	info, err := os.Stat(localNFSPath)
 	if err != nil {
@@ -46,6 +53,17 @@ func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) e
 		return fmt.Errorf("failed to remove write check file under %s: %w", localNFSPath, err)
 	}
 
+	mountSource, mounted, err := getMountSource(localNFSPath)
+	if err != nil {
+		return fmt.Errorf("failed to inspect local NFS mount for %s: %w", localNFSPath, err)
+	}
+	if !mounted {
+		return fmt.Errorf("local NFS path %s is not an NFS mount point", localNFSPath)
+	}
+	if normalizeNFSSource(mountSource) != expectedSource {
+		return fmt.Errorf("local NFS path %s is not mounted from %s", localNFSPath, expectedSource)
+	}
+
 	return nil
 }
 
@@ -61,4 +79,117 @@ func ImportArchiveToLocalNFS(localNFSPath, archivePath, name, version string, pr
 	}
 
 	return nil
+}
+
+func ReadImportedModelVersion(localNFSPath, name, version string) (*v1.ModelVersion, error) {
+	meta, err := bentoml.GetModelDetail(localNFSPath, strings.ToLower(name), strings.ToLower(version))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read imported model metadata: %w", err)
+	}
+
+	return &v1.ModelVersion{
+		Name:         meta.Version,
+		CreationTime: meta.CreationTime,
+		Size:         meta.Size,
+		Module:       meta.Module,
+	}, nil
+}
+
+func defaultGetMountSource(localPath string) (string, bool, error) {
+	absPath, err := filepath.Abs(localPath)
+	if err != nil {
+		return "", false, err
+	}
+	absPath = filepath.Clean(absPath)
+
+	switch runtime.GOOS {
+	case "linux":
+		return getLinuxMountSource(absPath)
+	case "darwin":
+		return getDarwinMountSource(absPath)
+	default:
+		return "", false, fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
+}
+
+func getLinuxMountSource(absPath string) (string, bool, error) {
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return "", false, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" {
+			continue
+		}
+
+		left, right, found := strings.Cut(line, " - ")
+		if !found {
+			continue
+		}
+
+		leftFields := strings.Fields(left)
+		rightFields := strings.Fields(right)
+		if len(leftFields) < 5 || len(rightFields) < 2 {
+			continue
+		}
+
+		fsType := rightFields[0]
+		if fsType != "nfs" && fsType != "nfs4" {
+			continue
+		}
+
+		mountPoint := filepath.Clean(unescapeMountInfoField(leftFields[4]))
+		if mountPoint == absPath {
+			return rightFields[1], true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+func getDarwinMountSource(absPath string) (string, bool, error) {
+	output, err := exec.Command("mount").Output()
+	if err != nil {
+		return "", false, err
+	}
+
+	for _, line := range strings.Split(string(output), "\n") {
+		source, rest, found := strings.Cut(line, " on ")
+		if !found {
+			continue
+		}
+
+		mountPoint, attrs, found := strings.Cut(rest, " (")
+		if !found || !strings.Contains(attrs, "nfs") {
+			continue
+		}
+
+		if filepath.Clean(mountPoint) == absPath {
+			return source, true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+func unescapeMountInfoField(value string) string {
+	replacer := strings.NewReplacer(
+		`\\`, `\`,
+		`\040`, " ",
+		`\011`, "\t",
+		`\012`, "\n",
+		`\134`, `\`,
+	)
+
+	return replacer.Replace(value)
+}
+
+func normalizeNFSSource(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return source
+	}
+
+	return strings.TrimRight(source, "/")
 }

--- a/internal/cli/model/direct_push.go
+++ b/internal/cli/model/direct_push.go
@@ -36,6 +36,7 @@ func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) e
 	if err != nil {
 		return fmt.Errorf("local NFS path %s is not available: %w", localNFSPath, err)
 	}
+
 	if !info.IsDir() {
 		return fmt.Errorf("local NFS path %s is not a directory", localNFSPath)
 	}
@@ -44,11 +45,14 @@ func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) e
 	if err != nil {
 		return fmt.Errorf("local NFS path %s is not writable: %w", localNFSPath, err)
 	}
+
 	probePath := probe.Name()
+
 	if err := probe.Close(); err != nil {
 		_ = os.Remove(probePath)
 		return fmt.Errorf("failed to close write check file under %s: %w", localNFSPath, err)
 	}
+
 	if err := os.Remove(probePath); err != nil {
 		return fmt.Errorf("failed to remove write check file under %s: %w", localNFSPath, err)
 	}
@@ -57,9 +61,11 @@ func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) e
 	if err != nil {
 		return fmt.Errorf("failed to inspect local NFS mount for %s: %w", localNFSPath, err)
 	}
+
 	if !mounted {
 		return fmt.Errorf("local NFS path %s is not an NFS mount point", localNFSPath)
 	}
+
 	if normalizeNFSSource(mountSource) != expectedSource {
 		return fmt.Errorf("local NFS path %s is not mounted from %s", localNFSPath, expectedSource)
 	}
@@ -100,6 +106,7 @@ func defaultGetMountSource(localPath string) (string, bool, error) {
 	if err != nil {
 		return "", false, err
 	}
+
 	absPath = filepath.Clean(absPath)
 
 	switch runtime.GOOS {
@@ -130,6 +137,7 @@ func getLinuxMountSource(absPath string) (string, bool, error) {
 
 		leftFields := strings.Fields(left)
 		rightFields := strings.Fields(right)
+
 		if len(leftFields) < 5 || len(rightFields) < 2 {
 			continue
 		}

--- a/internal/cli/model/direct_push.go
+++ b/internal/cli/model/direct_push.go
@@ -5,9 +5,7 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
@@ -109,14 +107,7 @@ func defaultGetMountSource(localPath string) (string, bool, error) {
 
 	absPath = filepath.Clean(absPath)
 
-	switch runtime.GOOS {
-	case "linux":
-		return getLinuxMountSource(absPath)
-	case "darwin":
-		return getDarwinMountSource(absPath)
-	default:
-		return "", false, fmt.Errorf("unsupported platform %s", runtime.GOOS)
-	}
+	return getLinuxMountSource(absPath)
 }
 
 func getLinuxMountSource(absPath string) (string, bool, error) {
@@ -150,31 +141,6 @@ func getLinuxMountSource(absPath string) (string, bool, error) {
 		mountPoint := filepath.Clean(unescapeMountInfoField(leftFields[4]))
 		if mountPoint == absPath {
 			return rightFields[1], true, nil
-		}
-	}
-
-	return "", false, nil
-}
-
-func getDarwinMountSource(absPath string) (string, bool, error) {
-	output, err := exec.Command("mount").Output()
-	if err != nil {
-		return "", false, err
-	}
-
-	for _, line := range strings.Split(string(output), "\n") {
-		source, rest, found := strings.Cut(line, " on ")
-		if !found {
-			continue
-		}
-
-		mountPoint, attrs, found := strings.Cut(rest, " (")
-		if !found || !strings.Contains(attrs, "nfs") {
-			continue
-		}
-
-		if filepath.Clean(mountPoint) == absPath {
-			return source, true, nil
 		}
 	}
 

--- a/internal/cli/model/direct_push.go
+++ b/internal/cli/model/direct_push.go
@@ -1,0 +1,64 @@
+package model
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry/bentoml"
+)
+
+func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) error {
+	if registry == nil || registry.Spec == nil {
+		return fmt.Errorf("direct model push only supports bentoml registries backed by nfs://")
+	}
+
+	parsedURL, err := url.Parse(registry.Spec.Url)
+	if err != nil {
+		return fmt.Errorf("invalid model registry URL %q: %w", registry.Spec.Url, err)
+	}
+
+	if registry.Spec.Type != v1.BentoMLModelRegistryType || parsedURL.Scheme != "nfs" {
+		return fmt.Errorf("direct model push only supports bentoml registries backed by nfs://")
+	}
+
+	info, err := os.Stat(localNFSPath)
+	if err != nil {
+		return fmt.Errorf("local NFS path %s is not available: %w", localNFSPath, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("local NFS path %s is not a directory", localNFSPath)
+	}
+
+	probe, err := os.CreateTemp(localNFSPath, ".neutree-write-check-*")
+	if err != nil {
+		return fmt.Errorf("local NFS path %s is not writable: %w", localNFSPath, err)
+	}
+	probePath := probe.Name()
+	if err := probe.Close(); err != nil {
+		_ = os.Remove(probePath)
+		return fmt.Errorf("failed to close write check file under %s: %w", localNFSPath, err)
+	}
+	if err := os.Remove(probePath); err != nil {
+		return fmt.Errorf("failed to remove write check file under %s: %w", localNFSPath, err)
+	}
+
+	return nil
+}
+
+func ImportArchiveToLocalNFS(localNFSPath, archivePath, name, version string, progress io.Writer) error {
+	archive, err := os.Open(filepath.Clean(archivePath))
+	if err != nil {
+		return fmt.Errorf("failed to open model archive: %w", err)
+	}
+	defer archive.Close()
+
+	if err := bentoml.ImportModel(localNFSPath, archive, name, version, true, progress); err != nil {
+		return fmt.Errorf("failed to import model archive to local NFS path: %w", err)
+	}
+
+	return nil
+}

--- a/internal/cli/model/direct_push_test.go
+++ b/internal/cli/model/direct_push_test.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry/bentoml"
+)
+
+func TestValidateDirectPushTargetRequiresBentomlNFSRegistry(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := ValidateDirectPushTarget(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "nfs://server:/exports/models",
+		},
+	}, tmpDir)
+	require.NoError(t, err)
+
+	err = ValidateDirectPushTarget(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.HuggingFaceModelRegistryType,
+			Url:  "https://huggingface.co",
+		},
+	}, tmpDir)
+	require.ErrorContains(t, err, "only supports bentoml registries backed by nfs://")
+
+	err = ValidateDirectPushTarget(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "file://localhost/tmp/models",
+		},
+	}, tmpDir)
+	require.ErrorContains(t, err, "only supports bentoml registries backed by nfs://")
+}
+
+func TestValidateDirectPushTargetRequiresWritableDirectory(t *testing.T) {
+	err := ValidateDirectPushTarget(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "nfs://server:/exports/models",
+		},
+	}, filepath.Join(t.TempDir(), "missing"))
+	require.ErrorContains(t, err, "local NFS path")
+}
+
+func TestImportArchiveToLocalNFSUsesBentoMLLayout(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "weights.bin"), []byte("weights"), 0o644))
+
+	archivePath, err := bentoml.CreateArchiveWithProgress(srcDir, "demo-model", "v1", nil)
+	require.NoError(t, err)
+	defer os.Remove(archivePath)
+
+	destDir := t.TempDir()
+	require.NoError(t, ImportArchiveToLocalNFS(destDir, archivePath, "demo-model", "v1", nil))
+
+	require.FileExists(t, filepath.Join(destDir, "models", "demo-model", "v1", "model.yaml"))
+	require.FileExists(t, filepath.Join(destDir, "models", "demo-model", "latest"))
+}

--- a/internal/cli/model/direct_push_test.go
+++ b/internal/cli/model/direct_push_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestValidateDirectPushTargetRequiresBentomlNFSRegistry(t *testing.T) {
 	tmpDir := t.TempDir()
+	stubMountSource(t, tmpDir, "server:/exports/models", true)
 
 	err := ValidateDirectPushTarget(&v1.ModelRegistry{
 		Spec: &v1.ModelRegistrySpec{
@@ -49,6 +50,28 @@ func TestValidateDirectPushTargetRequiresWritableDirectory(t *testing.T) {
 	require.ErrorContains(t, err, "local NFS path")
 }
 
+func TestValidateDirectPushTargetRequiresMatchingNFSMount(t *testing.T) {
+	tmpDir := t.TempDir()
+	stubMountSource(t, tmpDir, "server:/other", true)
+
+	err := ValidateDirectPushTarget(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "nfs://server:/exports/models",
+		},
+	}, tmpDir)
+	require.ErrorContains(t, err, "is not mounted from server:/exports/models")
+
+	stubMountSource(t, tmpDir, "", false)
+	err = ValidateDirectPushTarget(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "nfs://server:/exports/models",
+		},
+	}, tmpDir)
+	require.ErrorContains(t, err, "is not an NFS mount point")
+}
+
 func TestImportArchiveToLocalNFSUsesBentoMLLayout(t *testing.T) {
 	srcDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "weights.bin"), []byte("weights"), 0o644))
@@ -62,4 +85,35 @@ func TestImportArchiveToLocalNFSUsesBentoMLLayout(t *testing.T) {
 
 	require.FileExists(t, filepath.Join(destDir, "models", "demo-model", "v1", "model.yaml"))
 	require.FileExists(t, filepath.Join(destDir, "models", "demo-model", "latest"))
+}
+
+func TestReadImportedModelVersionReturnsLocalMetadata(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "weights.bin"), []byte("weights"), 0o644))
+
+	archivePath, err := bentoml.CreateArchiveWithProgress(srcDir, "Demo-Model", "V1", nil)
+	require.NoError(t, err)
+	defer os.Remove(archivePath)
+
+	destDir := t.TempDir()
+	require.NoError(t, ImportArchiveToLocalNFS(destDir, archivePath, "Demo-Model", "V1", nil))
+
+	version, err := ReadImportedModelVersion(destDir, "Demo-Model", "V1")
+	require.NoError(t, err)
+	require.Equal(t, "V1", version.Name)
+	require.NotEmpty(t, version.CreationTime)
+	require.NotEmpty(t, version.Size)
+}
+
+func stubMountSource(t *testing.T, path, source string, mounted bool) {
+	t.Helper()
+
+	original := getMountSource
+	getMountSource = func(localPath string) (string, bool, error) {
+		require.Equal(t, path, localPath)
+		return source, mounted, nil
+	}
+	t.Cleanup(func() {
+		getMountSource = original
+	})
 }

--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -218,9 +218,11 @@ func validateFinalizedModelVersion(req finalizeModelRequest, modelVersion *v1.Mo
 	if req.CreationTime != "" && modelVersion.CreationTime != req.CreationTime {
 		return fmt.Errorf("direct push creation_time does not match registry metadata")
 	}
+
 	if req.Size != "" && modelVersion.Size != req.Size {
 		return fmt.Errorf("direct push size does not match registry metadata")
 	}
+
 	if req.Module != "" && modelVersion.Module != req.Module {
 		return fmt.Errorf("direct push module does not match registry metadata")
 	}

--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -121,7 +121,7 @@ func RegisterModelsRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 
 				// Finalize a direct model push after the client writes to shared storage
 				models.POST("/:model/finalize",
-					middleware.RequirePermission("model:push", permissionDeps),
+					middleware.RequireWorkspacePermission("model:push", permissionDeps),
 					finalizeModel(deps))
 
 				// Download a model
@@ -139,12 +139,15 @@ func RegisterModelsRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 }
 
 type finalizeModelRequest struct {
-	Version string `json:"version"`
+	Version      string `json:"version"`
+	CreationTime string `json:"creation_time,omitempty"`
+	Size         string `json:"size,omitempty"`
+	Module       string `json:"module,omitempty"`
 }
 
 func finalizeModel(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		modelName := c.Param("model")
+		modelName := strings.ToLower(c.Param("model"))
 
 		var req finalizeModelRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -155,6 +158,7 @@ func finalizeModel(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
+		req.Version = strings.TrimSpace(req.Version)
 		if req.Version == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"message": "Version is required",
@@ -163,7 +167,8 @@ func finalizeModel(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		if req.Version == v1.LatestVersion {
+		version := strings.ToLower(req.Version)
+		if version == v1.LatestVersion {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"message": "Cannot use 'latest' as version, please specify a concrete version",
 			})
@@ -182,18 +187,45 @@ func finalizeModel(deps *Dependencies) gin.HandlerFunc {
 		}
 		defer (*modelRegistry).Disconnect() //nolint:errcheck
 
-		modelVersion, err := (*modelRegistry).GetModelVersion(modelName, req.Version)
+		modelVersion, err := (*modelRegistry).GetModelVersion(modelName, version)
 		if err != nil {
-			klog.Errorf("Failed to finalize model %s:%s: %v", modelName, req.Version, err)
+			klog.Errorf("Failed to finalize model %s:%s: %v", modelName, version, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"message": fmt.Sprintf("Failed to finalize model %s:%s: %v", modelName, req.Version, err),
+				"message": fmt.Sprintf("Failed to finalize model %s:%s: %v", modelName, version, err),
 			})
 
 			return
 		}
 
-		c.JSON(http.StatusOK, modelVersion)
+		if err := validateFinalizedModelVersion(req, modelVersion); err != nil {
+			c.JSON(http.StatusConflict, gin.H{
+				"message": err.Error(),
+			})
+
+			return
+		}
+
+		c.Status(http.StatusNoContent)
+		c.Writer.WriteHeaderNow()
 	}
+}
+
+func validateFinalizedModelVersion(req finalizeModelRequest, modelVersion *v1.ModelVersion) error {
+	if modelVersion == nil {
+		return fmt.Errorf("model version is missing after direct push")
+	}
+
+	if req.CreationTime != "" && modelVersion.CreationTime != req.CreationTime {
+		return fmt.Errorf("direct push creation_time does not match registry metadata")
+	}
+	if req.Size != "" && modelVersion.Size != req.Size {
+		return fmt.Errorf("direct push size does not match registry metadata")
+	}
+	if req.Module != "" && modelVersion.Module != req.Module {
+		return fmt.Errorf("direct push module does not match registry metadata")
+	}
+
+	return nil
 }
 
 // getModelRegistry retrieves and connects to a model registry

--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -119,6 +119,11 @@ func RegisterModelsRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 					middleware.RequirePermission("model:push", permissionDeps),
 					uploadModel(deps))
 
+				// Finalize a direct model push after the client writes to shared storage
+				models.POST("/:model/finalize",
+					middleware.RequirePermission("model:push", permissionDeps),
+					finalizeModel(deps))
+
 				// Download a model
 				models.GET("/:model/download",
 					middleware.RequirePermission("model:pull", permissionDeps),
@@ -130,6 +135,64 @@ func RegisterModelsRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 					deleteModel(deps))
 			}
 		}
+	}
+}
+
+type finalizeModelRequest struct {
+	Version string `json:"version"`
+}
+
+func finalizeModel(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		modelName := c.Param("model")
+
+		var req finalizeModelRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"message": "Invalid finalize request",
+			})
+
+			return
+		}
+
+		if req.Version == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"message": "Version is required",
+			})
+
+			return
+		}
+
+		if req.Version == v1.LatestVersion {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"message": "Cannot use 'latest' as version, please specify a concrete version",
+			})
+
+			return
+		}
+
+		modelRegistry, err := getModelRegistry(c, deps)
+		if err != nil {
+			klog.Errorf("Failed to get model registry: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": err.Error(),
+			})
+
+			return
+		}
+		defer (*modelRegistry).Disconnect() //nolint:errcheck
+
+		modelVersion, err := (*modelRegistry).GetModelVersion(modelName, req.Version)
+		if err != nil {
+			klog.Errorf("Failed to finalize model %s:%s: %v", modelName, req.Version, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": fmt.Sprintf("Failed to finalize model %s:%s: %v", modelName, req.Version, err),
+			})
+
+			return
+		}
+
+		c.JSON(http.StatusOK, modelVersion)
 	}
 }
 

--- a/internal/routes/models/models_test.go
+++ b/internal/routes/models/models_test.go
@@ -64,6 +64,24 @@ func createMockContext(workspace, registryName, modelName, searchQuery string) (
 	return c, w
 }
 
+func createFinalizeContext(workspace, registryName, modelName, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST",
+		"/api/v1/workspaces/"+workspace+"/model_registries/"+registryName+"/models/"+modelName+"/finalize",
+		bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = []gin.Param{
+		{Key: "workspace", Value: workspace},
+		{Key: "registry", Value: registryName},
+		{Key: "model", Value: modelName},
+	}
+
+	return c, w
+}
+
 // setupMocks creates and configures mocks for testing
 func setupMocks(t *testing.T) (*mocks.MockStorage, *model_registry_mocks.MockModelRegistry) {
 	// Create mocks
@@ -637,6 +655,34 @@ func TestDeleteModel_ValidationErrorSkipsRegistryDelete(t *testing.T) {
 	mockModelRegistry.AssertExpectations(t)
 }
 
+func TestFinalizeModel_Success(t *testing.T) {
+	mockStorage, mockModelRegistry := setupMocks(t)
+	deps := &Dependencies{Storage: mockStorage}
+	c, w := createFinalizeContext("default", "test-registry", "test-model", `{"version":"v1"}`)
+
+	modelRegistry := v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}
+	modelVersion := &v1.ModelVersion{Name: "v1", Size: "1MB"}
+
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{modelRegistry}, nil)
+	mockModelRegistry.On("Connect").Return(nil)
+	mockModelRegistry.On("Disconnect").Return(nil)
+	mockModelRegistry.On("GetModelVersion", "test-model", "v1").Return(modelVersion, nil)
+
+	finalizeModel(deps)(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response v1.ModelVersion
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "v1", response.Name)
+
+	mockStorage.AssertExpectations(t)
+	mockModelRegistry.AssertExpectations(t)
+}
+
 func TestUploadModel_InvalidName(t *testing.T) {
 	mockStorage, mockModelRegistry := setupMocks(t)
 	deps := &Dependencies{
@@ -678,4 +724,14 @@ func TestUploadModel_InvalidName(t *testing.T) {
 
 	mockStorage.AssertNotCalled(t, "ListModelRegistry", mock.Anything)
 	mockModelRegistry.AssertNotCalled(t, "ImportModel", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestFinalizeModel_RejectsMissingVersion(t *testing.T) {
+	deps := &Dependencies{}
+	c, w := createFinalizeContext("default", "test-registry", "test-model", `{}`)
+
+	finalizeModel(deps)(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Version is required")
 }

--- a/internal/routes/models/models_test.go
+++ b/internal/routes/models/models_test.go
@@ -658,12 +658,12 @@ func TestDeleteModel_ValidationErrorSkipsRegistryDelete(t *testing.T) {
 func TestFinalizeModel_Success(t *testing.T) {
 	mockStorage, mockModelRegistry := setupMocks(t)
 	deps := &Dependencies{Storage: mockStorage}
-	c, w := createFinalizeContext("default", "test-registry", "test-model", `{"version":"v1"}`)
+	c, w := createFinalizeContext("default", "test-registry", "Test-Model", `{"version":"V1","creation_time":"2026-06-25T00:00:00Z","size":"1MB"}`)
 
 	modelRegistry := v1.ModelRegistry{
 		Spec: &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
 	}
-	modelVersion := &v1.ModelVersion{Name: "v1", Size: "1MB"}
+	modelVersion := &v1.ModelVersion{Name: "V1", Size: "1MB", CreationTime: "2026-06-25T00:00:00Z"}
 
 	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{modelRegistry}, nil)
 	mockModelRegistry.On("Connect").Return(nil)
@@ -672,12 +672,8 @@ func TestFinalizeModel_Success(t *testing.T) {
 
 	finalizeModel(deps)(c)
 
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	var response v1.ModelVersion
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	assert.NoError(t, err)
-	assert.Equal(t, "v1", response.Name)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.String())
 
 	mockStorage.AssertExpectations(t)
 	mockModelRegistry.AssertExpectations(t)
@@ -734,4 +730,28 @@ func TestFinalizeModel_RejectsMissingVersion(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "Version is required")
+}
+
+func TestFinalizeModel_RejectsMismatchedMetadata(t *testing.T) {
+	mockStorage, mockModelRegistry := setupMocks(t)
+	deps := &Dependencies{Storage: mockStorage}
+	c, w := createFinalizeContext("default", "test-registry", "test-model", `{"version":"v1","creation_time":"local","size":"1MB"}`)
+
+	modelRegistry := v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}
+	modelVersion := &v1.ModelVersion{Name: "v1", Size: "1MB", CreationTime: "server"}
+
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{modelRegistry}, nil)
+	mockModelRegistry.On("Connect").Return(nil)
+	mockModelRegistry.On("Disconnect").Return(nil)
+	mockModelRegistry.On("GetModelVersion", "test-model", "v1").Return(modelVersion, nil)
+
+	finalizeModel(deps)(c)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "does not match")
+
+	mockStorage.AssertExpectations(t)
+	mockModelRegistry.AssertExpectations(t)
 }

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -48,6 +48,7 @@ func (s *ModelsService) FinalizePush(workspace, registry, modelName string, mode
 	if err != nil {
 		return err
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := s.client.do(req)

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -21,40 +21,47 @@ type ModelsService struct {
 }
 
 type finalizePushRequest struct {
-	Version string `json:"version"`
+	Version      string `json:"version"`
+	CreationTime string `json:"creation_time,omitempty"`
+	Size         string `json:"size,omitempty"`
+	Module       string `json:"module,omitempty"`
 }
 
-func (s *ModelsService) FinalizePush(workspace, registry, modelName, version string) (*v1.ModelVersion, error) {
-	body, err := json.Marshal(finalizePushRequest{Version: version})
+func (s *ModelsService) FinalizePush(workspace, registry, modelName string, modelVersion *v1.ModelVersion) error {
+	if modelVersion == nil {
+		return fmt.Errorf("model version is required")
+	}
+
+	body, err := json.Marshal(finalizePushRequest{
+		Version:      modelVersion.Name,
+		CreationTime: modelVersion.CreationTime,
+		Size:         modelVersion.Size,
+		Module:       modelVersion.Module,
+	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	url := fmt.Sprintf("%s/api/v1/workspaces/%s/model_registries/%s/models/%s/finalize", s.client.baseURL, workspace, registry, modelName)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := s.client.do(req)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusNoContent {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+		return fmt.Errorf("server returned non-204 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
 	}
 
-	var modelVersion v1.ModelVersion
-	if err := json.NewDecoder(resp.Body).Decode(&modelVersion); err != nil {
-		return nil, err
-	}
-
-	return &modelVersion, nil
+	return nil
 }
 
 // NewModelsService creates a new models service

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,6 +18,43 @@ import (
 // ModelsService handles communication with the model related endpoints
 type ModelsService struct {
 	client *Client
+}
+
+type finalizePushRequest struct {
+	Version string `json:"version"`
+}
+
+func (s *ModelsService) FinalizePush(workspace, registry, modelName, version string) (*v1.ModelVersion, error) {
+	body, err := json.Marshal(finalizePushRequest{Version: version})
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/api/v1/workspaces/%s/model_registries/%s/models/%s/finalize", s.client.baseURL, workspace, registry, modelName)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var modelVersion v1.ModelVersion
+	if err := json.NewDecoder(resp.Body).Decode(&modelVersion); err != nil {
+		return nil, err
+	}
+
+	return &modelVersion, nil
 }
 
 // NewModelsService creates a new models service

--- a/pkg/client/model_test.go
+++ b/pkg/client/model_test.go
@@ -11,7 +11,7 @@ import (
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
-func TestFinalizePushPostsVersionAndDecodesModelVersion(t *testing.T) {
+func TestFinalizePushPostsImportedMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/api/v1/workspaces/default/model_registries/registry/models/demo/finalize", r.URL.Path)
@@ -20,13 +20,18 @@ func TestFinalizePushPostsVersionAndDecodesModelVersion(t *testing.T) {
 		var body map[string]string
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		require.Equal(t, "v1", body["version"])
+		require.Equal(t, "2026-06-25T00:00:00Z", body["creation_time"])
+		require.Equal(t, "1MB", body["size"])
 
-		require.NoError(t, json.NewEncoder(w).Encode(&v1.ModelVersion{Name: "v1", Size: "1MB"}))
+		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
 	c := NewClient(server.URL, WithAPIKey("api-key"))
-	version, err := c.Models.FinalizePush("default", "registry", "demo", "v1")
+	err := c.Models.FinalizePush("default", "registry", "demo", &v1.ModelVersion{
+		Name:         "v1",
+		CreationTime: "2026-06-25T00:00:00Z",
+		Size:         "1MB",
+	})
 	require.NoError(t, err)
-	require.Equal(t, "v1", version.Name)
 }

--- a/pkg/client/model_test.go
+++ b/pkg/client/model_test.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+func TestFinalizePushPostsVersionAndDecodesModelVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/workspaces/default/model_registries/registry/models/demo/finalize", r.URL.Path)
+		require.Equal(t, "api-key", r.Header.Get("Authorization"))
+
+		var body map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "v1", body["version"])
+
+		require.NoError(t, json.NewEncoder(w).Encode(&v1.ModelVersion{Name: "v1", Size: "1MB"}))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+	version, err := c.Models.FinalizePush("default", "registry", "demo", "v1")
+	require.NoError(t, err)
+	require.Equal(t, "v1", version.Name)
+}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -50,6 +50,7 @@ type EngineArg struct {
 
 // cliBinary holds the path to the compiled neutree-cli binary.
 var cliBinary string
+var cleanupCLIBinary bool
 
 // Cluster phase timeouts shared across E2E tests.
 //
@@ -69,21 +70,45 @@ const (
 
 // BuildCLI compiles the neutree-cli binary to a temp directory.
 func BuildCLI() {
-	tmpDir, err := os.MkdirTemp("", "neutree-e2e-*")
+	resolved, cleanup, err := resolveCLIBinary()
 	Expect(err).NotTo(HaveOccurred())
+	cliBinary = resolved
+	cleanupCLIBinary = cleanup
+	if !cleanup {
+		return
+	}
+}
 
-	cliBinary = filepath.Join(tmpDir, "neutree-cli")
+func resolveCLIBinary() (string, bool, error) {
+	if cliPath := os.Getenv("E2E_CLI_BINARY"); cliPath != "" {
+		if _, err := os.Stat(cliPath); err != nil {
+			return "", false, err
+		}
+
+		return cliPath, false, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "neutree-e2e-*")
+	if err != nil {
+		return "", false, err
+	}
+
+	binary := filepath.Join(tmpDir, "neutree-cli")
 	projectRoot := filepath.Join(".", "..", "..")
-	buildCmd := exec.Command("go", "build", "-o", cliBinary, "./cmd/neutree-cli/")
+	buildCmd := exec.Command("go", "build", "-o", binary, "./cmd/neutree-cli/")
 	buildCmd.Dir = projectRoot
 	buildCmd.Stdout = GinkgoWriter
 	buildCmd.Stderr = GinkgoWriter
-	Expect(buildCmd.Run()).To(Succeed(), "failed to build neutree-cli")
+	if err := buildCmd.Run(); err != nil {
+		return "", false, err
+	}
+
+	return binary, true, nil
 }
 
 // CleanupCLI removes the compiled binary and its temp directory.
 func CleanupCLI() {
-	if cliBinary != "" {
+	if cliBinary != "" && cleanupCLIBinary {
 		os.RemoveAll(filepath.Dir(cliBinary))
 	}
 }

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -72,8 +72,10 @@ const (
 func BuildCLI() {
 	resolved, cleanup, err := resolveCLIBinary()
 	Expect(err).NotTo(HaveOccurred())
+
 	cliBinary = resolved
 	cleanupCLIBinary = cleanup
+
 	if !cleanup {
 		return
 	}
@@ -99,6 +101,7 @@ func resolveCLIBinary() (string, bool, error) {
 	buildCmd.Dir = projectRoot
 	buildCmd.Stdout = GinkgoWriter
 	buildCmd.Stderr = GinkgoWriter
+
 	if err := buildCmd.Run(); err != nil {
 		return "", false, err
 	}

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -1,0 +1,22 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCLIBinaryUsesEnvironmentOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	cliPath := filepath.Join(tmpDir, "neutree-cli")
+	require.NoError(t, os.WriteFile(cliPath, []byte("#!/bin/sh\n"), 0o755))
+
+	t.Setenv("E2E_CLI_BINARY", cliPath)
+
+	resolved, cleanup, err := resolveCLIBinary()
+	require.NoError(t, err)
+	require.False(t, cleanup)
+	require.Equal(t, cliPath, resolved)
+}

--- a/tests/e2e/model_test.go
+++ b/tests/e2e/model_test.go
@@ -267,6 +267,28 @@ var _ = Describe("Model", Ordered, func() {
 			Expect(ParseKV(r.Stdout)["Version"]).To(Equal(version))
 		})
 
+		It("should direct push a model to a pre-mounted NFS registry", Label("C2723966", "nfs-direct"), func() {
+			if profile.ModelRegistry.LocalNFSPath == "" || !strings.HasPrefix(profile.ModelRegistry.URL, "nfs://") {
+				Skip("model_registry.local_nfs_path and nfs:// model_registry.url are required")
+			}
+
+			name := "e2e-nfs-direct"
+			version := "v1.0"
+			DeferCleanup(Model.EnsureDeleted, name, version)
+
+			r := pushModel(name, version, 64, "--local-nfs-path", profile.ModelRegistry.LocalNFSPath)
+			ExpectSuccess(r)
+			ExpectStdoutContains(r, "pushed successfully")
+
+			r = Model.List()
+			ExpectSuccess(r)
+			Expect(ParseTable(r.Stdout)).To(ContainElement(HaveKeyWithValue("NAME", name)))
+
+			r = Model.Get(name + ":" + version)
+			ExpectSuccess(r)
+			Expect(ParseKV(r.Stdout)["Version"]).To(Equal(version))
+		})
+
 		It("should overwrite an existing version", Label("C2621665"), func() {
 			name := "e2e-push-overwrite"
 			version := "v1.0"

--- a/tests/e2e/profile.go
+++ b/tests/e2e/profile.go
@@ -61,9 +61,10 @@ type Profile struct {
 	} `yaml:"image_registry"`
 
 	ModelRegistry struct {
-		Type        string `yaml:"type"`
-		URL         string `yaml:"url"`
-		Credentials string `yaml:"credentials"`
+		Type         string `yaml:"type"`
+		URL          string `yaml:"url"`
+		Credentials  string `yaml:"credentials"`
+		LocalNFSPath string `yaml:"local_nfs_path"`
 	} `yaml:"model_registry"`
 
 	Workspace string `yaml:"workspace"`

--- a/tests/e2e/profile.yaml.example
+++ b/tests/e2e/profile.yaml.example
@@ -30,6 +30,9 @@ model_registry:
   type: hugging-face
   url: https://huggingface.co
   credentials: ""
+  # Pre-mounted BentoML NFS registry root for direct local model push tests.
+  # Required only for tests labeled nfs-direct.
+  local_nfs_path: ""
 
 workspace: default
 


### PR DESCRIPTION
## Issue

NEU-435

## Summary

Support a Linux-only pre-mounted NFS direct-write path for `neutree-cli model push`. The default HTTP multipart upload remains unchanged; direct mode writes to the user-provided local NFS mount and then asks `neutree-api` to verify the server-visible model metadata through an authenticated finalize endpoint.

## Changes

- Add `neutree-cli model push --local-nfs-path` for Linux hosts with pre-mounted NFS ModelRegistry roots.
- Add a CLI helper that validates `bentoml` + `nfs://` registries, verifies the Linux mount source from `/proc/self/mountinfo` matches the registry NFS source, and imports archives with the existing BentoML filesystem layout.
- Add `POST /api/v1/workspaces/:workspace/model_registries/:registry/models/:model/finalize` guarded by workspace-scoped `model:push`.
- Add a client `FinalizePush` method and focused unit tests.
- Add an E2E profile field, `E2E_CLI_BINARY` support, and guarded `nfs-direct` happy path case for environments with a shared local NFS mount.

## Test Plan

Unit test:

- [x] `go test ./internal/cli/model ./pkg/client ./internal/routes/models`
- [x] `go test ./cmd/neutree-cli/app/cmd/model ./internal/cli/model ./internal/model_registry/... ./pkg/client ./internal/routes/models ./tests/e2e`
- [x] `make prepare-build-cli && go test $(go list ./... | grep -v 'e2e\\|mocks\\|db/dbtest')`
- [x] `go test ./internal/cli/model ./pkg/client ./internal/routes/models ./cmd/neutree-cli/app/cmd/model ./tests/e2e` after Linux-only mount check change on head `ebf824c`
- [x] `./bin/golangci-lint run -v --fast=false` after Linux-only mount check change on head `ebf824c`
- [x] `go test ./internal/cli/model ./pkg/client ./internal/routes/models ./cmd/neutree-cli/app/cmd/model ./tests/e2e` after rebase from `origin/main` on head `ad00c255`
- [x] `./bin/golangci-lint run -v --fast=false` after rebase from `origin/main` on head `ad00c255`

DB test:

- [x] Not affected. This change does not add or modify DB schema, migrations, RLS, or model-version persistence.

E2E test:

- [x] Manual Step 5 on `192.168.20.158`, API/CLI commit `8cfd0b8c`: direct push to pre-mounted `nfs://10.255.1.54:/bentoml` succeeded; `model list` included `neu435-direct`; `model get neu435-direct:v1.0` returned `Version: v1.0`.
- [x] Code-backed Step 5 E2E: `E2E_CLI_BINARY=/home/neutree/e2e-test/neutree-cli-neu435-8cfd0b8c /home/neutree/e2e-test/neutree-e2e-neu435-linux-amd64 --ginkgo.label-filter='nfs-direct'` on `192.168.20.158` passed `C2723966` (1 passed, 245 skipped, 22.978s).
- [x] Step 10 regression on `192.168.20.158`, API/CLI/E2E head `b7879e4f`: code-backed `nfs-direct` E2E passed `C2723966` (1 passed, 245 skipped, 33.853s).
- [x] Step 10 manual regression on `192.168.20.158`, head `b7879e4f`: default HTTP upload succeeded for `neu435-http-b7879e4f:v1.0`; bad `--local-nfs-path` failed before finalize; non-`nfs://` registry with direct flag was rejected.
- [x] The later `ebf824c` change only removes the unused Darwin mount parser and keeps the Linux `/proc/self/mountinfo` path used in the Step 10 environment; no additional remote E2E rerun required by the rerun rule.
- [x] The later `ad00c255` rebase only replayed the existing NEU-435 commits onto `origin/main` and resolved an additive unit-test conflict; no additional remote E2E rerun required by the rerun rule.

## Risk & Rollback

Main risk is an operator passing a local path that is writable on the CLI machine but not the same NFS export configured on the ModelRegistry; the CLI checks the Linux mounted NFS source and the finalize endpoint checks server-visible model metadata. Rollback is to stop using `--local-nfs-path`; the existing HTTP upload path is unchanged.
