### PR TITLE
fix: preserve vLLM list engine args

### DIFF
--- a/cluster-image-builder/serve/_utils/coerce.py
+++ b/cluster-image-builder/serve/_utils/coerce.py
@@ -118,11 +118,18 @@ def _unwrap_optional(annotation: Any) -> Any:
     return annotation
 
 
-def _wants_dict_or_list(annotation: Any) -> bool:
-    """Return True if the annotation expects a dict or list type."""
+def _wants_dict(annotation: Any) -> bool:
+    """Return True if the annotation expects a dict type."""
     target = _unwrap_optional(annotation)
     origin = typing.get_origin(target)
-    return origin in (dict, list) or target in (dict, list)
+    return origin is dict or target is dict
+
+
+def _wants_list(annotation: Any) -> bool:
+    """Return True if the annotation expects a list type."""
+    target = _unwrap_optional(annotation)
+    origin = typing.get_origin(target)
+    return origin is list or target is list
 
 
 def _is_dataclass_like(tp: Any) -> bool:
@@ -132,6 +139,21 @@ def _is_dataclass_like(tp: Any) -> bool:
     if issubclass(tp, BaseModel):
         return True
     return dataclasses.is_dataclass(tp)
+
+
+def _validate_annotation_value(annotation: Any, value: Any, fallback: Any = None) -> Any:
+    """Best-effort validation/conversion for values already parsed from JSON."""
+    target = _unwrap_optional(annotation)
+    try:
+        return TypeAdapter(target).validate_python(value)
+    except Exception as e:
+        logger.warning(
+            "coerce_args: TypeAdapter validate_python failed for target=%s: %s",
+            getattr(target, "__name__", target), e,
+        )
+        if fallback is not None:
+            return fallback
+        return value
 
 
 def coerce_args(args: Dict[str, Any], model_class: type) -> None:
@@ -163,13 +185,24 @@ def coerce_args(args: Dict[str, Any], model_class: type) -> None:
             continue
         raw = args[field_name]
 
-        if _wants_dict_or_list(annotation):
+        if _wants_list(annotation):
+            try:
+                parsed = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                args[field_name] = _validate_annotation_value(annotation, [raw], fallback=raw)
+                continue
+
+            if isinstance(parsed, list):
+                args[field_name] = _validate_annotation_value(annotation, parsed, fallback=raw)
+            continue
+
+        if _wants_dict(annotation):
             try:
                 parsed = json.loads(raw)
             except (json.JSONDecodeError, TypeError):
                 continue
-            if isinstance(parsed, (dict, list)):
-                args[field_name] = parsed
+            if isinstance(parsed, dict):
+                args[field_name] = _validate_annotation_value(annotation, parsed)
             continue
 
         target = _unwrap_optional(annotation)

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -180,6 +180,28 @@ class TestCoerceArgsPEP604:
         coerce_args(args, FakeEngineV017)
         assert args["allowed_media_domains"] == ["a.com", "b.com"]
 
+    def test_pep604_optional_list_plain_string_wrapped(self):
+        args = {"allowed_media_domains": "a.com"}
+        coerce_args(args, FakeEngineV017)
+        assert args["allowed_media_domains"] == ["a.com"]
+
+    def test_pep604_optional_list_json_object_string_left_unchanged(self):
+        raw = '{"domain":"a.com"}'
+        args = {"allowed_media_domains": raw}
+        coerce_args(args, FakeEngineV017)
+        assert args["allowed_media_domains"] == raw
+
+    def test_pep604_list_elements_validated(self):
+        args = {"plain_list": '["1", "2", "3"]'}
+        coerce_args(args, SampleModel)
+        assert args["plain_list"] == [1, 2, 3]
+
+    def test_pep604_list_validation_failure_left_unchanged(self):
+        raw = '["not-an-int"]'
+        args = {"plain_list": raw}
+        coerce_args(args, SampleModel)
+        assert args["plain_list"] == raw
+
     def test_pep604_bare_dict_coerced(self):
         args = {"bare_dict": '{"k":"v"}'}
         coerce_args(args, FakeEngineV017)
