### PR TITLE
fix: stabilize SGLang metrics collection

### DIFF
--- a/cluster-image-builder/serve/_metrics/prometheus_multiproc.py
+++ b/cluster-image-builder/serve/_metrics/prometheus_multiproc.py
@@ -1,0 +1,50 @@
+"""Stable prometheus_client multiprocess directory helpers."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def ensure_prometheus_multiproc_dir(
+    *,
+    base_dir: str = "/tmp/neutree-prometheus-multiproc",
+    namespace: str = "default",
+) -> Path:
+    """Return a stable multiprocess dir and export it for prometheus_client."""
+    existing = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+    if existing:
+        path = Path(existing)
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+        return path
+
+    path = Path(base_dir) / namespace / str(os.getpid())
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(path)
+
+    return path
+
+
+def install_stable_prometheus_multiproc_dir(
+    common_module: Any,
+    engine_module: Any,
+    *,
+    base_dir: str = "/tmp/neutree-prometheus-multiproc",
+    namespace: str = "default",
+) -> Path:
+    """Patch SGLang's tempdir-based multiprocess setup with a stable path."""
+    path = ensure_prometheus_multiproc_dir(base_dir=base_dir, namespace=namespace)
+
+    def set_prometheus_multiproc_dir() -> str:
+        os.environ["PROMETHEUS_MULTIPROC_DIR"] = str(path)
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+        return str(path)
+
+    common_module.set_prometheus_multiproc_dir = set_prometheus_multiproc_dir
+    engine_module.set_prometheus_multiproc_dir = set_prometheus_multiproc_dir
+
+    return path

--- a/cluster-image-builder/serve/_metrics/sglang_ray_bridge.py
+++ b/cluster-image-builder/serve/_metrics/sglang_ray_bridge.py
@@ -50,9 +50,9 @@ def _sanitize_metric_name(name: str) -> str:
 
     SGLang emits ``sglang:cache_config_info`` (colon-separated namespace), but
     ``ray.util.metrics`` rejects ``:`` since the move to OpenTelemetry naming.
