### PR TITLE
feat: add vLLM v0.24.0 engine support

### DIFF
--- a/cluster-image-builder/serve/_metrics/ray_stat_logger.py
+++ b/cluster-image-builder/serve/_metrics/ray_stat_logger.py
@@ -14,6 +14,7 @@ RayKVConnectorProm = getattr(
     "RayKVConnectorPrometheus",
     getattr(_ray_wrappers, "RayKVConnectorProm", None),
 )
+RayPerfMetricsProm = getattr(_ray_wrappers, "RayPerfMetricsProm", None)
 
 logger = logging.getLogger("ray.serve")
 
@@ -57,6 +58,15 @@ def _make_extended_kv_connector_cls(base_cls, extra_labels):
     return Extended
 
 
+def _make_extended_perf_metrics_cls(base_cls, extra_labels):
+    """Extend PerfMetricsProm counters with custom labels via its _cls vars."""
+
+    class Extended(base_cls):
+        _counter_cls = _make_extended_metric_cls(RayCounterWrapper, extra_labels)
+
+    return Extended
+
+
 class NeutreeRayStatLogger(RayPrometheusStatLogger):
     """RayPrometheusStatLogger with Ray Serve context labels injected.
 
@@ -94,6 +104,9 @@ class NeutreeRayStatLogger(RayPrometheusStatLogger):
             if RayKVConnectorProm is not None:
                 self._kv_connector_cls = _make_extended_kv_connector_cls(
                     RayKVConnectorProm, extra_labels)
+            if RayPerfMetricsProm is not None:
+                self._perf_metrics_cls = _make_extended_perf_metrics_cls(
+                    RayPerfMetricsProm, extra_labels)
 
         super().__init__(vllm_config, engine_indexes)
 

--- a/cluster-image-builder/serve/_metrics/ray_stat_logger.py
+++ b/cluster-image-builder/serve/_metrics/ray_stat_logger.py
@@ -2,13 +2,17 @@ import logging
 import os
 
 from ray import serve
-from vllm.v1.metrics.ray_wrappers import (
-    RayPrometheusStatLogger,
-    RaySpecDecodingProm,
-    RayKVConnectorPrometheus,
-    RayGaugeWrapper,
-    RayCounterWrapper,
-    RayHistogramWrapper,
+from vllm.v1.metrics import ray_wrappers as _ray_wrappers
+
+RayPrometheusStatLogger = _ray_wrappers.RayPrometheusStatLogger
+RaySpecDecodingProm = _ray_wrappers.RaySpecDecodingProm
+RayGaugeWrapper = _ray_wrappers.RayGaugeWrapper
+RayCounterWrapper = _ray_wrappers.RayCounterWrapper
+RayHistogramWrapper = _ray_wrappers.RayHistogramWrapper
+RayKVConnectorProm = getattr(
+    _ray_wrappers,
+    "RayKVConnectorPrometheus",
+    getattr(_ray_wrappers, "RayKVConnectorProm", None),
 )
 
 logger = logging.getLogger("ray.serve")
@@ -43,7 +47,7 @@ def _make_extended_spec_decoding_cls(base_cls, extra_labels):
 
 
 def _make_extended_kv_connector_cls(base_cls, extra_labels):
-    """Extend KVConnectorPrometheus with custom labels via its _cls vars."""
+    """Extend KV connector metrics with custom labels via its _cls vars."""
 
     class Extended(base_cls):
         _gauge_cls = _make_extended_metric_cls(RayGaugeWrapper, extra_labels)
@@ -87,8 +91,9 @@ class NeutreeRayStatLogger(RayPrometheusStatLogger):
                 RayHistogramWrapper, extra_labels)
             self._spec_decoding_cls = _make_extended_spec_decoding_cls(
                 RaySpecDecodingProm, extra_labels)
-            self._kv_connector_cls = _make_extended_kv_connector_cls(
-                RayKVConnectorPrometheus, extra_labels)
+            if RayKVConnectorProm is not None:
+                self._kv_connector_cls = _make_extended_kv_connector_cls(
+                    RayKVConnectorProm, extra_labels)
 
         super().__init__(vllm_config, engine_indexes)
 

--- a/cluster-image-builder/serve/vllm/v0_24_0/app.py
+++ b/cluster-image-builder/serve/vllm/v0_24_0/app.py
@@ -192,6 +192,10 @@ class Backend:
         # params that were read but not popped) to prevent TypeError on init.
         filter_engine_args(args, AsyncEngineArgs)
 
+        self.served_model_names = args.get("served_model_name", self.model_id)
+        if isinstance(self.served_model_names, str):
+            self.served_model_names = [self.served_model_names]
+
         self.request_logger = RequestLogger(max_log_len=self.max_log_len) if args.get("enable_log_requests") else None
         set_default_fingerprint_mode(self.fingerprint_mode, self.fingerprint_value)
 
@@ -220,15 +224,12 @@ class Backend:
     async def _ensure_models(self):
         if self.openai_serving_models is None:
             self._ensure_model_config()
-            served_model_names = self.engine.model_config.served_model_name
-            if isinstance(served_model_names, str):
-                served_model_names = [served_model_names]
 
             self.openai_serving_models = OpenAIServingModels(
                 self.engine,
                 [
                     BaseModelPath(name=name, model_path=self.model_path)
-                    for name in served_model_names
+                    for name in self.served_model_names
                 ]
             )
         return self.openai_serving_models

--- a/cluster-image-builder/serve/vllm/v0_24_0/app.py
+++ b/cluster-image-builder/serve/vllm/v0_24_0/app.py
@@ -416,6 +416,24 @@ def _result_to_response(result: Any) -> Response:
     return JSONResponse(content=result)
 
 
+def _stream_error_status(error: Any) -> int:
+    if isinstance(error, dict):
+        code = error.get("code")
+        if isinstance(code, int) and not isinstance(code, bool) and 400 <= code <= 599:
+            return code
+        if isinstance(code, str):
+            try:
+                status_code = int(code)
+            except ValueError:
+                status_code = None
+            if status_code is not None and 400 <= status_code <= 599:
+                return status_code
+        if error.get("type") == "internal_server_error":
+            return 500
+
+    return 400
+
+
 def _stream_error_response(first_chunk: Any) -> Optional[JSONResponse]:
     if not isinstance(first_chunk, str) or not first_chunk.startswith("data:"):
         return None
@@ -432,9 +450,10 @@ def _stream_error_response(first_chunk: Any) -> Optional[JSONResponse]:
     if not isinstance(data, dict) or "error" not in data:
         return None
 
+    error = data["error"]
     return JSONResponse(
-        content=data["error"],
-        status_code=400,
+        content=error,
+        status_code=_stream_error_status(error),
     )
 
 

--- a/cluster-image-builder/serve/vllm/v0_24_0/app.py
+++ b/cluster-image-builder/serve/vllm/v0_24_0/app.py
@@ -1,0 +1,578 @@
+import os
+import enum
+import logging
+import time
+import json
+from typing import Dict, Optional, Any, AsyncGenerator, List
+
+from fastapi import FastAPI, Request
+from starlette.responses import StreamingResponse, JSONResponse, Response
+from fastapi.middleware.cors import CORSMiddleware
+from starlette_context.plugins import RequestIdPlugin
+from starlette_context.middleware import RawContextMiddleware
+from fastapi.middleware import Middleware
+
+from ray import serve
+from ray.serve import Application
+from ray.serve.config import RequestRouterConfig
+from ray.serve.handle import DeploymentHandle, DeploymentResponseGenerator
+
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.v1.engine.async_llm import AsyncLLM
+# v0.24.0 modules are organized into endpoint-specific sub-packages.
+from vllm.entrypoints.chat_utils import ChatTemplateConfig, load_chat_template
+from vllm.entrypoints.serve.utils.request_logger import RequestLogger
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse, ErrorInfo
+from vllm.entrypoints.serve.utils.fingerprint import set_default_fingerprint_mode
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.models.protocol import BaseModelPath
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+from vllm.entrypoints.pooling.embed.protocol import EmbeddingCompletionRequest
+from vllm.entrypoints.pooling.embed.serving import ServingEmbedding
+from vllm.entrypoints.pooling.scoring.protocol import RerankRequest
+from vllm.entrypoints.pooling.scoring.serving import ServingScores
+
+from downloader import get_downloader, build_request_from_model_args, download_with_markers
+from serve._metrics.ray_stat_logger import NeutreeRayStatLogger
+from serve._utils import coerce_args, filter_engine_args
+from serve._utils.runtime_env import build_backend_runtime_env
+from serve._utils.vllm_task_translate import task_kwargs as _task_kwargs
+
+
+class SchedulerType(str, enum.Enum):
+    POW2 = "pow2"
+    STATIC_HASH = "static_hash"
+    CONSISTENT_HASH = "consistent_hash"
+
+
+# Mapping from scheduler type to request router class path
+SCHEDULER_CLASS_PATHS = {
+    SchedulerType.STATIC_HASH: "serve._replica_scheduler.static_hash_scheduler:StaticHashReplicaScheduler",
+    SchedulerType.CONSISTENT_HASH: "serve._replica_scheduler.chwbl_scheduler:ConsistentHashReplicaScheduler",
+}
+
+
+@serve.deployment(ray_actor_options={"num_cpus": 1, "num_gpus": 1})
+class Backend:
+    def __init__(self,
+                 # Model config parameters
+                 model_registry_type: str,
+                 model_name: str,
+                 model_version: str,
+                 model_file: str = "",
+                 model_task: str = "",
+                 model_registry_path: str = "",
+                 model_path: str = "",
+                 model_serve_name: str = "",
+                 **engine_kwargs):
+        """
+        Backend deployment for vLLM inference.
+
+        Args:
+            model_registry_type: Type of model registry ("bentoml" or "hugging-face")
+            model_name: Name of the model in the registry
+            model_version: Version of the model
+            model_file: Specific model file name (for bentoml)
+            model_task: Task type (e.g., "text-generation", "text-embedding", "text-rerank")
+            **engine_kwargs: Additional keyword arguments passed directly to AsyncEngineArgs
+        """
+        backend, dl_req = build_request_from_model_args({
+            "registry_type": model_registry_type,
+            "name": model_name,
+            "version": model_version,
+            "file": model_file,
+            "task": model_task,
+            "registry_path": model_registry_path,
+            "path": model_path,
+        })
+
+        downloader = get_downloader(backend)
+        print(f"[Backend] Downloading model using backend={backend} from source={dl_req.source} to dest={dl_req.dest}")
+        download_with_markers(downloader, dl_req.source, dl_req.dest, credentials=dl_req.credentials,
+                              recursive=dl_req.recursive, overwrite=dl_req.overwrite,
+                              retries=dl_req.retries, timeout=dl_req.timeout, metadata=dl_req.metadata)
+        print(f"[Backend] Model download completed.")
+
+        self.model_id = model_serve_name
+        self.model_task = model_task
+
+        # Extract FrontendArgs BEFORE creating AsyncEngineArgs to avoid unexpected keyword errors.
+        # FrontendArgs are NOT engine parameters — they configure the Serving layer (chat, embedding, score).
+        # If left in engine_kwargs, they would be passed to AsyncEngineArgs and cause TypeError.
+
+        # Tool calling configuration
+        self.tool_parser = engine_kwargs.pop("tool_call_parser", None)
+        self.enable_auto_tools = engine_kwargs.pop("enable_auto_tool_choice", False)
+        if self.tool_parser:
+            self.enable_auto_tools = True
+        self.exclude_tools_when_tool_choice_none = engine_kwargs.pop("exclude_tools_when_tool_choice_none", False)
+
+        # Reasoning configuration (read but don't pop - engine needs these too)
+        self.reasoning_parser = engine_kwargs.get("reasoning_parser", None)
+
+        # Chat template parameters
+        self.chat_template = engine_kwargs.pop("chat_template", None)
+        self.chat_template_content_format = engine_kwargs.pop("chat_template_content_format", "auto")
+        self.trust_request_chat_template = engine_kwargs.pop("trust_request_chat_template", False)
+        _raw_kwargs = engine_kwargs.pop("default_chat_template_kwargs", None)
+        # Coerce JSON string → dict, following the same pattern as coerce_args().
+        if isinstance(_raw_kwargs, str):
+            try:
+                parsed = json.loads(_raw_kwargs)
+            except (json.JSONDecodeError, TypeError):
+                parsed = None
+            if isinstance(parsed, dict):
+                _raw_kwargs = parsed
+            else:
+                print(f"[Backend] WARNING: default_chat_template_kwargs is not a valid JSON dict: {_raw_kwargs!r}, ignoring")
+                _raw_kwargs = None
+        elif _raw_kwargs is not None and not isinstance(_raw_kwargs, dict):
+            print(f"[Backend] WARNING: default_chat_template_kwargs must be a dict or JSON object string, got {type(_raw_kwargs).__name__}; ignoring")
+            _raw_kwargs = None
+        self.default_chat_template_kwargs = _raw_kwargs
+
+        # Chat/serving behavior parameters
+        self.response_role = engine_kwargs.pop("response_role", "assistant")
+        self.enable_prompt_tokens_details = engine_kwargs.pop("enable_prompt_tokens_details", False)
+        self.return_tokens_as_token_ids = engine_kwargs.pop("return_tokens_as_token_ids", False)
+        self.enable_force_include_usage = engine_kwargs.pop("enable_force_include_usage", False)
+
+        # Logging/debugging parameters
+        self.enable_log_outputs = engine_kwargs.pop("enable_log_outputs", False)
+        self.enable_log_deltas = engine_kwargs.pop("enable_log_deltas", True)
+        self.log_error_stack = engine_kwargs.pop("log_error_stack", False)
+        self.max_log_len = engine_kwargs.pop("max_log_len", None)
+
+        # Pooling/scoring parameters
+        self.enable_flash_late_interaction = engine_kwargs.pop("enable_flash_late_interaction", True)
+
+        # Response fingerprint parameters
+        self.fingerprint_mode = engine_kwargs.pop("fingerprint_mode", "full")
+        self.fingerprint_value = engine_kwargs.pop("fingerprint_value", None)
+
+        # FrontendArgs not used in Ray Serve mode (pop to prevent AsyncEngineArgs errors)
+        engine_kwargs.pop("tool_parser_plugin", None)
+        engine_kwargs.pop("tool_server", None)
+        engine_kwargs.pop("tokens_only", None)
+        engine_kwargs.pop("enable_server_load_tracking", None)
+        engine_kwargs.pop("enable_tokenizer_info_endpoint", None)
+
+        # vLLM v0.17+ removed --task; auto-detect can fall back to a
+        # generate runner for multimodal embedding architectures, so the
+        # registry-level task is translated to --runner/--convert kwargs
+        # here. setdefault keeps user-supplied engine_args overrides intact.
+        for _k, _v in _task_kwargs(model_task).items():
+            engine_kwargs.setdefault(_k, _v)
+
+        # merge engine args
+        # NOTE: enable_prefix_caching is intentionally NOT set here.
+        # vLLM v0.8.0+ (V1 engine) defaults to True for generate models.
+        # vLLM v0.12.0+ uses ModelConfig.is_prefix_caching_supported for
+        # smart per-model-type defaults (e.g. False for encoder-only/hybrid).
+        # Letting vLLM decide avoids overriding those intelligent defaults
+        # and keeps behavior consistent with the Kubernetes deployment path.
+        args = dict(
+            model=model_path,
+            served_model_name=self.model_id,
+            disable_log_stats=False,
+        )
+
+        args.update(engine_kwargs)
+
+        # Coerce JSON string values to native types based on AsyncEngineArgs field
+        # annotations. This handles the SSH/Ray path where users may provide JSON
+        # values as strings (e.g. '{"temperature": 0.5}' instead of a native dict),
+        # since unlike the K8s CLI path there is no argparse layer to do json.loads.
+        coerce_args(args, AsyncEngineArgs)
+
+        # Drop any keys not recognised by AsyncEngineArgs (e.g. serving-only
+        # params that were read but not popped) to prevent TypeError on init.
+        filter_engine_args(args, AsyncEngineArgs)
+
+        self.request_logger = RequestLogger(max_log_len=self.max_log_len) if args.get("enable_log_requests") else None
+        set_default_fingerprint_mode(self.fingerprint_mode, self.fingerprint_value)
+
+        engine_args = AsyncEngineArgs(
+            **args
+        )
+
+        self.engine = AsyncLLM.from_engine_args(
+            engine_args,
+            stat_loggers=[NeutreeRayStatLogger],
+        )
+        self.model_config = None
+        self.openai_serving_chat = None
+        self.openai_serving_render = None
+        self.openai_serving_embedding = None
+        self.openai_serving_score = None
+        self.openai_serving_models = None
+        self.resolved_chat_template = None
+        self.supported_tasks = None
+
+    def _ensure_model_config(self):
+        if self.model_config is None:
+            self.model_config = self.engine.model_config
+        return self.model_config
+
+    async def _ensure_models(self):
+        if self.openai_serving_models is None:
+            self._ensure_model_config()
+            self.openai_serving_models = OpenAIServingModels(
+                self.engine,
+                [BaseModelPath(name=self.engine.model_config.served_model_name,
+                               model_path=self.engine.model_config.served_model_name)]
+            )
+        return self.openai_serving_models
+
+    async def _ensure_supported_tasks(self):
+        if self.supported_tasks is None:
+            self.supported_tasks = await self.engine.get_supported_tasks()
+        return self.supported_tasks
+
+    def _ensure_resolved_chat_template(self):
+        if self.resolved_chat_template is None:
+            self.resolved_chat_template = load_chat_template(self.chat_template)
+        return self.resolved_chat_template
+
+    def _chat_template_config(self):
+        return ChatTemplateConfig(
+            chat_template=self._ensure_resolved_chat_template(),
+            chat_template_content_format=self.chat_template_content_format,
+            trust_request_chat_template=self.trust_request_chat_template,
+        )
+
+    async def _ensure_render(self):
+        if self.openai_serving_render is None:
+            self._ensure_model_config()
+            models = await self._ensure_models()
+            self.openai_serving_render = OpenAIServingRender(
+                model_config=self.engine.model_config,
+                renderer=self.engine.renderer,
+                model_registry=models.registry,
+                request_logger=self.request_logger,
+                chat_template=self._ensure_resolved_chat_template(),
+                chat_template_content_format=self.chat_template_content_format,
+                trust_request_chat_template=self.trust_request_chat_template,
+                enable_auto_tools=self.enable_auto_tools,
+                exclude_tools_when_tool_choice_none=self.exclude_tools_when_tool_choice_none,
+                tool_parser=self.tool_parser,
+                reasoning_parser=self.reasoning_parser,
+                default_chat_template_kwargs=self.default_chat_template_kwargs,
+                log_error_stack=self.log_error_stack,
+            )
+        return self.openai_serving_render
+
+    async def _ensure_chat(self):
+        if self.openai_serving_chat is None:
+            self._ensure_model_config()
+            models = await self._ensure_models()
+            render = await self._ensure_render()
+
+            self.openai_serving_chat = OpenAIServingChat(
+                self.engine,
+                models,
+                self.response_role,
+                openai_serving_render=render,
+                request_logger=self.request_logger,
+                chat_template=self._ensure_resolved_chat_template(),
+                chat_template_content_format=self.chat_template_content_format,
+                trust_request_chat_template=self.trust_request_chat_template,
+                return_tokens_as_token_ids=self.return_tokens_as_token_ids,
+                enable_auto_tools=self.enable_auto_tools,
+                exclude_tools_when_tool_choice_none=self.exclude_tools_when_tool_choice_none,
+                tool_parser=self.tool_parser,
+                reasoning_parser=self.reasoning_parser,
+                enable_prompt_tokens_details=self.enable_prompt_tokens_details,
+                enable_force_include_usage=self.enable_force_include_usage,
+                enable_log_outputs=self.enable_log_outputs,
+                enable_log_deltas=self.enable_log_deltas,
+                default_chat_template_kwargs=self.default_chat_template_kwargs,
+            )
+        return self.openai_serving_chat
+
+    async def _ensure_embedding(self):
+        if self.openai_serving_embedding is None:
+            self._ensure_model_config()
+            models = await self._ensure_models()
+            self.openai_serving_embedding = ServingEmbedding(
+                self.engine,
+                models,
+                request_logger=self.request_logger,
+                chat_template_config=self._chat_template_config(),
+                return_tokens_as_token_ids=self.return_tokens_as_token_ids,
+                log_error_stack=self.log_error_stack,
+            )
+        return self.openai_serving_embedding
+
+    async def _ensure_score(self):
+        if self.openai_serving_score is None:
+            self._ensure_model_config()
+            models = await self._ensure_models()
+            supported_tasks = await self._ensure_supported_tasks()
+            self.openai_serving_score = ServingScores(
+                self.engine,
+                models,
+                supported_tasks=supported_tasks,
+                request_logger=self.request_logger,
+                chat_template_config=self._chat_template_config(),
+                return_tokens_as_token_ids=self.return_tokens_as_token_ids,
+                log_error_stack=self.log_error_stack,
+                enable_flash_late_interaction=self.enable_flash_late_interaction,
+            )
+        return self.openai_serving_score
+
+    async def generate(self, payload: Any):
+        await self._ensure_chat()
+        result = await self.openai_serving_chat.create_chat_completion(ChatCompletionRequest(**payload), None)
+
+        is_stream = payload.get("stream") is True
+
+        if isinstance(result, ErrorResponse):
+            if is_stream:
+                logging.error(f"Error during chat completion: {result.error.message}")
+                async def error_generator():
+                    import json
+                    error_data = {
+                        "error": {
+                            "message": "Request processing failed",
+                            "type": "internal_server_error",
+                            "details": str(result.error.message)
+                        }
+                    }
+                    yield f"data: {json.dumps(error_data)}\n\n"
+                    yield "data: [DONE]\n\n"
+                return error_generator()
+
+        return result
+
+    async def generate_embeddings(self, payload: Any):
+        await self._ensure_embedding()
+        try:
+            # Validate and convert the payload to an EmbeddingCompletionRequest
+            request = EmbeddingCompletionRequest(**payload)
+        except (TypeError, ValueError) as e:
+            logging.error(f"Invalid payload for EmbeddingCompletionRequest: {e}")
+            return ErrorResponse(
+                error=ErrorInfo(
+                    message=f"Invalid payload for EmbeddingCompletionRequest: {e}",
+                    type="invalid_request_error",
+                    code=400,
+                )
+            )
+        return await self.openai_serving_embedding(request, None)
+
+    async def rerank(self, payload: Any):
+        """
+        Rerank documents based on their relevance to a query.
+        Uses vLLM's native scoring serving callable for maximum compatibility and performance.
+        """
+        await self._ensure_score()
+        request = RerankRequest(**payload)
+        return await self.openai_serving_score(request, None)
+
+    async def show_available_models(self):
+        models = await self._ensure_models()
+        return await models.show_available_models()
+
+
+app = FastAPI()
+app.add_middleware(RawContextMiddleware, plugins=(RequestIdPlugin(validate=False),))
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _result_to_response(result: Any) -> Response:
+    if isinstance(result, Response):
+        return result
+    if isinstance(result, ErrorResponse):
+        return JSONResponse(content=result.model_dump(), status_code=result.error.code)
+    if hasattr(result, "model_dump"):
+        return JSONResponse(content=result.model_dump())
+    return JSONResponse(content=result)
+
+
+@serve.deployment(ray_actor_options={"num_cpus": 0.1})
+@serve.ingress(app)
+class Controller:
+    def __init__(self, backend: DeploymentHandle):
+        """
+        Controller deployment that handles HTTP routing and calls the backend.
+
+        Args:
+            backend: Handle to the Backend deployment
+        """
+        self.backend = backend
+        print("[Controller] Initialized with backend handle")
+
+    @app.post("/v1/chat/completions")
+    async def chat(self, request: Request):
+        req_obj = await request.json()
+        stream = req_obj.get("stream", False)
+
+        if stream:
+            # Get the streaming generator from the backend
+            r: DeploymentResponseGenerator = self.backend.options(stream=True).generate.remote(req_obj)
+
+            try:
+                first_chunk = await r.__anext__()
+                if isinstance(first_chunk, str) and "error" in first_chunk:
+                    import json
+                    error_data = json.loads(first_chunk.replace("data: ", "").strip())
+                    return JSONResponse(
+                        content=error_data["error"],
+                        status_code=400
+                    )
+            except:
+                pass
+
+            return StreamingResponse(
+                content=r,
+                media_type="text/event-stream"
+            )
+        else:
+            # Handle non-streaming response as before
+            result = await self.backend.options(stream=False).generate.remote(req_obj)
+            return _result_to_response(result)
+
+    @app.post("/v1/embeddings")
+    async def embeddings(self, request: Request):
+        """Embeddings endpoint for text-embedding models"""
+        req_obj = await request.json()
+        result = await self.backend.options(stream=False).generate_embeddings.remote(req_obj)
+        return _result_to_response(result)
+
+    @app.post("/v1/rerank")
+    async def rerank(self, request: Request):
+        """Rerank endpoint for cross-encoder/reranker models"""
+        req_obj = await request.json()
+        result = await self.backend.options(stream=False).rerank.remote(req_obj)
+        return _result_to_response(result)
+
+    @app.get("/v1/models")
+    async def models(self, request: Request):
+        result = await self.backend.show_available_models.remote()
+        return _result_to_response(result)
+
+    @app.get("/health")
+    async def health(self):
+        return {"status": "ok"}
+
+
+def _build_request_router_config(scheduler_config: Dict[str, Any]) -> Optional[RequestRouterConfig]:
+    """Build RequestRouterConfig based on scheduler configuration.
+
+    Args:
+        scheduler_config: Dictionary containing scheduler configuration with keys:
+            - type: SchedulerType (pow2, static_hash, consistent_hash)
+            - virtual_nodes: Number of virtual nodes for consistent hash (default: 100)
+            - load_factor: Load factor for bounded load (default: 1.25)
+            - max_user_messages_for_cache: Number of user messages for cache key (default: 2)
+
+    Returns:
+        RequestRouterConfig if custom scheduler is specified, None for default POW2.
+    """
+    scheduler_type = scheduler_config.get('type', SchedulerType.POW2)
+
+    # Use default POW2 scheduler
+    if scheduler_type == SchedulerType.POW2:
+        print(f"[app_builder] Using default POW2 scheduler")
+        return None
+
+    # Get the custom router class path
+    router_class_path = SCHEDULER_CLASS_PATHS.get(scheduler_type)
+    if not router_class_path:
+        print(f"[app_builder] Unknown scheduler type: {scheduler_type}, using default POW2")
+        return None
+
+    # Build kwargs for the custom router
+    router_kwargs = {}
+    if scheduler_type == SchedulerType.CONSISTENT_HASH:
+        router_kwargs = {
+            "virtual_nodes_per_replica": scheduler_config.get('virtual_nodes', 100),
+            "load_factor": scheduler_config.get('load_factor', 1.25),
+            "max_user_messages_for_cache": scheduler_config.get('max_user_messages_for_cache', 2),
+        }
+
+    print(f"[app_builder] Using custom scheduler: {scheduler_type}, class: {router_class_path}, kwargs: {router_kwargs}")
+
+    return RequestRouterConfig(
+        request_router_class=router_class_path,
+        request_router_kwargs=router_kwargs,
+    )
+
+
+def app_builder(args: Dict[str, Any]) -> Application:
+    """
+    Application builder function that configures and returns the Backend and Controller deployments.
+    """
+    # Extract configuration sections
+    model = args.get('model', {})
+    deployment_options = args.get('deployment_options', {})
+    engine_args = args.get('engine_args', {})  # vLLM-specific engine arguments
+
+    # Extract backend deployment options
+    backend_options = deployment_options.get('backend', {})
+    controller_options = deployment_options.get('controller', {})
+
+    # Extract scheduler configuration and build RequestRouterConfig
+    scheduler_config = deployment_options.get('scheduler', {})
+    request_router_config = _build_request_router_config(scheduler_config)
+
+    # Build backend deployment options
+    backend_deploy_options = {
+        "max_ongoing_requests": backend_options.get('max_ongoing_requests', 100),
+        "num_replicas": backend_options.get('num_replicas', 1),
+        "ray_actor_options": {
+            "num_cpus": backend_options.get('num_cpus', 1),
+            "num_gpus": backend_options.get('num_gpus', 1),
+            "memory": backend_options.get('memory', None),
+            "resources": backend_options.get('resources', {})
+        }
+    }
+
+    # Add request_router_config if custom scheduler is specified
+    if request_router_config is not None:
+        backend_deploy_options["request_router_config"] = request_router_config
+
+    # Override Backend's runtime_env.container with the full config (GPU options,
+    # volume mounts, NFS) so only Backend replicas require GPU nodes.
+    # Ray replaces "container" per-key, so this must be self-contained.
+    backend_container = args.get('backend_container')
+    if backend_container:
+        backend_deploy_options["ray_actor_options"]["runtime_env"] = \
+            build_backend_runtime_env(backend_container)
+
+    # Configure backend deployment
+    backend_deployment = Backend.options(**backend_deploy_options).bind(
+        model_registry_type=model.get('registry_type'),
+        model_name=model.get('name'),
+        model_version=model.get('version'),
+        model_file=model.get('file', ''),
+        model_task=model.get('task'),
+        model_registry_path=model.get('registry_path', ''),
+        model_path=model.get('path', ''),
+        model_serve_name=model.get('serve_name', ''),
+        # Pass all other engine args directly through
+        **engine_args
+    )
+
+    # Configure controller deployment
+    controller_deployment = Controller.options(
+        max_ongoing_requests=backend_options.get('max_ongoing_requests', 100) * backend_options.get('num_replicas', 1),
+        num_replicas=controller_options.get('num_replicas', 1),
+        ray_actor_options={
+            "num_cpus": controller_options.get('num_cpus', 0.1),
+            "num_gpus": controller_options.get('num_gpus', 0)
+        }
+    ).bind(
+        backend=backend_deployment,
+    )
+
+    return controller_deployment

--- a/cluster-image-builder/serve/vllm/v0_24_0/app.py
+++ b/cluster-image-builder/serve/vllm/v0_24_0/app.py
@@ -377,7 +377,17 @@ class Backend:
         Uses vLLM's native scoring serving callable for maximum compatibility and performance.
         """
         await self._ensure_score()
