### PR TITLE
feat(api-key): gate limit read/write on api_key:read / api_key:update

### DIFF
--- a/db/dbtest/api_key_limits_test.go
+++ b/db/dbtest/api_key_limits_test.go
@@ -3,8 +3,42 @@ package dbtest
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 )
+
+// grantGlobalPermissions creates a role carrying the given permissions and
+// assigns it globally to an existing user. In the community edition
+// api.has_permission ignores the workspace argument and degrades to a global
+// check, so a global assignment is what exercises the permission.
+func grantGlobalPermissions(t *testing.T, db *sql.DB, userID string, permissions []string) {
+	t.Helper()
+	ctx := context.Background()
+	roleName := "perms-" + userID
+	permsArray := "ARRAY['" + strings.Join(permissions, "','") + "']::api.permission_action[]"
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO api.roles (api_version, kind, metadata, spec)
+		VALUES ('v1', 'Role',
+			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
+			ROW(NULL, `+permsArray+`)::api.role_spec)`, roleName); err != nil {
+		t.Fatalf("failed to create role: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO api.role_assignments (api_version, kind, metadata, spec)
+		VALUES ('v1', 'RoleAssignment',
+			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
+			ROW($2::uuid, NULL, TRUE, $3)::api.role_assignment_spec)`,
+		"assign-"+userID, userID, roleName); err != nil {
+		t.Fatalf("failed to create role assignment: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM api.role_assignments WHERE (metadata).name = $1`, "assign-"+userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM api.roles WHERE (metadata).name = $1`, roleName)
+	})
+}
 
 // TestApiKeyLimits covers the API Key limits that live on api_key.spec.limits
 // (single object). Verifies create_api_key(p_limits),

--- a/db/dbtest/api_key_limits_test.go
+++ b/db/dbtest/api_key_limits_test.go
@@ -17,6 +17,9 @@ func TestApiKeyLimits(t *testing.T) {
 
 	user := CreateTestUser(t, "limitsuser", "limits@example.com", "testpassword")
 	other := CreateTestUser(t, "limitsother", "limitsother@example.com", "testpassword")
+	// Reading/writing a key's limits now requires api_key:read / api_key:update
+	// (on top of ownership); grant them to the owner.
+	grantGlobalPermissions(t, db, user.ID, []string{"api_key:read", "api_key:update"})
 
 	const limits = `{"token_quota":{"limit":300,"period":"monthly"},"rps":10,"rpm":600,"concurrency":8,"allowed_models":["gpt-4"],"disabled":false}`
 
@@ -229,6 +232,66 @@ func TestApiKeyLimits(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatalf("expected empty allowed_models to be accepted, got %v", err)
+		}
+	})
+
+	// Limit read/write are governed by api_key:read / api_key:update (on top of
+	// ownership): an owner reduced to read-only can view limits but not change
+	// them; an owner with neither cannot even read.
+	t.Run("limit RPCs enforce api_key:read / api_key:update", func(t *testing.T) {
+		// Owner with only api_key:read.
+		readOnly := CreateTestUser(t, "limitsro", "limitsro@example.com", "testpassword")
+		grantGlobalPermissions(t, db, readOnly.ID, []string{"api_key:read"})
+		var roKeyID string
+		if err := execWithContext(t, db, []SetContextFunc{setUserContext(readOnly.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx, `
+				SELECT id FROM api.create_api_key(
+					p_workspace := 'limits-ws', p_name := 'ro-key', p_quota := 0,
+					p_limits := '{"token_quota":{"limit":1000,"period":"daily"}}'::jsonb)`).Scan(&roKeyID)
+		}); err != nil {
+			t.Fatalf("read-only owner create key: %v", err)
+		}
+		t.Cleanup(func() { _, _ = db.ExecContext(ctx, "DELETE FROM api.api_keys WHERE id = $1", roKeyID) })
+
+		// read: allowed (returns its own limits).
+		var got sql.NullString
+		if err := execWithContext(t, db, []SetContextFunc{setUserContext(readOnly.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx, `SELECT api.get_api_key_limits($1)::text`, roKeyID).Scan(&got)
+		}); err != nil {
+			t.Fatalf("read-only owner get_api_key_limits: %v", err)
+		}
+		if !got.Valid {
+			t.Fatalf("expected read-only owner to read own limits, got NULL")
+		}
+		// write: denied (no api_key:update).
+		if err := execWithContext(t, db, []SetContextFunc{setUserContext(readOnly.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+			_, e := tx.ExecContext(ctx, `SELECT api.set_api_key_limits($1, '{"rps":1}'::jsonb)`, roKeyID)
+			return e
+		}); err == nil {
+			t.Fatalf("expected api_key:update to be required for set_api_key_limits")
+		}
+
+		// Owner with no api_key permissions: cannot even read own limits.
+		noPerm := CreateTestUser(t, "limitsnp", "limitsnp@example.com", "testpassword")
+		var npKeyID string
+		if err := execWithContext(t, db, []SetContextFunc{setUserContext(noPerm.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx, `
+				SELECT id FROM api.create_api_key(
+					p_workspace := 'limits-ws', p_name := 'np-key', p_quota := 0,
+					p_limits := '{"token_quota":{"limit":1000,"period":"daily"}}'::jsonb)`).Scan(&npKeyID)
+		}); err != nil {
+			t.Fatalf("no-perm owner create key: %v", err)
+		}
+		t.Cleanup(func() { _, _ = db.ExecContext(ctx, "DELETE FROM api.api_keys WHERE id = $1", npKeyID) })
+
+		var npGot sql.NullString
+		if err := execWithContext(t, db, []SetContextFunc{setUserContext(noPerm.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx, `SELECT api.get_api_key_limits($1)::text`, npKeyID).Scan(&npGot)
+		}); err != nil {
+			t.Fatalf("no-perm owner get_api_key_limits: %v", err)
+		}
+		if npGot.Valid {
+			t.Fatalf("expected NULL for owner without api_key:read, got %q", npGot.String)
 		}
 	})
 }