-    Replace with underscore so the Ray-exported name is ``sglang_<suffix>`` —
-    aligned with the vmagent relabel rule (``ray_sglang[:_]<name>`` →
-    ``sglang_<name>``) and with the Grafana dashboard filters.
+    Replace with underscore so Ray can export the metric as
+    ``ray_sglang_<suffix>``. vmagent converts that temporary Ray-safe name back
+    to the canonical upstream ``sglang:<suffix>`` form for storage and queries.
     """
     return name.replace(":", "_")
 

--- a/cluster-image-builder/serve/_metrics/sglang_ray_bridge.py
+++ b/cluster-image-builder/serve/_metrics/sglang_ray_bridge.py
@@ -18,6 +18,13 @@ an identical registry from the same shared dir gives us byte-for-byte
 identical aggregated samples to what SGLang would have served externally —
 no SGLang internal API is involved.
 
+Ray Serve LLM has an upstream ``stat_loggers``-based SGLang metrics bridge in
+progress, but that path depends on SGLang's pluggable metrics backend hooks
+(``ServerArgs.stat_loggers`` and ``STAT_LOGGER_ROLE_*``), which first shipped in
+SGLang v0.5.13. Neutree's current SGLang v0.5.10 image has
+``metrics_collector.py`` but not those injection hooks, so the multiprocess
+registry remains the compatible bridge point for this engine version.
+
 This module polls that registry on a fixed cadence and re-emits each sample
 through ``ray.util.metrics`` so Ray's prometheus exporter (already scraped by
 vmagent's ``file_sd_configs``) sees SGLang metrics under the canonical

--- a/cluster-image-builder/serve/_metrics/test_prometheus_multiproc.py
+++ b/cluster-image-builder/serve/_metrics/test_prometheus_multiproc.py
@@ -1,0 +1,59 @@
+import os
+import types
+
+from serve._metrics.prometheus_multiproc import (
+    ensure_prometheus_multiproc_dir,
+    install_stable_prometheus_multiproc_dir,
+)
+
+
+def test_ensure_prometheus_multiproc_dir_creates_stable_pid_dir(
+    monkeypatch, tmp_path
+):
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+    stale_file = tmp_path / "sglang" / str(os.getpid()) / "counter.db"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("stale")
+
+    path = ensure_prometheus_multiproc_dir(base_dir=str(tmp_path), namespace="sglang")
+
+    assert path == stale_file.parent
+    assert os.environ["PROMETHEUS_MULTIPROC_DIR"] == str(path)
+    assert path.exists()
+    assert list(path.iterdir()) == []
+
+
+def test_ensure_prometheus_multiproc_dir_preserves_existing_env(
+    monkeypatch, tmp_path
+):
+    existing = tmp_path / "custom"
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(existing))
+
+    path = ensure_prometheus_multiproc_dir(base_dir=str(tmp_path), namespace="sglang")
+
+    assert path == existing
+    assert existing.exists()
+    assert os.environ["PROMETHEUS_MULTIPROC_DIR"] == str(existing)
+
+
+def test_install_stable_prometheus_multiproc_dir_patches_common_and_engine(
+    monkeypatch, tmp_path
+):
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+    common_module = types.SimpleNamespace(
+        set_prometheus_multiproc_dir=lambda: "common-temp-dir"
+    )
+    engine_module = types.SimpleNamespace(
+        set_prometheus_multiproc_dir=lambda: "engine-temp-dir"
+    )
+
+    path = install_stable_prometheus_multiproc_dir(
+        common_module,
+        engine_module,
+        base_dir=str(tmp_path),
+        namespace="sglang",
+    )
+
+    assert path == tmp_path / "sglang" / str(os.getpid())
+    assert common_module.set_prometheus_multiproc_dir() == str(path)
+    assert engine_module.set_prometheus_multiproc_dir() == str(path)

--- a/cluster-image-builder/serve/_utils/coerce.py
+++ b/cluster-image-builder/serve/_utils/coerce.py
@@ -125,6 +125,11 @@ def _wants_dict_or_list(annotation: Any) -> bool:
     return origin in (dict, list) or target in (dict, list)
 
 
+def _wants_bool(annotation: Any) -> bool:
+    """Return True if the annotation expects a boolean type."""
+    return _unwrap_optional(annotation) is bool
+
+
 def _is_dataclass_like(tp: Any) -> bool:
     """True if *tp* is a class hydratable from JSON (Pydantic model or dataclass)."""
     if not isinstance(tp, type):
@@ -144,8 +149,9 @@ def coerce_args(args: Dict[str, Any], model_class: type) -> None:
     values through as-is.
 
     This function inspects each field's type annotation and converts JSON strings
-    for dict/list fields and for custom dataclass/Pydantic-model fields (via
-    TypeAdapter), leaving all other values untouched.
+    for dict/list fields, bool-like strings for bool fields, and JSON strings
+    for custom dataclass/Pydantic-model fields (via TypeAdapter), leaving all
+    other values untouched.
 
     Supports both Pydantic models/dataclasses and standard Python dataclasses.
 
@@ -170,6 +176,14 @@ def coerce_args(args: Dict[str, Any], model_class: type) -> None:
                 continue
             if isinstance(parsed, (dict, list)):
                 args[field_name] = parsed
+            continue
+
+        if _wants_bool(annotation):
+            value = raw.strip().lower()
+            if value == "true":
+                args[field_name] = True
+            elif value == "false":
+                args[field_name] = False
             continue
 
         target = _unwrap_optional(annotation)

--- a/cluster-image-builder/serve/_utils/coerce.py
+++ b/cluster-image-builder/serve/_utils/coerce.py
@@ -125,11 +125,6 @@ def _wants_dict_or_list(annotation: Any) -> bool:
     return origin in (dict, list) or target in (dict, list)
 
 
-def _wants_bool(annotation: Any) -> bool:
-    """Return True if the annotation expects a boolean type."""
-    return _unwrap_optional(annotation) is bool
-
-
 def _is_dataclass_like(tp: Any) -> bool:
     """True if *tp* is a class hydratable from JSON (Pydantic model or dataclass)."""
     if not isinstance(tp, type):
@@ -149,9 +144,8 @@ def coerce_args(args: Dict[str, Any], model_class: type) -> None:
     values through as-is.
 
     This function inspects each field's type annotation and converts JSON strings
-    for dict/list fields, bool-like strings for bool fields, and JSON strings
-    for custom dataclass/Pydantic-model fields (via TypeAdapter), leaving all
-    other values untouched.
+    for dict/list fields and for custom dataclass/Pydantic-model fields (via
+    TypeAdapter), leaving all other values untouched.
 
     Supports both Pydantic models/dataclasses and standard Python dataclasses.
 
@@ -176,14 +170,6 @@ def coerce_args(args: Dict[str, Any], model_class: type) -> None:
                 continue
             if isinstance(parsed, (dict, list)):
                 args[field_name] = parsed
-            continue
-
-        if _wants_bool(annotation):
-            value = raw.strip().lower()
-            if value == "true":
-                args[field_name] = True
-            elif value == "false":
-                args[field_name] = False
             continue
 
         target = _unwrap_optional(annotation)

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -16,7 +16,6 @@ from serve._utils.coerce import _get_field_annotations
 class SampleModel(BaseModel):
     name: str = ""
     count: int = 0
-    enabled: bool = False
     config: Optional[Dict[str, Any]] = None
     items: Optional[List[str]] = None
     tags: Dict[str, str] = {}
@@ -65,7 +64,6 @@ class FakeEngineV017:
     speculative_config: dict[str, Any] | None = None       # PEP 604 dict
     allowed_media_domains: list[str] | None = None          # PEP 604 list
     bare_dict: dict[str, str] = field(default_factory=dict) # PEP 604 bare
-    enable_metrics: bool = True
     attn_required: FakeAttentionConfig = field(default_factory=FakeAttentionConfig)
     attn_optional: FakeAttentionConfig | None = None        # PEP 604 + custom
     cfg_optional: FakePydanticConfig | None = None
@@ -93,12 +91,7 @@ class TestCoerceArgs:
     def test_int_field_untouched(self):
         args = {"count": "42"}
         coerce_args(args, SampleModel)
-        assert args["count"] == "42"  # int strings are intentionally not coerced
-
-    def test_bool_field_coerced_from_string(self):
-        args = {"enabled": "false"}
-        coerce_args(args, SampleModel)
-        assert args["enabled"] is False
+        assert args["count"] == "42"  # not coerced — only dict/list fields
 
     def test_non_string_value_skipped(self):
         args = {"config": {"already": "a dict"}}
@@ -191,12 +184,6 @@ class TestCoerceArgsPEP604:
         args = {"bare_dict": '{"k":"v"}'}
         coerce_args(args, FakeEngineV017)
         assert args["bare_dict"] == {"k": "v"}
-
-    def test_bool_string_false_coerced_for_engine_args(self):
-        args = {"enable_metrics": "false"}
-        coerce_args(args, FakeEngineV017)
-        assert args["enable_metrics"] is False
-
 
 class TestCoerceArgsDataclassHydration:
     def test_dataclass_field_hydrated_to_instance(self):

--- a/cluster-image-builder/serve/_utils/test_coerce.py
+++ b/cluster-image-builder/serve/_utils/test_coerce.py
@@ -16,6 +16,7 @@ from serve._utils.coerce import _get_field_annotations
 class SampleModel(BaseModel):
     name: str = ""
     count: int = 0
+    enabled: bool = False
     config: Optional[Dict[str, Any]] = None
     items: Optional[List[str]] = None
     tags: Dict[str, str] = {}
@@ -64,6 +65,7 @@ class FakeEngineV017:
     speculative_config: dict[str, Any] | None = None       # PEP 604 dict
     allowed_media_domains: list[str] | None = None          # PEP 604 list
     bare_dict: dict[str, str] = field(default_factory=dict) # PEP 604 bare
+    enable_metrics: bool = True
     attn_required: FakeAttentionConfig = field(default_factory=FakeAttentionConfig)
     attn_optional: FakeAttentionConfig | None = None        # PEP 604 + custom
     cfg_optional: FakePydanticConfig | None = None
@@ -91,7 +93,12 @@ class TestCoerceArgs:
     def test_int_field_untouched(self):
         args = {"count": "42"}
         coerce_args(args, SampleModel)
-        assert args["count"] == "42"  # not coerced — only dict/list fields
+        assert args["count"] == "42"  # int strings are intentionally not coerced
+
+    def test_bool_field_coerced_from_string(self):
+        args = {"enabled": "false"}
+        coerce_args(args, SampleModel)
+        assert args["enabled"] is False
 
     def test_non_string_value_skipped(self):
         args = {"config": {"already": "a dict"}}
@@ -184,6 +191,11 @@ class TestCoerceArgsPEP604:
         args = {"bare_dict": '{"k":"v"}'}
         coerce_args(args, FakeEngineV017)
         assert args["bare_dict"] == {"k": "v"}
+
+    def test_bool_string_false_coerced_for_engine_args(self):
+        args = {"enable_metrics": "false"}
+        coerce_args(args, FakeEngineV017)
+        assert args["enable_metrics"] is False
 
 
 class TestCoerceArgsDataclassHydration:

--- a/cluster-image-builder/serve/sglang/v0_5_10/app.py
+++ b/cluster-image-builder/serve/sglang/v0_5_10/app.py
@@ -34,6 +34,7 @@ from ray.serve.config import RequestRouterConfig
 from ray.serve.handle import DeploymentHandle, DeploymentResponseGenerator
 
 from downloader import build_request_from_model_args, download_with_markers, get_downloader
+from serve._metrics.prometheus_multiproc import install_stable_prometheus_multiproc_dir
 from serve._metrics.sglang_ray_bridge import PromToRayBridge
 from serve._utils import coerce_args, filter_engine_args
 from serve._utils.runtime_env import build_backend_runtime_env
@@ -259,16 +260,29 @@ class Backend:
         coerce_args(args, ServerArgs)
         filter_engine_args(args, ServerArgs)
 
-        from sglang.srt.entrypoints.engine import Engine
+        from sglang.srt.entrypoints import engine as sglang_engine
+
+        if args.get("enable_metrics"):
+            from sglang.srt.utils import common as sglang_common
+
+            metrics_dir = install_stable_prometheus_multiproc_dir(
+                sglang_common,
+                sglang_engine,
+                namespace="sglang",
+            )
+            logger.info(
+                "[Backend] Using stable PROMETHEUS_MULTIPROC_DIR for SGLang: %s",
+                metrics_dir,
+            )
 
         logger.info(
             f"[Backend] Initializing SGLang Engine with args: {sorted(args.keys())}"
         )
         # Engine.__init__ launches scheduler/detokenizer subprocesses and
-        # blocks until all are ready before returning. By this point
-        # PROMETHEUS_MULTIPROC_DIR is set in our env, so the bridge below
-        # can construct an identical CollectorRegistry.
-        self.engine = Engine(**args)
+        # blocks until all are ready before returning. When metrics are
+        # enabled, PROMETHEUS_MULTIPROC_DIR is already set in our env, so the
+        # bridge below can construct an identical CollectorRegistry.
+        self.engine = sglang_engine.Engine(**args)
         logger.info("[Backend] SGLang Engine initialized.")
 
         # Lazy-init OpenAI serving handlers — created on first request.
@@ -276,12 +290,13 @@ class Backend:
         self._completion = None
         self._embedding = None
 
-        # Spin up the SGLang prometheus -> Ray prometheus bridge. The bridge
-        # task survives until __del__ cancels it on actor preemption.
-        self._metrics_bridge = PromToRayBridge()
-        self._metrics_task = asyncio.get_event_loop().create_task(
-            self._metrics_bridge.run()
-        )
+        if args.get("enable_metrics"):
+            # Spin up the SGLang prometheus -> Ray prometheus bridge. The bridge
+            # task survives until __del__ cancels it on actor preemption.
+            self._metrics_bridge = PromToRayBridge()
+            self._metrics_task = asyncio.get_event_loop().create_task(
+                self._metrics_bridge.run()
+            )
 
     def __del__(self):
         # Belt-and-braces cleanup: Engine registers its own atexit handler,

--- a/internal/cluster/component/metrics/manifests.go
+++ b/internal/cluster/component/metrics/manifests.go
@@ -115,6 +115,11 @@ data:
       - source_labels: [__meta_kubernetes_pod_label_engine_version]
         action: replace
         target_label: engine_version
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'sglang[:_](.+)'
+        target_label: __name__
+        replacement: 'sglang:$1'
     # Scrape node-exporter metrics from all nodes (HTTP - without kube-rbac-proxy)
     - job_name: 'node-exporter-http'
       kubernetes_sd_configs:

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -92,6 +94,53 @@ func TestBuildVMAgentConfigIncludesHAMiMonitorScrape(t *testing.T) {
 	}
 
 	t.Fatalf("vmagent config map not found in resources")
+}
+
+func TestBuildVMAgentConfigNormalizesSGLangMetricNames(t *testing.T) {
+	metricsCmpt := &MetricsComponent{
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{
+				Name:      "test-cluster",
+				Workspace: "test-workspace",
+			},
+			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
+		},
+		namespace:       "test-namespace",
+		imagePrefix:     "test-image-prefix",
+		imagePullSecret: "test-image-pull-secret",
+	}
+
+	objs, err := metricsCmpt.GetMetricsResources()
+	if err != nil {
+		t.Fatalf("Failed to build vmagent resources: %v", err)
+	}
+
+	for _, obj := range objs.Items {
+		if obj.GetKind() == "ConfigMap" && obj.GetName() == "vmagent-config" {
+			config, _, _ := unstructured.NestedString(obj.Object, "data", "prometheus.yml")
+			assert.Assert(t, strings.Contains(config, "job_name: 'neutree-inference'"))
+			assert.Assert(t, strings.Contains(config, "metric_relabel_configs:"))
+			assert.Assert(t, strings.Contains(config, "source_labels: [__name__]"))
+			assert.Assert(t, strings.Contains(config, "regex: 'sglang[:_](.+)'"))
+			assert.Assert(t, strings.Contains(config, "target_label: __name__"))
+			assert.Assert(t, strings.Contains(config, "replacement: 'sglang:$1'"))
+			return
+		}
+	}
+
+	t.Fatalf("vmagent config map not found in resources")
+}
+
+func TestStaticRayVMAgentConfigNormalizesSGLangMetricNames(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "..", "observability", "vmagent", "prometheus.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read static vmagent config: %v", err)
+	}
+
+	config := string(data)
+	assert.Assert(t, strings.Contains(config, "regex: 'ray_sglang[:_](.+)'"))
+	assert.Assert(t, strings.Contains(config, "replacement: 'sglang:$1'"))
 }
 
 func TestBuildMetricsResourcesSkipsKubeStateMetricsBeforeV110(t *testing.T) {

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -105,6 +105,22 @@ func (k *kubernetesOrchestrator) setEngineDefaultArgs(data *DeploymentManifestVa
 	}
 }
 
+func setDefaultSGLangEnableMetrics(engineName string, engineArgs map[string]interface{}) {
+	if engineName != v1.EngineNameSGLang {
+		return
+	}
+
+	if _, ok := engineArgs["enable_metrics"]; ok {
+		return
+	}
+
+	if _, ok := engineArgs["enable-metrics"]; ok {
+		return
+	}
+
+	engineArgs["enable_metrics"] = true
+}
+
 // setEngineTensorParallelDefault auto-sets the engine's tensor-parallel-size
 // arg = GPU count when GPU > 1 and is a whole number. Must be called after
 // user engine_args are merged, because users may provide the key in either
@@ -145,6 +161,8 @@ func (k *kubernetesOrchestrator) setEngineArgs(data *DeploymentManifestVariables
 			maps.Copy(data.EngineArgs, v)
 		}
 	}
+
+	setDefaultSGLangEnableMetrics(engine.Metadata.Name, data.EngineArgs)
 
 	// Auto-set tensor-parallel-size after user args are merged, so we can
 	// detect user-provided values in either key format. Applies to engines

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -1508,7 +1508,62 @@ func TestKubernetesOrchestrator_setEngineArgs(t *testing.T) {
 				},
 			},
 			expectedArgs: map[string]interface{}{
-				"tp_size": 4,
+				"enable_metrics": true,
+				"tp_size":        4,
+			},
+		},
+		{
+			name: "sglang engine defaults enable_metrics",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{},
+			},
+			expectedArgs: map[string]interface{}{
+				"enable_metrics": true,
+			},
+		},
+		{
+			name: "sglang engine user-provided enable_metrics prevents default",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Variables: map[string]interface{}{
+						"engine_args": map[string]interface{}{
+							"enable_metrics": false,
+						},
+					},
+				},
+			},
+			expectedArgs: map[string]interface{}{
+				"enable_metrics": false,
+			},
+		},
+		{
+			name: "sglang engine user-provided kebab enable-metrics prevents default",
+			engine: &v1.Engine{
+				Metadata: &v1.Metadata{
+					Name: "sglang",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Variables: map[string]interface{}{
+						"engine_args": map[string]interface{}{
+							"enable-metrics": false,
+						},
+					},
+				},
+			},
+			expectedArgs: map[string]interface{}{
+				"enable-metrics": false,
 			},
 		},
 		{
@@ -1525,7 +1580,9 @@ func TestKubernetesOrchestrator_setEngineArgs(t *testing.T) {
 					},
 				},
 			},
-			expectedArgs: map[string]interface{}{},
+			expectedArgs: map[string]interface{}{
+				"enable_metrics": true,
+			},
 		},
 		{
 			name: "sglang engine fractional GPU should not set tp_size",
@@ -1541,7 +1598,9 @@ func TestKubernetesOrchestrator_setEngineArgs(t *testing.T) {
 					},
 				},
 			},
-			expectedArgs: map[string]interface{}{},
+			expectedArgs: map[string]interface{}{
+				"enable_metrics": true,
+			},
 		},
 		{
 			name: "sglang engine user-provided kebab tp-size prevents default",
@@ -1563,7 +1622,8 @@ func TestKubernetesOrchestrator_setEngineArgs(t *testing.T) {
 				},
 			},
 			expectedArgs: map[string]interface{}{
-				"tp-size": "2",
+				"enable_metrics": true,
+				"tp-size":        "2",
 			},
 		},
 		{
@@ -1586,7 +1646,8 @@ func TestKubernetesOrchestrator_setEngineArgs(t *testing.T) {
 				},
 			},
 			expectedArgs: map[string]interface{}{
-				"tp_size": "1",
+				"enable_metrics": true,
+				"tp_size":        "1",
 			},
 		},
 		{
@@ -1599,7 +1660,9 @@ func TestKubernetesOrchestrator_setEngineArgs(t *testing.T) {
 			endpoint: &v1.Endpoint{
 				Spec: &v1.EndpointSpec{},
 			},
-			expectedArgs: map[string]interface{}{},
+			expectedArgs: map[string]interface{}{
+				"enable_metrics": true,
+			},
 		},
 	}
 

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -1000,14 +1000,6 @@ func setDefaultSGLangEnableMetricsForApplication(endpoint *v1.Endpoint, app *das
 		engineArgs = make(map[string]interface{})
 	}
 
-	if v, hasDash := engineArgs["enable-metrics"]; hasDash {
-		if _, hasUnderscore := engineArgs["enable_metrics"]; !hasUnderscore {
-			engineArgs["enable_metrics"] = v
-		}
-
-		delete(engineArgs, "enable-metrics")
-	}
-
 	setDefaultSGLangEnableMetrics(endpoint.Spec.Engine.Engine, engineArgs)
 	app.Args["engine_args"] = engineArgs
 }

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -936,6 +936,8 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 
 	maps.Copy(app.Args, endpoint.Spec.Variables)
 
+	setDefaultSGLangEnableMetricsForApplication(endpoint, &app)
+
 	setDefaultTensorParallelSize(endpoint, &app, rayResource.NumGPUs)
 
 	setEngineSpecialEnv(endpoint, deployedCluster, applicationEnv)
@@ -986,6 +988,28 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 	}
 
 	return app, nil
+}
+
+func setDefaultSGLangEnableMetricsForApplication(endpoint *v1.Endpoint, app *dashboard.RayServeApplication) {
+	if endpoint.Spec.Engine == nil || endpoint.Spec.Engine.Engine != v1.EngineNameSGLang {
+		return
+	}
+
+	engineArgs, ok := app.Args["engine_args"].(map[string]interface{})
+	if !ok {
+		engineArgs = make(map[string]interface{})
+	}
+
+	if v, hasDash := engineArgs["enable-metrics"]; hasDash {
+		if _, hasUnderscore := engineArgs["enable_metrics"]; !hasUnderscore {
+			engineArgs["enable_metrics"] = v
+		}
+
+		delete(engineArgs, "enable-metrics")
+	}
+
+	setDefaultSGLangEnableMetrics(endpoint.Spec.Engine.Engine, engineArgs)
+	app.Args["engine_args"] = engineArgs
 }
 
 // setDefaultTensorParallelSize auto-sets the tensor-parallel field in

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2075,6 +2075,104 @@ func TestEndpointToApplication_TensorParallelSize(t *testing.T) {
 	}
 }
 
+func TestEndpointToApplication_SGLangEnableMetricsDefault(t *testing.T) {
+	nvidiaGPU := string(v1.AcceleratorTypeNVIDIAGPU)
+
+	modelRegistry := &v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.HuggingFaceModelRegistryType,
+		},
+	}
+	deployedCluster := &v1.Cluster{}
+
+	makeEndpoint := func(engineName string, variables map[string]interface{}) *v1.Endpoint {
+		ep := &v1.Endpoint{
+			Metadata: &v1.Metadata{
+				Workspace: "test",
+				Name:      "test-endpoint",
+			},
+			Spec: &v1.EndpointSpec{
+				Engine: &v1.EndpointEngineSpec{
+					Engine:  engineName,
+					Version: "v0.5.10",
+				},
+				Resources: &v1.ResourceSpec{
+					GPU: pointy.String("1"),
+				},
+				Replicas: v1.ReplicaSpec{
+					Num: pointy.Int(1),
+				},
+				Variables: variables,
+				Model: &v1.ModelSpec{
+					Name: "test-model",
+				},
+			},
+		}
+		ep.Spec.Resources.SetAcceleratorType(nvidiaGPU)
+
+		return ep
+	}
+
+	tests := []struct {
+		name         string
+		engineName   string
+		variables    map[string]interface{}
+		expectedArgs map[string]interface{}
+	}{
+		{
+			name:       "sglang defaults enable_metrics",
+			engineName: v1.EngineNameSGLang,
+			expectedArgs: map[string]interface{}{
+				"enable_metrics": true,
+			},
+		},
+		{
+			name:       "sglang user-provided enable_metrics prevents default",
+			engineName: v1.EngineNameSGLang,
+			variables: map[string]interface{}{
+				"engine_args": map[string]interface{}{
+					"enable_metrics": false,
+				},
+			},
+			expectedArgs: map[string]interface{}{
+				"enable_metrics": false,
+			},
+		},
+		{
+			name:       "sglang user-provided kebab enable-metrics prevents default",
+			engineName: v1.EngineNameSGLang,
+			variables: map[string]interface{}{
+				"engine_args": map[string]interface{}{
+					"enable-metrics": false,
+				},
+			},
+			expectedArgs: map[string]interface{}{
+				"enable_metrics": false,
+			},
+		},
+		{
+			name:         "vllm does not default enable_metrics",
+			engineName:   v1.EngineNameVLLM,
+			expectedArgs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := acceleratormocks.NewMockManager(t)
+			mgr.EXPECT().GetConverter(nvidiaGPU).
+				Return(plugin.NewGPUConverter(), true)
+
+			app, err := EndpointToApplication(makeEndpoint(tt.engineName, tt.variables),
+				deployedCluster, modelRegistry, nil, nil, mgr)
+			assert.NoError(t, err)
+
+			engineArgs, _ := app.Args["engine_args"].(map[string]interface{})
+			assert.Equal(t, tt.expectedArgs, engineArgs)
+		})
+	}
+}
+
 func TestEndpointToApplication_setEngineSpecialEnv(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2139,18 +2139,6 @@ func TestEndpointToApplication_SGLangEnableMetricsDefault(t *testing.T) {
 			},
 		},
 		{
-			name:       "sglang user-provided kebab enable-metrics prevents default",
-			engineName: v1.EngineNameSGLang,
-			variables: map[string]interface{}{
-				"engine_args": map[string]interface{}{
-					"enable-metrics": false,
-				},
-			},
-			expectedArgs: map[string]interface{}{
-				"enable_metrics": false,
-			},
-		},
-		{
 			name:         "vllm does not default enable_metrics",
 			engineName:   v1.EngineNameVLLM,
 			expectedArgs: nil,

--- a/observability/grafana/dashboards/sglang_grafana_dashboard.json
+++ b/observability/grafana/dashboards/sglang_grafana_dashboard.json
@@ -130,7 +130,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -146,7 +146,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -163,7 +163,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang_e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -180,7 +180,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg(rate(sglang_e2e_request_latency_seconds_sum{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]) /  rate(sglang_e2e_request_latency_seconds_count{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))\r\n",
+          "expr": "avg(rate(sglang:e2e_request_latency_seconds_sum{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]) /  rate(sglang:e2e_request_latency_seconds_count{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -246,7 +246,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-09
+          "le": 1e-9
         },
         "legend": {
           "show": true
@@ -274,7 +274,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum(increase(sglang_e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])) by (le)\r\n",
+          "expr": "sum(increase(sglang:e2e_request_latency_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])) by (le)\r\n",
           "format": "heatmap",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -376,7 +376,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -392,7 +392,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -409,7 +409,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang_time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval])))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -426,7 +426,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg(rate(sglang_time_to_first_token_seconds_sum{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]) /  rate(sglang_time_to_first_token_seconds_count{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))\r\n",
+          "expr": "avg(rate(sglang:time_to_first_token_seconds_sum{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]) /  rate(sglang:time_to_first_token_seconds_count{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))\r\n",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -496,7 +496,7 @@
           "color": "rgba(255,0,255,0.7)"
         },
         "filterValues": {
-          "le": 1e-09
+          "le": 1e-9
         },
         "legend": {
           "show": true
@@ -524,7 +524,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "sum by(le) (increase(sglang_time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))",
+          "expr": "sum by(le) (increase(sglang:time_to_first_token_seconds_bucket{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}[$__rate_interval]))",
           "format": "heatmap",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -627,7 +627,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sglang_num_running_reqs{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+          "expr": "sglang:num_running_reqs{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -728,7 +728,7 @@
             "uid": "ddyfngn31dg5cf"
           },
           "editorMode": "code",
-          "expr": "sglang_gen_throughput{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+          "expr": "sglang:gen_throughput{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -826,7 +826,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sglang_cache_hit_rate{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+          "expr": "sglang:cache_hit_rate{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -927,7 +927,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sglang_num_queue_reqs{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
+          "expr": "sglang:num_queue_reqs{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,

--- a/observability/vmagent/prometheus.yml
+++ b/observability/vmagent/prometheus.yml
@@ -27,13 +27,10 @@ scrape_configs:
       regex: 'ray_vllm[:_](.+)'
       target_label: __name__
       replacement: 'vllm:$1'
-  # Strip Ray's auto-prepended ray_ from SGLang metrics so dashboard panels
-  # query the names SGLang upstream uses natively (e.g.
-  # sglang_e2e_request_latency_seconds_bucket). Symmetric to the vLLM rule
-  # above but with sglang_ output (not sglang:) — SGLang upstream uses an
-  # underscore separator throughout, including in their reference Grafana
-  # dashboard, so preserving that lets us reuse upstream queries verbatim.
+  # Convert Ray-exported SGLang metrics back to the canonical upstream
+  # colon-separated form. PromToRayBridge has to use an underscore internally
+  # because Ray rejects ":" in metric names; dashboards should query sglang:*.
     - source_labels: [__name__]
       regex: 'ray_sglang[:_](.+)'
       target_label: __name__
-      replacement: 'sglang_$1'
+      replacement: 'sglang:$1'

--- a/scripts/dashboard/configs/sglang_convert.json
+++ b/scripts/dashboard/configs/sglang_convert.json
@@ -15,9 +15,16 @@
       "is_regex": true
     },
     {
+      "name": "normalize_sglang_metric_namespace",
+      "description": "Store SGLang metric names in the canonical upstream namespace form used by Neutree vmagent relabeling: sglang:<metric>.",
+      "pattern": "\\bsglang_([a-zA-Z0-9_]+)\\b",
+      "replacement": "sglang:\\1",
+      "is_regex": true
+    },
+    {
       "name": "inject_neutree_filters",
-      "description": "Append Neutree multi-tenant filters to every sglang_<name>(_<word>)* metric reference. Matches both unfiltered and filter-stripped forms; the look-ahead guards against double-injection on metrics that are already followed by an opening brace.",
-      "pattern": "(sglang_[a-zA-Z0-9_]+)(?!\\{)",
+      "description": "Append Neutree multi-tenant filters to every sglang:<name>(_<word>)* metric reference. Matches both unfiltered and filter-stripped forms; the look-ahead guards against double-injection on metrics that are already followed by an opening brace.",
+      "pattern": "(sglang:[a-zA-Z0-9_]+)(?!\\{)",
       "replacement": "\\1{application=~\"$Application\",deployment=~\"$Deployment\",replica=~\"$Replica\",neutree_cluster=~\"$Cluster\"}",
       "is_regex": true
     }


### PR DESCRIPTION
## Issue

NEU-481

## Summary

This fixes SGLang metrics collection in both Kubernetes and static Ray deployment paths. Kubernetes SGLang endpoints now enable metrics by default and normalize native `sglang:*` metric names to the canonical `sglang:<metric>` form; static Ray SGLang endpoints now use a stable prometheus multiprocess directory before embedded Engine startup so `PromToRayBridge` can reliably forward samples, with vmagent restoring the final `sglang:<metric>` names. The SGLang Grafana dashboard now queries the same canonical `sglang:<metric>` names.

## Changes

- Add a stable `PROMETHEUS_MULTIPROC_DIR` helper for SGLang embedded Engine startup.
- Patch SGLang common/engine multiprocess setup before `Engine` construction and start `PromToRayBridge` only when metrics are enabled.
- Default SGLang `enable_metrics=true` in both Kubernetes and static Ray control-plane paths while preserving explicit user overrides.
- Normalize Kubernetes native SGLang metrics from `sglang[:_](.+)` to `sglang:$1` under the `neutree-inference` scrape job.
- Normalize static Ray bridge metrics from `ray_sglang[:_](.+)` to `sglang:$1` in the control-plane vmagent config.
- Update the SGLang Grafana dashboard and dashboard conversion config to query canonical `sglang:<metric>` names.
- Add focused Python and Go regression tests.

## Test Plan

### Unit test

- [x] `PYTHONPATH=cluster-image-builder pytest -q cluster-image-builder/serve/_metrics` - 3 passed
- [x] `PYTHONPATH=cluster-image-builder pytest -q cluster-image-builder/serve/_utils/test_coerce.py cluster-image-builder/serve/_metrics` - 41 passed after dropping the out-of-scope bool-string compatibility fix
- [x] `python3 -m py_compile cluster-image-builder/serve/_metrics/prometheus_multiproc.py cluster-image-builder/serve/sglang/v0_5_10/app.py` - passed
- [x] `go test ./internal/orchestrator -count=1` - passed
- [x] `go test ./internal/cluster/component/metrics -count=1` - passed
- [x] `go test ./internal/orchestrator -run TestEndpointToApplication_SGLangEnableMetricsDefault -count=1` - passed after requiring canonical `enable_metrics` input in the static Ray path
- [x] `go test ./internal/orchestrator ./internal/cluster/component/metrics -count=1` - passed after dropping the out-of-scope bool-string compatibility fix and the static Ray `enable-metrics` compatibility branch
- [x] Dashboard JSON/config validation via Node: parsed `observability/grafana/dashboards/sglang_grafana_dashboard.json` and `scripts/dashboard/configs/sglang_convert.json`; verified no `sglang_*` metric references remain and canonical `sglang:*` refs exist - passed
- [x] `git diff --check` - passed

### DB test

- [x] Not affected. This change does not touch database schema, migrations, or storage behavior.

### E2E test

- [x] `NEUTREE_SERVER_URL=http://192.168.20.158:3000 E2E_PROFILE_PATH=/var/folders/hl/g_tf97kn4hs6f824n7kp6sz80000gn/T/neutree-test-NEU-481-step5-profile.yaml make e2e-test LABEL_FILTER=neu481 E2E_TIMEOUT=120m` - passed on PR head `f4d7b8f1`: 3/250 specs ran, 3 passed, 0 failed, 247 skipped, 684.501s.
- [x] Environment: CP `192.168.20.158`; K8s `neutree-ci-test` with endpoint pod scheduled on `neutree-df-bm-2` / `NVIDIA-L20`; SSH/static GPU host `172.20.172.120` with 4x NVIDIA L20. CP runtime was hot-swapped at entrypoints `/neutree-core` and `/neutree-api` to `f4d7b8f1`; CP vmagent config used `replacement: 'sglang:$1'`.
- [x] K8s SGLang check: endpoint `neu481-k8s-324954` used `product: NVIDIA-L20`, engine command included `--enable-metrics`, K8s `vmagent-config` rendered `regex: 'sglang[:_](.+)'` -> `replacement: 'sglang:$1'`, and VictoriaMetrics query `count({__name__=~"sglang:.*",application="neu481-k8s-324954"}) > 0` passed.
- [x] SSH/static TP=2 check: endpoint `neu481-ssh-tp2-324954` on `172.20.172.120` reached Running; Ray Serve app config had `engine_args.enable_metrics=true` and `tp_size=2`; backend logs contained stable `/tmp/neutree-prometheus-multiproc/sglang/<pid>` setup and `[PromToRayBridge] init`; VictoriaMetrics query `count({__name__=~"sglang:.*",application=~".*neu481-ssh-tp2-324954.*"}) > 0` passed; recent logs had no prometheus multiprocess `.db` FileNotFoundError.
- [x] SSH/static override check: endpoint `neu481-ssh-off-324954` reached Running and Ray Serve app config preserved explicit boolean `engine_args.enable_metrics=false`.
- [x] Manual testing: not required separately because the scoped E2E covers the deployed K8s and static Ray SGLang metrics paths on the requested L20 environment; the later dashboard change is covered by static dashboard JSON/query-name validation.