### PR TITLE
fix: add Grafana service URL fallback

### DIFF
--- a/deploy/chart/neutree/templates/_helpers.tpl
+++ b/deploy/chart/neutree/templates/_helpers.tpl
@@ -225,12 +225,29 @@ Priority:
 {{- end -}}
 
 {{/*
+Grafana is provided by a dependency chart. Its Service name is derived from
+the subchart's release context, not this parent chart's fullname.
+*/}}
+{{- define "neutree.grafana.serviceName" -}}
+{{- $grafana := .Values.grafana -}}
+{{- if $grafana.fullnameOverride -}}
+{{- tpl $grafana.fullnameOverride . | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "grafana" $grafana.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Choose the Grafana URL exposed by the API system-info endpoint.
 Priority:
 1. system.grafana.url explicit override
 2. grafana.grafana.ini.server.root_url
-No in-cluster fallback is used because this URL is consumed as a user-facing
-external address.
+3. in-cluster Grafana Service URL when the dependency is enabled
 */}}
 {{- define "neutree.grafana.url" -}}
 {{- $url := .Values.system.grafana.url -}}
@@ -238,6 +255,9 @@ external address.
 {{- $grafanaRootURL := dig "grafana.ini" "server" "root_url" "" .Values.grafana -}}
 {{- if $grafanaRootURL -}}
 {{- $url = tpl (toString $grafanaRootURL) . -}}
+{{- else if .Values.grafana.service.enabled -}}
+{{- $port := .Values.grafana.service.port | default 80 -}}
+{{- $url = printf "http://%s:%v" (include "neutree.grafana.serviceName" .) $port -}}
 {{- end -}}
 {{- end -}}
 {{- $url -}}


### PR DESCRIPTION
## Issue

NEU-485

## Summary

The Helm chart enabled Grafana by default but did not pass a Grafana URL to `neutree-api` unless users explicitly set `system.grafana.url` or `grafana.grafana.ini.server.root_url`. This made the UI report Grafana monitoring as unconfigured even when the bundled Grafana Service was available. This change falls back to the in-cluster Grafana Service URL so `neutree-api` can resolve the external LoadBalancer address at startup.

## Changes

- Add a helper that derives the Grafana subchart Service name using the same `fullnameOverride`, `nameOverride`, and release-name rules as the Grafana chart.
- Update `neutree.grafana.url` priority to fall back to `http://<grafana-service>:<service.port>` when Grafana is enabled and no explicit URL/root URL is configured.
- Preserve existing precedence for `system.grafana.url` and `grafana.grafana.ini.server.root_url`.

## Test Plan

Unit test

- `git diff --check`
- `helm lint deploy/chart/neutree --set jwtSecret=dummy-secret`
- `helm template neutree deploy/chart/neutree --show-only templates/neutree-api-deployment.yaml --set jwtSecret=dummy-secret` verified `--grafana-url=http://neutree-grafana:80`.
- `helm template neutree deploy/chart/neutree --show-only templates/neutree-api-deployment.yaml --set jwtSecret=dummy-secret --set-string 'grafana.grafana\.ini.server.root_url=https://grafana.example.com'` verified root URL precedence.
- `helm template neutree deploy/chart/neutree --show-only templates/neutree-api-deployment.yaml --set jwtSecret=dummy-secret --set system.grafana.url=https://system.example.com --set-string 'grafana.grafana\.ini.server.root_url=https://grafana.example.com'` verified system URL precedence.
- `helm template neutree deploy/chart/neutree --show-only templates/neutree-api-deployment.yaml --set jwtSecret=dummy-secret --set grafana.enabled=false` verified `--grafana-url` is omitted.
- `helm template custom deploy/chart/neutree --show-only templates/neutree-api-deployment.yaml --set jwtSecret=dummy-secret --set grafana.fullnameOverride=my-grafana` verified fullname override fallback.
- `helm template custom deploy/chart/neutree --show-only templates/neutree-api-deployment.yaml --set jwtSecret=dummy-secret --set grafana.nameOverride=metrics-ui` verified name override fallback.
- `helm template neutree deploy/chart/neutree --set jwtSecret=dummy-secret` rendered the full chart successfully.

DB test

- Not required. This change does not touch database schema, migrations, storage code, or RLS behavior.

E2E test

- Not required for this Trivial Helm helper change. Verification is covered by Helm lint and render cases; no deployed runtime behavior, API route, controller, or database path changed.

## Risk & Rollback

Risk is low and limited to Helm rendering of `neutree-api` arguments. Explicit Grafana URLs keep their existing precedence. Rollback by reverting this commit; deployments that already set `system.grafana.url` or `grafana.grafana.ini.server.root_url` are unaffected.
