### PR TITLE
fix: preserve effective vLLM model path

### DIFF
--- a/cluster-image-builder/serve/vllm/test_served_model_alias_registry.py
+++ b/cluster-image-builder/serve/vllm/test_served_model_alias_registry.py
@@ -75,6 +75,23 @@ def _assigns_served_model_names_from_effective_args(node):
     )
 
 
+def _assigns_model_path_from_effective_args(node):
+    if not isinstance(node, ast.Assign):
+        return False
+    if not any(_is_self_model_path(target) for target in node.targets):
+        return False
+    value = node.value
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Attribute)
+        and value.func.attr == "get"
+        and _is_name(value.func.value, "args")
+        and value.args
+        and isinstance(value.args[0], ast.Constant)
+        and value.args[0].value == "model"
+    )
+
+
 def _calls_base_model_path_directly(node):
     return isinstance(node, ast.Call) and _is_name(node.func, "BaseModelPath")
 
@@ -108,6 +125,9 @@ class TestVLLMServedModelAliasRegistry(unittest.TestCase):
                 served_model_names_assignments = [
                     node for node in ast.walk(tree) if _assigns_served_model_names_from_effective_args(node)
                 ]
+                model_path_assignments = [
+                    node for node in ast.walk(tree) if _assigns_model_path_from_effective_args(node)
+                ]
                 direct_base_model_path_calls = [
                     node for node in ast.walk(tree) if _calls_base_model_path_directly(node)
                 ]
@@ -125,6 +145,11 @@ class TestVLLMServedModelAliasRegistry(unittest.TestCase):
                     len(served_model_names_assignments),
                     1,
                     f"{app_file} should store the effective served_model_name after coercion",
+                )
+                self.assertEqual(
+                    len(model_path_assignments),
+                    1,
+                    f"{app_file} should store the effective model path after coercion",
                 )
                 self.assertEqual(
                     len(served_model_names_calls),

--- a/cluster-image-builder/serve/vllm/v0_11_2/app.py
+++ b/cluster-image-builder/serve/vllm/v0_11_2/app.py
@@ -90,7 +90,6 @@ class Backend:
         print(f"[Backend] Model download completed.")
 
         self.model_id = model_serve_name
-        self.model_path = model_path
         self.model_task = model_task
 
         # Extract our custom parameters BEFORE creating AsyncEngineArgs to avoid unexpected keyword errors
@@ -146,6 +145,7 @@ class Backend:
         # params that were read but not popped) to prevent TypeError on init.
         filter_engine_args(args, AsyncEngineArgs)
 
+        self.model_path = args.get("model", model_path)
         self.served_model_names = args.get("served_model_name", self.model_id)
         if isinstance(self.served_model_names, str):
             self.served_model_names = [self.served_model_names]

--- a/cluster-image-builder/serve/vllm/v0_17_1/app.py
+++ b/cluster-image-builder/serve/vllm/v0_17_1/app.py
@@ -92,7 +92,6 @@ class Backend:
         print(f"[Backend] Model download completed.")
 
         self.model_id = model_serve_name
-        self.model_path = model_path
         self.model_task = model_task
 
         # Extract FrontendArgs BEFORE creating AsyncEngineArgs to avoid unexpected keyword errors.
@@ -183,6 +182,7 @@ class Backend:
         # params that were read but not popped) to prevent TypeError on init.
         filter_engine_args(args, AsyncEngineArgs)
 
+        self.model_path = args.get("model", model_path)
         self.served_model_names = args.get("served_model_name", self.model_id)
         if isinstance(self.served_model_names, str):
             self.served_model_names = [self.served_model_names]

--- a/cluster-image-builder/serve/vllm/v0_8_5/app.py
+++ b/cluster-image-builder/serve/vllm/v0_8_5/app.py
@@ -117,7 +117,6 @@ class Backend:
         print(f"[Backend] Model download completed.")
 
         self.model_id = model_serve_name
-        self.model_path = model_path
         self.model_task = model_task
 
         # Extract our custom parameters BEFORE creating AsyncEngineArgs to avoid unexpected keyword errors
@@ -169,6 +168,7 @@ class Backend:
         # params that were read but not popped) to prevent TypeError on init.
         filter_engine_args(args, AsyncEngineArgs)
 
+        self.model_path = args.get("model", model_path)
         self.served_model_names = args.get("served_model_name", self.model_id)
         if isinstance(self.served_model_names, str):
             self.served_model_names = [self.served_model_names]


### PR DESCRIPTION
## Issue

Follow-up to NEU-488 / PR #454.

## Summary

Preserve the effective vLLM `model` argument for OpenAI model alias registration. PR #454 merged the list-alias fix, but reviewer follow-up found that `self.model_path` was captured before `engine_kwargs` could override `model`. This patch stores `self.model_path` from post-filter effective args in all current vLLM SSH apps, so `BaseModelPath.model_path` follows the same model value the engine receives.

## Changes

- Updated vLLM SSH apps for `v0.8.5`, `v0.11.2`, and `v0.17.1` to set `self.model_path = args.get("model", model_path)` after coercion/filtering.
- Extended the static alias registry guard to require effective model-path assignment for all current vLLM apps.

## Test Plan

### Unit test

- [x] `PYTHONPATH=cluster-image-builder pytest cluster-image-builder/serve/vllm/test_served_model_alias_registry.py -q` -- 2 passed, 6 subtests passed.
- [x] `PYTHONPATH=cluster-image-builder pytest cluster-image-builder/serve/_utils/test_vllm_model_aliases.py cluster-image-builder/serve/_utils/test_coerce.py cluster-image-builder/serve/_utils/test_runtime_env.py cluster-image-builder/serve/_utils/test_vllm_task_translate.py cluster-image-builder/serve/vllm/test_served_model_alias_registry.py cluster-image-builder/serve/vllm/test_request_id_plugin_config.py -v` -- 59 passed, 9 subtests passed.
- [x] `python3 -m py_compile cluster-image-builder/serve/vllm/v0_8_5/app.py cluster-image-builder/serve/vllm/v0_11_2/app.py cluster-image-builder/serve/vllm/v0_17_1/app.py cluster-image-builder/serve/vllm/test_served_model_alias_registry.py`
- [x] `git diff --check`

### DB test

- [x] Not affected. This change does not touch DB migrations, storage, or API/controller code.

### E2E test

- [x] Not rerun for this follow-up. PR #454 already passed the vLLM SSH alias E2E path; this patch only corrects the alias registry model-path source for the `engine_args.model` override edge case and is covered by the static guard above.

Manual testing is not required because the deterministic vLLM alias workflow was covered in PR #454 and this follow-up is guarded by targeted static/unit verification.

## Risk & Rollback

Risk is limited to vLLM SSH OpenAI model registry metadata when users override `engine_args.model`. Rollback is to restore the previous constructor-argument `model_path` assignment.
