### PR TITLE
fix(gateway): api-key model allowlist degrades to deny-all on mapped routes

### DIFF
--- a/gateway/kong/plugins/neutree-ai-access/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-access/handler.lua
@@ -33,6 +33,16 @@ local function consumer_id()
 end
 
 local function request_model()
+    -- Prefer the client-facing model stashed by neutree-ai-gateway (priority
+    -- 1100) before it rewrites the request body for model mapping. This plugin
+    -- (895) runs after that rewrite, so re-reading the raw body here is
+    -- unreliable (it can come back nil) — which would make any key with an
+    -- allowed_models list reject every request. Fall back to the body for routes
+    -- without the gateway plugin.
+    local stashed = kong.ctx.shared and kong.ctx.shared.neutree_request_model
+    if type(stashed) == "string" and stashed ~= "" then
+        return stashed
+    end
     local raw = kong.request.get_raw_body()
     if raw and raw ~= "" then
         local decoded = cjson.decode(raw)

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -1206,6 +1206,10 @@ function AIGatewayHandler:access(conf)
         local openai_req = convert_request(anthropic_req)
         kong.ctx.plugin.anthropic_mode = true
         kong.ctx.plugin.request_model = anthropic_req.model
+        -- Expose the client-facing model to later consumer plugins (e.g.
+        -- neutree-ai-access allowlist) BEFORE the request body is rewritten for
+        -- model mapping, since they cannot reliably re-read the body afterwards.
+        kong.ctx.shared.neutree_request_model = anthropic_req.model
         kong.ctx.plugin.response_model = nil
         kong.ctx.plugin.is_stream = anthropic_req.stream == true
         kong.ctx.plugin.route_type = "/v1/chat/completions"
@@ -1314,6 +1318,10 @@ function AIGatewayHandler:access(conf)
     end
 
     kong.ctx.plugin.request_model = ai_request.model
+    -- Expose the client-facing model to later consumer plugins (e.g.
+    -- neutree-ai-access allowlist) BEFORE the request body is rewritten for
+    -- model mapping, since they cannot reliably re-read the body afterwards.
+    kong.ctx.shared.neutree_request_model = ai_request.model
     kong.ctx.plugin.is_stream = ai_request.stream == true
 
     if conf.upstreams then


### PR DESCRIPTION
## Bug

`neutree-ai-access` enforces a key's `allowed_models` allowlist by reading the
request model from the body (`request_model()` → `kong.request.get_raw_body()`).
But it runs at priority **895**, *after* `neutree-ai-gateway` (**1100**) has
rewritten the request body for model mapping (`set_raw_body`) and enabled
buffering. Re-reading the raw body at that point can return `nil`, so the access
plugin sees **no model** and rejects **every** request for any key that has an
`allowed_models` list — the allowlist silently degrades to **deny-all** on
gateway-handled routes (e.g. external endpoints with model mapping).

Found via real-gateway e2e: a key with `allowed_models:[qwen3.6-27b]` got
`403 model_not_permitted` even when requesting exactly `qwen3.6-27b` (and also
when the allowlist was set to the mapped upstream name — confirming the access
plugin reads the model as `nil`, not the mapped value). The mocked-PDK unit test
missed it because it stubs `get_raw_body` to return the body.

## Fix

`neutree-ai-gateway` already parses the client-facing model before mapping; have
it also stash it in `kong.ctx.shared.neutree_request_model` (cross-plugin
context) for both the OpenAI and Anthropic paths. `neutree-ai-access`'s
`request_model()` now prefers that stash, falling back to the body for routes
without the gateway plugin. The gateway runs first (1100 > key-auth 1003 >
access 895), so the stash is always set before access reads it.

## Verification (real gateway, .245)

Patched the deployed handlers with the same change + `kong reload`:
- key with `allowed_models:[deepseek-v4-pro]` requesting **`deepseek-v4-pro`** →
  **passes access** (reaches upstream) — previously 403.
- same key requesting **`qwen3.6-27b`** → **403 model_not_permitted** (still
  rejects disallowed).
- key with `allowed_models:[qwen3.6-27b]` (quota-exhausted) requesting
  **`qwen3.6-27b`** → **429 quota_exceeded** (model passed access, quota blocked).

Affects OSS + EE (shared gateway lua). No DB/schema change.
