### PR TITLE
fix: preserve non-Docker Hub image paths

### DIFF
--- a/internal/cli/packageimport/image_pusher.go
+++ b/internal/cli/packageimport/image_pusher.go
@@ -115,13 +115,38 @@ func (p *ImagePusher) buildTargetImage(imagePrefix string, imgSpec *ImageSpec) s
 	// Remove any existing registry from the image name
 	imageName := extractImageNameWithoutRegistry(imgSpec.ImageName)
 
-	// If the image name doesn't contain a slash, it's a Docker Hub library image
-	// We need to add the "library" prefix to maintain the correct path structure
-	if !strings.Contains(imageName, "/") {
+	if shouldAddDockerHubLibraryPrefix(imgSpec.ImageName, imageName) {
 		imageName = "library/" + imageName
 	}
 
 	return fmt.Sprintf("%s/%s:%s", imagePrefix, imageName, imgSpec.Tag)
+}
+
+func shouldAddDockerHubLibraryPrefix(originalImageName, imageName string) bool {
+	return !strings.Contains(imageName, "/") && isDockerHubImageName(originalImageName)
+}
+
+func isDockerHubImageName(imageName string) bool {
+	registry, ok := imageRegistry(imageName)
+	if !ok {
+		return true
+	}
+
+	return registry == "docker.io" || registry == "index.docker.io" || registry == "registry-1.docker.io"
+}
+
+func imageRegistry(imageName string) (string, bool) {
+	idx := strings.Index(imageName, "/")
+	if idx == -1 {
+		return "", false
+	}
+
+	firstPart := imageName[:idx]
+	if strings.Contains(firstPart, ".") || strings.Contains(firstPart, ":") {
+		return firstPart, true
+	}
+
+	return "", false
 }
 
 // loadImage loads a Docker image from a tar file
@@ -201,15 +226,9 @@ func (w *klogWriter) Write(p []byte) (int, error) {
 
 // extractImageNameWithoutRegistry removes any existing registry prefix from the image name
 func extractImageNameWithoutRegistry(imageName string) string {
-	// Check if there's a registry prefix (contains / before any other structure)
-	if idx := strings.Index(imageName, "/"); idx != -1 {
-		// Check if this is a registry prefix (contains . or :)
-		firstPart := imageName[:idx]
-		if strings.Contains(firstPart, ".") || strings.Contains(firstPart, ":") {
-			// This is a registry, remove it
-			return imageName[idx+1:]
-		}
+	if registry, ok := imageRegistry(imageName); ok {
+		return strings.TrimPrefix(imageName, registry+"/")
 	}
-	// No registry prefix found, return as-is
+
 	return imageName
 }

--- a/internal/cli/packageimport/image_pusher_test.go
+++ b/internal/cli/packageimport/image_pusher_test.go
@@ -81,10 +81,46 @@ func TestImagePusherBuildTargetImage(t *testing.T) {
 			expected: "registry.example.com/neutree/library/postgres:v13.0.0",
 		},
 		{
+			name:        "push explicit dockerhub official image to custom registry",
+			imagePrefix: "registry.example.com",
+			imgSpec: &ImageSpec{
+				ImageName: "docker.io/postgres",
+				Tag:       "v13.0.0",
+			},
+			expected: "registry.example.com/library/postgres:v13.0.0",
+		},
+		{
+			name:        "push index dockerhub official image to custom registry",
+			imagePrefix: "registry.example.com",
+			imgSpec: &ImageSpec{
+				ImageName: "index.docker.io/postgres",
+				Tag:       "v13.0.0",
+			},
+			expected: "registry.example.com/library/postgres:v13.0.0",
+		},
+		{
+			name:        "push registry-1 dockerhub official image to custom registry",
+			imagePrefix: "registry.example.com",
+			imgSpec: &ImageSpec{
+				ImageName: "registry-1.docker.io/postgres",
+				Tag:       "v13.0.0",
+			},
+			expected: "registry.example.com/library/postgres:v13.0.0",
+		},
+		{
 			name:        "push non dockerhub registry image without namespace",
 			imagePrefix: "registry.example.com",
 			imgSpec: &ImageSpec{
 				ImageName: "private.example.com/postgres",
+				Tag:       "v13.0.0",
+			},
+			expected: "registry.example.com/postgres:v13.0.0",
+		},
+		{
+			name:        "push registry port image without namespace",
+			imagePrefix: "registry.example.com",
+			imgSpec: &ImageSpec{
+				ImageName: "private.example.com:5000/postgres",
 				Tag:       "v13.0.0",
 			},
 			expected: "registry.example.com/postgres:v13.0.0",

--- a/internal/cli/packageimport/image_pusher_test.go
+++ b/internal/cli/packageimport/image_pusher_test.go
@@ -80,6 +80,15 @@ func TestImagePusherBuildTargetImage(t *testing.T) {
 			},
 			expected: "registry.example.com/neutree/library/postgres:v13.0.0",
 		},
+		{
+			name:        "push non dockerhub registry image without namespace",
+			imagePrefix: "registry.example.com",
+			imgSpec: &ImageSpec{
+				ImageName: "private.example.com/postgres",
+				Tag:       "v13.0.0",
+			},
+			expected: "registry.example.com/postgres:v13.0.0",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue

NEU-507

## Summary

Fix package import image retagging so a non-Docker-Hub registry image without a namespace keeps its repository path instead of receiving Docker Hub's `library/` namespace.

## Changes

- Add Docker Hub registry detection before adding the implicit `library/` namespace.
- Reuse registry-prefix detection for image path stripping.
- Add regression tests for explicit Docker Hub aliases and non-Docker-Hub registry retagging.

## Test Plan

### Unit test

- [x] `go test -count=1 ./internal/cli/packageimport ./cmd/neutree-cli/app/cmd/packageimport ./cmd/neutree-cli/app/util`
- [x] `go vet ./internal/cli/packageimport`
- [x] `git diff --check`
- [ ] `go vet ./...` not completed: current worktree lacks embedded launch assets, failing at `cmd/neutree-cli/app/cmd/launch/manifests/core.go:7:12: pattern neutree-core.tar: no matching files found`.
- [ ] `go test ./...` not completed: same missing embedded `neutree-core.tar` asset failure.
- [ ] `golangci-lint run ./internal/cli/packageimport/...` not completed: local `golangci-lint v1.53.3` built with Go 1.20.6 reports typecheck errors against the Go 1.23.7 standard library and package imports.

### DB test

- [x] Not affected. This change does not touch database schema, migrations, storage, or RLS behavior.

### E2E test

- [x] Not affected. This is a Trivial CLI package import image-reference normalization fix covered by unit tests; it does not require a deployed Neutree control plane or live E2E environment.

## Risk & Rollback

Risk is limited to package import image retagging. Docker Hub official images still receive `library/`; non-Docker-Hub registry paths no longer do. Rollback is reverting this PR.