--- a/db/dbtest/helper.go
+++ b/db/dbtest/helper.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -14,6 +15,37 @@ import (
 
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
+
+// grantGlobalPermissions creates a role carrying the given permissions and
+// assigns it globally to an existing user. In the community edition
+// api.has_permission ignores the workspace argument and degrades to a global
+// check, so a global assignment is what exercises the permission.
+func grantGlobalPermissions(t *testing.T, db *sql.DB, userID string, permissions []string) {
+	t.Helper()
+	ctx := context.Background()
+	roleName := "perms-" + userID
+	permsArray := "ARRAY['" + strings.Join(permissions, "','") + "']::api.permission_action[]"
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO api.roles (api_version, kind, metadata, spec)
+		VALUES ('v1', 'Role',
+			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
+			ROW(NULL, `+permsArray+`)::api.role_spec)`, roleName); err != nil {
+		t.Fatalf("failed to create role: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO api.role_assignments (api_version, kind, metadata, spec)
+		VALUES ('v1', 'RoleAssignment',
+			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
+			ROW($2::uuid, NULL, TRUE, $3)::api.role_assignment_spec)`,
+		"assign-"+userID, userID, roleName); err != nil {
+		t.Fatalf("failed to create role assignment: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM api.role_assignments WHERE (metadata).name = $1`, "assign-"+userID)
+		_, _ = db.ExecContext(ctx, `DELETE FROM api.roles WHERE (metadata).name = $1`, roleName)
+	})
+}
 
 // GetTestDB returns a connection to the test database
 // The database is pre-migrated by docker-compose

