### PR TITLE
fix: return PostgREST-shaped errors from model-catalog recipe validation

### DIFF
--- a/internal/routes/proxies/model_catalog_proxy.go
+++ b/internal/routes/proxies/model_catalog_proxy.go
@@ -53,7 +53,11 @@ func validateModelCatalogRecipe() gin.HandlerFunc {
 
 		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body: " + err.Error()})
+			c.JSON(http.StatusBadRequest, &validationError{
+				Code:    "10223",
+				Message: "failed to read request body: " + err.Error(),
+				Hint:    "Retry the request",
+			})
 			c.Abort()
 
 			return
@@ -73,7 +77,11 @@ func validateModelCatalogRecipe() gin.HandlerFunc {
 
 		if trimmed[0] == '[' {
 			if err := json.Unmarshal(trimmed, &catalogs); err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid model_catalog payload: " + err.Error()})
+				c.JSON(http.StatusBadRequest, &validationError{
+					Code:    "10223",
+					Message: "invalid model_catalog payload: " + err.Error(),
+					Hint:    "Check the model catalog spec fields and types",
+				})
 				c.Abort()
 
 				return
@@ -81,7 +89,11 @@ func validateModelCatalogRecipe() gin.HandlerFunc {
 		} else {
 			var one v1.ModelCatalog
 			if err := json.Unmarshal(trimmed, &one); err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid model_catalog payload: " + err.Error()})
+				c.JSON(http.StatusBadRequest, &validationError{
+					Code:    "10223",
+					Message: "invalid model_catalog payload: " + err.Error(),
+					Hint:    "Check the model catalog spec fields and types",
+				})
 				c.Abort()
 
 				return
@@ -98,7 +110,11 @@ func validateModelCatalogRecipe() gin.HandlerFunc {
 			}
 
 			if err := recipe.ValidateModelCatalogSpec(catalog.Spec); err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				c.JSON(http.StatusBadRequest, &validationError{
+					Code:    "10224",
+					Message: err.Error(),
+					Hint:    "Fix the recipe definition and retry",
+				})
 				c.Abort()
 
 				return


### PR DESCRIPTION
The recipe-validation middleware replied with `{"error": "..."}` while every other proxy validation on this route family (clusters, models) uses the PostgREST error shape `{code, message, hint}` that the SPA's data provider parses. The mismatch made every recipe validation reason surface as **"Unknown error"** in the import dialog.

Use the shared `validationError` type — codes `10223` (payload decode) / `10224` (recipe invariant).

Found and verified by running the recipe e2e suite (neutree-ai/ui#295) against a live env: with this fix (hot-swapped binary) + the paired UI fix, the import dialog shows the concrete reason per document (e.g. `model_catalog: feature "reasoning" conflicts_with unknown feature "ghost_feature"`), and the suite is 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)