-        request = RerankRequest(**payload)
+        try:
+            request = RerankRequest(**payload)
+        except (TypeError, ValueError) as e:
+            logging.error(f"Invalid payload for RerankRequest: {e}")
+            return ErrorResponse(
+                error=ErrorInfo(
+                    message=f"Invalid payload for RerankRequest: {e}",
+                    type="invalid_request_error",
+                    code=400,
+                )
+            )
         return await self.openai_serving_score(request, None)
 
     async def show_available_models(self):
@@ -406,6 +416,28 @@ def _result_to_response(result: Any) -> Response:
     return JSONResponse(content=result)
 
 
+def _stream_error_response(first_chunk: Any) -> Optional[JSONResponse]:
+    if not isinstance(first_chunk, str) or not first_chunk.startswith("data:"):
+        return None
+
+    payload = first_chunk.removeprefix("data:").strip()
+    if payload == "[DONE]":
+        return None
+
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(data, dict) or "error" not in data:
+        return None
+
+    return JSONResponse(
+        content=data["error"],
+        status_code=400,
+    )
+
+
 @serve.deployment(ray_actor_options={"num_cpus": 0.1})
 @serve.ingress(app)
 class Controller:
@@ -430,18 +462,33 @@ class Controller:
 
             try:
                 first_chunk = await r.__anext__()
