### PR TITLE
fix(serve-image): pin protobuf below 6 for Ray 2.53 compatibility

### DIFF
--- a/cluster-image-builder/Dockerfile
+++ b/cluster-image-builder/Dockerfile
@@ -68,7 +68,12 @@ WORKDIR ${HOME}
 RUN --mount=type=bind,from=build_ray,src=/ray,target=/install \
     cd /install \
     && uv pip install --system -r python/requirements.txt \
-    && uv pip install --system .whl/*.whl
+    && uv pip install --system .whl/*.whl \
+    # Ray's requirements leave protobuf unbounded; protobuf >= 6.30 removes
+    # FieldDescriptor.label, which breaks Ray 2.53's generated protos at Serve
+    # deploy time (DeploymentConfig.from_proto_bytes -> AttributeError). Pin
+    # below 6 until Ray is upgraded to a protobuf-6-compatible release.
+    && uv pip install --system "protobuf>=4.25,<6"
 
 # Relax Python patch version check (cluster 3.12.x vs engine 3.12.x)
 ENV RAY_DEFAULT_PYTHON_VERSION_MATCH_LEVEL=minor


### PR DESCRIPTION
## Problem

Recent `neutree-serve` builds (verified on `v1.1.1-alpha.1`) ship **protobuf 7.35.1** alongside **ray 2.53.0**. protobuf ≥ 6.30 removed `FieldDescriptor.label`, which Ray 2.53's generated protos still use — so **every Ray Serve deploy on such an image fails** in the controller:

```
Unexpected error occurred while applying config for application '...':
  File ".../ray/serve/_private/deploy_utils.py", line 70, in deploy_args_to_deployment_info
    deployment_config = DeploymentConfig.from_proto_bytes(deployment_config_proto_bytes)
AttributeError: 'google._upb._message.FieldDescriptor' object has no attribute 'label'
```

Root cause: the serve image installs Ray from source using Ray's own `python/requirements.txt`, which leaves protobuf unbounded — the resolver picked 7.35.1 at build time.

## Reproduction

Live static node joined to a control plane running latest main: any endpoint deploy fails with the traceback above. `docker exec ray_container pip list` → `protobuf 7.35.1`, `ray 2.53.0`. Downgrading protobuf inside the container to 5.29.5 and restarting Ray lets the same deploy proceed.

## Fix

Pin `protobuf>=4.25,<6` right after the Ray install in `cluster-image-builder/Dockerfile`, until Ray moves to a protobuf-6-compatible release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)