### PR TITLE
fix: keep Ray model downloads observable

### DIFF
--- a/api/v1/endpoint_types.go
+++ b/api/v1/endpoint_types.go
@@ -55,10 +55,13 @@ const (
 )
 
 type EndpointStatus struct {
-	Phase                      EndpointPhase           `json:"phase,omitempty"`
-	ServiceURL                 string                  `json:"service_url,omitempty"`
-	LastTransitionTime         string                  `json:"last_transition_time,omitempty"`
-	ErrorMessage               string                  `json:"error_message,omitempty"`
+	Phase              EndpointPhase `json:"phase,omitempty"`
+	ServiceURL         string        `json:"service_url,omitempty"`
+	LastTransitionTime string        `json:"last_transition_time,omitempty"`
+	ErrorMessage       string        `json:"error_message,omitempty"`
+	// ModelDownloadCompletedHash is reserved for future model download tracking extensions,
+	// such as node- or replica-level completion metadata. It must not be used alone as
+	// proof that the current node or replica has completed downloading.
 	ModelDownloadCompletedHash *string                 `json:"model_download_completed_hash,omitempty"`
 	Resources                  *EndpointResourceStatus `json:"resources,omitempty"`
 }

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -450,6 +450,69 @@ func (f *FakeK8sClient) WithRunningInitContainer(containerName string) *FakeK8sC
 	return f
 }
 
