### PR TITLE
Enable Vector config watch

### DIFF
--- a/deploy/chart/neutree/templates/vector-install.yaml
+++ b/deploy/chart/neutree/templates/vector-install.yaml
@@ -234,6 +234,7 @@ spec:
           args:
             - --config-dir
             - /etc/vector/
+            - --watch-config
           env:
             - name: VECTOR_LOG
               value: "info"

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -339,6 +339,7 @@ services:
     command:
       - --config-dir
       - /etc/vector/
+      - --watch-config
     volumes:
       - {{ .NeutreeCoreWorkDir }}/vector:/etc/vector
       - {{ .NeutreeCoreWorkDir }}/vector-trace:/var/log/vector


### PR DESCRIPTION
## Issue

n/a

## Summary

Enable Vector's config watcher in both Kubernetes and Docker deployment modes so Vector can reload updated configuration files without requiring a container restart. This prevents newly rendered Vector config, such as trace sinks, from remaining inactive until the pod or container is manually restarted.

## Changes

- Add `--watch-config` to the Helm chart Vector container args.
- Add `--watch-config` to the Docker Compose Vector command.

## Test Plan

- [ ] E2E (if affected): not affected
- [ ] DB integration (`make db-test`): not affected
- [x] Rendered Helm chart with `helm template neutree deploy/chart/neutree --set jwtSecret=test-secret`.
- [x] Verified rendered Vector args include `--config-dir /etc/vector/ --watch-config`.
- [x] Verified on an isolated test Deployment in Kubernetes that Vector 0.47.0 reloads a ConfigMap-projected config without pod restart; logs showed `Configuration file changed`, `New configuration loaded successfully`, and marker output changed from v1 to v2 while restart count stayed 0.
- [x] Verified Docker mode on a clean throwaway container over SSH (`root@192.168.24.140`): bind-mounted a temp `/etc/vector` config dir, changed the config from `v1-docker-watch` to `v2-docker-watch`, observed `Vector has reloaded`, and confirmed restart count and `StartedAt` were unchanged.

## Risk & Rollback

No DB schema changes. The change only adds Vector's built-in config watcher flag. Runtime risk is limited to Vector reloading config after mounted config changes; existing startup behavior remains unchanged. Rollback by removing `--watch-config` from the Helm and Docker Vector commands and redeploying.