### PR TITLE
feat: add split embed dashboards

### DIFF
--- a/observability/grafana/dashboards/neutree_cluster_overview_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_cluster_overview_embed_dashboard.json
@@ -1,0 +1,555 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "count(count by (node) (neutree_node_ready{neutree_cluster=~\"$Cluster\"}))",
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_node_accelerator_total{neutree_cluster=~\"$Cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Total GPUs",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 10,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_node_accelerator_free{neutree_cluster=~\"$Cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Free GPUs",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 15,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg(neutree_accelerator_utilization_ratio{neutree_cluster=~\"$Cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU avg",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_accelerator_memory_used_bytes{neutree_cluster=~\"$Cluster\"}) / clamp_min(sum(neutree_accelerator_memory_total_bytes{neutree_cluster=~\"$Cluster\"}), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "VRAM avg",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "1 - avg(rate(neutree_node_cpu_seconds_total{neutree_cluster=~\"$Cluster\",mode=\"idle\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "CPU avg"
+        },
+        {
+          "expr": "sum(neutree_node_memory_used_bytes{neutree_cluster=~\"$Cluster\"}) / clamp_min(sum(neutree_node_memory_total_bytes{neutree_cluster=~\"$Cluster\"}), 1)",
+          "refId": "B",
+          "legendFormat": "Memory avg"
+        },
+        {
+          "expr": "avg(neutree_accelerator_utilization_ratio{neutree_cluster=~\"$Cluster\"})",
+          "refId": "C",
+          "legendFormat": "GPU avg"
+        },
+        {
+          "expr": "sum(neutree_accelerator_memory_used_bytes{neutree_cluster=~\"$Cluster\"}) / clamp_min(sum(neutree_accelerator_memory_total_bytes{neutree_cluster=~\"$Cluster\"}), 1)",
+          "refId": "D",
+          "legendFormat": "VRAM avg"
+        }
+      ],
+      "title": "Utilization trend",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "label_join(label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint!=\"\",replica!=\"\"}), \"endpoint_replica\", \" / \", \"endpoint\", \"replica\"), \"node_gpu\", \" / \", \"node\", \"accelerator_index\")",
+          "refId": "A",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "allocation info",
+          "range": false
+        },
+        {
+          "expr": "label_join(label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint!=\"\",replica!=\"\"}), \"endpoint_replica\", \" / \", \"endpoint\", \"replica\"), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (node, accelerator_uuid) group_left(pcie_bus_id, pcie_generation, pcie_width, numa_node) max by (node, accelerator_uuid, pcie_bus_id, pcie_generation, pcie_width, numa_node) (neutree_node_accelerator_hardware_info{neutree_cluster=~\"$Cluster\"})",
+          "refId": "B",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "hardware info",
+          "range": false
+        },
+        {
+          "expr": "label_join(label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint!=\"\",replica!=\"\"}), \"endpoint_replica\", \" / \", \"endpoint\", \"replica\"), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (node, accelerator_uuid) group_left(architecture, cuda_capability, driver_version, cuda_driver_version, nvlink, nvswitch) max by (node, accelerator_uuid, architecture, cuda_capability, driver_version, cuda_driver_version, nvlink, nvswitch) (neutree_node_accelerator_nvidia_info{neutree_cluster=~\"$Cluster\"})",
+          "refId": "C",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "nvidia info",
+          "range": false
+        },
+        {
+          "expr": "label_join(label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint!=\"\",replica!=\"\"}), \"endpoint_replica\", \" / \", \"endpoint\", \"replica\"), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (endpoint, replica, node, accelerator_uuid, accelerator_index) group_left() max by (endpoint, replica, node, accelerator_uuid, accelerator_index) (neutree_endpoint_replica_accelerator_utilization_ratio{neutree_cluster=~\"$Cluster\",endpoint!=\"\",replica!=\"\"})",
+          "refId": "H",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "gpu util",
+          "range": false
+        },
+        {
+          "expr": "label_join(label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint!=\"\",replica!=\"\"}), \"endpoint_replica\", \" / \", \"endpoint\", \"replica\"), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (node, accelerator_uuid) group_left() (sum by (node, accelerator_uuid) (rate(neutree_accelerator_pcie_tx_bytes_total{neutree_cluster=~\"$Cluster\"}[$__rate_interval])) + sum by (node, accelerator_uuid) (rate(neutree_accelerator_pcie_rx_bytes_total{neutree_cluster=~\"$Cluster\"}[$__rate_interval])))",
+          "refId": "I",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "pcie throughput",
+          "range": false
+        },
+        {
+          "expr": "label_join(label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint!=\"\",replica!=\"\"}), \"endpoint_replica\", \" / \", \"endpoint\", \"replica\"), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (node, accelerator_uuid) group_left() max by (node, accelerator_uuid) (neutree_accelerator_temperature_celsius{neutree_cluster=~\"$Cluster\"})",
+          "refId": "J",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "temperature",
+          "range": false
+        }
+      ],
+      "title": "GPU allocation details",
+      "type": "table",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "Value #A": true,
+              "Value #B": true,
+              "Value #C": true,
+              "node": true,
+              "accelerator_uuid": true,
+              "accelerator_index": true,
+              "endpoint": true,
+              "replica": true
+            },
+            "indexByName": {
+              "endpoint_replica": 0,
+              "node_gpu": 1,
+              "product": 2,
+              "physical_vram_usage": 4,
+              "vram_usage": 3,
+              "Value #H": 5,
+              "Value #I": 6,
+              "Value #J": 7,
+              "architecture": 8,
+              "cuda_capability": 9,
+              "driver_version": 10,
+              "cuda_driver_version": 11,
+              "nvlink": 12,
+              "nvswitch": 13,
+              "pcie_bus_id": 14,
+              "pcie_generation": 15,
+              "pcie_width": 16,
+              "numa_node": 17
+            },
+            "renameByName": {
+              "endpoint_replica": "Endpoint / Replica",
+              "node_gpu": "Node / GPU",
+              "product": "Product",
+              "Value #H": "GPU Util",
+              "Value #I": "PCIe Throughput",
+              "Value #J": "Temperature",
+              "architecture": "Architecture",
+              "cuda_capability": "CUDA Capability",
+              "driver_version": "Driver",
+              "cuda_driver_version": "CUDA Driver",
+              "nvlink": "NVLink",
+              "nvswitch": "NVSwitch",
+              "pcie_bus_id": "PCIe Bus",
+              "pcie_generation": "PCIe Gen",
+              "pcie_width": "PCIe Width",
+              "numa_node": "NUMA",
+              "physical_vram_usage": "Physical VRAM Used / Total",
+              "vram_usage": "VRAM Used / Allocated"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Util"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PCIe Throughput"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Temperature"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "celsius"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NVLink"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "unknown": {
+                        "text": "-"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NVSwitch"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "unknown": {
+                        "text": "-"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint / Replica"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 220
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Node / GPU"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 190
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PCIe Bus"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 180
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Physical VRAM Used / Total"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VRAM Used / Allocated"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NUMA"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "unknown": {
+                        "text": "-"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "md",
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "id": "Node / GPU",
+            "displayName": "Node / GPU",
+            "desc": false
+          }
+        ]
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 40,
+  "tags": [
+    "neutree",
+    "cluster",
+    "overview",
+    "embed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "neutree-cluster",
+          "value": "neutree-cluster"
+        },
+        "name": "datasource",
+        "query": "prometheus",
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_node_ready, neutree_cluster)",
+        "includeAll": true,
+        "name": "Cluster",
+        "query": "label_values(neutree_node_ready, neutree_cluster)",
+        "refresh": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Neutree Cluster Overview Embed",
+  "uid": "neutree-cluster-overview-embed",
+  "version": 1
+}

--- a/observability/grafana/dashboards/neutree_endpoint_cache_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_endpoint_cache_embed_dashboard.json
@@ -1,0 +1,201 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(label_value(vllm:cache_config_info{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",kv_cache_size_tokens=~\"[0-9]+\"}, \"kv_cache_size_tokens\")) or sum(label_value(vllm:cache_config_info{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",num_gpu_blocks=~\"[0-9]+\",block_size=~\"[0-9]+\"}, \"num_gpu_blocks\") * label_value(vllm:cache_config_info{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",num_gpu_blocks=~\"[0-9]+\",block_size=~\"[0-9]+\"}, \"block_size\")) or sum(sglang:max_total_num_tokens{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "KV token capacity",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "locale",
+          "decimals": 0
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg(vllm:kv_cache_usage_perc{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}) or avg(vllm:gpu_cache_usage_perc{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}) or avg(sglang:token_usage{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "KV usage",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(vllm:prefix_cache_hits_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / clamp_min(sum(rate(vllm:prefix_cache_queries_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])), 1e-9)) or (sum(rate(sglang:realtime_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",mode=\"prefill_cache\"}[$__rate_interval])) / clamp_min(sum(rate(sglang:realtime_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",mode=~\"prefill_cache|prefill_compute\"}[$__rate_interval])), 1e-9))",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache hit",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "vllm:kv_cache_usage_perc{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"} or vllm:gpu_cache_usage_perc{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"} or sglang:token_usage{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}",
+          "refId": "A",
+          "legendFormat": "{{replica}} usage"
+        }
+      ],
+      "title": "KV usage trend",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "(sum by (replica) (rate(vllm:prefix_cache_hits_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / clamp_min(sum by (replica) (rate(vllm:prefix_cache_queries_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])), 1e-9)) or (sum by (replica) (rate(sglang:realtime_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",mode=\"prefill_cache\"}[$__rate_interval])) / clamp_min(sum by (replica) (rate(sglang:realtime_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",mode=~\"prefill_cache|prefill_compute\"}[$__rate_interval])), 1e-9))",
+          "refId": "A",
+          "legendFormat": "{{replica}} hit"
+        }
+      ],
+      "title": "Cache hit trend",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 40,
+  "tags": [
+    "neutree",
+    "endpoint",
+    "cache",
+    "embed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "neutree-cluster",
+          "value": "neutree-cluster"
+        },
+        "name": "datasource",
+        "query": "prometheus",
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_node_ready, neutree_cluster)",
+        "includeAll": true,
+        "name": "Cluster",
+        "query": "label_values(neutree_node_ready, neutree_cluster)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "includeAll": false,
+        "name": "Endpoint",
+        "query": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "refresh": 1,
+        "type": "query",
+        "multi": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Neutree Endpoint Cache Embed",
+  "uid": "neutree-endpoint-cache-embed",
+  "version": 1
+}

--- a/observability/grafana/dashboards/neutree_endpoint_latency_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_endpoint_latency_embed_dashboard.json
@@ -1,0 +1,341 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A"
+        }
+      ],
+      "title": "E2E P95",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A"
+        }
+      ],
+      "title": "TTFT P95",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:request_time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(vllm:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(sglang:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A"
+        }
+      ],
+      "title": "TPOT P95",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(sglang:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A"
+        }
+      ],
+      "title": "ITL P95",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(vllm:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.5, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "P50"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(vllm:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.9, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "P90"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "C",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(vllm:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.99, sum by (le) (rate(sglang:e2e_request_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "D",
+          "legendFormat": "P99"
+        }
+      ],
+      "title": "E2E latency trend",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(vllm:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.5, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "P50"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(vllm:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.9, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "P90"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "C",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(vllm:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.99, sum by (le) (rate(sglang:time_to_first_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "D",
+          "legendFormat": "P99"
+        }
+      ],
+      "title": "TTFT latency trend",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(vllm:request_time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(vllm:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(sglang:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "P50"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(vllm:request_time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(vllm:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(sglang:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "P90"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:request_time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(vllm:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(sglang:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "C",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(vllm:request_time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(vllm:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]) or rate(sglang:time_per_output_token_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "D",
+          "legendFormat": "P99"
+        }
+      ],
+      "title": "TPOT latency trend",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.5, sum by (le) (rate(sglang:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "P50"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.9, sum by (le) (rate(sglang:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "P90"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(sglang:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "C",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(vllm:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.99, sum by (le) (rate(sglang:inter_token_latency_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "D",
+          "legendFormat": "P99"
+        }
+      ],
+      "title": "ITL latency trend",
+      "type": "timeseries",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 40,
+  "tags": [
+    "neutree",
+    "endpoint",
+    "latency",
+    "embed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "neutree-cluster",
+          "value": "neutree-cluster"
+        },
+        "name": "datasource",
+        "query": "prometheus",
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_node_ready, neutree_cluster)",
+        "includeAll": true,
+        "name": "Cluster",
+        "query": "label_values(neutree_node_ready, neutree_cluster)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "includeAll": false,
+        "name": "Endpoint",
+        "query": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "refresh": 1,
+        "type": "query",
+        "multi": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Neutree Endpoint Latency Embed",
+  "uid": "neutree-endpoint-latency-embed",
+  "version": 1
+}

--- a/observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json
@@ -1,0 +1,623 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\"}) or on() vector(0)",
+          "refId": "A",
+          "legendFormat": "{{product}}"
+        }
+      ],
+      "title": "Consumed GPUs",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_endpoint_replica_accelerator_memory_used_bytes{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "VRAM used",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(neutree_endpoint_replica_cpu_usage_seconds_total{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",workload_role=\"backend\"}[$__rate_interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU cores",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_endpoint_replica_memory_working_set_bytes{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",workload_role=\"backend\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory working set",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "max by (node, accelerator_uuid, replica, accelerator_index) (neutree_endpoint_replica_accelerator_utilization_ratio{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\"})",
+          "refId": "A",
+          "legendFormat": "replica-{{replica}}-node-{{node}}-gpu-{{accelerator_index}}"
+        }
+      ],
+      "title": "GPU utilization trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "max by (node, accelerator_uuid, replica, accelerator_index) (neutree_endpoint_replica_accelerator_memory_used_bytes{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\"}) / clamp_min(max by (node, accelerator_uuid, replica, accelerator_index) (neutree_endpoint_replica_accelerator_memory_allocated_bytes{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\"}), 1)",
+          "refId": "A",
+          "legendFormat": "replica-{{replica}}-node-{{node}}-gpu-{{accelerator_index}}"
+        }
+      ],
+      "title": "VRAM utilization trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "sum by (replica) (rate(neutree_endpoint_replica_cpu_usage_seconds_total{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",workload_role=\"backend\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "replica-{{replica}}"
+        }
+      ],
+      "title": "CPU usage trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 9,
+      "targets": [
+        {
+          "expr": "sum by (replica) (neutree_endpoint_replica_memory_working_set_bytes{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",workload_role=\"backend\"})",
+          "refId": "A",
+          "legendFormat": "replica-{{replica}}"
+        }
+      ],
+      "title": "Memory usage trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"}), \"node_gpu\", \" / \", \"node\", \"accelerator_index\")",
+          "refId": "A",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "allocation info",
+          "range": false
+        },
+        {
+          "expr": "label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"}), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (node, accelerator_uuid) group_left(pcie_bus_id, pcie_generation, pcie_width, numa_node) max by (node, accelerator_uuid, pcie_bus_id, pcie_generation, pcie_width, numa_node) (neutree_node_accelerator_hardware_info{neutree_cluster=~\"$Cluster\"})",
+          "refId": "B",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "hardware info",
+          "range": false
+        },
+        {
+          "expr": "label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"}), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (node, accelerator_uuid) group_left(architecture, cuda_capability, driver_version, cuda_driver_version, nvlink, nvswitch) max by (node, accelerator_uuid, architecture, cuda_capability, driver_version, cuda_driver_version, nvlink, nvswitch) (neutree_node_accelerator_nvidia_info{neutree_cluster=~\"$Cluster\"})",
+          "refId": "C",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "nvidia info",
+          "range": false
+        },
+        {
+          "expr": "label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"}), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (endpoint, replica, node, accelerator_uuid, accelerator_index) group_left() max by (endpoint, replica, node, accelerator_uuid, accelerator_index) (neutree_endpoint_replica_accelerator_utilization_ratio{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"})",
+          "refId": "H",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "gpu util",
+          "range": false
+        },
+        {
+          "expr": "label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"}), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (node, accelerator_uuid) group_left() (sum by (node, accelerator_uuid) (rate(neutree_accelerator_pcie_tx_bytes_total{neutree_cluster=~\"$Cluster\"}[$__rate_interval])) + sum by (node, accelerator_uuid) (rate(neutree_accelerator_pcie_rx_bytes_total{neutree_cluster=~\"$Cluster\"}[$__rate_interval])))",
+          "refId": "I",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "pcie throughput",
+          "range": false
+        },
+        {
+          "expr": "label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"}), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (node, accelerator_uuid) group_left() max by (node, accelerator_uuid) (neutree_accelerator_temperature_celsius{neutree_cluster=~\"$Cluster\"})",
+          "refId": "J",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "temperature",
+          "range": false
+        },
+        {
+          "expr": "max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, node_gpu, model_replica, model_name) ((label_join((label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"}), \"node_gpu\", \" / \", \"node\", \"accelerator_index\") * on (replica) group_left(model_name) (max by (replica, model_name) (vllm:num_requests_running{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"} or vllm:request_success_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"} or vllm:engine_sleep_state{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"} or sglang:num_running_reqs{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"} or sglang:num_requests_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"}) or label_replace(max by (replica, served_model_name) (sglang:num_running_reqs{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",served_model_name=~\".+\"} or sglang:num_requests_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",served_model_name=~\".+\"}), \"model_name\", \"$1\", \"served_model_name\", \"(.*)\"))), \"model_replica\", \" / \", \"model_name\", \"replica\")) or (label_join(label_set(label_join(max by (endpoint, replica, node, accelerator_uuid, accelerator_index, product, physical_vram_usage, vram_usage) (neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\",endpoint=\"$Endpoint\",replica!=\"\"}), \"node_gpu\", \" / \", \"node\", \"accelerator_index\"), \"model_name\", \"-\"), \"model_replica\", \" / \", \"model_name\", \"replica\") unless on (replica) (max by (replica, model_name) (vllm:num_requests_running{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"} or vllm:request_success_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"} or vllm:engine_sleep_state{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"} or sglang:num_running_reqs{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"} or sglang:num_requests_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",model_name=~\".+\"}) or label_replace(max by (replica, served_model_name) (sglang:num_running_reqs{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",served_model_name=~\".+\"} or sglang:num_requests_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\",served_model_name=~\".+\"}), \"model_name\", \"$1\", \"served_model_name\", \"(.*)\"))))",
+          "refId": "K",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "model",
+          "range": false
+        }
+      ],
+      "title": "GPU allocation details",
+      "type": "table",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "Value #A": true,
+              "Value #B": true,
+              "Value #C": true,
+              "node": true,
+              "accelerator_uuid": true,
+              "accelerator_index": true,
+              "endpoint": true,
+              "replica": true,
+              "model_name": true,
+              "Value #K": true
+            },
+            "indexByName": {
+              "model_replica": 0,
+              "node_gpu": 1,
+              "product": 2,
+              "physical_vram_usage": 4,
+              "vram_usage": 3,
+              "Value #H": 5,
+              "Value #I": 6,
+              "Value #J": 7,
+              "architecture": 8,
+              "cuda_capability": 9,
+              "driver_version": 10,
+              "cuda_driver_version": 11,
+              "nvlink": 12,
+              "nvswitch": 13,
+              "pcie_bus_id": 14,
+              "pcie_generation": 15,
+              "pcie_width": 16,
+              "numa_node": 17
+            },
+            "renameByName": {
+              "model_replica": "Model / Replica",
+              "node_gpu": "Node / GPU",
+              "product": "Product",
+              "Value #H": "GPU Util",
+              "Value #I": "PCIe Throughput",
+              "Value #J": "Temperature",
+              "architecture": "Architecture",
+              "cuda_capability": "CUDA Capability",
+              "driver_version": "Driver",
+              "cuda_driver_version": "CUDA Driver",
+              "nvlink": "NVLink",
+              "nvswitch": "NVSwitch",
+              "pcie_bus_id": "PCIe Bus",
+              "pcie_generation": "PCIe Gen",
+              "pcie_width": "PCIe Width",
+              "numa_node": "NUMA",
+              "physical_vram_usage": "Physical VRAM Used / Total",
+              "vram_usage": "VRAM Used / Allocated"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Util"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PCIe Throughput"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Temperature"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "celsius"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NVLink"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "unknown": {
+                        "text": "-"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NVSwitch"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "unknown": {
+                        "text": "-"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Model / Replica"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 260
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Node / GPU"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 190
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PCIe Bus"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 180
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Physical VRAM Used / Total"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "VRAM Used / Allocated"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              },
+              {
+                "id": "custom.wrapText",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "NUMA"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "unknown": {
+                        "text": "-"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "md",
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "id": "Model / Replica",
+            "displayName": "Model / Replica",
+            "desc": false
+          }
+        ]
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 40,
+  "tags": [
+    "neutree",
+    "endpoint",
+    "overview",
+    "embed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "neutree-cluster",
+          "value": "neutree-cluster"
+        },
+        "name": "datasource",
+        "query": "prometheus",
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_node_ready, neutree_cluster)",
+        "includeAll": true,
+        "name": "Cluster",
+        "query": "label_values(neutree_node_ready, neutree_cluster)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "includeAll": false,
+        "name": "Endpoint",
+        "query": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "refresh": 1,
+        "type": "query",
+        "multi": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Neutree Endpoint Overview Embed",
+  "uid": "neutree-endpoint-overview-embed",
+  "version": 2
+}

--- a/observability/grafana/dashboards/neutree_endpoint_queue_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_endpoint_queue_embed_dashboard.json
@@ -1,0 +1,243 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(vllm:num_requests_running{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}) or sum(sglang:num_running_reqs{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Running",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(vllm:num_requests_waiting{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}) or sum(sglang:num_queue_reqs{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Waiting",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(vllm:num_preemptions_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or on() vector(0)) + (sum(rate(sglang:num_retracted_requests_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or on() vector(0))",
+          "refId": "A"
+        }
+      ],
+      "title": "Preemptions / Retractions",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:request_queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(sglang:queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue time P95",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "sum by (replica) (vllm:num_requests_running{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}) or sum by (replica) (sglang:num_running_reqs{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
+          "refId": "A",
+          "legendFormat": "{{replica}} running"
+        },
+        {
+          "expr": "sum by (replica) (vllm:num_requests_waiting{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}) or sum by (replica) (sglang:num_queue_reqs{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
+          "refId": "B",
+          "legendFormat": "{{replica}} waiting"
+        },
+        {
+          "expr": "sum by (replica) (rate(vllm:num_preemptions_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "C",
+          "legendFormat": "{{replica}} preemptions/s"
+        },
+        {
+          "expr": "sum by (replica) (rate(sglang:num_retracted_requests_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "D",
+          "legendFormat": "{{replica}} retractions/s"
+        }
+      ],
+      "title": "Queue status trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(vllm:request_queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.5, sum by (le) (rate(sglang:queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "P50"
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(vllm:request_queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.9, sum by (le) (rate(sglang:queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "P90"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(vllm:request_queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.95, sum by (le) (rate(sglang:queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "C",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(vllm:request_queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or histogram_quantile(0.99, sum by (le) (rate(sglang:queue_time_seconds_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
+          "refId": "D",
+          "legendFormat": "P99"
+        }
+      ],
+      "title": "Queue time trend",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 40,
+  "tags": [
+    "neutree",
+    "endpoint",
+    "queue",
+    "embed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "neutree-cluster",
+          "value": "neutree-cluster"
+        },
+        "name": "datasource",
+        "query": "prometheus",
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_node_ready, neutree_cluster)",
+        "includeAll": true,
+        "name": "Cluster",
+        "query": "label_values(neutree_node_ready, neutree_cluster)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "includeAll": false,
+        "name": "Endpoint",
+        "query": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "refresh": 1,
+        "type": "query",
+        "multi": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Neutree Endpoint Queue Embed",
+  "uid": "neutree-endpoint-queue-embed",
+  "version": 1
+}

--- a/observability/grafana/dashboards/neutree_endpoint_token_latency_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_endpoint_token_latency_embed_dashboard.json
@@ -1,0 +1,299 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(vllm:prompt_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(rate(sglang:prompt_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Prompt tokens/s",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(vllm:generation_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(rate(sglang:generation_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(sglang:gen_throughput{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Generation tokens/s",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(vllm:prompt_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(rate(sglang:prompt_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) + (sum(rate(vllm:generation_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(rate(sglang:generation_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(sglang:gen_throughput{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}))",
+          "refId": "A"
+        }
+      ],
+      "title": "Total tokens/s",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "sum(rate(vllm:prompt_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(rate(sglang:prompt_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "prompt tokens/s"
+        },
+        {
+          "expr": "sum(rate(vllm:generation_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(rate(sglang:generation_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(sglang:gen_throughput{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
+          "refId": "B",
+          "legendFormat": "generation tokens/s"
+        },
+        {
+          "expr": "(sum(rate(vllm:prompt_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(rate(sglang:prompt_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) + (sum(rate(vllm:generation_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(rate(sglang:generation_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum(sglang:gen_throughput{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}))",
+          "refId": "C",
+          "legendFormat": "total tokens/s"
+        }
+      ],
+      "title": "Token throughput trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Heatmap of request prompt length",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 5,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "none"
+        },
+        "color": {
+          "mode": "scheme",
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "exponent": 0.5,
+          "steps": 64
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "value": "Request count"
+        },
+        "tooltip": {
+          "mode": "single",
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Prompt Length",
+          "unit": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by(le) (increase(vllm:request_prompt_tokens_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum by(le) (increase(sglang:prompt_tokens_histogram_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{le}}",
+          "format": "heatmap",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "title": "Request Prompt Length",
+      "type": "heatmap"
+    },
+    {
+      "datasource": "${datasource}",
+      "description": "Heatmap of request generation length",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 6,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "none"
+        },
+        "color": {
+          "mode": "scheme",
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "exponent": 0.5,
+          "steps": 64
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "value": "Request count"
+        },
+        "tooltip": {
+          "mode": "single",
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Generation Length",
+          "unit": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by(le) (increase(vllm:request_generation_tokens_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) or sum by(le) (increase(sglang:generation_tokens_histogram_bucket{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{le}}",
+          "format": "heatmap",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "title": "Request Generation Length",
+      "type": "heatmap"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 40,
+  "tags": [
+    "neutree",
+    "endpoint",
+    "token",
+    "embed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "neutree-cluster",
+          "value": "neutree-cluster"
+        },
+        "name": "datasource",
+        "query": "prometheus",
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_node_ready, neutree_cluster)",
+        "includeAll": true,
+        "name": "Cluster",
+        "query": "label_values(neutree_node_ready, neutree_cluster)",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "includeAll": false,
+        "name": "Endpoint",
+        "query": "label_values(neutree_endpoint_replica_accelerator_allocation{neutree_cluster=~\"$Cluster\"}, endpoint)",
+        "refresh": 1,
+        "type": "query",
+        "multi": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Neutree Endpoint Token Latency Embed",
+  "uid": "neutree-endpoint-token-latency-embed",
+  "version": 1
+}

--- a/observability/grafana/dashboards/neutree_overview_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_overview_embed_dashboard.json
@@ -1,0 +1,378 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "count(count by (node) (neutree_node_ready{neutree_cluster=~\"$Cluster\"}))",
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_node_accelerator_total{neutree_cluster=~\"$Cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg(neutree_accelerator_utilization_ratio{neutree_cluster=~\"$Cluster\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU avg",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_accelerator_memory_used_bytes{neutree_cluster=~\"$Cluster\"}) / clamp_min(sum(neutree_accelerator_memory_total_bytes{neutree_cluster=~\"$Cluster\"}), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU memory",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 1,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(vllm:request_success_total{neutree_cluster=~\"$Cluster\"}[$__rate_interval])) or on() vector(0)) + ((sum(rate(sglang:num_requests_total{neutree_cluster=~\"$Cluster\"}[$__rate_interval])) or sum(rate(sglang:e2e_request_latency_seconds_count{neutree_cluster=~\"$Cluster\"}[$__rate_interval]))) or on() vector(0))",
+          "refId": "A"
+        }
+      ],
+      "title": "Current QPS",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "id": 2,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "((sum(rate(vllm:e2e_request_latency_seconds_sum{neutree_cluster=~\"$Cluster\"}[$__rate_interval])) or on() vector(0)) + (sum(rate(sglang:e2e_request_latency_seconds_sum{neutree_cluster=~\"$Cluster\"}[$__rate_interval])) or on() vector(0))) / clamp_min((sum(rate(vllm:e2e_request_latency_seconds_count{neutree_cluster=~\"$Cluster\"}[$__rate_interval])) or on() vector(0)) + (sum(rate(sglang:e2e_request_latency_seconds_count{neutree_cluster=~\"$Cluster\"}[$__rate_interval])) or on() vector(0)), 1e-9)",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg latency",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 3,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "1 - avg(rate(neutree_node_cpu_seconds_total{neutree_cluster=~\"$Cluster\",mode=\"idle\"}[$__rate_interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU avg",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(neutree_node_memory_used_bytes{neutree_cluster=~\"$Cluster\"}) / clamp_min(sum(neutree_node_memory_total_bytes{neutree_cluster=~\"$Cluster\"}), 1)",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory avg",
+      "type": "stat"
+    },
+    {
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 10,
+      "targets": [
+        {
+          "expr": "sum by (product) (neutree_node_accelerator_total{neutree_cluster=~\"$Cluster\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{product}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (product) (neutree_node_accelerator_free{neutree_cluster=~\"$Cluster\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{product}}",
+          "refId": "B"
+        }
+      ],
+      "title": "GPU inventory by model",
+      "type": "table",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "product": 0,
+              "Value": 1,
+              "Value #A": 1,
+              "Value #B": 2
+            },
+            "renameByName": {
+              "product": "Model",
+              "Value": "Total",
+              "Value #A": "Total",
+              "Value #B": "Free"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "datasource": "${datasource}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "1 - avg(rate(neutree_node_cpu_seconds_total{neutree_cluster=~\"$Cluster\",mode=\"idle\"}[$__rate_interval]))",
+          "legendFormat": "CPU",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(neutree_node_memory_used_bytes{neutree_cluster=~\"$Cluster\"}) / clamp_min(sum(neutree_node_memory_total_bytes{neutree_cluster=~\"$Cluster\"}), 1)",
+          "legendFormat": "Memory",
+          "refId": "B"
+        },
+        {
+          "expr": "avg(neutree_accelerator_utilization_ratio{neutree_cluster=~\"$Cluster\"})",
+          "legendFormat": "GPU",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(neutree_accelerator_memory_used_bytes{neutree_cluster=~\"$Cluster\"}) / clamp_min(sum(neutree_accelerator_memory_total_bytes{neutree_cluster=~\"$Cluster\"}), 1)",
+          "legendFormat": "GPU memory",
+          "refId": "D"
+        }
+      ],
+      "title": "Cluster utilization",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 40,
+  "tags": [
+    "neutree",
+    "overview",
+    "embed"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "neutree-cluster",
+          "value": "neutree-cluster"
+        },
+        "hide": 0,
+        "name": "datasource",
+        "query": "prometheus",
+        "type": "datasource"
+      },
+      {
+        "datasource": "${datasource}",
+        "definition": "label_values(neutree_node_ready, neutree_cluster)",
+        "includeAll": true,
+        "multi": false,
+        "name": "Cluster",
+        "query": "label_values(neutree_node_ready, neutree_cluster)",
+        "refresh": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Neutree Overview Embed",
+  "uid": "neutree-overview-embed",
+  "version": 1
+}


### PR DESCRIPTION
## Issue

n/a

## Summary

Add split Grafana embed dashboards for Neutree overview, cluster overview, and endpoint monitoring views so the UI can embed focused dashboard pages instead of a single broad dashboard.

## Changes

- Add Neutree overview embed dashboard.
- Add cluster overview embed dashboard.
- Add endpoint overview, latency, throughput, queue, and cache embed dashboards.
- Keep this dashboard-only branch scoped to 7 dashboard JSON files under `observability/grafana/dashboards`.

## Review Notes

- These files are the dashboard source-of-truth files. The existing `vendir.yml` / `sync-deploy-manifests` flow mirrors `observability/grafana/dashboards` into Docker and Helm dashboard payload directories during packaging.
- These dashboards depend on the monitoring metrics contract introduced by the related monitoring work, including `neutree_endpoint_replica_*`, `neutree_node_*`, and accelerator hardware/allocation metrics.
- Endpoint engine panels intentionally use exact `application="$Endpoint"` matching; this assumes the engine metrics bridge emits `application` equal to the Neutree endpoint name.
- Neutree overview `Current QPS` and `Avg latency` currently aggregate engine-side `vllm:*` / `sglang:*` metrics as a temporary request source; a follow-up should switch these panels to Kong/API gateway metrics so the overview uses ingress request semantics.

## Test Plan

Unit test:
- Passed: `python3 -m json.tool observability/grafana/dashboards/neutree_*_embed_dashboard.json`
- Passed: `git diff --check`

DB test:
- Not affected; dashboard JSON-only change.

E2E test:
- Not run for this draft PR; this isolated branch only adds dashboard JSON files and does not change deployed services, database schema, or runtime code. Live dashboard validation is covered by the cumulative monitoring branch because these dashboards depend on that metrics contract. Manual testing is not required before draft review for this source-only split.

## Risk & Rollback

Risk is limited to Grafana dashboard rendering and query compatibility with the monitoring metrics contract. Rollback is reverting this commit to remove the added embed dashboard JSON files.