+func (f *FakeK8sClient) WithCompletedAndRunningInitContainers(containerName string) *FakeK8sClient {
+	completedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-init-completed",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app":      "inference",
+				"endpoint": "chat-model",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  containerName,
+					Ready: true,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+							Reason:   "Completed",
+							Message:  "Init container completed successfully",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	runningPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-init-running",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app":      "inference",
+				"endpoint": "chat-model",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  containerName,
+					Ready: false,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Now(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, pod := range []*corev1.Pod{completedPod, runningPod} {
+		err := f.Client.Create(context.Background(), pod)
+		if err != nil {
+			f.t.Fatalf("failed to create pod: %v", err)
+		}
+	}
+
+	return f
+}
+
 func (f *FakeK8sClient) WithWaitingInitContainer(containerName, reason string) *FakeK8sClient {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2957,6 +3020,20 @@ func TestKubernetesOrchestrator_getEndpointStats(t *testing.T) {
 				return NewFakeK8sClient(t).
 					WithDeployment(newEndpoint().Metadata.Name, 1, 0, 0).
 					WithRunningInitContainer(modelDownloaderInitContainerName)
+			},
+			expectedPhase:  v1.EndpointPhaseMODELDOWNLOADING,
+			expectErrorMsg: modelDownloaderInitContainerName + " init container is running",
+			expectError:    false,
+		},
+		{
+			name: "return ModelDownloading when one model-downloader init container is complete and another is running",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(t *testing.T) *FakeK8sClient {
+				return NewFakeK8sClient(t).
+					WithDeployment(newEndpoint().Metadata.Name, 2, 1, 1).
+					WithCompletedAndRunningInitContainers(modelDownloaderInitContainerName)
 			},
 			expectedPhase:  v1.EndpointPhaseMODELDOWNLOADING,
 			expectErrorMsg: modelDownloaderInitContainerName + " init container is running",

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -594,6 +594,7 @@ func pendingRayModelDownloadMessage(
 }
 
 func currentModelDownloadHashMatches(endpoint *v1.Endpoint, currentModelHash string) bool {
+	// The hash is extension metadata, not node- or replica-level completion evidence.
 	if currentModelHash == "" || endpoint == nil || endpoint.Status == nil {
 		return false
 	}
@@ -623,37 +624,24 @@ func resolveRayStartupModelDownloadStatus(
 		return phase, modelDownloadCompleted, false, nil
 	}
 
-	var errorMessages []string
-	modelDownloadIncomplete := false
-
 	markerState, markerMsg, markerErr := inspectRayModelDownloadLogs(svc, appStatus)
 	if markerErr != nil {
 		klog.V(4).Info("failed to inspect Ray actor model download logs", "error", markerErr)
 	}
 
 	switch markerState {
-	case modelDownloadMarkerFailed:
-		phase = v1.EndpointPhaseFAILED
-		modelDownloadIncomplete = true
-
-		errorMessages = append(errorMessages, markerMsg)
 	case modelDownloadMarkerDone:
-		modelDownloadCompleted = true
+		return phase, true, false, nil
+	case modelDownloadMarkerFailed:
+		return v1.EndpointPhaseFAILED, false, true, []string{markerMsg}
 	case modelDownloadMarkerInProgress:
-		phase = v1.EndpointPhaseMODELDOWNLOADING
-		modelDownloadIncomplete = true
-
-		errorMessages = append(errorMessages, markerMsg)
+		return v1.EndpointPhaseMODELDOWNLOADING, false, true, []string{markerMsg}
 	case modelDownloadMarkerNone:
-		if !modelDownloadCompleted {
-			phase = v1.EndpointPhaseMODELDOWNLOADING
-			modelDownloadIncomplete = true
-
-			errorMessages = append(errorMessages, pendingRayModelDownloadMessage(appStatus, markerMsg, markerErr))
-		}
+		return v1.EndpointPhaseMODELDOWNLOADING, false, true,
+			[]string{pendingRayModelDownloadMessage(appStatus, markerMsg, markerErr)}
 	}
 
-	return phase, modelDownloadCompleted, modelDownloadIncomplete, errorMessages
+	return phase, modelDownloadCompleted, false, nil
 }
 
 // GetEndpointStatus retrieves the status of a specific endpoint from Ray Serve.

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2765,6 +2765,54 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:            false,
 		},
 		{
+			name: "return Deploying and mark model download completed when all backend replicas are done",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {
+									Name:   "BACKEND",
+									Status: "UPDATING",
+									Replicas: []dashboard.Replica{
+										{
+											ActorID:   "actor-1",
+											ReplicaID: "backend-replica-1",
+										},
+										{
+											ActorID:   "actor-2",
+											ReplicaID: "backend-replica-2",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+				mockDashboard.On("GetActorLog", "actor-1", "out", 200).
+					Return("NEUTREE_MODEL_DOWNLOAD_START\nNEUTREE_MODEL_DOWNLOAD_DONE\n", nil)
+				mockDashboard.On("GetActorLog", "actor-1", "err", 200).Return("", nil)
+				mockDashboard.On("GetActorLog", "actor-2", "out", 200).
+					Return("NEUTREE_MODEL_DOWNLOAD_START\nNEUTREE_MODEL_DOWNLOAD_DONE\n", nil)
+				mockDashboard.On("GetActorLog", "actor-2", "err", 200).Return("", nil)
+			},
+			expectedPhase:          v1.EndpointPhaseDEPLOYING,
+			expectCurrentModelHash: true,
+			expectError:            false,
+		},
+		{
 			name: "return ModelDownloading when one backend replica is still downloading even if another replica is done",
 			inputEndpoint: func() *v1.Endpoint {
 				return newEndpoint()
@@ -2813,7 +2861,61 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:                  false,
 		},
 		{
-			name: "return Deploying when current model download is already completed and actor has no done marker",
+			name: "return ModelDownloading when one backend replica is done and another has no marker",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				currentHash := endpointModelHashForTest(t, ep)
+				ep.Status = &v1.EndpointStatus{
+					Phase:                      v1.EndpointPhaseDEPLOYING,
+					ModelDownloadCompletedHash: stringPtr(currentHash),
+				}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {
+									Name:   "BACKEND",
+									Status: "UPDATING",
+									Replicas: []dashboard.Replica{
+										{
+											ActorID:   "actor-1",
+											ReplicaID: "backend-replica-1",
+										},
+										{
+											ActorID:   "actor-2",
+											ReplicaID: "backend-replica-2",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+				mockDashboard.On("GetActorLog", "actor-1", "out", 200).
+					Return("NEUTREE_MODEL_DOWNLOAD_START\nNEUTREE_MODEL_DOWNLOAD_DONE\n", nil)
+				mockDashboard.On("GetActorLog", "actor-1", "err", 200).Return("", nil)
+				mockDashboard.On("GetActorLog", "actor-2", "out", 200).Return("", nil)
+				mockDashboard.On("GetActorLog", "actor-2", "err", 200).Return("", nil)
+			},
+			expectedPhase:                v1.EndpointPhaseMODELDOWNLOADING,
+			expectModelDownloadHashEmpty: true,
+			expectErrorMsg:               "has no model download marker yet",
+			expectError:                  false,
+		},
+		{
+			name: "return ModelDownloading when current model hash matches but actor has no done marker",
 			inputEndpoint: func() *v1.Endpoint {
 				ep := newEndpoint()
 				currentHash := endpointModelHashForTest(t, ep)
@@ -2854,9 +2956,57 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 				mockDashboard.On("GetActorLog", "actor-1", "out", 200).Return("", nil)
 				mockDashboard.On("GetActorLog", "actor-1", "err", 200).Return("", nil)
 			},
-			expectedPhase:          v1.EndpointPhaseDEPLOYING,
-			expectCurrentModelHash: true,
-			expectError:            false,
+			expectedPhase:                v1.EndpointPhaseMODELDOWNLOADING,
+			expectModelDownloadHashEmpty: true,
+			expectErrorMsg:               "has no model download marker yet",
+			expectError:                  false,
+		},
+		{
+			name: "return ModelDownloading and clear completed hash when current model hash matches but actor is downloading",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				currentHash := endpointModelHashForTest(t, ep)
+				ep.Status = &v1.EndpointStatus{
+					Phase:                      v1.EndpointPhaseDEPLOYING,
+					ModelDownloadCompletedHash: stringPtr(currentHash),
+				}
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {
+									Name:   "BACKEND",
+									Status: "UPDATING",
+									Replicas: []dashboard.Replica{
+										{
+											ActorID:   "actor-1",
+											ReplicaID: "backend-replica-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+				mockDashboard.On("GetActorLog", "actor-1", "out", 200).Return("NEUTREE_MODEL_DOWNLOAD_START\n", nil)
+				mockDashboard.On("GetActorLog", "actor-1", "err", 200).Return("", nil)
+			},
+			expectedPhase:                v1.EndpointPhaseMODELDOWNLOADING,
+			expectModelDownloadHashEmpty: true,
+			expectErrorMsg:               "model download in progress",
+			expectError:                  false,
 		},
 		{
 			name: "return ModelDownloading when stored model download hash does not match current model",


### PR DESCRIPTION
## Issue

NEU-484

## Summary

Ray endpoint status could stay in `Deploying` when a previous `model_download_completed_hash` matched the current model, even though backend actors were recreated or rescheduled without visible model download completion evidence. This change aligns Ray startup status with the Kubernetes initContainer semantics: while the backend is still starting, lack of download completion evidence remains `ModelDownloading`.

## Changes

- Treat Ray `DEPLOYING` / `NOT_STARTED` with no backend download completion marker as `ModelDownloading`, regardless of a previously stored model download hash.
- Clear stale model download completion metadata when Ray actor logs show failed, in-progress, or unknown download state.
- Mark `model_download_completed_hash` as future extension metadata, not proof that the current node or replica has completed downloading.
- Simplify Ray startup model download status resolution to make the marker-state behavior explicit.
- Add Ray regression coverage for matching-hash backend restarts with missing or active download markers.
- Add multi-replica Ray coverage for all backend replicas done versus one replica missing completion evidence.
- Add Kubernetes multi-Pod characterization coverage confirming that one completed model-downloader initContainer does not hide another running one.

## Test Plan

### Unit test

- [x] `go test -count=1 ./internal/orchestrator`
- [x] `go vet ./internal/orchestrator`
- [x] `git diff --check`

Notes:
- `go vet ./...` and `go test ./...` are blocked by an existing missing embedded artifact: `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`.
- `golangci-lint run ./internal/orchestrator/...` is blocked by the local lint binary version mismatch (`v1.53.3`, built with Go 1.20.6) against the active Go 1.23.7 toolchain; it typechecks Go 1.23 stdlib constructs incorrectly and also reports existing generated mock issues.

### DB test

- [x] Not affected. This change does not modify storage or migrations.

### E2E test

- [x] Not required. This is a narrow orchestrator status resolver bug fix covered by orchestrator tests; no deployed artifact or user flow requires E2E validation.

## Risk & Rollback

Risk is limited to startup status classification. The behavior is more conservative: during backend startup, `ModelDownloading` is shown until download completion evidence is observed. Rollback is reverting this commit.