### PR TITLE
fix: recognize legacy model download completion log

### DIFF
--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -48,6 +48,8 @@ const (
 	modelDownloadStartMarker  = "NEUTREE_MODEL_DOWNLOAD_START"
 	modelDownloadDoneMarker   = "NEUTREE_MODEL_DOWNLOAD_DONE"
 	modelDownloadFailedMarker = "NEUTREE_MODEL_DOWNLOAD_FAILED"
+
+	legacyModelDownloadDoneMarker = "Model download completed."
 )
 
 type modelDownloadMarkerState int
@@ -452,7 +454,8 @@ func modelDownloadStateFromLog(logText string) modelDownloadMarkerState {
 		return modelDownloadMarkerFailed
 	}
 
-	if strings.Contains(logText, modelDownloadDoneMarker) {
+	if strings.Contains(logText, modelDownloadDoneMarker) ||
+		strings.Contains(logText, legacyModelDownloadDoneMarker) {
 		return modelDownloadMarkerDone
 	}
 

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2798,6 +2798,89 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectError:            false,
 		},
 		{
+			name: "return Deploying and mark model download completed when backend actor log contains legacy done message",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {
+									Name:   "BACKEND",
+									Status: "UPDATING",
+									Replicas: []dashboard.Replica{
+										{
+											ActorID:   "actor-1",
+											ReplicaID: "backend-replica-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+				mockDashboard.On("GetActorLog", "actor-1", "out", 200).
+					Return("[Backend] Model download completed.\n", nil)
+				mockDashboard.On("GetActorLog", "actor-1", "err", 200).Return("", nil)
+			},
+			expectedPhase:          v1.EndpointPhaseDEPLOYING,
+			expectCurrentModelHash: true,
+			expectError:            false,
+		},
+		{
+			name: "return Failed when backend actor log contains failed marker and legacy done message",
+			inputEndpoint: func() *v1.Endpoint {
+				return newEndpoint()
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            "DEPLOYING",
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {
+									Name:   "BACKEND",
+									Status: "UPDATING",
+									Replicas: []dashboard.Replica{
+										{
+											ActorID:   "actor-1",
+											ReplicaID: "backend-replica-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+				mockDashboard.On("GetActorLog", "actor-1", "out", 200).
+					Return("NEUTREE_MODEL_DOWNLOAD_FAILED\n[Backend] Model download completed.\n", nil)
+				mockDashboard.On("GetActorLog", "actor-1", "err", 200).Maybe().Return("", nil)
+			},
+			expectedPhase:                v1.EndpointPhaseFAILED,
+			expectModelDownloadHashEmpty: true,
+			expectErrorMsg:               "model download failed",
+			expectError:                  false,
+		},
+		{
 			name: "return Deploying when backend actor is done even if controller actor has no download markers",
 			inputEndpoint: func() *v1.Endpoint {
 				return newEndpoint()


### PR DESCRIPTION
## Issue

n/a

## Summary

Older engine versions log `[Backend] Model download completed.` after model download finishes, while the current Ray status parser only recognized `NEUTREE_MODEL_DOWNLOAD_DONE`. This keeps endpoints in `ModelDownloading` even though the backend already completed the download.

## Changes

- Treat `Model download completed.` as a legacy model-download done marker in Ray backend actor logs.
- Add regression coverage for the legacy done message.
- Add a failure-precedence regression to confirm a failed marker still wins if both failure and legacy completion text appear in the same log tail.

## Test Plan

Unit test:
- `go test ./internal/orchestrator -run TestRayOrchestrator_GetEndpointStatus/legacy -count=1` failed before the implementation with `ModelDownloading` and an empty model download hash, then passed after the fix.
- `go test ./internal/orchestrator -run TestRayOrchestrator_GetEndpointStatus -count=1` passed after adding the failure-precedence regression.
- `go vet ./internal/orchestrator/...` passed.
- `go test ./internal/orchestrator/... -count=1` passed.
- `./bin/golangci-lint run ./internal/orchestrator/...` passed.
- `go vet ./...` passed after generating ignored embedded CLI manifest tar assets.
- `go test -count=1 $(go list ./... | grep -v 'e2e\|mocks\|db/dbtest')` passed.
- `./bin/golangci-lint run` passed.
- GitHub `pr-check` passed on head `4970ec7f53d39859c4d69ea8cbcedc614bd3d933`.

DB test:
- Not affected. No database schema, storage, migration, or RLS changes.
- `go test ./...` was also attempted; only `db/dbtest` failed because local PostgreSQL was not running at `127.0.0.1:5432`.

E2E test:
- Not run for this Trivial log-parser compatibility fix. The deployed behavior is covered by Ray orchestrator unit regressions for the exact legacy log message and failure precedence. Manual testing is not required.

## Risk & Rollback

Risk is low and backward-compatible: the parser now accepts an additional completion message while preserving existing start, done, and failed marker precedence. Roll back by reverting this PR.