### PR TITLE
fix: support vLLM served model alias lists

### DIFF
--- a/cluster-image-builder/serve/_utils/__init__.py
+++ b/cluster-image-builder/serve/_utils/__init__.py
@@ -1,3 +1,9 @@
 from serve._utils.coerce import coerce_args, filter_engine_args
+from serve._utils.vllm_model_aliases import build_base_model_paths, served_model_names
 
-__all__ = ["coerce_args", "filter_engine_args"]
+__all__ = [
+    "build_base_model_paths",
+    "coerce_args",
+    "filter_engine_args",
+    "served_model_names",
+]

--- a/cluster-image-builder/serve/_utils/test_vllm_model_aliases.py
+++ b/cluster-image-builder/serve/_utils/test_vllm_model_aliases.py
@@ -1,0 +1,48 @@
+"""Tests for vLLM OpenAI model alias registration helpers."""
+
+from dataclasses import dataclass
+
+from serve._utils.vllm_model_aliases import build_base_model_paths
+
+
+@dataclass
+class FakeBaseModelPath:
+    name: str
+    model_path: str
+
+
+class TestBuildBaseModelPaths:
+    def test_expands_served_model_name_list_to_individual_base_paths(self):
+        paths = build_base_model_paths(
+            FakeBaseModelPath,
+            ["primary-model", "neu-vllm-list-alias"],
+            "/models/qwen",
+        )
+
+        assert paths == [
+            FakeBaseModelPath(name="primary-model", model_path="/models/qwen"),
+            FakeBaseModelPath(name="neu-vllm-list-alias", model_path="/models/qwen"),
+        ]
+
+    def test_preserves_single_string_served_model_name(self):
+        paths = build_base_model_paths(
+            FakeBaseModelPath,
+            "primary-model",
+            "/models/qwen",
+        )
+
+        assert paths == [
+            FakeBaseModelPath(name="primary-model", model_path="/models/qwen"),
+        ]
+
+    def test_accepts_tuple_aliases(self):
+        paths = build_base_model_paths(
+            FakeBaseModelPath,
+            ("primary-model", "tuple-alias"),
+            "/models/qwen",
+        )
+
+        assert paths == [
+            FakeBaseModelPath(name="primary-model", model_path="/models/qwen"),
+            FakeBaseModelPath(name="tuple-alias", model_path="/models/qwen"),
+        ]

--- a/cluster-image-builder/serve/_utils/vllm_model_aliases.py
+++ b/cluster-image-builder/serve/_utils/vllm_model_aliases.py
@@ -1,0 +1,24 @@
+"""Helpers for vLLM OpenAI model alias registration."""
+
+from typing import List, Sequence, Type, TypeVar, Union
+
+
+T = TypeVar("T")
+ServedModelName = Union[str, Sequence[str]]
+
+
+def served_model_names(served_model_name: ServedModelName) -> List[str]:
+    if isinstance(served_model_name, str):
+        return [served_model_name]
+    return list(served_model_name)
+
+
+def build_base_model_paths(
+    base_model_path_cls: Type[T],
+    served_model_name: ServedModelName,
+    model_path: str,
+) -> List[T]:
+    return [
+        base_model_path_cls(name=name, model_path=model_path)
+        for name in served_model_names(served_model_name)
+    ]

