### PR TITLE
fix(engine-vllm): install audio deps for speech models

### DIFF
--- a/cluster-image-builder/requirements/common.txt
+++ b/cluster-image-builder/requirements/common.txt
@@ -3,3 +3,9 @@ starlette<1.0.0
 starlette-context>=0.3.6
 pydantic-settings>=2.8.1
 kantoku>=0.18.3
+# Audio support (the `vllm[audio]` extra). The vllm-openai base image ships
+# without it, so speech models (e.g. ASR) otherwise fail at request time with
+# "Please install vllm[audio] for audio support". Installed directly rather
+# than via the extra to avoid resolving a different vllm than the base image.
+librosa>=0.10
+soundfile>=0.12


### PR DESCRIPTION
## Problem

The `vllm-openai` base image for the engine ships without the audio extra, so serving a model with task `automatic-speech-recognition` fails at request time:

```
ImportError: Please install vllm[audio] for audio support
```

## Fix

Add `librosa` + `soundfile` (the `vllm[audio]` extra) to the common engine requirements. Installed directly rather than via `vllm[audio]` so the resolver keeps the vllm version pinned by the base image.

## Verification

On an L4 node, an ASR endpoint (Qwen3-ASR-1.7B, vllm v0.17.1) transcribes audio correctly through the chat channel once these deps are present:

```
input:  an 11s speech clip
output: And so, my fellow Americans, ask not what your country can do for
        you. Ask what you can do for your country.
```

## Follow-up (not in this PR)

The serve adapter exposes chat/embeddings/rerank/models but no `/v1/audio/transcriptions` route, so audio must go through the chat channel. Adding the dedicated transcription endpoint is a larger, per-engine-version change and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)