--- a/db/dbtest/helper.go
+++ b/db/dbtest/helper.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -15,37 +14,6 @@ import (
 
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
-
-// grantGlobalPermissions creates a role carrying the given permissions and
-// assigns it globally to an existing user. In the community edition
-// api.has_permission ignores the workspace argument and degrades to a global
-// check, so a global assignment is what exercises the permission.
-func grantGlobalPermissions(t *testing.T, db *sql.DB, userID string, permissions []string) {
-	t.Helper()
-	ctx := context.Background()
-	roleName := "perms-" + userID
-	permsArray := "ARRAY['" + strings.Join(permissions, "','") + "']::api.permission_action[]"
-
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO api.roles (api_version, kind, metadata, spec)
-		VALUES ('v1', 'Role',
-			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
-			ROW(NULL, `+permsArray+`)::api.role_spec)`, roleName); err != nil {
-		t.Fatalf("failed to create role: %v", err)
-	}
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO api.role_assignments (api_version, kind, metadata, spec)
-		VALUES ('v1', 'RoleAssignment',
-			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
-			ROW($2::uuid, NULL, TRUE, $3)::api.role_assignment_spec)`,
-		"assign-"+userID, userID, roleName); err != nil {
-		t.Fatalf("failed to create role assignment: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = db.ExecContext(ctx, `DELETE FROM api.role_assignments WHERE (metadata).name = $1`, "assign-"+userID)
-		_, _ = db.ExecContext(ctx, `DELETE FROM api.roles WHERE (metadata).name = $1`, roleName)
-	})
-}
 
 // GetTestDB returns a connection to the test database
 // The database is pre-migrated by docker-compose

--- a/db/dbtest/workspace_user_permissions_test.go
+++ b/db/dbtest/workspace_user_permissions_test.go
@@ -47,6 +47,8 @@ func TestWorkspaceUserPermissions_HasExpectedPermissions(t *testing.T) {
 		"external_endpoint:delete",
 		"endpoint:trace-read",
 		"external_endpoint:trace-read",
+		"api_key:read",
+		"api_key:update",
 	}
 
 	var permissions []string

--- a/db/migrations/072_apikey_permissions.down.sql
+++ b/db/migrations/072_apikey_permissions.down.sql
@@ -1,0 +1,4 @@
+-- PostgreSQL cannot safely drop enum values once added (every dependent column /
+-- stored value would have to be rewritten), so this is intentionally a no-op.
+-- The grants and RPC enforcement that USE these values are reverted in 073.down.
+SELECT 1;

--- a/db/migrations/072_apikey_permissions.up.sql
+++ b/db/migrations/072_apikey_permissions.up.sql
@@ -1,0 +1,10 @@
+-- Add api_key limit read/write permissions to the permission_action enum.
+--
+-- API-key limits (token quota + access limits, incl. disable) were only
+-- owner-scoped (RLS user_id = auth.uid()) with no RBAC permission. Add
+-- api_key:read / api_key:update so reading and editing a key's limits can be
+-- governed by roles (e.g. a read-only member can view but not change limits).
+-- Enum values must be committed before they can be referenced by grants /
+-- has_permission, so the grants + RPC enforcement live in the next migration (073).
+ALTER TYPE api.permission_action ADD VALUE IF NOT EXISTS 'api_key:read';
+ALTER TYPE api.permission_action ADD VALUE IF NOT EXISTS 'api_key:update';

--- a/db/migrations/073_apikey_permission_enforcement.down.sql
+++ b/db/migrations/073_apikey_permission_enforcement.down.sql
@@ -100,7 +100,9 @@ BEGIN
         'external_endpoint:read',
         'external_endpoint:create',
         'external_endpoint:update',
-        'external_endpoint:delete'
+        'external_endpoint:delete',
+        'endpoint:trace-read',
+        'external_endpoint:trace-read'
     ]::api.permission_action[];
 
     UPDATE api.roles

