### PR TITLE
fix: omit empty gateway request arrays

### DIFF
--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -18,6 +18,10 @@ local function is_table(v)
     return type(v) == "table"
 end
 
+local function is_empty_table(v)
+    return is_table(v) and next(v) == nil
+end
+
 local function string_or_empty(v)
     return type(v) == "string" and v or ""
 end
@@ -594,7 +598,7 @@ local function convert_request(anthropic_req)
     end
     openai_req.messages = messages
 
-    if anthropic_req.stop_sequences then
+    if anthropic_req.stop_sequences and not is_empty_table(anthropic_req.stop_sequences) then
         openai_req.stop = anthropic_req.stop_sequences
     end
     if anthropic_req.stream then
@@ -1353,6 +1357,12 @@ function AIGatewayHandler:access(conf)
             kong.service.request.set_path(build_upstream_path(matched_entry, strip_api_version_prefix(suffix)))
         end
         ai_request.model = matched_entry.model_mapping[ai_request.model]
+        if is_empty_table(ai_request.tools) then
+            ai_request.tools = nil
+        end
+        if is_empty_table(ai_request.stop) then
+            ai_request.stop = nil
+        end
         local new_body = cjson.encode(ai_request)
         if new_body then
             kong.service.request.set_raw_body(new_body)

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -598,7 +598,7 @@ local function convert_request(anthropic_req)
     end
     openai_req.messages = messages
 
-    if anthropic_req.stop_sequences and not is_empty_table(anthropic_req.stop_sequences) then
+    if is_table(anthropic_req.stop_sequences) and not is_empty_table(anthropic_req.stop_sequences) then
         openai_req.stop = anthropic_req.stop_sequences
     end
     if anthropic_req.stream then

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -549,6 +549,21 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 
 			_, upstreamReq = waitForUpstreamRequest()
 			assertStringArrayField(upstreamReq, "stop", "END")
+
+			mockUpstream.ClearRequests()
+
+			resp, status = sendRawAnthropicMessage(serviceURL, map[string]any{
+				"model":      "fast",
+				"max_tokens": 32,
+				"messages": []map[string]any{
+					{"role": "user", "content": "hello null stop sequences"},
+				},
+				"stop_sequences": nil,
+			})
+			Expect(status).To(Equal(http.StatusOK), "unexpected Anthropic response: %v", resp)
+
+			_, upstreamReq = waitForUpstreamRequest()
+			assertFieldOmitted(upstreamReq, "stop")
 		})
 
 		// NEU-428: when an OpenAI-compatible upstream returns "tool_calls": null

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -140,6 +140,20 @@ func countMessagesByRole(messages []any, role string) int {
 	return count
 }
 