-                if isinstance(first_chunk, str) and "error" in first_chunk:
-                    import json
-                    error_data = json.loads(first_chunk.replace("data: ", "").strip())
-                    return JSONResponse(
-                        content=error_data["error"],
-                        status_code=400
-                    )
-            except:
-                pass
+            except StopAsyncIteration:
+                return StreamingResponse(
+                    content=iter(()),
+                    media_type="text/event-stream"
+                )
+            except Exception as e:
+                logging.exception("Failed to initialize chat completion stream")
+                return JSONResponse(
+                    content={
+                        "message": "Failed to initialize chat completion stream",
+                        "type": "internal_server_error",
+                        "details": str(e),
+                    },
+                    status_code=500
+                )
+
+            error_response = _stream_error_response(first_chunk)
+            if error_response is not None:
+                return error_response
+
+            async def stream_with_first_chunk():
+                yield first_chunk
+                async for chunk in r:
+                    yield chunk
 
             return StreamingResponse(
-                content=r,
+                content=stream_with_first_chunk(),
                 media_type="text/event-stream"
             )
         else:

--- a/cluster-image-builder/serve/vllm/v0_24_0/app.py
+++ b/cluster-image-builder/serve/vllm/v0_24_0/app.py
@@ -96,6 +96,7 @@ class Backend:
         print(f"[Backend] Model download completed.")
 
         self.model_id = model_serve_name
+        self.model_path = model_path
         self.model_task = model_task
 
         # Extract FrontendArgs BEFORE creating AsyncEngineArgs to avoid unexpected keyword errors.
@@ -219,10 +220,16 @@ class Backend:
     async def _ensure_models(self):
         if self.openai_serving_models is None:
             self._ensure_model_config()
+            served_model_names = self.engine.model_config.served_model_name
+            if isinstance(served_model_names, str):
+                served_model_names = [served_model_names]
+
             self.openai_serving_models = OpenAIServingModels(
                 self.engine,
-                [BaseModelPath(name=self.engine.model_config.served_model_name,
-                               model_path=self.engine.model_config.served_model_name)]
+                [
+                    BaseModelPath(name=name, model_path=self.model_path)
+                    for name in served_model_names
+                ]
             )
         return self.openai_serving_models
 

--- a/internal/engine/builtin.go
+++ b/internal/engine/builtin.go
@@ -26,6 +26,11 @@ func GetBuiltinEngines() ([]*v1.Engine, error) {
 		return nil, err
 	}
 
