### PR TITLE
fix: show local NFS model import progress

### DIFF
--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -23,6 +23,7 @@ func NewPushCmd() *cobra.Command {
 	var description string
 	var labelsFlag []string
 	var localNFSPath string
+	var skipLocalNFSMountCheck bool
 
 	cmd := &cobra.Command{
 		Use:          "push [local_model_path]",
@@ -112,12 +113,24 @@ func NewPushCmd() *cobra.Command {
 			}
 
 			if localNFSPath != "" {
-				if err := cliModel.ValidateDirectPushTarget(modelRegistry, localNFSPath); err != nil {
+				options := cliModel.DirectPushValidationOptions{
+					SkipMountCheck: skipLocalNFSMountCheck,
+				}
+				if err := cliModel.ValidateDirectPushTarget(modelRegistry, localNFSPath, options); err != nil {
+					return err
+				}
+				if skipLocalNFSMountCheck {
+					fmt.Fprintln(cmd.ErrOrStderr(),
+						"\nWarning: skipped local NFS mount check; ensure --local-nfs-path points "+
+							"to the model registry export root, or inference nodes may not see the model.")
+				}
+
+				importBar, err := newLocalNFSImportProgressBar(modelPath)
+				if err != nil {
 					return err
 				}
 
-				fmt.Println("Importing model...")
-				if err := cliModel.ImportArchiveToLocalNFS(localNFSPath, modelPath, modelName, version, nil); err != nil {
+				if err := cliModel.ImportArchiveToLocalNFS(localNFSPath, modelPath, modelName, version, importBar); err != nil {
 					return err
 				}
 
@@ -174,12 +187,23 @@ func NewPushCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&description, "description", "d", "", "Description of the model")
 	cmd.Flags().StringSliceVarP(&labelsFlag, "label", "l", nil, "Labels in the format key=value")
 	cmd.Flags().StringVar(&localNFSPath, "local-nfs-path", "", "Path to a pre-mounted NFS ModelRegistry root for direct local import")
+	cmd.Flags().BoolVar(&skipLocalNFSMountCheck, "skip-local-nfs-mount-check", false,
+		"Skip NFS mount/source validation for --local-nfs-path when running on the NFS server export path")
 
 	if err := cmd.MarkFlagRequired("name"); err != nil {
 		panic(fmt.Sprintf("Failed to mark flag 'name' as required: %v", err))
 	}
 
 	return cmd
+}
+
+func newLocalNFSImportProgressBar(modelPath string) (io.Writer, error) {
+	fileInfo, err := os.Stat(modelPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get model file info: %w", err)
+	}
+
+	return progressbar.DefaultBytes(fileInfo.Size(), "Importing model"), nil
 }
 
 // calculateDirectorySize calculates the total size of all files in a directory

--- a/internal/cli/model/direct_push.go
+++ b/internal/cli/model/direct_push.go
@@ -14,7 +14,11 @@ import (
 
 var getMountSource = defaultGetMountSource
 
-func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) error {
+type DirectPushValidationOptions struct {
+	SkipMountCheck bool
+}
+
+func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string, options DirectPushValidationOptions) error {
 	if registry == nil || registry.Spec == nil {
 		return fmt.Errorf("direct model push only supports bentoml registries backed by nfs://")
 	}
@@ -55,6 +59,10 @@ func ValidateDirectPushTarget(registry *v1.ModelRegistry, localNFSPath string) e
 		return fmt.Errorf("failed to remove write check file under %s: %w", localNFSPath, err)
 	}
 
+	if options.SkipMountCheck {
+		return nil
+	}
+
 	mountSource, mounted, err := getMountSource(localNFSPath)
 	if err != nil {
 		return fmt.Errorf("failed to inspect local NFS mount for %s: %w", localNFSPath, err)
@@ -78,7 +86,12 @@ func ImportArchiveToLocalNFS(localNFSPath, archivePath, name, version string, pr
 	}
 	defer archive.Close()
 
-	if err := bentoml.ImportModel(localNFSPath, archive, name, version, true, progress); err != nil {
+	var reader io.Reader = archive
+	if progress != nil {
+		reader = io.TeeReader(archive, progress)
+	}
+
+	if err := bentoml.ImportModel(localNFSPath, reader, name, version, true, nil); err != nil {
 		return fmt.Errorf("failed to import model archive to local NFS path: %w", err)
 	}
 

--- a/internal/cli/model/direct_push_test.go
+++ b/internal/cli/model/direct_push_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +21,7 @@ func TestValidateDirectPushTargetRequiresBentomlNFSRegistry(t *testing.T) {
 			Type: v1.BentoMLModelRegistryType,
 			Url:  "nfs://server:/exports/models",
 		},
-	}, tmpDir)
+	}, tmpDir, DirectPushValidationOptions{})
 	require.NoError(t, err)
 
 	err = ValidateDirectPushTarget(&v1.ModelRegistry{
@@ -28,7 +29,7 @@ func TestValidateDirectPushTargetRequiresBentomlNFSRegistry(t *testing.T) {
 			Type: v1.HuggingFaceModelRegistryType,
 			Url:  "https://huggingface.co",
 		},
-	}, tmpDir)
+	}, tmpDir, DirectPushValidationOptions{})
 	require.ErrorContains(t, err, "only supports bentoml registries backed by nfs://")
 
 	err = ValidateDirectPushTarget(&v1.ModelRegistry{
@@ -36,7 +37,7 @@ func TestValidateDirectPushTargetRequiresBentomlNFSRegistry(t *testing.T) {
 			Type: v1.BentoMLModelRegistryType,
 			Url:  "file://localhost/tmp/models",
 		},
-	}, tmpDir)
+	}, tmpDir, DirectPushValidationOptions{})
 	require.ErrorContains(t, err, "only supports bentoml registries backed by nfs://")
 }
 