+func assertFieldOmitted(upstreamReq map[string]any, field string) {
+	_, ok := upstreamReq[field]
+	Expect(ok).To(BeFalse(), "%s must be omitted instead of encoded as {}", field)
+}
+
+func assertStringArrayField(upstreamReq map[string]any, field string, expected ...string) {
+	values, ok := upstreamReq[field].([]any)
+	Expect(ok).To(BeTrue(), "%s must be encoded as a JSON array", field)
+	Expect(values).To(HaveLen(len(expected)))
+	for i, value := range values {
+		Expect(value).To(Equal(expected[i]))
+	}
+}
+
 func assertMalformedToolUseBlocks(content []anthropic.ContentBlockUnion) {
 	toolUses := make(map[string]anthropic.ContentBlockUnion)
 	for _, block := range content {
@@ -267,6 +281,42 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 			last, _ := waitForUpstreamRequest()
 			Expect(last.Headers.Get("Authorization")).To(Equal("Bearer "+mockAuthToken),
 				"upstream should receive the configured auth header")
+		})
+
+		// TestRail: C2728777
+		It("should omit empty array fields before upstream rewrite", Label("C2728777", "empty-array-request-fields"), func() {
+			mockUpstream.ClearRequests()
+
+			status, body, err := doInferenceRequest(serviceURL, "/v1/chat/completions", map[string]any{
+				"model": "fast",
+				"messages": []map[string]any{
+					{"role": "user", "content": "hello empty arrays"},
+				},
+				"tools": []map[string]any{},
+				"stop":  []string{},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(http.StatusOK), "unexpected OpenAI response: %s", body)
+
+			last, upstreamReq := waitForUpstreamRequest()
+			Expect(last.Path).To(Equal("/v1/chat/completions"))
+			assertFieldOmitted(upstreamReq, "tools")
+			assertFieldOmitted(upstreamReq, "stop")
+
+			mockUpstream.ClearRequests()
+
+			status, body, err = doInferenceRequest(serviceURL, "/v1/chat/completions", map[string]any{
+				"model": "fast",
+				"messages": []map[string]any{
+					{"role": "user", "content": "hello non-empty stop"},
+				},
+				"stop": []string{"END"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(http.StatusOK), "unexpected OpenAI response: %s", body)
+
+			_, upstreamReq = waitForUpstreamRequest()
+			assertStringArrayField(upstreamReq, "stop", "END")
 		})
 	})
 
@@ -433,6 +483,42 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 			Expect(ok).To(BeTrue())
 			Expect(first["role"]).To(Equal("developer"))
 			Expect(first["content"]).To(Equal("unsupported"))
+		})
+
+		// TestRail: C2728776
+		It("should omit empty arrays before OpenAI upstream conversion", Label("C2728776", "empty-array-request-fields"), func() {
+			mockUpstream.ClearRequests()
+
+			resp, status := sendRawAnthropicMessage(serviceURL, map[string]any{
+				"model":      "fast",
+				"max_tokens": 32,
+				"messages": []map[string]any{
+					{"role": "user", "content": "hello empty arrays"},
+				},
+				"tools":          []map[string]any{},
+				"stop_sequences": []string{},
+			})
+			Expect(status).To(Equal(http.StatusOK), "unexpected Anthropic response: %v", resp)
+
+			last, upstreamReq := waitForUpstreamRequest()
+			Expect(last.Path).To(Equal("/v1/chat/completions"))
+			assertFieldOmitted(upstreamReq, "tools")
+			assertFieldOmitted(upstreamReq, "stop")
+
+			mockUpstream.ClearRequests()
+
+			resp, status = sendRawAnthropicMessage(serviceURL, map[string]any{
+				"model":      "fast",
+				"max_tokens": 32,
+				"messages": []map[string]any{
+					{"role": "user", "content": "hello non-empty stop sequences"},
+				},
+				"stop_sequences": []string{"END"},
+			})
+			Expect(status).To(Equal(http.StatusOK), "unexpected Anthropic response: %v", resp)
+
+			_, upstreamReq = waitForUpstreamRequest()
+			assertStringArrayField(upstreamReq, "stop", "END")
 		})
 
 		// NEU-428: when an OpenAI-compatible upstream returns "tool_calls": null

--- a/tests/e2e/external_endpoint_test.go
+++ b/tests/e2e/external_endpoint_test.go
@@ -154,6 +154,20 @@ func assertStringArrayField(upstreamReq map[string]any, field string, expected .
 	}
 }
 
+func assertOpenAIFunctionTool(upstreamReq map[string]any, expectedName string) {
+	tools, ok := upstreamReq["tools"].([]any)
+	Expect(ok).To(BeTrue(), "tools must be encoded as a JSON array")
+	Expect(tools).To(HaveLen(1))
+
+	tool, ok := tools[0].(map[string]any)
+	Expect(ok).To(BeTrue(), "tool entries should be objects")
+	Expect(tool["type"]).To(Equal("function"))
+
+	function, ok := tool["function"].(map[string]any)
+	Expect(ok).To(BeTrue(), "function tool should contain a function object")
+	Expect(function["name"]).To(Equal(expectedName))
+}
+
 func assertMalformedToolUseBlocks(content []anthropic.ContentBlockUnion) {
 	toolUses := make(map[string]anthropic.ContentBlockUnion)
 	for _, block := range content {
@@ -308,15 +322,31 @@ var _ = Describe("ExternalEndpoint", Ordered, Label("external-endpoint"), func()
 			status, body, err = doInferenceRequest(serviceURL, "/v1/chat/completions", map[string]any{
 				"model": "fast",
 				"messages": []map[string]any{
-					{"role": "user", "content": "hello non-empty stop"},
+					{"role": "user", "content": "hello non-empty fields"},
 				},
 				"stop": []string{"END"},
+				"tools": []map[string]any{
+					{
+						"type": "function",
+						"function": map[string]any{
+							"name":        "lookup_weather",
+							"description": "Look up weather.",
+							"parameters": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"city": map[string]any{"type": "string"},
+								},
+							},
+						},
+					},
+				},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(status).To(Equal(http.StatusOK), "unexpected OpenAI response: %s", body)
 
 			_, upstreamReq = waitForUpstreamRequest()
 			assertStringArrayField(upstreamReq, "stop", "END")
+			assertOpenAIFunctionTool(upstreamReq, "lookup_weather")
 		})
 	})
 


