### PR TITLE
fix(gateway): strip upstream Accept-Encoding so ai-traces are readable

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -197,6 +197,14 @@ local function set_upstream_target(entry)
     kong.service.request.clear_header("x-credential-identifier")
     kong.service.request.clear_header("x-anonymous-consumer")
 
+    -- Force an identity (uncompressed) upstream response. External providers
+    -- (e.g. minimax) honour Accept-Encoding and return brotli/gzip bodies, which
+    -- Kong does NOT auto-decompress: get_raw_body() would then yield compressed
+    -- bytes, garbling ai.trace.response_body and silently breaking the
+    -- cjson.decode used for token/usage accounting. Self-hosted upstreams reply
+    -- uncompressed, so this only changes the external-provider path.
+    kong.service.request.clear_header("Accept-Encoding")
+
     if entry.auth_header and entry.auth_header ~= "" then
         kong.service.request.set_header("Authorization", entry.auth_header)
     end


### PR DESCRIPTION
## Problem

On the **EE → external provider** path (reproduced with **minimax**), the
`ai-traces` view shows the response body as garbled binary, and token/usage for
those requests is missing. Self-hosted upstreams (vLLM) and providers like
deepseek are unaffected.

## Root cause

`neutree-ai-gateway` captures the upstream response body two ways —
`kong.service.response.get_raw_body()` / accumulated `ngx.arg[1]` chunks — and:

- writes it to `ai.trace.response_body` in the `log` phase (`handler.lua`), and
- `cjson.decode`s it for token/usage accounting.

The plugin never sets `Accept-Encoding` on the upstream request nor inspects
`Content-Encoding` on the response, and **Kong does not auto-decompress proxied
bodies**. Providers that honour `Accept-Encoding` (minimax) return a
brotli/gzip-compressed body, so `get_raw_body()` yields the *compressed bytes*:

- `ai.trace.response_body` is stored as compressed binary → garbled in the UI;
- `cjson.decode` fails silently → token/usage for that request is dropped.

Vector (`vector.yml`) and the trace query API (`internal/routes/logs/ai_trace.go`)
pass the field through verbatim, so the garbling originates entirely at capture.

Self-hosted upstreams reply uncompressed, which is why only external providers
that negotiate compression were affected.

## Fix

Clear `Accept-Encoding` when preparing the upstream request (alongside the
existing consumer-header clears in `set_upstream_target`), forcing an identity
response from every provider. This is:

- **source-agnostic** — overrides whatever the client advertised, so it does not
  matter whether the client or an intermediary set the header;
- **narrow** — only changes providers that would otherwise compress; self-hosted
  upstreams already reply uncompressed;
- **client-transparent** — the response returned to the caller is a separate
  content negotiation and is unaffected.

Fixes both the garbled trace body and the dropped token/usage on the affected
path.

## Note / follow-up

This resolves the standard case where compression is `Accept-Encoding`-gated
(the norm for `br`/`gzip`). If a provider's CDN were to compress *unconditionally*
(ignoring `Accept-Encoding`), stripping the header would not help and we'd need
to decode by `Content-Encoding` instead. Worth confirming on the minimax path
after deploy (check the trace body is readable and `total_tokens` is populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)