--- a/db/migrations/073_apikey_permission_enforcement.down.sql
+++ b/db/migrations/073_apikey_permission_enforcement.down.sql
@@ -1,0 +1,123 @@
+-- Revert the api_key permission enforcement: restore the limit RPC bodies to
+-- their pre-073 form (validation gate kept, permission checks removed) and revert
+-- the preset-role grants. (Admin keeps api_key:* because enum values cannot be
+-- dropped; that is harmless.)
+
+-- get_api_key_limits without the api_key:read check.
+CREATE OR REPLACE FUNCTION api.get_api_key_limits(p_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+AS $$
+DECLARE
+    v_limits JSONB;
+    v_uid    UUID;
+    v_limit  BIGINT;
+    v_period TEXT;
+    v_used   BIGINT;
+BEGIN
+    SELECT (spec).limits, user_id INTO v_limits, v_uid FROM api.api_keys WHERE id = p_id;
+    IF NOT FOUND OR v_uid IS DISTINCT FROM auth.uid() THEN
+        RETURN NULL;
+    END IF;
+    v_limits := COALESCE(v_limits, '{}'::jsonb);
+
+    v_limit := (v_limits #>> '{token_quota,limit}')::bigint;
+    IF v_limit IS NOT NULL AND v_limit > 0 THEN
+        v_period := COALESCE(v_limits #>> '{token_quota,period}', 'monthly');
+        v_used := api.api_key_period_usage(p_id, v_period);
+        v_limits := jsonb_set(
+            v_limits, '{token_quota}',
+            (v_limits->'token_quota')
+                || jsonb_build_object('used', v_used, 'remaining', v_limit - v_used)
+        );
+    END IF;
+    RETURN v_limits;
+END;
+$$;
+
+-- set_api_key_limits without the api_key:update check.
+CREATE OR REPLACE FUNCTION api.set_api_key_limits(p_id UUID, p_limits JSONB)
+RETURNS api.api_keys
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_result api.api_keys;
+BEGIN
+    PERFORM api.validate_api_key_limits(p_limits);
+
+    UPDATE api.api_keys k
+    SET spec = ROW(
+        COALESCE((p_limits #>> '{token_quota,limit}')::bigint, 0),
+        (k.spec).expires_in,
+        p_limits
+    )::api.api_key_spec
+    WHERE k.id = p_id AND k.user_id = auth.uid()
+    RETURNING * INTO v_result;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'API key not found or not owned by caller';
+    END IF;
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Revert workspace-user permission set to the pre-073 list (without api_key).
+CREATE OR REPLACE FUNCTION api.update_workspace_user_permissions()
+RETURNS VOID AS $$
+DECLARE
+    workspace_user_permissions api.permission_action[];
+BEGIN
+    workspace_user_permissions := ARRAY[
+        'workspace:read',
+        'endpoint:read',
+        'endpoint:create',
+        'endpoint:update',
+        'endpoint:delete',
+        'image_registry:read',
+        'image_registry:create',
+        'image_registry:update',
+        'image_registry:delete',
+        'model_registry:read',
+        'model_registry:create',
+        'model_registry:update',
+        'model_registry:delete',
+        'model:read',
+        'model:push',
+        'model:pull',
+        'model:delete',
+        'engine:read',
+        'engine:create',
+        'engine:update',
+        'engine:delete',
+        'cluster:read',
+        'cluster:create',
+        'cluster:update',
+        'cluster:delete',
+        'model_catalog:read',
+        'model_catalog:create',
+        'model_catalog:update',
+        'model_catalog:delete',
+        'external_endpoint:read',
+        'external_endpoint:create',
+        'external_endpoint:update',
+        'external_endpoint:delete'
+    ]::api.permission_action[];
+
+    UPDATE api.roles
+    SET spec = ROW((spec).preset_key, workspace_user_permissions)::api.role_spec
+    WHERE (metadata).name = 'workspace-user';
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT api.update_workspace_user_permissions();
+
+-- Remove api_key:read / api_key:update from workspace-admin.
+UPDATE api.roles
+SET spec = ROW(
+    (spec).preset_key,
+    ARRAY(
+        SELECT p FROM unnest((spec).permissions) AS p
+        WHERE p NOT IN ('api_key:read','api_key:update')
+    )::api.permission_action[]
+)::api.role_spec
+WHERE (metadata).name = 'workspace-admin';

--- a/db/migrations/073_apikey_permission_enforcement.up.sql
+++ b/db/migrations/073_apikey_permission_enforcement.up.sql
@@ -1,0 +1,148 @@
+-- Grant the new api_key permissions to preset roles and enforce them on the
+-- api-key limit read/write RPCs, on top of the existing owner check.
+
+-- 1) Preset role grants (mirrors the external_endpoint rollout).
+-- Admin: regrant all enum permissions (picks up the new api_key:* values).
+SELECT api.update_admin_permissions();
+
+-- Workspace admin: api_key limit read + write.
+UPDATE api.roles
+SET spec = ROW(
+    (spec).preset_key,
+    (spec).permissions || ARRAY[
+        'api_key:read',
+        'api_key:update'
+    ]::api.permission_action[]
+)::api.role_spec
+WHERE (metadata).name = 'workspace-admin';
+
+-- Workspace user: api_key limit read + write of their own keys (self-service).
+-- Kept in update_workspace_user_permissions so a future regrant preserves it.
+CREATE OR REPLACE FUNCTION api.update_workspace_user_permissions()
+RETURNS VOID AS $$
+DECLARE
+    workspace_user_permissions api.permission_action[];
+BEGIN
+    workspace_user_permissions := ARRAY[
+        'workspace:read',
+        'endpoint:read',
+        'endpoint:create',
+        'endpoint:update',
+        'endpoint:delete',
+        'image_registry:read',
+        'image_registry:create',
+        'image_registry:update',
+        'image_registry:delete',
+        'model_registry:read',
+        'model_registry:create',
+        'model_registry:update',
+        'model_registry:delete',
+        'model:read',
+        'model:push',
+        'model:pull',
+        'model:delete',
+        'engine:read',
+        'engine:create',
+        'engine:update',
+        'engine:delete',
+        'cluster:read',
+        'cluster:create',
+        'cluster:update',
+        'cluster:delete',
+        'model_catalog:read',
+        'model_catalog:create',
+        'model_catalog:update',
+        'model_catalog:delete',
+        'external_endpoint:read',
+        'external_endpoint:create',
+        'external_endpoint:update',
+        'external_endpoint:delete',
+        'api_key:read',
+        'api_key:update'
+    ]::api.permission_action[];
+
+    UPDATE api.roles
+    SET spec = ROW((spec).preset_key, workspace_user_permissions)::api.role_spec
+    WHERE (metadata).name = 'workspace-user';
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT api.update_workspace_user_permissions();
+
+-- 2) get_api_key_limits: require the caller to own the key AND hold api_key:read
+-- in the key's workspace (soft-deny -> NULL, consistent with the prior non-owner
+-- behavior). Body otherwise unchanged.
+CREATE OR REPLACE FUNCTION api.get_api_key_limits(p_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+AS $$
+DECLARE
+    v_limits JSONB;
+    v_uid    UUID;
+    v_ws     TEXT;
+    v_limit  BIGINT;
+    v_period TEXT;
+    v_used   BIGINT;
+BEGIN
+    SELECT (spec).limits, user_id, (metadata).workspace INTO v_limits, v_uid, v_ws
+    FROM api.api_keys WHERE id = p_id;
+    -- NULL-safe owner check: a NULL auth.uid() (anon) must not slip past `<>`.
+    IF NOT FOUND OR v_uid IS DISTINCT FROM auth.uid() THEN
+        RETURN NULL;
+    END IF;
+    -- Reading limits requires api_key:read in the key's workspace.
+    IF NOT api.has_permission(auth.uid(), 'api_key:read', v_ws) THEN
+        RETURN NULL;
+    END IF;
+    v_limits := COALESCE(v_limits, '{}'::jsonb);
+
+    v_limit := (v_limits #>> '{token_quota,limit}')::bigint;
+    IF v_limit IS NOT NULL AND v_limit > 0 THEN
+        v_period := COALESCE(v_limits #>> '{token_quota,period}', 'monthly');
+        v_used := api.api_key_period_usage(p_id, v_period);
+        v_limits := jsonb_set(
+            v_limits, '{token_quota}',
+            (v_limits->'token_quota')
+                || jsonb_build_object('used', v_used, 'remaining', v_limit - v_used)
+        );
+    END IF;
+    RETURN v_limits;
+END;
+$$;
+
+-- 3) set_api_key_limits: require the caller to own the key AND hold
+-- api_key:update in the key's workspace. Validation gate unchanged. This also
+-- governs disabling a key, which the UI performs via set_api_key_limits.
+CREATE OR REPLACE FUNCTION api.set_api_key_limits(p_id UUID, p_limits JSONB)
+RETURNS api.api_keys
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_result api.api_keys;
+    v_owner  UUID;
+    v_ws     TEXT;
+BEGIN
+    SELECT user_id, (metadata).workspace INTO v_owner, v_ws
+    FROM api.api_keys WHERE id = p_id;
+    IF NOT FOUND OR v_owner IS DISTINCT FROM auth.uid() THEN
+        RAISE EXCEPTION 'API key not found or not owned by caller';
+    END IF;
+
+    IF NOT api.has_permission(auth.uid(), 'api_key:update', v_ws) THEN
+        RAISE EXCEPTION 'permission denied: api_key:update required' USING ERRCODE = '42501';
+    END IF;
+
+    PERFORM api.validate_api_key_limits(p_limits);
+
+    UPDATE api.api_keys k
+    SET spec = ROW(
+        COALESCE((p_limits #>> '{token_quota,limit}')::bigint, 0),
+        (k.spec).expires_in,
+        p_limits
+    )::api.api_key_spec
+    WHERE k.id = p_id AND k.user_id = auth.uid()
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;

--- a/db/migrations/073_apikey_permission_enforcement.up.sql
+++ b/db/migrations/073_apikey_permission_enforcement.up.sql
@@ -57,6 +57,8 @@ BEGIN
         'external_endpoint:create',
         'external_endpoint:update',
         'external_endpoint:delete',
+        'endpoint:trace-read',
+        'external_endpoint:trace-read',
         'api_key:read',
         'api_key:update'
     ]::api.permission_action[];


### PR DESCRIPTION
## What

API-key **limit read/write** is now governed by RBAC permissions, on top of the
existing owner check. Previously a key's limits (token quota + access limits,
incl. disabling) were only owner-scoped (RLS `user_id = auth.uid()`) with no
permission — unlike every other resource — so an owner whose `api_key:update`
was revoked could still edit limits via the RPC (the UI hides the button, but the
API is also an entry point).

## Changes

- **Migration 072**: add `api_key:read`, `api_key:update` to the `permission_action`
  enum (own migration so the values are committed before use).
- **Migration 073**:
  - Grant `api_key:read`/`api_key:update` to the `admin` (regrant-all), `workspace-admin`
    and `workspace-user` preset roles (mirrors the external_endpoint rollout), so
    existing self-service key management is preserved.
  - `get_api_key_limits`: require the caller to own the key **and** hold
    `api_key:read` in the key's workspace (soft-deny → NULL, as before for non-owners).
  - `set_api_key_limits`: require ownership **and** `api_key:update` (`42501` →
    HTTP 403). This also governs disable (the UI disables via `set_api_key_limits`).
  - Validation gate (071) unchanged.
- `create_api_key` is intentionally left owner-only — creating a key is not a
  limit read/write, and gating it would break unrelated flows/tests.
- **db-test**: a read-only owner can view limits but not edit; an owner with no
  api_key permission cannot even read. Adds a `grantGlobalPermissions` helper.

## Verification

- `go vet ./db/dbtest/...` clean.
- Migrations 072/073 apply cleanly on a live OSS env (schema 71→73); enum +
  role grants verified (`admin`/`workspace-user`/`workspace-admin` gain `api_key:update`).
- Full db-test runs in CI.

Companion UI PR adds `api_key:read`/`api_key:update` to the role editor's permission
list (icon + i18n).