### PR DESCRIPTION
## Issue

NEU-415

## Summary

Kong request rewrite paths can decode JSON empty arrays as empty Lua tables and re-encode them as JSON objects. This change omits optional empty array fields in the affected gateway rewrite paths while preserving non-empty arrays.

## Changes

- Omit empty Anthropic `stop_sequences` instead of forwarding it as OpenAI `stop: {}`.
- Omit empty OpenAI `tools` and `stop` before direct model-mapping rewrite re-encodes the request body.
- Add ExternalEndpoint E2E coverage for Anthropic and OpenAI empty arrays, non-empty `stop` and OpenAI `tools` preservation, and `stop_sequences: null` omission checks.

## Test Plan

Unit test
- [x] `go vet -p=1 ./...`
- [x] `go test -p=1 $(go list ./... | grep -v 'e2e\|mocks\|db/dbtest')`
- [x] `go test -p=1 ./tests/e2e/... -run TestE2E -count=1`
- [x] `make build-neutree-cli`
- [x] `git diff --check`
- [x] Copilot fix local check: `gofmt -w tests/e2e/external_endpoint_test.go && go test -p=1 ./tests/e2e/... -run TestE2E -count=1 && git diff --check`
- [ ] `golangci-lint run ./tests/e2e/...` not completed locally: system `golangci-lint` v1.53.3 fails typecheck on the existing E2E/Ginkgo package shape, and local disk space is too low to install the repo target v1.64.6.

DB test
- [x] Not affected: no DB schema, storage, or migration changes.

E2E test
- [x] Manual C2728777 OpenAI empty arrays on CP `10.255.1.54`: request with `tools: []` and `stop: []` returned HTTP 200; mock upstream received `/v1/chat/completions` without `tools` or `stop`; non-empty `stop: ["END"]` was preserved.
- [x] Manual C2728776 Anthropic empty arrays on CP `10.255.1.54`: request with `tools: []` and `stop_sequences: []` returned HTTP 200; mock upstream received `/v1/chat/completions` without `tools` or `stop`; non-empty `stop_sequences: ["END"]` was converted to upstream `stop: ["END"]`.
- [x] Code-backed E2E: `E2E_PROFILE_PATH=<reviewfix-profile> NEUTREE_SERVER_URL=http://10.255.1.54:3000 NEUTREE_API_KEY=<masked> E2E_CLI_BINARY=<local-cli> go test -v -timeout 6h ./tests/e2e/... --ginkgo.v --ginkgo.no-color --ginkgo.silence-skips --ginkgo.timeout=30m --ginkgo.label-filter='C2728776 || C2728777'` -> `SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 250 Skipped` in 34.269s; rerun includes non-empty OpenAI `tools` preservation assertion.
- [x] Step 10 regression after Copilot fix: deployed `handler.lua` SHA256 `7dc115271154b8cbf3d6ca043f713ea3ec0b6f6fc054e841db2f10a13588b297` to CP `10.255.1.54`, restarted Kong at `2026-07-07T03:24:24Z`, then reran `go test -v -timeout 6h ./tests/e2e/... --ginkgo.v --ginkgo.no-color --ginkgo.silence-skips --ginkgo.timeout=30m --ginkgo.label-filter='C2728776 || C2728777'` -> `SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 250 Skipped` in 23.485s.
- [x] Runtime version evidence: PR head `df58c065`; gateway runtime change commits `61e3bb46` and `df58c065`; CP baseline `v1.1.0-nightly-20260705`; Step 10 regression deployed `neutree-ai-gateway/handler.lua` SHA256 `7dc115271154b8cbf3d6ca043f713ea3ec0b6f6fc054e841db2f10a13588b297` and restarted Kong at `2026-07-07T03:24:24Z`; commit `99efcb52` is E2E-only.

## Risk & Rollback

Risk is limited to gateway request body rewriting for optional array fields. Non-empty arrays are preserved. Rollback is reverting this commit and redeploying the gateway plugin artifact.