@@ -46,7 +47,7 @@ func TestValidateDirectPushTargetRequiresWritableDirectory(t *testing.T) {
 			Type: v1.BentoMLModelRegistryType,
 			Url:  "nfs://server:/exports/models",
 		},
-	}, filepath.Join(t.TempDir(), "missing"))
+	}, filepath.Join(t.TempDir(), "missing"), DirectPushValidationOptions{})
 	require.ErrorContains(t, err, "local NFS path")
 }
 
@@ -59,7 +60,7 @@ func TestValidateDirectPushTargetRequiresMatchingNFSMount(t *testing.T) {
 			Type: v1.BentoMLModelRegistryType,
 			Url:  "nfs://server:/exports/models",
 		},
-	}, tmpDir)
+	}, tmpDir, DirectPushValidationOptions{})
 	require.ErrorContains(t, err, "is not mounted from server:/exports/models")
 
 	stubMountSource(t, tmpDir, "", false)
@@ -68,8 +69,31 @@ func TestValidateDirectPushTargetRequiresMatchingNFSMount(t *testing.T) {
 			Type: v1.BentoMLModelRegistryType,
 			Url:  "nfs://server:/exports/models",
 		},
-	}, tmpDir)
+	}, tmpDir, DirectPushValidationOptions{})
 	require.ErrorContains(t, err, "is not an NFS mount point")
+}
+
+func TestValidateDirectPushTargetCanSkipMountCheckForNFSServerPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	mountCheckCalled := false
+
+	original := getMountSource
+	getMountSource = func(localPath string) (string, bool, error) {
+		mountCheckCalled = true
+		return "", false, nil
+	}
+	t.Cleanup(func() {
+		getMountSource = original
+	})
+
+	err := ValidateDirectPushTarget(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "nfs://server:/exports/models",
+		},
+	}, tmpDir, DirectPushValidationOptions{SkipMountCheck: true})
+	require.NoError(t, err)
+	require.False(t, mountCheckCalled)
 }
 
 func TestImportArchiveToLocalNFSUsesBentoMLLayout(t *testing.T) {
@@ -85,6 +109,24 @@ func TestImportArchiveToLocalNFSUsesBentoMLLayout(t *testing.T) {
 
 	require.FileExists(t, filepath.Join(destDir, "models", "demo-model", "v1", "model.yaml"))
 	require.FileExists(t, filepath.Join(destDir, "models", "demo-model", "latest"))
+}
+
+func TestImportArchiveToLocalNFSWritesProgress(t *testing.T) {
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "weights.bin"), []byte("weights"), 0o644))
+
+	archivePath, err := bentoml.CreateArchiveWithProgress(srcDir, "demo-model", "v1", nil)
+	require.NoError(t, err)
+	defer os.Remove(archivePath)
+
+	archiveInfo, err := os.Stat(archivePath)
+	require.NoError(t, err)
+
+	var progress bytes.Buffer
+	destDir := t.TempDir()
+	require.NoError(t, ImportArchiveToLocalNFS(destDir, archivePath, "demo-model", "v1", &progress))
+
+	require.Equal(t, archiveInfo.Size(), int64(progress.Len()))
 }
 
 func TestReadImportedModelVersionReturnsLocalMetadata(t *testing.T) {


### PR DESCRIPTION
## Issue

n/a

## Summary

Show a visible import progress bar when `neutree model push` uses `--local-nfs-path`. The direct NFS path already skips HTTP upload, but the local archive import previously passed no progress writer and only printed a static `Importing model...` line.

## Changes

- Add an `Importing model` progress bar for the `--local-nfs-path` direct import branch.
- Count progress while reading the `.bentomodel` archive so import progress is visible without a pre-scan or second decompression pass.
- Add focused tests for the CLI progress writer, command-level direct NFS wiring, and direct NFS import progress propagation.

## Test Plan

Unit test:

- [x] `go test -count=1 ./cmd/neutree-cli/app/cmd/model ./internal/cli/model`
- [x] `go vet ./cmd/neutree-cli/app/cmd/model ./internal/cli/model`
- [x] `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6 run ./cmd/neutree-cli/app/cmd/model ./internal/cli/model`
- [x] `git diff --check`

DB test:

- [x] Not affected. This change only touches CLI progress display and unit tests.

E2E test:

- [x] Not required. The change is isolated to local CLI output for the existing direct NFS import path and is covered by focused unit tests.

## Risk & Rollback

Risk is low. The direct import behavior still calls the existing `ImportArchiveToLocalNFS`; only the progress writer path changes from silent import to archive-read progress. Rollback is to revert this PR, which restores the previous static import message.