--- a/cluster-image-builder/serve/vllm/test_served_model_alias_registry.py
+++ b/cluster-image-builder/serve/vllm/test_served_model_alias_registry.py
@@ -1,0 +1,154 @@
+"""Static guard for vLLM OpenAI model alias registry wiring."""
+
+import ast
+import pathlib
+import unittest
+
+
+VLLM_APP_FILES = (
+    pathlib.Path("v0_8_5/app.py"),
+    pathlib.Path("v0_11_2/app.py"),
+    pathlib.Path("v0_17_1/app.py"),
+)
+
+
+def _is_name(node, name):
+    return isinstance(node, ast.Name) and node.id == name
+
+
+def _is_self_model_path(node):
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "model_path"
+        and _is_name(node.value, "self")
+    )
+
+
+def _is_self_served_model_names(node):
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "served_model_names"
+        and _is_name(node.value, "self")
+    )
+
+
+def _imports_build_base_model_paths(tree):
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.module != "serve._utils":
+            continue
+        if any(alias.name == "build_base_model_paths" for alias in node.names):
+            return True
+    return False
+
+
+def _calls_build_base_model_paths_with_actual_model_path(call):
+    if not isinstance(call, ast.Call) or not _is_name(call.func, "build_base_model_paths"):
+        return False
+    if not call.args or not _is_name(call.args[0], "BaseModelPath"):
+        return False
+    return any(_is_self_model_path(arg) for arg in call.args) or any(
+        keyword.arg == "model_path" and _is_self_model_path(keyword.value)
+        for keyword in call.keywords
+    )
+
+
+def _calls_build_base_model_paths_with_served_model_names(call):
+    if not isinstance(call, ast.Call) or not _is_name(call.func, "build_base_model_paths"):
+        return False
+    return len(call.args) >= 2 and _is_self_served_model_names(call.args[1])
+
+
+def _assigns_served_model_names_from_effective_args(node):
+    if not isinstance(node, ast.Assign):
+        return False
+    if not any(_is_self_served_model_names(target) for target in node.targets):
+        return False
+    value = node.value
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "get"
+        and _is_name(value.func.value, "args")
+        and value.args
+        and isinstance(value.args[0], ast.Constant)
+        and value.args[0].value == "served_model_name"
+    )
+
+
+def _calls_base_model_path_directly(node):
+    return isinstance(node, ast.Call) and _is_name(node.func, "BaseModelPath")
+
+
+def _is_model_config_served_model_name(node):
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "served_model_name"
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "model_config"
+    )
+
+
+class TestVLLMServedModelAliasRegistry(unittest.TestCase):
+    def test_vllm_apps_register_each_alias_with_actual_model_path(self):
+        base_dir = pathlib.Path(__file__).parent
+
+        for app_file in VLLM_APP_FILES:
+            with self.subTest(app_file=str(app_file)):
+                tree = ast.parse((base_dir / app_file).read_text())
+                alias_helper_calls = [
+                    node
+                    for node in ast.walk(tree)
+                    if _calls_build_base_model_paths_with_actual_model_path(node)
+                ]
+                served_model_names_calls = [
+                    node
+                    for node in alias_helper_calls
+                    if _calls_build_base_model_paths_with_served_model_names(node)
+                ]
+                served_model_names_assignments = [
+                    node for node in ast.walk(tree) if _assigns_served_model_names_from_effective_args(node)
+                ]
+                direct_base_model_path_calls = [
+                    node for node in ast.walk(tree) if _calls_base_model_path_directly(node)
+                ]
+
+                self.assertTrue(
+                    _imports_build_base_model_paths(tree),
+                    f"{app_file} should import build_base_model_paths",
+                )
+                self.assertEqual(
+                    len(alias_helper_calls),
+                    1,
+                    f"{app_file} should build OpenAI base model paths through build_base_model_paths",
+                )
+                self.assertEqual(
+                    len(served_model_names_assignments),
+                    1,
+                    f"{app_file} should store the effective served_model_name after coercion",
+                )
+                self.assertEqual(
+                    len(served_model_names_calls),
+                    1,
+                    f"{app_file} should use the effective served_model_name as alias source",
+                )
+                self.assertEqual(
+                    direct_base_model_path_calls,
+                    [],
+                    f"{app_file} should not pass served_model_name directly into BaseModelPath",
+                )
+
+    def test_metrics_labels_do_not_use_raw_model_config_served_model_name(self):
+        base_dir = pathlib.Path(__file__).parent
+
+        for app_file in VLLM_APP_FILES:
+            with self.subTest(app_file=str(app_file)):
+                tree = ast.parse((base_dir / app_file).read_text())
+
+                self.assertFalse(
+                    any(_is_model_config_served_model_name(node) for node in ast.walk(tree)),
+                    "metrics labels should use normalized served_model_names, not raw vLLM model_config",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cluster-image-builder/serve/vllm/v0_11_2/app.py
+++ b/cluster-image-builder/serve/vllm/v0_11_2/app.py
@@ -31,7 +31,7 @@ from vllm.entrypoints.openai.serving_models import BaseModelPath, OpenAIServingM
 
 from downloader import get_downloader, build_request_from_model_args, download_with_markers
 from serve._metrics.ray_stat_logger import NeutreeRayStatLogger
-from serve._utils import coerce_args, filter_engine_args
+from serve._utils import build_base_model_paths, coerce_args, filter_engine_args
 from serve._utils.runtime_env import build_backend_runtime_env
 
 
@@ -90,6 +90,7 @@ class Backend:
         print(f"[Backend] Model download completed.")
 
         self.model_id = model_serve_name
+        self.model_path = model_path
         self.model_task = model_task
 
         # Extract our custom parameters BEFORE creating AsyncEngineArgs to avoid unexpected keyword errors
@@ -145,6 +146,10 @@ class Backend:
         # params that were read but not popped) to prevent TypeError on init.
         filter_engine_args(args, AsyncEngineArgs)
 
+        self.served_model_names = args.get("served_model_name", self.model_id)
+        if isinstance(self.served_model_names, str):
+            self.served_model_names = [self.served_model_names]
+
         engine_args = AsyncEngineArgs(
             **args
         )
@@ -169,8 +174,11 @@ class Backend:
             self._ensure_model_config()
             self.openai_serving_models = OpenAIServingModels(
                 self.engine,
-                [BaseModelPath(name=self.engine.model_config.served_model_name,
-                               model_path=self.engine.model_config.served_model_name)]
+                build_base_model_paths(
+                    BaseModelPath,
+                    self.served_model_names,
+                    self.model_path,
+                )
             )
         return self.openai_serving_models
 

--- a/cluster-image-builder/serve/vllm/v0_17_1/app.py
+++ b/cluster-image-builder/serve/vllm/v0_17_1/app.py
@@ -32,7 +32,7 @@ from vllm.entrypoints.pooling.score.serving import ServingScores
 
 from downloader import get_downloader, build_request_from_model_args, download_with_markers
 from serve._metrics.ray_stat_logger import NeutreeRayStatLogger
-from serve._utils import coerce_args, filter_engine_args
+from serve._utils import build_base_model_paths, coerce_args, filter_engine_args
 from serve._utils.runtime_env import build_backend_runtime_env
 from serve._utils.vllm_task_translate import task_kwargs as _task_kwargs
 
@@ -92,6 +92,7 @@ class Backend:
         print(f"[Backend] Model download completed.")
 
         self.model_id = model_serve_name
+        self.model_path = model_path
         self.model_task = model_task
 
         # Extract FrontendArgs BEFORE creating AsyncEngineArgs to avoid unexpected keyword errors.
@@ -182,6 +183,10 @@ class Backend:
         # params that were read but not popped) to prevent TypeError on init.
         filter_engine_args(args, AsyncEngineArgs)
 
+        self.served_model_names = args.get("served_model_name", self.model_id)
+        if isinstance(self.served_model_names, str):
+            self.served_model_names = [self.served_model_names]
+
         engine_args = AsyncEngineArgs(
             **args
         )
@@ -206,8 +211,11 @@ class Backend:
             self._ensure_model_config()
             self.openai_serving_models = OpenAIServingModels(
                 self.engine,
-                [BaseModelPath(name=self.engine.model_config.served_model_name,
-                               model_path=self.engine.model_config.served_model_name)]
+                build_base_model_paths(
+                    BaseModelPath,
+                    self.served_model_names,
+                    self.model_path,
+                )
             )
         return self.openai_serving_models
 

--- a/cluster-image-builder/serve/vllm/v0_8_5/app.py
+++ b/cluster-image-builder/serve/vllm/v0_8_5/app.py
@@ -31,7 +31,7 @@ from vllm.entrypoints.openai.serving_models import BaseModelPath, OpenAIServingM
 from vllm.engine.metrics import RayPrometheusStatLogger
 
 from downloader import get_downloader, build_request_from_model_args, download_with_markers
-from serve._utils import coerce_args, filter_engine_args
+from serve._utils import build_base_model_paths, coerce_args, filter_engine_args
 from serve._utils.runtime_env import build_backend_runtime_env
 
 
@@ -117,6 +117,7 @@ class Backend:
         print(f"[Backend] Model download completed.")
 
         self.model_id = model_serve_name
+        self.model_path = model_path
         self.model_task = model_task
 
         # Extract our custom parameters BEFORE creating AsyncEngineArgs to avoid unexpected keyword errors
@@ -168,6 +169,10 @@ class Backend:
         # params that were read but not popped) to prevent TypeError on init.
         filter_engine_args(args, AsyncEngineArgs)
 
+        self.served_model_names = args.get("served_model_name", self.model_id)
+        if isinstance(self.served_model_names, str):
+            self.served_model_names = [self.served_model_names]
+
         engine_args = AsyncEngineArgs(
             **args
         )
@@ -183,7 +188,7 @@ class Backend:
         labels = {
             "deployment":  ctx.deployment,
             "replica":     ctx.replica_tag,
-            "model_name":  self.engine.engine.model_config.served_model_name,
+            "model_name":  str(self.served_model_names[0] if self.served_model_names else self.model_id),
             "engine":      os.environ.get("ENGINE_NAME", "unknown"),
             "engine_version": os.environ.get("ENGINE_VERSION", "unknown"),
         }
@@ -208,8 +213,11 @@ class Backend:
             self.openai_serving_models = OpenAIServingModels(
                 self.engine,
                 model_config,
-                [BaseModelPath(name=self.engine.engine.model_config.served_model_name,
-                               model_path=self.engine.engine.model_config.served_model_name)]
+                build_base_model_paths(
+                    BaseModelPath,
+                    self.served_model_names,
+                    self.model_path,
+                )
             )
         return self.openai_serving_models
 


### PR DESCRIPTION
## Issue

NEU-488

## Summary

Fix SSH/Ray Serve vLLM OpenAI model registration when `served_model_name` is a list. The serving layer now preserves the effective `engine_args.served_model_name` value after coercion/filtering, normalizes it to a list, and registers one `BaseModelPath` per alias while preserving the actual model path used by the engine.

SGLang remains string-only for `served_model_name`; Step 5 checked it separately and found an environment image blocker unrelated to this PR's vLLM change.

## Changes

- Added a shared vLLM alias helper under `cluster-image-builder/serve/_utils`.
- Updated vLLM SSH apps for `v0.8.5`, `v0.11.2`, and `v0.17.1` to use the effective `served_model_name` list for OpenAI model registration.
- Added helper tests and a static guard to keep all current vLLM apps on the effective-alias registry path.

## Test Plan

### Unit test

- [x] `PYTHONPATH=cluster-image-builder pytest cluster-image-builder/serve/vllm/test_served_model_alias_registry.py -q` — 1 passed, 3 subtests passed.
- [x] `PYTHONPATH=cluster-image-builder pytest cluster-image-builder/serve/_utils/test_vllm_model_aliases.py cluster-image-builder/serve/_utils/test_coerce.py cluster-image-builder/serve/_utils/test_runtime_env.py cluster-image-builder/serve/_utils/test_vllm_task_translate.py cluster-image-builder/serve/vllm/test_served_model_alias_registry.py cluster-image-builder/serve/vllm/test_request_id_plugin_config.py -v` — 59 passed, 9 subtests passed.
- [x] `python3 -m py_compile cluster-image-builder/serve/vllm/v0_8_5/app.py cluster-image-builder/serve/vllm/v0_11_2/app.py cluster-image-builder/serve/vllm/v0_17_1/app.py cluster-image-builder/serve/vllm/test_served_model_alias_registry.py`
- [x] `git diff --check`
- [x] Copilot review fix at PR head `f1077ac309612850533561e95289bdf8dd1737cc`: v0.8.5 metrics `model_name` label now uses the first normalized served alias; targeted tests above, `py_compile`, and `git diff --check` passed.

### DB test

- [x] Not affected. This change does not touch DB migrations, storage, or API/controller code.

### E2E test

- [x] Rebuilt vLLM images from alias-fix head `d19e2a58447c837b62f387bc4dbd8c20b7ea9623` with Ray input `ray-2.53.0-neutree-fix`: runs `28466666864`, `28466668869`, `28466693906` all passed.
- [x] Copied/imported vLLM test images to CP `192.168.20.158` / registry `192.168.22.100`: `v0.8.5-neutree488-ray2.53.0`, `v0.11.2-neutree488-ray2.53.0`, `v0.17.1-neutree488-ray2.53.0`.
- [x] `make e2e-test LABEL_FILTER='endpoint && ssh && config && !sglang' E2E_TIMEOUT=120m` on CP `192.168.20.158`, SSH node `192.168.19.218` — 15 passed, 0 failed. This includes `C2724893`; primary model and `neu-vllm-list-alias` chat completion both returned HTTP 200.
- [x] TestRail run `6567` updated by E2E reporter for the included cases.
- [ ] Full `endpoint && ssh && config` including SGLang is blocked by the available SSH E2E node, not this PR: the node is NVIDIA T4 / sm75, while upstream SGLang v0.5 targets deprecating sm75 support and the v0.5.10 `sgl-kernel` build no longer targets sm75. This is an environment compatibility blocker outside the vLLM alias fix.

Manual testing is not required for the vLLM path because the code-backed E2E covers the deterministic SSH/Ray Serve alias workflow.

## Risk & Rollback

Risk is limited to vLLM SSH runtime image behavior for OpenAI model alias registration. Rollback is to restore the previous single `BaseModelPath` construction in the three vLLM app files and rebuild the affected vLLM engine images.