@@ -257,11 +279,12 @@ class TestCoerceArgsDataclassHydration:
         type objects. _is_dataclass_like / _wants_dict_or_list must short-
         circuit on str — annotation is not a type, no hydration attempted,
         original string preserved."""
-        from serve._utils.coerce import _is_dataclass_like, _wants_dict_or_list
+        from serve._utils.coerce import _is_dataclass_like, _wants_dict, _wants_list
 
         # Both predicates safely return False on raw annotation strings.
         assert _is_dataclass_like("FakeAttentionConfig") is False
-        assert _wants_dict_or_list("dict[str, Any] | None") is False
+        assert _wants_dict("dict[str, Any] | None") is False
+        assert _wants_list("list[str] | None") is False
 
 
 # ---------------------------------------------------------------------------

--- a/internal/engine/vllm/v0.11.2/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.11.2/templates/kubernetes/default.yaml
@@ -117,7 +117,14 @@ spec:
           {{- end }}
           {{- if .EngineArgs }}
           {{- range $key, $value := .EngineArgs }}
-          {{- if eq (printf "%v" $value) "true" }}
+          {{- if kindIs "slice" $value }}
+          {{- if gt (len $value) 0 }}
+          - --{{ $key }}
+          {{- range $item := $value }}
+          - {{ $item | quote }}
+          {{- end }}
+          {{- end }}
+          {{- else if eq (printf "%v" $value) "true" }}
           - --{{ $key }}
           {{- else if eq (printf "%v" $value) "false" }}
           {{- /* skip: store_true flags reject "--flag false"; passing false means "leave at default" */ -}}

--- a/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
@@ -123,7 +123,14 @@ spec:
           {{- end }}
           {{- if .EngineArgs }}
           {{- range $key, $value := .EngineArgs }}
-          {{- if eq (printf "%v" $value) "true" }}
+          {{- if kindIs "slice" $value }}
+          {{- if gt (len $value) 0 }}
+          - --{{ $key }}
+          {{- range $item := $value }}
+          - {{ $item | quote }}
+          {{- end }}
+          {{- end }}
+          {{- else if eq (printf "%v" $value) "true" }}
           - --{{ $key }}
           {{- else if eq (printf "%v" $value) "false" }}
           {{- /* skip: store_true flags reject "--flag false"; passing false means "leave at default" */ -}}

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -249,6 +249,13 @@ func escapeEngineArgsForTemplate(args map[string]interface{}) {
 					args[k] = escapeForYAMLDoubleQuote(val)
 				}
 			}
+		default:
+			if list, ok := toInterfaceSlice(val); ok {
+				b, err := json.Marshal(list)
+				if err == nil {
+					args[k] = escapeForYAMLDoubleQuote(string(b))
+				}
+			}
 		}
 	}
 }

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -153,7 +154,75 @@ func (k *kubernetesOrchestrator) setEngineArgs(data *DeploymentManifestVariables
 
 	// Prepare engine arg values for YAML double-quoted template rendering.
 	// Handles native maps, unescaped JSON strings, and pre-escaped strings.
-	escapeEngineArgsForTemplate(data.EngineArgs)
+	prepareEngineArgsForTemplate(data.EngineArgs, engine.Metadata.Name)
+}
+
+func prepareEngineArgsForTemplate(args map[string]interface{}, engineName string) {
+	if engineName != v1.EngineNameVLLM {
+		escapeEngineArgsForTemplate(args)
+		return
+	}
+
+	for k, v := range args {
+		if list, ok := toInterfaceSlice(v); ok {
+			args[k] = list
+			continue
+		}
+
+		if val, ok := v.(string); ok {
+			var parsed interface{}
+			if err := json.Unmarshal([]byte(val), &parsed); err == nil {
+				if list, ok := toInterfaceSlice(parsed); ok {
+					args[k] = list
+					continue
+				}
+			}
+		}
+
+		args[k] = prepareEngineArgValueForDoubleQuote(v)
+	}
+}
+
+func prepareEngineArgValueForDoubleQuote(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}, []interface{}:
+		b, err := json.Marshal(v)
+		if err == nil {
+			return escapeForYAMLDoubleQuote(string(b))
+		}
+	case string:
+		var parsed interface{}
+		if err := json.Unmarshal([]byte(val), &parsed); err == nil {
+			switch parsed.(type) {
+			case map[string]interface{}, []interface{}:
+				return escapeForYAMLDoubleQuote(val)
+			}
+		}
+	}
+
+	return v
+}
+
+func toInterfaceSlice(v interface{}) ([]interface{}, bool) {
+	if s, ok := v.([]interface{}); ok {
+		return s, true
+	}
+
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() || (rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array) {
+		return nil, false
+	}
+
+	if rv.Type().Elem().Kind() == reflect.Uint8 {
+		return nil, false
+	}
+
+	out := make([]interface{}, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		out[i] = rv.Index(i).Interface()
+	}
+
+	return out, true
 }
 
 // escapeEngineArgsForTemplate prepares engine arg values for use in YAML

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -1727,6 +1727,23 @@ func TestPrepareEngineArgsForTemplate_NonVLLMListCompatibility(t *testing.T) {
 	assert.Equal(t, `[1,2]`, args["cuda_graph_bs"])
 }
 
+func TestPrepareEngineArgsForTemplate_SGLangJSONListSemantics(t *testing.T) {
+	args := map[string]interface{}{
+		"forward_hooks": []interface{}{
+			map[string]interface{}{
+				"name": "trace",
+				"path": "hooks.TraceHook",
+			},
+		},
+		"remote_instance_weight_loader_send_weights_group_ports": []int{29500, 29501},
+	}
+
+	prepareEngineArgsForTemplate(args, v1.EngineNameSGLang)
+
+	assert.Equal(t, `[{\"name\":\"trace\",\"path\":\"hooks.TraceHook\"}]`, args["forward_hooks"])
+	assert.Equal(t, `[29500,29501]`, args["remote_instance_weight_loader_send_weights_group_ports"])
+}
+
 func TestKubernetesOrchestrator_setEnvironmentVariables(t *testing.T) {
 	k := &kubernetesOrchestrator{}
 
@@ -3291,6 +3308,63 @@ func TestBuildDeployment_VLLMListEngineArgs(t *testing.T) {
 			assert.NotContains(t, tokens, `["a.Processor","b.Processor"]`)
 		})
 	}
+}
+
+func TestBuildDeployment_SGLangJSONListEngineArgs(t *testing.T) {
+	tmpl := realEmbeddedTemplate(t, "sglang-v0.5.10")
+
+	data := DeploymentManifestVariables{
+		NeutreeVersion:  "v0.1.0",
+		ClusterName:     "test-cluster",
+		Workspace:       "test-workspace",
+		Namespace:       "default",
+		ImagePrefix:     "registry.example.com",
+		ImageRepo:       "myrepo",
+		ImageTag:        "v1.0.0",
+		ImagePullSecret: "my-secret",
+		EngineName:      v1.EngineNameSGLang,
+		EngineVersion:   "v1.0.0",
+		EndpointName:    "test-endpoint",
+		ModelArgs: map[string]interface{}{
+			"name":          "qwen",
+			"task":          "text-generation",
+			"path":          "/mnt/models/qwen",
+			"registry_type": "bentoml",
+			"registry_path": "/mnt/registry/qwen",
+			"serve_name":    "qwen",
+		},
+		EngineArgs: map[string]interface{}{
+			"forward_hooks": []interface{}{
+				map[string]interface{}{
+					"name": "trace",
+					"path": "hooks.TraceHook",
+				},
+			},
+			"remote_instance_weight_loader_send_weights_group_ports": []int{29500, 29501},
+		},
+		Resources: map[string]string{
+			"cpu":    "500m",
+			"memory": "1Gi",
+		},
+		RoutingLogic: "roundrobin",
+		Replicas:     1,
+	}
+
+	prepareEngineArgsForTemplate(data.EngineArgs, v1.EngineNameSGLang)
+
+	objs, err := buildDeploymentObjects(tmpl, data)
+	require.NoError(t, err, "template render must succeed")
+
+	tokens := extractEngineCLITokens(t, objs)
+
+	assertFlagWithValue(t, tokens, "--forward-hooks", `[{"name":"trace","path":"hooks.TraceHook"}]`)
+	assertFlagWithValue(t, tokens, "--remote-instance-weight-loader-send-weights-group-ports", `[29500,29501]`)
+	assert.NotContains(t, tokens, `{"name":"trace","path":"hooks.TraceHook"}`,
+		"SGLang json_list_type expects one JSON array token, not expanded list items")
+	assert.NotContains(t, tokens, "29500",
+		"SGLang json_list_type expects one JSON array token, not expanded list items")
+	assert.NotContains(t, tokens, "29501",
+		"SGLang json_list_type expects one JSON array token, not expanded list items")
 }
 
 // makePauseTestCtx builds a minimal OrchestratorContext for pause/delete tests:

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -1697,6 +1697,36 @@ func TestEscapeEngineArgsForTemplate(t *testing.T) {
 	}
 }
 
+func TestPrepareEngineArgsForTemplate_VLLMListSemantics(t *testing.T) {
+	args := map[string]interface{}{
+		"served_model_name":          []interface{}{"base-model", "neu-vllm-list-alias"},
+		"logits_processors":          `["a.Processor","b.Processor"]`,
+		"allowed_media_domains":      []string{"a.example.com", "b.example.com"},
+		"override_generation_config": map[string]interface{}{"temperature": 0.8},
+		"gpu_memory_utilization":     "0.85",
+		"enable_prefix_caching":      "false",
+	}
+
+	prepareEngineArgsForTemplate(args, v1.EngineNameVLLM)
+
+	assert.Equal(t, []interface{}{"base-model", "neu-vllm-list-alias"}, args["served_model_name"])
+	assert.Equal(t, []interface{}{"a.Processor", "b.Processor"}, args["logits_processors"])
+	assert.Equal(t, []interface{}{"a.example.com", "b.example.com"}, args["allowed_media_domains"])
+	assert.Equal(t, `{\"temperature\":0.8}`, args["override_generation_config"])
+	assert.Equal(t, "0.85", args["gpu_memory_utilization"])
+	assert.Equal(t, "false", args["enable_prefix_caching"])
+}
+
+func TestPrepareEngineArgsForTemplate_NonVLLMListCompatibility(t *testing.T) {
+	args := map[string]interface{}{
+		"cuda_graph_bs": []interface{}{1, 2},
+	}
+
+	prepareEngineArgsForTemplate(args, v1.EngineNameSGLang)
+
+	assert.Equal(t, `[1,2]`, args["cuda_graph_bs"])
+}
+
 func TestKubernetesOrchestrator_setEnvironmentVariables(t *testing.T) {
 	k := &kubernetesOrchestrator{}
 
@@ -3199,6 +3229,70 @@ func TestBuildDeployment_BooleanEngineArgs(t *testing.T) {
 	}
 }
 
+func TestBuildDeployment_VLLMListEngineArgs(t *testing.T) {
+	cases := []struct {
+		name        string
+		templateKey string
+	}{
+		{
+			name:        "vllm-v0.11.2",
+			templateKey: "vllm-v0.11.2",
+		},
+		{
+			name:        "vllm-v0.17.1",
+			templateKey: "vllm-v0.17.1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := realEmbeddedTemplate(t, tc.templateKey)
+
+			data := DeploymentManifestVariables{
+				NeutreeVersion:  "v0.1.0",
+				ClusterName:     "test-cluster",
+				Workspace:       "test-workspace",
+				Namespace:       "default",
+				ImagePrefix:     "registry.example.com",
+				ImageRepo:       "myrepo",
+				ImageTag:        "v1.0.0",
+				ImagePullSecret: "my-secret",
+				EngineName:      v1.EngineNameVLLM,
+				EngineVersion:   "v1.0.0",
+				EndpointName:    "test-endpoint",
+				ModelArgs: map[string]interface{}{
+					"name":          "gpt-4",
+					"task":          "text-generation",
+					"path":          "/mnt/models/gpt-4",
+					"registry_type": "bentoml",
+					"registry_path": "/mnt/registry/gpt-4-model",
+					"serve_name":    "gpt-4-serve",
+				},
+				EngineArgs: map[string]interface{}{
+					"served_model_name": []interface{}{"gpt-4", "neu-vllm-list-alias"},
+					"logits_processors": []interface{}{"a.Processor", "b.Processor"},
+				},
+				Resources: map[string]string{
+					"cpu":    "500m",
+					"memory": "1Gi",
+				},
+				RoutingLogic: "roundrobin",
+				Replicas:     1,
+			}
+
+			objs, err := buildDeploymentObjects(tmpl, data)
+			require.NoError(t, err, "template render must succeed")
+
+			tokens := extractEngineCLITokens(t, objs)
+
+			assertFlagWithValues(t, tokens, "--served_model_name", "gpt-4", "neu-vllm-list-alias")
+			assertFlagWithValues(t, tokens, "--logits_processors", "a.Processor", "b.Processor")
+			assert.NotContains(t, tokens, `["gpt-4","neu-vllm-list-alias"]`)
+			assert.NotContains(t, tokens, `["a.Processor","b.Processor"]`)
+		})
+	}
+}
+
 // makePauseTestCtx builds a minimal OrchestratorContext for pause/delete tests:
 // only fields that pauseEndpoint / deleteEndpoint actually read.
 func makePauseTestCtx(ctrlClient client.Client, name string) *OrchestratorContext {
@@ -3416,6 +3510,20 @@ func assertFlagWithValue(t *testing.T, tokens []string, flag, value string) {
 	require.Less(t, idx+1, len(tokens), "flag %q should have a following value token", flag)
 	assert.Equal(t, value, tokens[idx+1],
 		"flag %q should be followed by %q; got %q", flag, value, tokens[idx+1])
+}
+
+func assertFlagWithValues(t *testing.T, tokens []string, flag string, values ...string) {
+	t.Helper()
+
+	idx := indexOf(tokens, flag)
+	require.NotEqual(t, -1, idx, "expected flag %q in tokens %v", flag, tokens)
+	require.LessOrEqual(t, idx+len(values), len(tokens)-1,
+		"flag %q should have %d following value token(s)", flag, len(values))
+
+	for i, value := range values {
+		assert.Equal(t, value, tokens[idx+1+i],
+			"flag %q value token %d should be %q; got %q", flag, i, value, tokens[idx+1+i])
+	}
 }
 
 func indexOf(tokens []string, target string) int {

--- a/tests/e2e/endpoint_k8s_config_test.go
+++ b/tests/e2e/endpoint_k8s_config_test.go
@@ -503,7 +503,7 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 			}
 		})
 
-		It("should deploy with all schema data types", Label("C2642246"), func() {
+		It("should deploy with all schema data types", Label("C2642246", "C2724892"), func() {
 			yamlPath := applyEndpoint(schemaEpName, clusterName, withEngineArgs(allSchemaTypesEngineArgs()))
 			defer os.Remove(yamlPath)
 
@@ -535,6 +535,20 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 				Expect(argsStr).To(ContainSubstring("--seed"), "integer")
 				Expect(argsStr).To(ContainSubstring("--override_generation_config"), "object/JSON")
 
+				listFlagIdx := -1
+				for i, tok := range allArgs {
+					if tok == "--served_model_name" {
+						listFlagIdx = i
+						break
+					}
+				}
+				Expect(listFlagIdx).NotTo(Equal(-1), "list arg flag")
+				Expect(len(allArgs)).To(BeNumerically(">", listFlagIdx+2), "list arg values")
+				Expect(allArgs[listFlagIdx+1]).To(Equal(profileModelName()), "first list value")
+				Expect(allArgs[listFlagIdx+2]).To(Equal("neu-vllm-list-alias"), "second list value")
+				Expect(argsStr).NotTo(ContainSubstring(fmt.Sprintf(`["%s","neu-vllm-list-alias"]`, profileModelName())),
+					"list arg must not remain a single JSON array token")
+
 				// Boolean false engine_args must drop the flag entirely. vLLM
 				// argparse rejects `--flag false` (store_true is nargs=0), so
 				// the template skips both `--<flag>` and `"false"` when the
@@ -559,6 +573,10 @@ var _ = Describe("K8s Endpoint Config", Ordered, Label("endpoint", "k8s", "confi
 			code, body, err := inferChat(ep.Status.ServiceURL, "Hello schema types")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(code).To(Equal(200), "inference failed: %s", body)
+
+			code, body, err = inferChatWithModel(ep.Status.ServiceURL, "neu-vllm-list-alias", "Hello schema alias")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(200), "alias inference failed: %s", body)
 		})
 	})
 

--- a/tests/e2e/endpoint_ssh_config_test.go
+++ b/tests/e2e/endpoint_ssh_config_test.go
@@ -248,7 +248,7 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 			}
 		})
 
-		It("should deploy with all schema data types in engine_args", Label("C2642245", "C2644062"), func() {
+		It("should deploy with all schema data types in engine_args", Label("C2642245", "C2644062", "C2724893"), func() {
 			yamlPath := applyEndpoint(schemaEpName, clusterName, withEngineArgs(allSchemaTypesEngineArgs()))
 			defer os.Remove(yamlPath)
 
@@ -277,6 +277,10 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 			Expect(eaMap).To(HaveKeyWithValue("dtype", "half"))
 			Expect(eaMap).To(HaveKey("seed"))
 			Expect(eaMap["seed"]).To(BeNumerically("==", 42))
+			Expect(eaMap).To(HaveKey("served_model_name"))
+			servedModelNames, ok := eaMap["served_model_name"].([]interface{})
+			Expect(ok).To(BeTrue(), "served_model_name should remain a list")
+			Expect(servedModelNames).To(Equal([]interface{}{profileModelName(), "neu-vllm-list-alias"}))
 		})
 
 		It("should serve inference with all-types config", func() {
@@ -284,6 +288,10 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 			code, body, err := inferChat(ep.Status.ServiceURL, "Hello with all schema types")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(code).To(Equal(200), "inference failed: %s", body)
+
+			code, body, err = inferChatWithModel(ep.Status.ServiceURL, "neu-vllm-list-alias", "Hello with schema alias")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(code).To(Equal(200), "alias inference failed: %s", body)
 		})
 	})
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1541,6 +1541,7 @@ func allSchemaTypesEngineArgs() []EngineArg {
 		{Key: "enforce_eager", Value: "true"},
 		{Key: "enable_prefix_caching", Value: "false"},
 		{Key: "seed", Value: "42"},
+		{Key: "served_model_name", Value: fmt.Sprintf(`["%s","neu-vllm-list-alias"]`, profileModelName())},
 		{Key: "override_generation_config", Value: `'{"temperature": 0.8}'`},
 	}
 }
@@ -1673,8 +1674,12 @@ func doInferenceRequest(serviceURL, path string, reqBody map[string]any) (int, s
 }
 
 func inferChat(serviceURL, prompt string) (int, string, error) {
+	return inferChatWithModel(serviceURL, profileModelName(), prompt)
+}
+
+func inferChatWithModel(serviceURL, model, prompt string) (int, string, error) {
 	return doInferenceRequest(serviceURL, "/v1/chat/completions", map[string]any{
-		"model": profileModelName(),
+		"model": model,
 		"messages": []map[string]string{
 			{"role": "user", "content": prompt},
 		},


### PR DESCRIPTION
## Issue

NEU-471

## Summary

Fix vLLM list-valued `engine_args` so SSH/Ray deployments preserve list values and Kubernetes deployments render list values as multiple CLI argv tokens, matching `vllm serve` list argument semantics.

## Changes

- Split Python SSH/Ray coercion for `list[...]` and `dict[...]` annotations.
- Preserve native list values, parse JSON array strings as lists, and wrap plain strings as single-item lists for list annotations.
- Add vLLM-only Kubernetes engine arg preparation so list values remain list-shaped for templates while non-vLLM engines keep JSON-string CLI behavior.
- Update vLLM v0.11.2 and v0.17.1 Kubernetes templates to render list args as one flag followed by multiple value tokens.
- Preserve SGLang K8s JSON-list semantics by keeping SGLang list args as one JSON array token, including typed slices such as `[]int`.
- Add regression coverage for Python coercion, K8s template rendering, vLLM K8s/SSH config E2E cases, and SGLang JSON-list K8s rendering.

## Test Plan

### Unit test

- [x] `PYTHONPATH=cluster-image-builder pytest cluster-image-builder/serve/_utils/test_coerce.py -q`
- [x] `go test ./internal/orchestrator -run 'Test(PrepareEngineArgsForTemplate|BuildDeployment_VLLMListEngineArgs|BuildDeployment_SGLangJSONListEngineArgs|BuildDeployment_BooleanEngineArgs|EscapeEngineArgsForTemplate)'`
- [x] `go test ./internal/orchestrator`
- [x] `go test ./internal/engine`
- [x] `go test ./tests/e2e`
- [x] `go test ./api/... ./internal/... ./tests/e2e`
- [x] `git diff --check`
- [ ] `go test ./...` blocked locally by missing embedded asset `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`.

### DB test

- N/A. No DB schema, migration, query, or RLS changes.

### E2E test

- [x] Built engine image `neutree/engine-vllm:v0.11.2-neutree471-ray2.53.0` from head `c9046bff` with Ray input `ray-2.53.0-neutree-fix`; GitHub Actions run `28336360552`.
- [x] Copied engine image to the E2E registry as digest `sha256:1d9fd7376f6436fce788228736c580cbd721de99d58c349672a640245e2046d1`.
- [x] Hot-updated test control plane `192.168.20.158` with branch binaries and imported manifest version `vllm:v0.11.2-neutree471`.
- [x] `go test ./tests/e2e -run TestE2E -count=1 -timeout 90m -v --ginkgo.label-filter='C2724892' --ginkgo.v --ginkgo.poll-progress-after=5m` -> PASS in 233.920s.
- [x] `go test ./tests/e2e -run TestE2E -count=1 -timeout 90m -v --ginkgo.label-filter='C2724893' --ginkgo.v --ginkgo.poll-progress-after=5m` -> PASS in 278.118s.
- [x] C2724894 is covered by focused unit/template coverage; live custom `logits_processors` material is not required for this fix.
- [x] SGLang JSON-list CLI behavior is covered by unit/template tests because the safe list-shaped SGLang flags require custom forward hooks or remote weight-loader settings and are not suitable as a routine live E2E happy path.
- Manual testing is not required; the affected vLLM K8s and SSH/Ray workflows are covered by the E2E cases above, and SGLang list semantics are covered by focused template tests.

E2E environment note: the test control plane ran the current branch binaries for the vLLM E2E rerun at `c9046bff`. The later `a631f1df` commit only adds SGLang JSON-list unit/template coverage plus a typed-slice JSON escaping fix in the non-vLLM K8s path. The data-plane cluster image version used `v1.0.1` because the E2E registry did not have the matching nightly router image. The shared L20 node needed an authenticated pre-pull of the 14GB engine image after the registry tag was refreshed to avoid validating against the old cached digest.

## Risk & Rollback

- vLLM list args are intentionally expanded for CLI `nargs` semantics.
- SGLang list args intentionally remain one JSON array token for `json_list_type` CLI semantics.
- vLLM object/scalar/bool behavior and SGLang boolean behavior are covered by regression tests.
- Rollback: revert this PR to restore the previous single-token list rendering/coercion behavior.
- `v0.19.1` is intentionally out of scope for this PR and should be handled as a separate backport/follow-up if needed.