+	vllmV0_24_0EngineSchema, err := GetVLLMV0_24_0EngineSchema()
+	if err != nil {
+		return nil, err
+	}
+
 	sglangV0_5_10EngineSchema, err := GetSGLangV0_5_10EngineSchema()
 	if err != nil {
 		return nil, err
@@ -112,6 +117,21 @@ func GetBuiltinEngines() ([]*v1.Engine, error) {
 						DeployTemplate: map[string]map[string]string{
 							"kubernetes": {
 								"default": GetVLLMV0_17_1DeployTemplate(),
+							},
+						},
+					},
+					{
+						Version:      "v0.24.0",
+						ValuesSchema: vllmV0_24_0EngineSchema,
+						Images: map[string]*v1.EngineImage{
+							"nvidia_gpu": {
+								ImageName: "neutree/engine-vllm",
+								Tag:       "v0.24.0-ray2.53.0",
+							},
+						},
+						DeployTemplate: map[string]map[string]string{
+							"kubernetes": {
+								"default": GetVLLMV0_24_0DeployTemplate(),
 							},
 						},
 					},

--- a/internal/engine/builtin.go
+++ b/internal/engine/builtin.go
@@ -126,7 +126,7 @@ func GetBuiltinEngines() ([]*v1.Engine, error) {
 						Images: map[string]*v1.EngineImage{
 							"nvidia_gpu": {
 								ImageName: "neutree/engine-vllm",
-								Tag:       "v0.24.0-ray2.53.0",
+								Tag:       "v0.24.0-neutree1-ray2.53.0",
 							},
 						},
 						DeployTemplate: map[string]map[string]string{

--- a/internal/engine/builtin_test.go
+++ b/internal/engine/builtin_test.go
@@ -42,18 +42,21 @@ func TestGetBuiltinEngines(t *testing.T) {
 		for _, v := range e.Spec.Versions {
 			switch v.Version {
 			case "v0.11.2", "v0.17.1", "v0.24.0":
-				if _, ok := v.Images["nvidia_gpu"]; !ok {
+				img, ok := v.Images["nvidia_gpu"]
+				if !ok {
 					t.Errorf("vllm %s missing nvidia_gpu image", v.Version)
+					continue
+				}
+				if img == nil {
+					t.Errorf("vllm %s nvidia_gpu image config is nil", v.Version)
+					continue
 				}
 				if v.Version == "v0.24.0" {
-					img := v.Images["nvidia_gpu"]
-					if img != nil {
-						if got, want := img.ImageName, "neutree/engine-vllm"; got != want {
-							t.Errorf("vllm %s nvidia_gpu image name mismatch: got %q, want %q", v.Version, got, want)
-						}
-						if got, want := img.Tag, "v0.24.0-neutree1-ray2.53.0"; got != want {
-							t.Errorf("vllm %s nvidia_gpu tag mismatch: got %q, want %q", v.Version, got, want)
-						}
+					if got, want := img.ImageName, "neutree/engine-vllm"; got != want {
+						t.Errorf("vllm %s nvidia_gpu image name mismatch: got %q, want %q", v.Version, got, want)
+					}
+					if got, want := img.Tag, "v0.24.0-neutree1-ray2.53.0"; got != want {
+						t.Errorf("vllm %s nvidia_gpu tag mismatch: got %q, want %q", v.Version, got, want)
 					}
 				}
 				if k8sTemplates, ok := v.DeployTemplate["kubernetes"]; !ok {

--- a/internal/engine/builtin_test.go
+++ b/internal/engine/builtin_test.go
@@ -41,9 +41,20 @@ func TestGetBuiltinEngines(t *testing.T) {
 
 		for _, v := range e.Spec.Versions {
 			switch v.Version {
-			case "v0.11.2", "v0.17.1":
+			case "v0.11.2", "v0.17.1", "v0.24.0":
 				if _, ok := v.Images["nvidia_gpu"]; !ok {
 					t.Errorf("vllm %s missing nvidia_gpu image", v.Version)
+				}
+				if v.Version == "v0.24.0" {
+					img := v.Images["nvidia_gpu"]
+					if img != nil {
+						if got, want := img.ImageName, "neutree/engine-vllm"; got != want {
+							t.Errorf("vllm %s nvidia_gpu image name mismatch: got %q, want %q", v.Version, got, want)
+						}
+						if got, want := img.Tag, "v0.24.0-ray2.53.0"; got != want {
+							t.Errorf("vllm %s nvidia_gpu tag mismatch: got %q, want %q", v.Version, got, want)
+						}
+					}
 				}
 				if k8sTemplates, ok := v.DeployTemplate["kubernetes"]; !ok {
 					t.Errorf("vllm %s missing kubernetes deploy template", v.Version)
@@ -52,6 +63,10 @@ func TestGetBuiltinEngines(t *testing.T) {
 				}
 			}
 		}
+	}
+
+	if _, err := GetDeployTemplate("vllm-v0.24.0"); err != nil {
+		t.Fatalf("DeployTemplates lookup for vLLM v0.24.0 failed: %v", err)
 	}
 
 	// Verify sglang v0.5.10 has nvidia_gpu image, k8s default template, and supported tasks (rerank excluded).

--- a/internal/engine/builtin_test.go
+++ b/internal/engine/builtin_test.go
@@ -51,7 +51,7 @@ func TestGetBuiltinEngines(t *testing.T) {
 						if got, want := img.ImageName, "neutree/engine-vllm"; got != want {
 							t.Errorf("vllm %s nvidia_gpu image name mismatch: got %q, want %q", v.Version, got, want)
 						}
-						if got, want := img.Tag, "v0.24.0-ray2.53.0"; got != want {
+						if got, want := img.Tag, "v0.24.0-neutree1-ray2.53.0"; got != want {
 							t.Errorf("vllm %s nvidia_gpu tag mismatch: got %q, want %q", v.Version, got, want)
 						}
 					}

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -15,6 +15,9 @@ var vllmV0_11_2EngineSchema []byte
 //go:embed vllm/v0.17.1/schema.json
 var vllmV0_17_1EngineSchema []byte
 
+//go:embed vllm/v0.24.0/schema.json
+var vllmV0_24_0EngineSchema []byte
+
 //go:embed llama-cpp/v0.3.7/schema.json
 var llamaCppV0_3_7EngineSchema []byte
 
@@ -50,6 +53,16 @@ func GetVLLMV0_17_1EngineSchema() (map[string]interface{}, error) {
 	return schema, nil
 }
 
+// GetVLLMV0_24_0EngineSchema returns the parsed JSON schema for vLLM V0.24.0 engine
+func GetVLLMV0_24_0EngineSchema() (map[string]interface{}, error) {
+	var schema map[string]interface{}
+	if err := json.Unmarshal(vllmV0_24_0EngineSchema, &schema); err != nil {
+		return nil, fmt.Errorf("failed to parse vLLM V0.24.0 engine schema: %w", err)
+	}
+
+	return schema, nil
+}
+
 // GetLlamaCppDefaultEngineSchema returns the parsed JSON schema for Llama.cpp V0.3.7 engine
 func GetLlamaCppDefaultEngineSchema() (map[string]interface{}, error) {
 	var schema map[string]interface{}
@@ -76,6 +89,7 @@ var EngineSchemas = map[string]func() (map[string]interface{}, error){
 	"llama-cpp-v0.3.7": GetLlamaCppDefaultEngineSchema,
 	"vllm-v0.11.2":     GetVLLMV0_11_2EngineSchema,
 	"vllm-v0.17.1":     GetVLLMV0_17_1EngineSchema,
+	"vllm-v0.24.0":     GetVLLMV0_24_0EngineSchema,
 	"sglang-v0.5.10":   GetSGLangV0_5_10EngineSchema,
 }
 

--- a/internal/engine/schema_test.go
+++ b/internal/engine/schema_test.go
@@ -34,6 +34,45 @@ func TestGetVLLMV0_17_1EngineSchema(t *testing.T) {
 	}
 }
 
+func TestGetVLLMV0_24_0EngineSchema(t *testing.T) {
+	schema, err := GetVLLMV0_24_0EngineSchema()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if schema == nil {
+		t.Fatal("expected schema to be non-nil")
+	}
+
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("schema.properties missing or wrong type")
+	}
+
+	for _, key := range []string{
+		"device_ids",
+		"quantization_config",
+		"diffusion_config",
+		"fingerprint_mode",
+		"fingerprint_value",
+		"enable_flash_late_interaction",
+		"enable_log_requests",
+	} {
+		if _, ok := props[key].(map[string]interface{}); !ok {
+			t.Errorf("schema missing required vLLM v0.24.0 property %q", key)
+		}
+	}
+
+	for _, key := range []string{"swap_space", "use_gpu_for_pooling_score", "lora_modules", "log_config_file"} {
+		if _, ok := props[key]; ok {
+			t.Errorf("schema must not include unsupported or obsolete property %q", key)
+		}
+	}
+
+	if _, err := GetEngineSchema("vllm-v0.24.0"); err != nil {
+		t.Fatalf("EngineSchemas lookup for vLLM v0.24.0 failed: %v", err)
+	}
+}
+
 func TestGetLlamaCppDefaultEngineSchema(t *testing.T) {
 	schema, err := GetLlamaCppDefaultEngineSchema()
 	if err != nil {

--- a/internal/engine/template.go
+++ b/internal/engine/template.go
@@ -12,6 +12,9 @@ var vllmV0_11_2DeployTemplate string
 //go:embed vllm/v0.17.1/templates/kubernetes/default.yaml
 var vllmV0_17_1DeployTemplate string
 
+//go:embed vllm/v0.24.0/templates/kubernetes/default.yaml
+var vllmV0_24_0DeployTemplate string
+
 //go:embed llama-cpp/v0.3.7/templates/kubernetes/default.yaml
 var llamaCppDefaultDeployTemplate string
 
@@ -28,6 +31,11 @@ func GetVLLMV0_17_1DeployTemplate() string {
 	return base64.StdEncoding.EncodeToString([]byte(vllmV0_17_1DeployTemplate))
 }
 
+// GetVLLMV0_24_0DeployTemplate returns the default deployment template for vLLM V0.24.0 engine
+func GetVLLMV0_24_0DeployTemplate() string {
+	return base64.StdEncoding.EncodeToString([]byte(vllmV0_24_0DeployTemplate))
+}
+
 // GetLlamaCppDefaultDeployTemplate returns the default deployment template for Llama.cpp V0.3.7 engine
 func GetLlamaCppDefaultDeployTemplate() string {
 	return base64.StdEncoding.EncodeToString([]byte(llamaCppDefaultDeployTemplate))
@@ -42,6 +50,7 @@ func GetSGLangV0_5_10DeployTemplate() string {
 var DeployTemplates = map[string]func() string{
 	"vllm-v0.11.2":     GetVLLMV0_11_2DeployTemplate,
 	"vllm-v0.17.1":     GetVLLMV0_17_1DeployTemplate,
+	"vllm-v0.24.0":     GetVLLMV0_24_0DeployTemplate,
 	"llama-cpp-v0.3.7": GetLlamaCppDefaultDeployTemplate,
 	"sglang-v0.5.10":   GetSGLangV0_5_10DeployTemplate,
 }

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -124,6 +124,23 @@ func TestBuiltInKubernetesTemplatesPreserveNumericEndpointName(t *testing.T) {
 	}
 }
 
+func TestVLLMTemplatePreservesListEngineArgs(t *testing.T) {
+	vars := newTestVLLMVars("v0.24.0", "text-generation")
+	vars["EngineArgs"] = map[string]any{
+		"served_model_name": []any{"test-model", "neu-vllm-list-alias"},
+	}
+
+	objs, err := util.RenderKubernetesManifest(vllmV0_24_0DeployTemplate, vars)
+	require.NoError(t, err)
+
+	deploy := mustFindRenderedObject(t, objs.Items, "Deployment", "ep-test")
+	cmd := mustExtractContainerCommand(t, deploy.Object, "vllm-engine")
+
+	assert.Equal(t, "test-model", flagValue(cmd, "--served_model_name"), "full cmd=%v", cmd)
+	assert.Contains(t, cmd, "neu-vllm-list-alias", "full cmd=%v", cmd)
+	assert.NotContains(t, cmd, `["test-model","neu-vllm-list-alias"]`, "full cmd=%v", cmd)
+}
+
 // newTestVLLMVars returns the minimum render variables the current vLLM
 // templates require. We mirror the shape produced by setModelArgs in the
 // kubernetes orchestrator without taking a dependency on that package.

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -11,12 +11,29 @@ import (
 	"github.com/neutree-ai/neutree/internal/util"
 )
 
-// TestVLLMV0_17_1TemplateTaskTranslation locks in the contract that the
-// v0.17.1 K8s deploy template explicitly translates the Neutree model task
-// to vLLM's --runner / --convert flags. Without this, vLLM's auto-detect
-// falls back to a generate runner for multimodal embedding architectures
-// and silently breaks /v1/embeddings.
-func TestVLLMV0_17_1TemplateTaskTranslation(t *testing.T) {
+// TestVLLMTemplateTaskTranslation locks in the contract that current vLLM K8s
+// deploy templates explicitly translate the Neutree model task to vLLM's
+// --runner / --convert flags. Without this, vLLM's auto-detect falls back to a
+// generate runner for multimodal embedding architectures and silently breaks
+// /v1/embeddings.
+func TestVLLMTemplateTaskTranslation(t *testing.T) {
+	templates := []struct {
+		name     string
+		version  string
+		template string
+	}{
+		{
+			name:     "vllm v0.17.1",
+			version:  "v0.17.1",
+			template: vllmV0_17_1DeployTemplate,
+		},
+		{
+			name:     "vllm v0.24.0",
+			version:  "v0.24.0",
+			template: vllmV0_24_0DeployTemplate,
+		},
+	}
+
 	tests := []struct {
 		name        string
 		task        string
@@ -43,18 +60,22 @@ func TestVLLMV0_17_1TemplateTaskTranslation(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			vars := newTestVLLMV0_17_1Vars(tc.task)
-			objs, err := util.RenderKubernetesManifest(vllmV0_17_1DeployTemplate, vars)
-			require.NoError(t, err)
-			require.NotEmpty(t, objs.Items)
+	for _, tmpl := range templates {
+		t.Run(tmpl.name, func(t *testing.T) {
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					vars := newTestVLLMVars(tmpl.version, tc.task)
+					objs, err := util.RenderKubernetesManifest(tmpl.template, vars)
+					require.NoError(t, err)
+					require.NotEmpty(t, objs.Items)
 
-			deploy := mustFindRenderedObject(t, objs.Items, "Deployment", "ep-test")
-			cmd := mustExtractContainerCommand(t, deploy.Object, "vllm-engine")
+					deploy := mustFindRenderedObject(t, objs.Items, "Deployment", "ep-test")
+					cmd := mustExtractContainerCommand(t, deploy.Object, "vllm-engine")
 
-			assert.Equal(t, tc.wantRunner, flagValue(cmd, "--runner"), "full cmd=%v", cmd)
-			assert.Equal(t, tc.wantConvert, flagValue(cmd, "--convert"), "full cmd=%v", cmd)
+					assert.Equal(t, tc.wantRunner, flagValue(cmd, "--runner"), "full cmd=%v", cmd)
+					assert.Equal(t, tc.wantConvert, flagValue(cmd, "--convert"), "full cmd=%v", cmd)
+				})
+			}
 		})
 	}
 }
@@ -73,6 +94,10 @@ func TestBuiltInKubernetesTemplatesPreserveNumericEndpointName(t *testing.T) {
 			template: vllmV0_17_1DeployTemplate,
 		},
 		{
+			name:     "vllm v0.24.0",
+			template: vllmV0_24_0DeployTemplate,
+		},
+		{
 			name:     "sglang v0.5.10",
 			template: sglangV0_5_10DeployTemplate,
 		},
@@ -84,7 +109,7 @@ func TestBuiltInKubernetesTemplatesPreserveNumericEndpointName(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			vars := newTestVLLMV0_17_1Vars("text-generation")
+			vars := newTestVLLMVars("v0.17.1", "text-generation")
 			vars["EndpointName"] = "4096"
 
 			objs, err := util.RenderKubernetesManifest(tc.template, vars)
@@ -99,22 +124,22 @@ func TestBuiltInKubernetesTemplatesPreserveNumericEndpointName(t *testing.T) {
 	}
 }
 
-// newTestVLLMV0_17_1Vars returns the minimum render variables the v0.17.1
-// template requires. We mirror the shape produced by setModelArgs in the
+// newTestVLLMVars returns the minimum render variables the current vLLM
+// templates require. We mirror the shape produced by setModelArgs in the
 // kubernetes orchestrator without taking a dependency on that package.
-func newTestVLLMV0_17_1Vars(task string) map[string]any {
+func newTestVLLMVars(version, task string) map[string]any {
 	return map[string]any{
 		"EndpointName":   "ep-test",
 		"Namespace":      "default",
 		"EngineName":     "vllm-engine",
-		"EngineVersion":  "v0.17.1",
+		"EngineVersion":  version,
 		"RoutingLogic":   "rr",
 		"ClusterName":    "test",
 		"Workspace":      "ws",
 		"Replicas":       1,
 		"ImagePrefix":    "registry.test",
 		"ImageRepo":      "neutree/engine-vllm",
-		"ImageTag":       "v0.17.1",
+		"ImageTag":       version,
 		"NeutreeVersion": "v0.0.0",
 		"ModelArgs": map[string]any{
 			"name":          "test-model",

--- a/internal/engine/vllm/v0.24.0/schema.json
+++ b/internal/engine/vllm/v0.24.0/schema.json
@@ -1,0 +1,1329 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "vLLM v0.24.0 Engine Arguments",
+  "description": "JSON schema for vLLM v0.24.0 engine arguments supported by Neutree.",
+  "properties": {
+    "model": {
+      "description": "Name or path of the Hugging Face model to use",
+      "type": "string"
+    },
+    "enable_return_routed_experts": {
+      "default": false,
+      "description": "Enable returning routed expert info",
+      "type": "boolean"
+    },
+    "model_weights": {
+      "description": "Path to model weights separate from config",
+      "type": "string"
+    },
+    "served_model_name": {
+      "description": "The model name(s) used in the API",
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "tokenizer": {
+      "description": "Name or path of the Hugging Face tokenizer to use",
+      "type": "string"
+    },
+    "hf_config_path": {
+      "description": "Name or path of the Hugging Face config to use",
+      "type": "string"
+    },
+    "runner": {
+      "default": "auto",
+      "description": "The type of model runner to use",
+      "type": "string",
+      "enum": [
+        "auto",
+        "generate",
+        "pooling",
+        "draft"
+      ]
+    },
+    "convert": {
+      "default": "auto",
+      "description": "Convert the model using adapters",
+      "type": "string",
+      "enum": [
+        "auto",
+        "none",
+        "embed",
+        "classify"
+      ]
+    },
+    "skip_tokenizer_init": {
+      "default": false,
+      "description": "Skip initialization of tokenizer and detokenizer",
+      "type": "boolean"
+    },
+    "enable_prompt_embeds": {
+      "default": false,
+      "description": "Enable passing text embeddings via prompt_embeds",
+      "type": "boolean"
+    },
+    "tokenizer_mode": {
+      "default": "auto",
+      "description": "The tokenizer mode to use",
+      "type": "string"
+    },
+    "trust_remote_code": {
+      "default": false,
+      "description": "Trust remote code from Hugging Face",
+      "type": "boolean"
+    },
+    "allowed_local_media_path": {
+      "default": "",
+      "description": "Allowed local media path for security",
+      "type": "string"
+    },
+    "allowed_media_domains": {
+      "description": "Allowed media domains for multi-modal inputs",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "download_dir": {
+      "description": "Directory to download and load weights",
+      "type": "string"
+    },
+    "safetensors_load_strategy": {
+      "default": "lazy",
+      "description": "Loading strategy for safetensors weights",
+      "type": "string"
+    },
+    "safetensors_prefetch_num_threads": {
+      "type": "integer",
+      "description": "Safetensors prefetch num threads"
+    },
+    "safetensors_prefetch_block_size": {
+      "type": "integer",
+      "description": "Safetensors prefetch block size"
+    },
+    "load_format": {
+      "default": "auto",
+      "description": "The format of model weights to load",
+      "type": "string"
+    },
+    "config_format": {
+      "default": "auto",
+      "description": "The format of the model config to load",
+      "type": "string"
+    },
+    "dtype": {
+      "default": "auto",
+      "description": "Data type for model weights and activations",
+      "type": "string",
+      "enum": [
+        "auto",
+        "half",
+        "float16",
+        "bfloat16",
+        "float",
+        "float32"
+      ]
+    },
+    "kv_cache_dtype": {
+      "default": "auto",
+      "description": "Data type for KV cache storage",
+      "type": "string",
+      "enum": [
+        "auto",
+        "float16",
+        "bfloat16",
+        "fp8",
+        "fp8_e4m3",
+        "fp8_e5m2",
+        "fp8_inc",
+        "fp8_ds_mla",
+        "turboquant_k8v4",
+        "turboquant_4bit_nc",
+        "turboquant_k3v4_nc",
+        "turboquant_3bit_nc",
+        "int8_per_token_head",
+        "fp8_per_token_head",
+        "nvfp4"
+      ]
+    },
+    "seed": {
+      "minimum": 0,
+      "description": "Random seed for reproducibility",
+      "type": "integer"
+    },
+    "max_model_len": {
+      "description": "Model context length",
+      "type": "integer"
+    },
+    "cudagraph_capture_sizes": {
+      "description": "Sizes to capture cudagraph",
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
+    "max_cudagraph_capture_size": {
+      "description": "Maximum cudagraph capture size",
+      "type": "integer"
+    },
+    "ir_op_priority": {
+      "type": "object",
+      "description": "Ir op priority"
+    },
+    "distributed_executor_backend": {
+      "description": "Backend for distributed model workers",
+      "type": [
+        "string",
+        "object"
+      ]
+    },
+    "pipeline_parallel_size": {
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of pipeline parallel groups",
+      "type": "integer"
+    },
+    "master_addr": {
+      "default": "127.0.0.1",
+      "description": "Distributed master address",
+      "type": "string"
+    },
+    "master_port": {
+      "default": 29501,
+      "description": "Distributed master port",
+      "type": "integer"
+    },
+    "nnodes": {
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of nodes for multi-node inference",
+      "type": "integer"
+    },
+    "node_rank": {
+      "minimum": 0,
+      "default": 0,
+      "description": "Distributed node rank",
+      "type": "integer"
+    },
+    "distributed_timeout_seconds": {
+      "type": "integer",
+      "description": "Distributed timeout seconds"
+    },
+    "cpu_distributed_timeout_seconds": {
+      "type": "integer",
+      "description": "Cpu distributed timeout seconds"
+    },
+    "numa_bind": {
+      "type": "boolean",
+      "description": "Numa bind"
+    },
+    "numa_bind_nodes": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Numa bind nodes"
+    },
+    "numa_bind_cpus": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Numa bind cpus"
+    },
+    "tensor_parallel_size": {
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of tensor parallel groups",
+      "type": "integer"
+    },
+    "prefill_context_parallel_size": {
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of prefill context parallel groups",
+      "type": "integer"
+    },
+    "decode_context_parallel_size": {
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of decode context parallel groups",
+      "type": "integer"
+    },
+    "dcp_comm_backend": {
+      "type": "string",
+      "enum": [
+        "ag_rs",
+        "a2a"
+      ],
+      "description": "Dcp comm backend"
+    },
+    "dcp_kv_cache_interleave_size": {
+      "description": "KV cache interleave size for decode context parallelism",
+      "type": "integer"
+    },
+    "cp_kv_cache_interleave_size": {
+      "description": "KV cache interleave size for context parallelism",
+      "type": "integer"
+    },
+    "data_parallel_size": {
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of data parallel replicas",
+      "type": "integer"
+    },
+    "data_parallel_rank": {
+      "minimum": 0,
+      "description": "Data parallel rank of this instance",
+      "type": "integer"
+    },
+    "data_parallel_start_rank": {
+      "minimum": 0,
+      "description": "Starting data parallel rank for secondary nodes",
+      "type": "integer"
+    },
+    "data_parallel_size_local": {
+      "minimum": 1,
+      "description": "Number of data parallel replicas on this node",
+      "type": "integer"
+    },
+    "data_parallel_address": {
+      "description": "Address of data parallel cluster head-node",
+      "type": "string"
+    },
+    "data_parallel_rpc_port": {
+      "description": "Port for data parallel RPC communication",
+      "type": "integer"
+    },
+    "data_parallel_hybrid_lb": {
+      "default": false,
+      "description": "Use hybrid DP load balancing mode",
+      "type": "boolean"
+    },
+    "data_parallel_external_lb": {
+      "default": false,
+      "description": "Use external DP load balancing mode",
+      "type": "boolean"
+    },
+    "data_parallel_multi_port_external_lb": {
+      "type": "boolean",
+      "default": false,
+      "description": "Data parallel multi port external lb"
+    },
+    "data_parallel_backend": {
+      "default": "mp",
+      "description": "Backend for data parallel",
+      "type": "string",
+      "enum": [
+        "ray",
+        "mp"
+      ]
+    },
+    "enable_expert_parallel": {
+      "default": false,
+      "description": "Enable expert parallelism for MoE models",
+      "type": "boolean"
+    },
+    "enable_ep_weight_filter": {
+      "type": "boolean",
+      "description": "Enable ep weight filter"
+    },
+    "moe_backend": {
+      "description": "Explicit kernel selection for MoE",
+      "type": "string",
+      "enum": [
+        "auto",
+        "triton",
+        "deep_gemm",
+        "deep_gemm_mega_moe",
+        "cutlass",
+        "flashinfer_trtllm",
+        "flashinfer_cutlass",
+        "flashinfer_cutedsl",
+        "flashinfer_b12x",
+        "marlin",
+        "humming",
+        "triton_unfused",
+        "aiter",
+        "emulation"
+      ]
+    },
+    "linear_backend": {
+      "type": "string",
+      "enum": [
+        "auto",
+        "cutlass",
+        "flashinfer_cutlass",
+        "flashinfer_trtllm",
+        "flashinfer_cudnn",
+        "marlin",
+        "triton",
+        "deep_gemm",
+        "torch",
+        "aiter",
+        "machete",
+        "fbgemm",
+        "conch",
+        "exllama",
+        "emulation"
+      ],
+      "description": "Linear backend"
+    },
+    "all2all_backend": {
+      "description": "All2All backend for MoE expert parallel",
+      "type": "string",
+      "enum": [
+        "naive",
+        "pplx",
+        "deepep_high_throughput",
+        "deepep_low_latency",
+        "mori",
+        "nixl_ep",
+        "allgather_reducescatter",
+        "flashinfer_all2allv",
+        "flashinfer_nvlink_two_sided",
+        "flashinfer_nvlink_one_sided"
+      ]
+    },
+    "enable_elastic_ep": {
+      "default": false,
+      "description": "Enable elastic expert parallelism",
+      "type": "boolean"
+    },
+    "enable_dbo": {
+      "default": false,
+      "description": "Enable dual batch overlap",
+      "type": "boolean"
+    },
+    "ubatch_size": {
+      "description": "Micro-batch size for dual batch overlap",
+      "type": "integer"
+    },
+    "dbo_decode_token_threshold": {
+      "default": 32,
+      "description": "Token threshold for dual batch overlap decode",
+      "type": "integer"
+    },
+    "dbo_prefill_token_threshold": {
+      "default": 512,
+      "description": "Token threshold for dual batch overlap prefill",
+      "type": "integer"
+    },
+    "disable_nccl_for_dp_synchronization": {
+      "description": "Force DP sync to use Gloo instead of NCCL",
+      "type": "boolean"
+    },
+    "eplb_config": {
+      "description": "Expert parallelism load balancing configuration",
+      "type": "object"
+    },
+    "enable_eplb": {
+      "default": false,
+      "description": "Enable expert parallelism load balancing",
+      "type": "boolean"
+    },
+    "expert_placement_strategy": {
+      "default": "linear",
+      "description": "Expert placement strategy for MoE layers",
+      "type": "string",
+      "enum": [
+        "linear",
+        "round_robin"
+      ]
+    },
+    "max_parallel_loading_workers": {
+      "description": "Maximum number of parallel loading workers",
+      "type": "integer"
+    },
+    "block_size": {
+      "description": "Size of a contiguous cache block",
+      "type": "integer"
+    },
+    "enable_prefix_caching": {
+      "description": "Enable prefix caching",
+      "type": "boolean"
+    },
+    "prefix_caching_hash_algo": {
+      "default": "sha256",
+      "description": "Hash algorithm for prefix caching",
+      "type": "string",
+      "enum": [
+        "sha256",
+        "sha256_cbor",
+        "xxhash",
+        "xxhash_cbor"
+      ]
+    },
+    "disable_sliding_window": {
+      "default": false,
+      "description": "Disable sliding window attention",
+      "type": "boolean"
+    },
+    "disable_cascade_attn": {
+      "default": false,
+      "description": "Disable cascade attention for V1",
+      "type": "boolean"
+    },
+    "offload_backend": {
+      "default": "auto",
+      "description": "Backend for weight offloading",
+      "type": "string"
+    },
+    "cpu_offload_gb": {
+      "minimum": 0,
+      "default": 0,
+      "description": "The space in GiB to offload to CPU",
+      "type": "number"
+    },
+    "cpu_offload_params": {
+      "description": "Parameter names to offload to CPU",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "offload_group_size": {
+      "description": "Group size for weight offloading",
+      "type": "integer"
+    },
+    "offload_num_in_group": {
+      "description": "Number of layers in each offload group",
+      "type": "integer"
+    },
+    "offload_prefetch_step": {
+      "description": "Prefetch step for weight offloading",
+      "type": "integer"
+    },
+    "offload_params": {
+      "description": "Parameter names for offloading",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "gpu_memory_utilization": {
+      "minimum": 0,
+      "maximum": 1.0,
+      "default": 0.9,
+      "description": "The fraction of GPU memory to be used",
+      "type": "number"
+    },
+    "kv_cache_memory_bytes": {
+      "description": "Size of KV Cache per GPU in bytes",
+      "type": "integer"
+    },
+    "max_num_batched_tokens": {
+      "description": "Maximum number of batched tokens per iteration",
+      "type": "integer"
+    },
+    "max_num_partial_prefills": {
+      "default": 1,
+      "description": "Max concurrent partial prefills for chunked prefill",
+      "type": "integer"
+    },
+    "max_long_partial_prefills": {
+      "default": 1,
+      "description": "Max concurrent long prompts for chunked prefill",
+      "type": "integer"
+    },
+    "long_prefill_token_threshold": {
+      "default": 0,
+      "description": "Token threshold for long prefill",
+      "type": "integer"
+    },
+    "max_num_seqs": {
+      "description": "Maximum number of sequences per iteration",
+      "type": "integer"
+    },
+    "max_logprobs": {
+      "default": 20,
+      "description": "Maximum number of log probabilities to return",
+      "type": "integer"
+    },
+    "logprobs_mode": {
+      "default": "raw_logprobs",
+      "description": "Indicates the content returned in logprobs",
+      "type": "string",
+      "enum": [
+        "raw_logits",
+        "raw_logprobs",
+        "processed_logits",
+        "processed_logprobs"
+      ]
+    },
+    "use_fp64_gumbel": {
+      "type": "boolean",
+      "description": "Use fp64 gumbel"
+    },
+    "disable_log_stats": {
+      "default": false,
+      "description": "Disable logging statistics",
+      "type": "boolean"
+    },
+    "aggregate_engine_logging": {
+      "default": false,
+      "description": "Log aggregate statistics with data parallel",
+      "type": "boolean"
+    },
+    "revision": {
+      "description": "The specific model version to use",
+      "type": "string"
+    },
+    "code_revision": {
+      "description": "The specific revision to use for the model code",
+      "type": "string"
+    },
+    "hf_token": {
+      "description": "Hugging Face token for authentication",
+      "type": [
+        "string",
+        "boolean"
+      ]
+    },
+    "hf_overrides": {
+      "default": {},
+      "description": "Arguments to be forwarded to HuggingFace config",
+      "type": "object"
+    },
+    "tokenizer_revision": {
+      "description": "Revision of the tokenizer to use",
+      "type": "string"
+    },
+    "quantization": {
+      "description": "Method used to quantize the weights",
+      "type": "string"
+    },
+    "quantization_config": {
+      "type": "object",
+      "description": "User-facing quantization configuration. Carries per-layer-kind QuantSpecs (linear, moe) and ignore patterns; see :class:`QuantizationConfigArgs`. Auto-populated from the matching online shorthand when `quantization` is one of the values in `ONLINE_QUANT_SHORTHAND_NAMES`."
+    },
+    "allow_deprecated_quantization": {
+      "default": false,
+      "description": "Allow deprecated quantization methods",
+      "type": "boolean"
+    },
+    "enforce_eager": {
+      "default": false,
+      "description": "Always use eager-mode PyTorch",
+      "type": "boolean"
+    },
+    "disable_custom_all_reduce": {
+      "default": false,
+      "description": "Disable custom all-reduce kernels",
+      "type": "boolean"
+    },
+    "language_model_only": {
+      "default": false,
+      "description": "Only load language model, skip non-LM components",
+      "type": "boolean"
+    },
+    "limit_mm_per_prompt": {
+      "default": {},
+      "description": "Maximum number of multi-modal items per prompt",
+      "type": "object"
+    },
+    "enable_mm_embeds": {
+      "default": false,
+      "description": "Enable passing multimodal embeddings",
+      "type": "boolean"
+    },
+    "interleave_mm_strings": {
+      "default": false,
+      "description": "Enable fully interleaved multimodal prompts",
+      "type": "boolean"
+    },
+    "media_io_kwargs": {
+      "default": {},
+      "description": "Additional args for processing media inputs",
+      "type": "object"
+    },
+    "mm_processor_kwargs": {
+      "description": "Arguments forwarded to multi-modal processor",
+      "type": "object"
+    },
+    "mm_processor_cache_gb": {
+      "default": 4,
+      "description": "Size (GiB) of multi-modal processor cache",
+      "type": "number"
+    },
+    "mm_processor_cache_type": {
+      "description": "Type of cache for multi-modal processor",
+      "type": "string",
+      "enum": [
+        "shm",
+        "lru"
+      ]
+    },
+    "mm_shm_cache_max_object_size_mb": {
+      "default": 128,
+      "description": "Max object size (MiB) in shared memory cache",
+      "type": "integer"
+    },
+    "mm_encoder_only": {
+      "default": false,
+      "description": "Only use multimodal encoder",
+      "type": "boolean"
+    },
+    "mm_encoder_tp_mode": {
+      "description": "Multi-modal encoder tensor parallel mode",
+      "type": "string",
+      "enum": [
+        "weights",
+        "data"
+      ]
+    },
+    "mm_encoder_attn_backend": {
+      "description": "Multi-modal encoder attention backend",
+      "type": "string"
+    },
+    "mm_encoder_attn_dtype": {
+      "type": "string",
+      "description": "Mm encoder attn dtype"
+    },
+    "mm_encoder_fp8_scale_path": {
+      "type": "string",
+      "description": "Mm encoder fp8 scale path"
+    },
+    "mm_encoder_fp8_scale_save_path": {
+      "type": "string",
+      "description": "Mm encoder fp8 scale save path"
+    },
+    "mm_encoder_fp8_scale_save_margin": {
+      "type": "number",
+      "description": "Mm encoder fp8 scale save margin"
+    },
+    "io_processor_plugin": {
+      "description": "IOProcessor plugin name to load at startup",
+      "type": "string"
+    },
+    "renderer_num_workers": {
+      "type": "integer",
+      "default": 1,
+      "description": "Renderer num workers"
+    },
+    "skip_mm_profiling": {
+      "default": false,
+      "description": "Skip multimodal memory profiling",
+      "type": "boolean"
+    },
+    "video_pruning_rate": {
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Pruning rate for video via Efficient Video Sampling",
+      "type": "number"
+    },
+    "mm_tensor_ipc": {
+      "type": "string",
+      "enum": [
+        "direct_rpc",
+        "torch_shm"
+      ],
+      "description": "Mm tensor ipc"
+    },
+    "enable_lora": {
+      "description": "Enable handling of LoRA adapters",
+      "type": "boolean",
+      "default": false
+    },
+    "max_loras": {
+      "minimum": 1,
+      "default": 1,
+      "description": "Maximum number of LoRA adapters",
+      "type": "integer"
+    },
+    "max_lora_rank": {
+      "default": 16,
+      "description": "Maximum LoRA rank",
+      "type": "integer",
+      "enum": [
+        1,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        320,
+        512
+      ]
+    },
+    "default_mm_loras": {
+      "description": "Default LoRA paths for specific modalities",
+      "type": "object"
+    },
+    "fully_sharded_loras": {
+      "default": false,
+      "description": "Use fully sharded LoRA layers",
+      "type": "boolean"
+    },
+    "max_cpu_loras": {
+      "description": "Maximum number of LoRAs to store in CPU memory",
+      "type": "integer"
+    },
+    "lora_dtype": {
+      "default": "auto",
+      "description": "Data type for LoRA",
+      "type": "string"
+    },
+    "lora_target_modules": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Lora target modules"
+    },
+    "enable_tower_connector_lora": {
+      "default": false,
+      "description": "Enable tower connector LoRA",
+      "type": "boolean"
+    },
+    "specialize_active_lora": {
+      "default": false,
+      "description": "Specialize CUDA graphs for active LoRA",
+      "type": "boolean"
+    },
+    "enable_mixed_moe_lora_format": {
+      "type": "boolean",
+      "description": "Enable mixed moe lora format"
+    },
+    "ray_workers_use_nsight": {
+      "default": false,
+      "description": "Profile Ray workers with nsight",
+      "type": "boolean"
+    },
+    "num_gpu_blocks_override": {
+      "description": "Override profiled num_gpu_blocks",
+      "type": "integer"
+    },
+    "model_loader_extra_config": {
+      "default": {},
+      "description": "Extra config for model loader",
+      "type": "object"
+    },
+    "ignore_patterns": {
+      "default": [
+        "original/**/*"
+      ],
+      "description": "Patterns to ignore when loading model",
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "enable_chunked_prefill": {
+      "description": "Enable chunked prefill requests",
+      "type": "boolean"
+    },
+    "disable_chunked_mm_input": {
+      "default": false,
+      "description": "Disable partial scheduling of multimodal items",
+      "type": "boolean"
+    },
+    "scheduler_reserve_full_isl": {
+      "type": "boolean",
+      "description": "Scheduler reserve full isl"
+    },
+    "disable_hybrid_kv_cache_manager": {
+      "description": "Disable hybrid KV cache manager",
+      "type": "boolean"
+    },
+    "structured_outputs_config": {
+      "description": "Structured outputs configuration",
+      "type": "object"
+    },
+    "reasoning_parser": {
+      "default": "",
+      "description": "Reasoning parser to use",
+      "type": "string"
+    },
+    "reasoning_parser_plugin": {
+      "description": "Path to reasoning parser plugin",
+      "type": "string"
+    },
+    "speculative_config": {
+      "description": "Speculative decoding configuration",
+      "type": "object"
+    },
+    "spec_method": {
+      "type": "string",
+      "description": "Spec method"
+    },
+    "spec_model": {
+      "type": "string",
+      "description": "Spec model"
+    },
+    "spec_tokens": {
+      "type": "integer",
+      "description": "Spec tokens"
+    },
+    "show_hidden_metrics_for_version": {
+      "description": "Show hidden metrics since specified version",
+      "type": "string"
+    },
+    "otlp_traces_endpoint": {
+      "description": "OpenTelemetry traces target URL",
+      "type": "string"
+    },
+    "collect_detailed_traces": {
+      "description": "Collect detailed traces for specified modules",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "kv_cache_metrics": {
+      "default": false,
+      "description": "Enable KV cache metrics",
+      "type": "boolean"
+    },
+    "kv_cache_metrics_sample": {
+      "default": 0.0,
+      "description": "KV cache metrics sampling rate",
+      "type": "number"
+    },
+    "cudagraph_metrics": {
+      "default": false,
+      "description": "Enable CUDA graph metrics",
+      "type": "boolean"
+    },
+    "enable_layerwise_nvtx_tracing": {
+      "default": false,
+      "description": "Enable layer-wise NVTX tracing",
+      "type": "boolean"
+    },
+    "enable_mfu_metrics": {
+      "default": false,
+      "description": "Enable MFU metrics",
+      "type": "boolean"
+    },
+    "enable_logging_iteration_details": {
+      "default": false,
+      "description": "Enable logging per-iteration details",
+      "type": "boolean"
+    },
+    "enable_mm_processor_stats": {
+      "default": false,
+      "description": "Enable multi-modal processor statistics",
+      "type": "boolean"
+    },
+    "scheduling_policy": {
+      "default": "fcfs",
+      "description": "The scheduling policy to use",
+      "type": "string",
+      "enum": [
+        "fcfs",
+        "priority"
+      ]
+    },
+    "scheduler_cls": {
+      "description": "The scheduler class to use",
+      "type": [
+        "string",
+        "object"
+      ]
+    },
+    "pooler_config": {
+      "description": "Pooler config for output pooling behavior",
+      "type": "object"
+    },
+    "compilation_config": {
+      "description": "torch.compile and cudagraph configuration",
+      "type": "object"
+    },
+    "attention_config": {
+      "description": "Attention configuration",
+      "type": "object"
+    },
+    "mamba_config": {
+      "type": "object",
+      "description": "Mamba config"
+    },
+    "kernel_config": {
+      "description": "Kernel configuration",
+      "type": "object"
+    },
+    "enable_flashinfer_autotune": {
+      "default": false,
+      "description": "Enable FlashInfer auto-tuning",
+      "type": "boolean"
+    },
+    "worker_cls": {
+      "default": "auto",
+      "description": "Full name of the worker class to use",
+      "type": "string"
+    },
+    "worker_extension_cls": {
+      "default": "",
+      "description": "Worker extension class name",
+      "type": "string"
+    },
+    "profiler_config": {
+      "description": "Profiler configuration",
+      "type": "object"
+    },
+    "kv_transfer_config": {
+      "description": "Distributed KV cache transfer config",
+      "type": "object"
+    },
+    "kv_events_config": {
+      "description": "Event publishing configuration",
+      "type": "object"
+    },
+    "ec_transfer_config": {
+      "description": "Distributed EC cache transfer config",
+      "type": "object"
+    },
+    "reasoning_config": {
+      "type": "object",
+      "description": "Reasoning config"
+    },
+    "generation_config": {
+      "default": "auto",
+      "description": "Path to generation config",
+      "type": "string"
+    },
+    "enable_sleep_mode": {
+      "default": false,
+      "description": "Enable sleep mode for the engine",
+      "type": "boolean"
+    },
+    "enable_cumem_allocator": {
+      "type": "boolean",
+      "description": "Enable cumem allocator"
+    },
+    "override_generation_config": {
+      "default": {},
+      "description": "Override generation config parameters",
+      "type": "object"
+    },
+    "model_impl": {
+      "default": "auto",
+      "description": "Which implementation of the model to use",
+      "type": "string"
+    },
+    "override_attention_dtype": {
+      "description": "Override dtype for attention",
+      "type": "string"
+    },
+    "attention_backend": {
+      "description": "Attention backend to use",
+      "type": "string"
+    },
+    "calculate_kv_scales": {
+      "default": false,
+      "description": "Enable dynamic calculation of k_scale and v_scale",
+      "type": "boolean"
+    },
+    "kv_cache_dtype_skip_layers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Kv cache dtype skip layers"
+    },
+    "mamba_cache_dtype": {
+      "default": "auto",
+      "description": "Data type for Mamba cache",
+      "type": "string",
+      "enum": [
+        "auto",
+        "float32",
+        "float16",
+        "bfloat16"
+      ]
+    },
+    "mamba_ssm_cache_dtype": {
+      "default": "auto",
+      "description": "Data type for Mamba SSM state",
+      "type": "string",
+      "enum": [
+        "auto",
+        "float32",
+        "float16",
+        "bfloat16"
+      ]
+    },
+    "mamba_block_size": {
+      "description": "Block size for mamba cache",
+      "type": "integer"
+    },
+    "mamba_cache_mode": {
+      "default": "auto",
+      "description": "Mamba cache mode",
+      "type": "string",
+      "enum": [
+        "all",
+        "align",
+        "none"
+      ]
+    },
+    "mamba_backend": {
+      "type": "string",
+      "enum": [
+        "triton",
+        "flashinfer"
+      ],
+      "description": "Mamba backend"
+    },
+    "enable_mamba_cache_stochastic_rounding": {
+      "type": "boolean",
+      "description": "Enable mamba cache stochastic rounding"
+    },
+    "mamba_cache_philox_rounds": {
+      "type": "integer",
+      "description": "Mamba cache philox rounds"
+    },
+    "additional_config": {
+      "default": {},
+      "description": "Additional platform-specific configuration",
+      "type": "object"
+    },
+    "use_tqdm_on_load": {
+      "default": true,
+      "description": "Enable tqdm progress bar when loading",
+      "type": "boolean"
+    },
+    "pt_load_map_location": {
+      "default": "cpu",
+      "description": "Map location for loading pytorch checkpoint",
+      "type": [
+        "string",
+        "object"
+      ]
+    },
+    "logits_processors": {
+      "description": "Logits processors class names",
+      "type": "array"
+    },
+    "async_scheduling": {
+      "description": "Perform async scheduling",
+      "type": "boolean"
+    },
+    "stream_interval": {
+      "default": 1,
+      "description": "Interval for streaming in terms of tokens",
+      "type": "integer"
+    },
+    "kv_sharing_fast_prefill": {
+      "default": false,
+      "description": "Enable KV sharing fast prefill optimization",
+      "type": "boolean"
+    },
+    "optimization_level": {
+      "default": 0,
+      "description": "Optimization level (O0-O3)",
+      "type": "integer",
+      "enum": [
+        0,
+        1,
+        2,
+        3
+      ]
+    },
+    "performance_mode": {
+      "description": "Simplifies performance tuning",
+      "type": "string",
+      "enum": [
+        "balanced",
+        "interactivity",
+        "throughput"
+      ]
+    },
+    "kv_offloading_size": {
+      "description": "Size of KV cache offloading buffer (GiB)",
+      "type": "number"
+    },
+    "kv_offloading_backend": {
+      "description": "Backend for KV cache offloading",
+      "type": "string",
+      "enum": [
+        "native",
+        "lmcache"
+      ]
+    },
+    "tokens_only": {
+      "default": false,
+      "description": "Only enable Tokens In/Out endpoint",
+      "type": "boolean"
+    },
+    "shutdown_timeout": {
+      "type": "integer",
+      "default": 0,
+      "description": "Shutdown timeout"
+    },
+    "weight_transfer_config": {
+      "description": "Weight transfer configuration",
+      "type": "object"
+    },
+    "fail_on_environ_validation": {
+      "default": false,
+      "description": "Fail on environment variable validation errors",
+      "type": "boolean"
+    },
+    "gdn_prefill_backend": {
+      "type": "string",
+      "enum": [
+        "flashinfer",
+        "triton",
+        "cutedsl"
+      ],
+      "description": "Gdn prefill backend"
+    },
+    "enable_log_requests": {
+      "default": false,
+      "description": "Enable logging of API requests",
+      "type": "boolean"
+    },
+    "chat_template": {
+      "description": "Chat template file path or inline template",
+      "type": "string"
+    },
+    "chat_template_content_format": {
+      "default": "auto",
+      "description": "Chat template content format",
+      "type": "string",
+      "enum": [
+        "auto",
+        "string",
+        "openai"
+      ]
+    },
+    "trust_request_chat_template": {
+      "default": false,
+      "description": "Trust chat template from request",
+      "type": "boolean"
+    },
+    "default_chat_template_kwargs": {
+      "description": "Default kwargs for chat template renderer",
+      "type": "object"
+    },
+    "response_role": {
+      "default": "assistant",
+      "description": "Role name to return for generation",
+      "type": "string"
+    },
+    "return_tokens_as_token_ids": {
+      "default": false,
+      "description": "Represent tokens as token_id:{id} strings",
+      "type": "boolean"
+    },
+    "enable_auto_tool_choice": {
+      "default": false,
+      "description": "Enable auto tool choice",
+      "type": "boolean"
+    },
+    "exclude_tools_when_tool_choice_none": {
+      "default": false,
+      "description": "Exclude tools when tool_choice is none",
+      "type": "boolean"
+    },
+    "tool_call_parser": {
+      "description": "Tool call parser to use",
+      "type": "string"
+    },
+    "tool_parser_plugin": {
+      "default": "",
+      "description": "Tool parser plugin path",
+      "type": "string"
+    },
+    "tool_server": {
+      "description": "Tool server host:port pairs",
+      "type": "string"
+    },
+    "max_log_len": {
+      "type": "integer",
+      "description": "Max number of prompt characters or prompt ID numbers being printed in log. The default of None means unlimited."
+    },
+    "enable_prompt_tokens_details": {
+      "default": false,
+      "description": "Enable prompt tokens details in response",
+      "type": "boolean"
+    },
+    "enable_server_load_tracking": {
+      "default": false,
+      "description": "Track server_load_metrics in app state",
+      "type": "boolean"
+    },
+    "enable_force_include_usage": {
+      "default": false,
+      "description": "Include usage on every request",
+      "type": "boolean"
+    },
+    "enable_tokenizer_info_endpoint": {
+      "default": false,
+      "description": "Enable /get_tokenizer_info endpoint",
+      "type": "boolean"
+    },
+    "enable_log_outputs": {
+      "default": false,
+      "description": "Log model outputs",
+      "type": "boolean"
+    },
+    "enable_log_deltas": {
+      "default": true,
+      "description": "Log output deltas when enable_log_outputs is set",
+      "type": "boolean"
+    },
+    "log_error_stack": {
+      "default": false,
+      "description": "Log stack trace of error responses",
+      "type": "boolean"
+    },
+    "fingerprint_mode": {
+      "type": "string",
+      "enum": [
+        "full",
+        "hash",
+        "custom",
+        "none"
+      ],
+      "default": "full",
+      "description": "Controls the system_fingerprint field on responses"
+    },
+    "fingerprint_value": {
+      "type": "string",
+      "description": "Literal fingerprint string used when ``--fingerprint-mode=custom``."
+    },
+    "enable_flash_late_interaction": {
+      "type": "boolean",
+      "default": true,
+      "description": "Run pooling score MaxSim on GPU in the API server process"
+    },
+    "device_ids": {
+      "type": "array",
+      "items": {
+        "type": [
+          "integer",
+          "string"
+        ]
+      },
+      "description": "Physical device IDs or device UUIDs to assign to the engine. Do not mix integer IDs and UUID strings."
+    },
+    "diffusion_config": {
+      "type": "object",
+      "description": "Diffusion model configuration passed as a JSON object to vLLM."
+    },
+    "jit_monitor_verbose": {
+      "type": "boolean",
+      "description": "Enable verbose JIT monitor logging."
+    },
+    "prefill_schedule_interval": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Scheduler prefill schedule interval."
+    },
+    "watermark": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Scheduler watermark for cache block allocation."
+    }
+  },
+  "additionalProperties": false
+}

--- a/internal/engine/vllm/v0.24.0/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.24.0/templates/kubernetes/default.yaml
@@ -1,0 +1,173 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .EndpointName }}"
+  namespace: {{ .Namespace }}
+  labels:
+    engine: {{ .EngineName }}
+    engine_version: {{ .EngineVersion }}
+    routing_logic: {{ .RoutingLogic }}
+    app: inference
+spec:
+  replicas: {{ .Replicas }}
+  progressDeadlineSeconds: 1200
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      cluster: {{ .ClusterName }}
+      workspace: {{ .Workspace }}
+      endpoint: "{{ .EndpointName }}"
+      app: inference
+  template:
+    metadata:
+      {{- if .Annotations }}
+      annotations:
+        {{- range $key, $value := .Annotations }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      labels:
+        engine: {{ .EngineName }}
+        engine_version: {{ .EngineVersion }}
+        cluster: {{ .ClusterName }}
+        workspace: {{ .Workspace }}
+        endpoint: "{{ .EndpointName }}"
+        routing_logic: {{ .RoutingLogic }}
+        app: inference
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: endpoint
+                      operator: In
+                      values:
+                        - "{{ .EndpointName }}"
+                topologyKey: "kubernetes.io/hostname"
+      {{- if .NodeSelector }}
+      nodeSelector:
+        {{- range $key, $value := .NodeSelector }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      {{- if .ImagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .ImagePullSecret }}
+      {{- end }}
+
+      {{- if .Volumes }}
+      volumes:
+{{ .Volumes | toYaml | indent 6 }}
+      {{- end }}
+      initContainers:
+        - name: model-downloader
+          image: {{ .ImagePrefix }}/neutree/neutree-runtime:{{ .NeutreeVersion }}
+          command:
+            - bash
+            - -c
+          args:
+            - >-
+              python3 -m neutree.downloader
+              --name="{{ .ModelArgs.name }}"
+              --registry_type="{{ .ModelArgs.registry_type }}"
+              --registry_path="{{ .ModelArgs.registry_path }}"
+              --path="{{ .ModelArgs.path }}"
+              --version="{{ .ModelArgs.version }}"
+              --file="{{ .ModelArgs.file }}"
+              --task="{{ .ModelArgs.task }}"
+          env:
+           {{ range $key, $value := .Env }}
+           - name: {{ $key }}
+             value: "{{ $value }}"
+           {{ end }}
+          {{- if .VolumeMounts }}
+          volumeMounts:
+{{ .VolumeMounts | toYaml | indent 10 }}
+          {{- end }}
+
+      containers:
+        - name: {{ .EngineName }}
+          image: {{ .ImagePrefix }}/{{ .ImageRepo }}:{{ .ImageTag }}
+          command:
+          - vllm
+          - serve
+          - {{ .ModelArgs.path }}
+          - --host
+          - "0.0.0.0"
+          - "--port"
+          - "8000"
+          - --served-model-name
+          - {{ .ModelArgs.serve_name }}
+          {{/* vLLM v0.24.0 uses --runner/--convert; auto-detect can fall back to a
+               generate runner for multimodal embedding architectures, so
+               translate the registry-level task explicitly. The shared
+               serve/_utils/vllm_task_translate table mirrors these flags
+               on the Ray Serve path. */}}
+          {{- if eq .ModelArgs.task "text-embedding" }}
+          - --runner
+          - pooling
+          - --convert
+          - embed
+          {{- else if eq .ModelArgs.task "text-rerank" }}
+          - --runner
+          - pooling
+          - --convert
+          - classify
+          {{- end }}
+          {{- if .EngineArgs }}
+          {{- range $key, $value := .EngineArgs }}
+          {{- if eq (printf "%v" $value) "true" }}
+          - --{{ $key }}
+          {{- else if eq (printf "%v" $value) "false" }}
+          {{- /* skip: store_true flags reject "--flag false"; passing false means "leave at default" */ -}}
+          {{- else }}
+          - --{{ $key }}
+          - "{{ $value }}"
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          resources:
+            limits:
+              {{- range $key, $value := .Resources }}
+              {{ $key }}: {{ $value }}
+              {{- end }}
+            requests:
+              {{- range $key, $value := .Resources }}
+              {{ $key }}: {{ $value }}
+              {{- end }}
+          env:
+           {{ range $key, $value := .Env }}
+           - name: {{ $key }}
+             value: "{{ $value }}"
+           {{ end }}
+          ports:
+            - containerPort: 8000
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          {{- if .VolumeMounts }}
+          volumeMounts:
+{{ .VolumeMounts | toYaml | indent 10 }}
+          {{- end }}

--- a/internal/engine/vllm/v0.24.0/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.24.0/templates/kubernetes/default.yaml
@@ -123,7 +123,14 @@ spec:
           {{- end }}
           {{- if .EngineArgs }}
           {{- range $key, $value := .EngineArgs }}
-          {{- if eq (printf "%v" $value) "true" }}
+          {{- if kindIs "slice" $value }}
+          {{- if gt (len $value) 0 }}
+          - --{{ $key }}
+          {{- range $item := $value }}
+          - {{ $item | quote }}
+          {{- end }}
+          {{- end }}
+          {{- else if eq (printf "%v" $value) "true" }}
           - --{{ $key }}
           {{- else if eq (printf "%v" $value) "false" }}
           {{- /* skip: store_true flags reject "--flag false"; passing false means "leave at default" */ -}}

--- a/tests/e2e/endpoint_ssh_config_test.go
+++ b/tests/e2e/endpoint_ssh_config_test.go
@@ -285,7 +285,14 @@ var _ = Describe("SSH Endpoint Config", Ordered, Label("endpoint", "ssh", "confi
 
 		It("should serve inference with all-types config", func() {
 			ep := getEndpoint(schemaEpName)
-			code, body, err := inferChat(ep.Status.ServiceURL, "Hello with all schema types")
+
+			code, modelIDs, body, err := listOpenAIModelIDs(ep.Status.ServiceURL)
+			Expect(err).NotTo(HaveOccurred(), "list models failed: %s", body)
+			Expect(code).To(Equal(200), "list models failed: %s", body)
+			Expect(modelIDs).To(ContainElement(profileModelName()))
+			Expect(modelIDs).To(ContainElement("neu-vllm-list-alias"))
+
+			code, body, err = inferChat(ep.Status.ServiceURL, "Hello with all schema types")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(code).To(Equal(200), "inference failed: %s", body)
 

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1735,6 +1735,7 @@ func listOpenAIModelIDs(serviceURL string) (int, []string, string, error) {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
+
 	if err := json.Unmarshal(body, &modelList); err != nil {
 		return resp.StatusCode, nil, string(body), err
 	}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1701,6 +1701,52 @@ func doInferenceRequest(serviceURL, path string, reqBody map[string]any) (int, s
 	return resp.StatusCode, string(body), nil
 }
 
+func listOpenAIModelIDs(serviceURL string) (int, []string, string, error) {
+	client := &http.Client{Timeout: 60 * time.Second}
+
+	req, err := http.NewRequest(http.MethodGet,
+		strings.TrimRight(serviceURL, "/")+"/v1/models",
+		nil,
+	)
+	if err != nil {
+		return 0, nil, "", err
+	}
+
+	authValue := Cfg.APIKey
+	if !strings.HasPrefix(authValue, "Bearer ") {
+		authValue = "Bearer " + authValue
+	}
+
+	req.Header.Set("Authorization", authValue)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, "", err
+	}
+
+	var modelList struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &modelList); err != nil {
+		return resp.StatusCode, nil, string(body), err
+	}
+
+	ids := make([]string, 0, len(modelList.Data))
+	for _, model := range modelList.Data {
+		ids = append(ids, model.ID)
+	}
+
+	return resp.StatusCode, ids, string(body), nil
+}
+
 func inferChat(serviceURL, prompt string) (int, string, error) {
 	return inferChatWithModel(serviceURL, profileModelName(), prompt)
 }


### PR DESCRIPTION
## Issue

NEU-488

## Summary

Add built-in Neutree support for vLLM v0.24.0, including schema, Kubernetes template, Ray Serve app wiring, image tag registration, and regression coverage for `served_model_name` list aliases in SSH/Ray Serve endpoints.

## Changes

- Add vLLM v0.24.0 builtin engine schema and Kubernetes deployment template.
- Register the v0.24.0 engine version and patch image tag in the engine builtin registry.
- Add the v0.24.0 Ray Serve app implementation with vLLM v0.24 serving API compatibility.
- Update the shared vLLM Ray stat logger wrapper for the v0.24 KV connector class rename.
- Preserve list-valued engine args in the v0.24.0 Kubernetes template.
- Register every `served_model_name` alias with OpenAI serving models so `/v1/models` and alias inference both work in SSH/Ray Serve mode.
- Preserve the first successful streaming chat SSE chunk after stream error pre-checking.
- Preserve structured stream error HTTP status codes when vLLM emits an SSE error before the first successful chunk.
- Return structured 400 responses for invalid rerank request payloads.
- Add focused Go and E2E regression coverage for schema/template rendering and list alias behavior.

## Test Plan

### Unit test

- [x] `go test ./internal/engine/... -count=1`
- [x] `go vet ./internal/engine/...`
- [x] `go build ./internal/engine/`
- [x] `go test ./tests/e2e -run TestRenderTemplate_EngineArgsRange -count=1`
- [x] `go build ./tests/e2e/...`
- [x] `python3 -m py_compile cluster-image-builder/serve/_metrics/ray_stat_logger.py cluster-image-builder/serve/vllm/v0_24_0/app.py`
- [x] `git diff --check`

### DB test

- [x] Not affected. This change does not modify database schema, storage code, or migrations.

### E2E test

- [x] Built final patch image through GitHub Actions `release-engine-image-vllm` run `28497098970`.
- [x] Final patch image: `docker.io/neutree/engine-vllm:v0.24.0-neutree1-ray2.53.0@sha256:623a31187d450a3a0200674192ac0f54d772abdc812a0c91f9260aaa4c3f3cd4`.
- [x] Synced final patch image to test registry: `192.168.22.100/neutree-e2e-test/neutree/engine-vllm:v0.24.0-neutree1-ray2.53.0@sha256:623a31187d450a3a0200674192ac0f54d772abdc812a0c91f9260aaa4c3f3cd4`.
- [x] SSH node `192.168.19.218` pre-pulled image ID `sha256:26f8e4f6ac7ba184152446372434a510b0f1eccaee6e4f7f572f8609e812b6d6`.
- [x] SSH inference suite: `make e2e-test LABEL_FILTER='endpoint && ssh && inference && !sglang && !tp2 && !auto-tp' E2E_TIMEOUT=120m` passed with `8 Passed | 0 Failed | 240 Skipped`.
- [x] SSH config suite: `make e2e-test LABEL_FILTER='endpoint && ssh && config && !sglang' E2E_TIMEOUT=120m` passed with `15 Passed | 0 Failed | 233 Skipped`.
- [x] Copilot-fix patch regression on the refreshed image: `make e2e-test LABEL_FILTER='endpoint && ssh && (inference || config) && !multi-version && !sglang && !tp2 && !auto-tp' E2E_TIMEOUT=150m` passed with `20 Passed | 0 Failed | 228 Skipped`.
- [x] Config E2E covered `served_model_name` list preservation, `/v1/models` listing of the alias, primary-name chat inference, and alias chat inference.
- [x] Regression E2E covered Ray Serve config/runtime deployment checks, backend container/runtime env checks, env propagation, serving-only arg handling, all schema-type engine args, chat inference, wrong-model error, embedding inference, and rerank inference.
- [x] Broad regression including `multi-version` passed the v0.24.0 chat deploy/inference/wrong-model checks, then stalled on unrelated old `v0.17.1-ray2.53.0` image pull for the comparison endpoint. Final focused regression excluded `multi-version` after cleaning the environment.

## Risk & Rollback

No DB migration or API contract change is included. The main risk is vLLM v0.24.0 serving API drift; this is covered by the patch image build and SSH E2E validation. Rollback is to remove v0.24.0 from the builtin engine list or switch deployments back to an earlier vLLM engine version.
