### PR TITLE
fix: validate vGPU endpoint preflight

### DIFF
--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -92,81 +91,87 @@ func validateEndpointVGPUPreflight(
 		return nil
 	}
 
-	// Only validate writes that directly touch endpoint resources.
-	if endpoint.Spec == nil || endpoint.Spec.Resources == nil {
+	if endpoint.Spec == nil {
 		return nil
 	}
-
-	if method != http.MethodPatch && !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
-		return nil
-	}
-
-	if store == nil {
-		return endpointVGPULookupError("storage is required to validate endpoint accelerator virtualization")
-	}
-
-	var existing *v1.Endpoint
 
 	if method == http.MethodPatch {
-		resolved, validationErr := resolveEndpointPatch(store, queryParams)
-		if validationErr != nil {
-			return validationErr
+		if !endpointPatchMayAffectVGPUValidation(endpoint) {
+			return nil
 		}
-
-		existing = resolved
-		merged := mergeEndpointPatch(existing, endpoint)
-		endpoint = &merged
 	}
 
-	if endpoint.Spec == nil || endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
-		return nil
-	}
-
-	if validationErr := validateEndpointVGPUResourceShape(endpoint.Spec.Resources); validationErr != nil {
+	targetEndpoint, validationErr := endpointVGPUValidationTarget(store, method, queryParams, endpoint)
+	if validationErr != nil {
 		return validationErr
 	}
 
-	clusterName := endpoint.Spec.Cluster
-	if clusterName == "" {
-		return endpointVGPUTargetError("spec.cluster is required for endpoint accelerator virtualization")
+	if targetEndpoint == nil || targetEndpoint.Spec == nil {
+		return nil
 	}
 
-	workspace := defaultWorkspace
-	if endpoint.Metadata != nil && endpoint.Metadata.Workspace != "" {
-		workspace = endpoint.Metadata.Workspace
+	if validationErr := validateEndpointReplicaCount(targetEndpoint.Spec); validationErr != nil {
+		return validationErr
 	}
 
-	clusters, err := store.ListCluster(storage.ListOption{
-		Filters: endpointClusterLookupFilters(clusterName, workspace),
-	})
-	if err != nil {
-		return endpointVGPULookupError("failed to look up cluster for endpoint accelerator virtualization")
+	if targetEndpoint.Spec.Resources == nil || !targetEndpoint.Spec.Resources.HasAcceleratorVirtualization() {
+		return nil
 	}
 
-	if len(clusters) == 0 {
-		return endpointVGPUTargetError(fmt.Sprintf("cluster %s/%s not found", workspace, clusterName))
+	if endpointReplicaCount(targetEndpoint.Spec) == 0 {
+		return nil
 	}
 
-	if len(clusters) > 1 {
-		return endpointVGPUTargetError(fmt.Sprintf("multiple clusters matched %s/%s", workspace, clusterName))
+	cluster, validationErr := resolveEndpointVGPUCluster(store, targetEndpoint)
+	if validationErr != nil {
+		return validationErr
 	}
 
-	cluster := &clusters[0]
 	if validationErr := validateEndpointVGPUCluster(cluster); validationErr != nil {
 		return validationErr
 	}
 
-	if method == http.MethodPatch && canAddBackEndpointVGPUAllocation(existing, clusterName, workspace) {
-		cluster = clusterWithEndpointVGPUAllocationAddedBack(cluster, existing)
+	if validationErr := validateEndpointVGPUResourceShape(targetEndpoint.Spec.Resources); validationErr != nil {
+		return validationErr
 	}
 
-	return validateEndpointVGPUCapacity(endpoint.Spec.Resources, cluster)
+	if validationErr := validateEndpointVGPUMemorySpec(targetEndpoint.Spec.Resources, cluster); validationErr != nil {
+		return validationErr
+	}
+
+	// Capacity is intentionally left to scheduling/runtime status. Cluster
+	// resource snapshots can be stale and should not be used as admission gates.
+	return nil
+}
+
+func endpointVGPUValidationTarget(
+	store storage.Storage,
+	method string,
+	queryParams url.Values,
+	endpoint *v1.Endpoint,
+) (*v1.Endpoint, *validationError) {
+	if method != http.MethodPatch {
+		return endpoint, nil
+	}
+
+	resolved, validationErr := resolveEndpointPatch(store, queryParams)
+	if validationErr != nil {
+		return nil, validationErr
+	}
+
+	merged := mergeEndpointPatch(resolved, endpoint)
+
+	return &merged, nil
 }
 
 func resolveEndpointPatch(
 	store storage.Storage,
 	queryParams url.Values,
 ) (*v1.Endpoint, *validationError) {
+	if store == nil {
+		return nil, endpointVGPULookupError("storage is required to validate endpoint accelerator virtualization")
+	}
+
 	filters := queryParamsToFilters(queryParams)
 	if len(filters) == 0 {
 		return nil, endpointVGPUTargetError("endpoint lookup filters are required for vGPU resource PATCH")
@@ -186,6 +191,39 @@ func resolveEndpointPatch(
 	}
 
 	return &endpoints[0], nil
+}
+
+func resolveEndpointVGPUCluster(store storage.Storage, endpoint *v1.Endpoint) (*v1.Cluster, *validationError) {
+	if store == nil {
+		return nil, endpointVGPULookupError("storage is required to validate endpoint accelerator virtualization")
+	}
+
+	clusterName := endpoint.Spec.Cluster
+	if clusterName == "" {
+		return nil, endpointVGPUTargetError("spec.cluster is required for endpoint accelerator virtualization")
+	}
+
+	workspace := defaultWorkspace
+	if endpoint.Metadata != nil && endpoint.Metadata.Workspace != "" {
+		workspace = endpoint.Metadata.Workspace
+	}
+
+	clusters, err := store.ListCluster(storage.ListOption{
+		Filters: endpointClusterLookupFilters(clusterName, workspace),
+	})
+	if err != nil {
+		return nil, endpointVGPULookupError("failed to look up cluster for endpoint accelerator virtualization")
+	}
+
+	if len(clusters) == 0 {
+		return nil, endpointVGPUTargetError(fmt.Sprintf("cluster %s/%s not found", workspace, clusterName))
+	}
+
+	if len(clusters) > 1 {
+		return nil, endpointVGPUTargetError(fmt.Sprintf("multiple clusters matched %s/%s", workspace, clusterName))
+	}
+
+	return &clusters[0], nil
 }
 
 func mergeEndpointPatch(existing *v1.Endpoint, patch *v1.Endpoint) v1.Endpoint {
@@ -240,6 +278,10 @@ func mergeEndpointPatch(existing *v1.Endpoint, patch *v1.Endpoint) v1.Endpoint {
 			merged.Spec.Cluster = patch.Spec.Cluster
 		}
 
+		if patch.Spec.Replicas.Num != nil {
+			merged.Spec.Replicas.Num = patch.Spec.Replicas.Num
+		}
+
 		if patch.Spec.Resources != nil {
 			merged.Spec.Resources = mergeEndpointResourceSpec(merged.Spec.Resources, patch.Spec.Resources)
 		}
@@ -275,9 +317,40 @@ func mergeEndpointResourceSpec(existing *v1.ResourceSpec, patch *v1.ResourceSpec
 		for key, value := range patch.Accelerator {
 			merged.Accelerator[key] = value
 		}
+
+		if acceleratorPatchClearsVirtualization(patch.Accelerator) {
+			clearAcceleratorVirtualization(merged.Accelerator)
+		}
 	}
 
 	return merged
+}
+
+func acceleratorPatchClearsVirtualization(accelerator map[string]string) bool {
+	if accelerator == nil {
+		return false
+	}
+
+	_, hasType := accelerator[v1.AcceleratorTypeKey]
+	_, hasProduct := accelerator[v1.AcceleratorProductKey]
+
+	return hasType && hasProduct && !acceleratorHasVirtualization(accelerator)
+}
+
+func clearAcceleratorVirtualization(accelerator map[string]string) {
+	delete(accelerator, v1.AcceleratorVirtualizationMemoryMiBKey)
+	delete(accelerator, v1.AcceleratorVirtualizationMemoryPercentKey)
+	delete(accelerator, v1.AcceleratorVirtualizationCorePercentKey)
+}
+
+func acceleratorHasVirtualization(accelerator map[string]string) bool {
+	for key := range accelerator {
+		if v1.IsAcceleratorVirtualizationKey(key) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func copyEndpointResourceSpec(resources *v1.ResourceSpec) *v1.ResourceSpec {
@@ -296,28 +369,21 @@ func copyEndpointResourceSpec(resources *v1.ResourceSpec) *v1.ResourceSpec {
 	return &copied
 }
 
+func endpointPatchMayAffectVGPUValidation(endpoint *v1.Endpoint) bool {
+	if endpoint == nil || endpoint.Spec == nil {
+		return false
+	}
+
+	return endpoint.Spec.Resources != nil ||
+		endpoint.Spec.Cluster != "" ||
+		endpoint.Spec.Replicas.Num != nil
+}
+
 func endpointClusterLookupFilters(cluster, workspace string) []storage.Filter {
 	return []storage.Filter{
 		{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(cluster)},
 		{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
 	}
-}
-
-func canAddBackEndpointVGPUAllocation(
-	endpoint *v1.Endpoint,
-	cluster string,
-	targetWorkspace string,
-) bool {
-	if endpoint == nil || endpoint.Spec == nil {
-		return false
-	}
-
-	endpointWorkspace := defaultWorkspace
-	if endpoint.Metadata != nil && endpoint.Metadata.Workspace != "" {
-		endpointWorkspace = endpoint.Metadata.Workspace
-	}
-
-	return endpoint.Spec.Cluster == cluster && endpointWorkspace == targetWorkspace
 }
 
 func validateEndpointVGPUCluster(cluster *v1.Cluster) *validationError {
@@ -371,11 +437,11 @@ func validateEndpointVGPUResourceShape(resources *v1.ResourceSpec) *validationEr
 		}
 	}
 
-	if resources.GetAcceleratorVirtualizationMemoryMiB() != "" && resources.GetAcceleratorVirtualizationMemoryPercent() != "" {
+	if resources.GetAcceleratorVirtualizationMemoryPercent() != "" {
 		return &validationError{
 			Code:    "10219",
-			Message: "virtualization memory_mib and memory_percent are mutually exclusive",
-			Hint:    "Set only one of virtualization.memory_mib or virtualization.memory_percent",
+			Message: "virtualization memory_percent is not supported",
+			Hint:    "Set virtualization.memory_mib instead of virtualization.memory_percent",
 		}
 	}
 
@@ -383,92 +449,118 @@ func validateEndpointVGPUResourceShape(resources *v1.ResourceSpec) *validationEr
 		return endpointResourceValueError(err)
 	}
 
-	if _, err := parseOptionalPositiveInteger(resources.GetAcceleratorVirtualizationMemoryMiB(), "virtualization.memory_mib"); err != nil {
+	if _, err := parseRequiredPositiveInteger(resources.GetAcceleratorVirtualizationMemoryMiB(), "virtualization.memory_mib"); err != nil {
 		return endpointResourceValueError(err)
 	}
 
-	if err := validatePercentResource(resources.GetAcceleratorVirtualizationMemoryPercent(), "virtualization.memory_percent"); err != nil {
-		return endpointResourceValueError(err)
-	}
-
-	if err := validatePercentResource(resources.GetAcceleratorVirtualizationCorePercent(), "virtualization.core_percent"); err != nil {
+	if err := validateZeroToHundredPercentResource(resources.GetAcceleratorVirtualizationCorePercent(), "virtualization.core_percent"); err != nil {
 		return endpointResourceValueError(err)
 	}
 
 	return nil
 }
 
-func validateEndpointVGPUCapacity(resources *v1.ResourceSpec, cluster *v1.Cluster) *validationError {
+func validateEndpointVGPUMemorySpec(resources *v1.ResourceSpec, cluster *v1.Cluster) *validationError {
 	if resources == nil || !resources.HasAcceleratorVirtualization() {
 		return nil
 	}
 
-	requestedGPU, err := parsePositiveIntegerResource(resources.GPU, "spec.resources.gpu")
+	requestedMemoryMiB, err := parseRequiredPositiveInteger(
+		resources.GetAcceleratorVirtualizationMemoryMiB(),
+		"virtualization.memory_mib",
+	)
 	if err != nil {
 		return endpointResourceValueError(err)
 	}
 
 	product := resources.GetAcceleratorProduct()
-	resourceInfo := clusterResourceInfo(cluster)
+	maxMemoryMiB, ok := clusterProductMaxMemoryMiB(cluster, product)
 
-	productResources, productTelemetryReady := vgpuProductResources(resourceInfo)
-	if !productTelemetryReady {
-		return nil
-	}
-
-	productResource := productResources[v1.AcceleratorProduct(product)]
-	if productResource == nil {
-		return endpointVGPUCapacityError(fmt.Sprintf("product=%s has no available accelerator virtualization capacity", product))
-	}
-
-	if productResource.Virtualization == nil {
-		return nil
-	}
-
-	requestedMemoryMiB, memoryTelemetryReady, err := requestedVGPUMemoryMiB(resources, resourceInfo, product)
-	if err != nil {
-		return endpointVGPUCapacityError(err.Error())
-	}
-
-	if !memoryTelemetryReady {
-		requestedMemoryMiB = 0
-	}
-
-	requestedCoreUnits, err := requestedVGPUCoreUnits(resources)
-	if err != nil {
-		return endpointVGPUCapacityError(err.Error())
-	}
-
-	satisfiableDevices, matchingDevices, matchingDeviceCountReady, deviceTelemetryReady :=
-		countSatisfiableVGPUDevices(resourceInfo, product, requestedMemoryMiB, requestedCoreUnits)
-	if satisfiableDevices >= requestedGPU {
-		return nil
-	}
-
-	if !deviceTelemetryReady {
-		return nil
-	}
-
-	if matchingDeviceCountReady && matchingDevices < requestedGPU {
-		return endpointVGPUCapacityError(fmt.Sprintf(
-			"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d matching_devices=%d satisfiable_devices=%d",
+	if !ok {
+		return endpointResourceValueError(fmt.Errorf(
+			"unable to determine physical GPU memory_mib for accelerator product %s",
 			product,
-			requestedGPU,
-			requestedMemoryMiB,
-			requestedCoreUnits,
-			matchingDevices,
-			satisfiableDevices,
 		))
 	}
 
-	return endpointVGPUCapacityError(fmt.Sprintf(
-		"product=%s requested_gpu=%d requested_memory_mib=%d requested_core_units=%d satisfiable_devices=%d",
-		product,
-		requestedGPU,
-		requestedMemoryMiB,
-		requestedCoreUnits,
-		satisfiableDevices,
-	))
+	if requestedMemoryMiB > maxMemoryMiB {
+		return endpointResourceValueError(fmt.Errorf(
+			"virtualization.memory_mib must be less than or equal to physical GPU memory_mib %d for accelerator product %s",
+			maxMemoryMiB,
+			product,
+		))
+	}
+
+	return nil
+}
+
+func clusterProductMaxMemoryMiB(cluster *v1.Cluster, product string) (int64, bool) {
+	resourceInfo := clusterResourceInfo(cluster)
+	if resourceInfo == nil {
+		return 0, false
+	}
+
+	if memoryMiB, ok := clusterProductMetadataMemoryMiB(resourceInfo, product); ok {
+		return memoryMiB, true
+	}
+
+	var maxMemoryMiB int64
+
+	for _, node := range resourceInfo.NodeResources {
+		if node == nil {
+			continue
+		}
+
+		for _, device := range node.Devices {
+			if device == nil || device.Product != product || device.Allocatable == nil {
+				continue
+			}
+
+			if device.Allocatable.MemoryMiB > maxMemoryMiB {
+				maxMemoryMiB = device.Allocatable.MemoryMiB
+			}
+		}
+	}
+
+	return maxMemoryMiB, maxMemoryMiB > 0
+}
+
+func clusterProductMetadataMemoryMiB(resourceInfo *v1.ClusterResources, product string) (int64, bool) {
+	if resourceInfo.AcceleratorMetadata == nil {
+		return 0, false
+	}
+
+	metadata := resourceInfo.AcceleratorMetadata[v1.AcceleratorTypeNVIDIAGPU]
+	if metadata == nil || metadata.Products == nil {
+		return 0, false
+	}
+
+	productMetadata := metadata.Products[v1.AcceleratorProduct(product)]
+	if productMetadata == nil || productMetadata.MemoryTotalMiB <= 0 {
+		return 0, false
+	}
+
+	return int64(productMetadata.MemoryTotalMiB), true
+}
+
+func endpointReplicaCount(spec *v1.EndpointSpec) int64 {
+	if spec == nil || spec.Replicas.Num == nil {
+		return 1
+	}
+
+	return int64(*spec.Replicas.Num)
+}
+
+func validateEndpointReplicaCount(spec *v1.EndpointSpec) *validationError {
+	if spec == nil || spec.Replicas.Num == nil {
+		return nil
+	}
+
+	if *spec.Replicas.Num < 0 {
+		return endpointResourceValueError(fmt.Errorf("spec.replicas.num must be a non-negative integer"))
+	}
+
+	return nil
 }
 
 func clusterResourceInfo(cluster *v1.Cluster) *v1.ClusterResources {
@@ -479,246 +571,12 @@ func clusterResourceInfo(cluster *v1.Cluster) *v1.ClusterResources {
 	return cluster.Status.ResourceInfo
 }
 
-func clusterWithEndpointVGPUAllocationAddedBack(cluster *v1.Cluster, endpoint *v1.Endpoint) *v1.Cluster {
-	if cluster == nil || endpoint == nil || endpoint.Status == nil || endpoint.Status.Resources == nil {
-		return cluster
-	}
-
-	resourceInfo := clusterResourceInfo(cluster)
-	if resourceInfo == nil {
-		return cluster
-	}
-
-	for _, replica := range endpoint.Status.Resources.Replicas {
-		for _, allocation := range replica.Devices {
-			addEndpointVGPUAllocation(resourceInfo, replica, allocation)
-		}
-	}
-
-	return cluster
-}
-
-func addEndpointVGPUAllocation(
-	resourceInfo *v1.ClusterResources,
-	replica v1.ReplicaDeviceAllocation,
-	allocation v1.DeviceAllocation,
-) {
-	if resourceInfo == nil || allocation.UUID == "" || allocation.Product == "" {
-		return
-	}
-
-	nodeID := allocation.NodeID
-	if nodeID == "" {
-		nodeID = replica.NodeID
-	}
-
-	if nodeID != "" {
-		if node := resourceInfo.NodeResources[nodeID]; addAllocationToMatchingDevice(node, allocation) {
-			addAvailableVGPUProductResource(resourceInfo, allocation)
-			return
-		}
-	}
-
-	for _, node := range resourceInfo.NodeResources {
-		if addAllocationToMatchingDevice(node, allocation) {
-			addAvailableVGPUProductResource(resourceInfo, allocation)
-			return
-		}
-	}
-}
-
-func addAllocationToMatchingDevice(node *v1.NodeResourceStatus, allocation v1.DeviceAllocation) bool {
-	if node == nil {
-		return false
-	}
-
-	for _, device := range node.Devices {
-		if device == nil || device.UUID != allocation.UUID || device.Product != allocation.Product {
-			continue
-		}
-
-		if device.Available == nil {
-			device.Available = &v1.DeviceResourcePool{}
-		}
-
-		device.Available.MemoryMiB += allocation.MemoryMiB
-		device.Available.CoreUnits += allocation.CoreUnits
-
-		return true
-	}
-
-	return false
-}
-
-func addAvailableVGPUProductResource(
-	resourceInfo *v1.ClusterResources,
-	allocation v1.DeviceAllocation,
-) {
-	if resourceInfo.Available == nil {
-		resourceInfo.Available = &v1.ResourceInfo{}
-	}
-
-	if resourceInfo.Available.AcceleratorGroups == nil {
-		resourceInfo.Available.AcceleratorGroups = map[v1.AcceleratorType]*v1.AcceleratorGroup{}
-	}
-
-	group := resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
-	if group == nil {
-		group = &v1.AcceleratorGroup{}
-		resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU] = group
-	}
-
-	if group.Products == nil {
-		group.Products = map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{}
-	}
-
-	product := v1.AcceleratorProduct(allocation.Product)
-
-	productResource := group.Products[product]
-	if productResource == nil {
-		productResource = &v1.AcceleratorProductResource{}
-		group.Products[product] = productResource
-	}
-
-	if productResource.Virtualization == nil {
-		productResource.Virtualization = &v1.AcceleratorVirtualizationResource{}
-	}
-
-	productResource.Virtualization.MemoryMiB += float64(allocation.MemoryMiB)
-	productResource.Virtualization.CoreUnits += float64(allocation.CoreUnits)
-
-	if productResource.Quantity < 1 {
-		productResource.Quantity = 1
-	}
-}
-
-func vgpuProductResources(resourceInfo *v1.ClusterResources) (map[v1.AcceleratorProduct]*v1.AcceleratorProductResource, bool) {
-	if resourceInfo == nil || resourceInfo.Available == nil || resourceInfo.Available.AcceleratorGroups == nil {
-		return nil, false
-	}
-
-	group := resourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
-	if group == nil || group.Products == nil {
-		return map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{}, true
-	}
-
-	return group.Products, true
-}
-
-func requestedVGPUMemoryMiB(resources *v1.ResourceSpec, resourceInfo *v1.ClusterResources, product string) (int64, bool, error) {
-	if memoryMiB := resources.GetAcceleratorVirtualizationMemoryMiB(); memoryMiB != "" {
-		parsed, err := parseRequiredPositiveInteger(memoryMiB, "virtualization.memory_mib")
-
-		return parsed, true, err
-	}
-
-	memoryPercent := resources.GetAcceleratorVirtualizationMemoryPercent()
-	if memoryPercent == "" {
-		return 0, true, nil
-	}
-
-	percent, err := parseRequiredPositiveInteger(memoryPercent, "virtualization.memory_percent")
-	if err != nil {
-		return 0, true, err
-	}
-
-	totalMemoryMiB, ok := productTotalMemoryMiB(resourceInfo, product)
-	if !ok || totalMemoryMiB <= 0 {
-		return 0, false, nil
-	}
-
-	return int64(math.Ceil(totalMemoryMiB * float64(percent) / 100)), true, nil
-}
-
-func productTotalMemoryMiB(resourceInfo *v1.ClusterResources, product string) (float64, bool) {
-	if resourceInfo == nil || resourceInfo.AcceleratorMetadata == nil {
-		return 0, false
-	}
-
-	metadata := resourceInfo.AcceleratorMetadata[v1.AcceleratorTypeNVIDIAGPU]
-	if metadata == nil || metadata.Products == nil {
-		return 0, false
-	}
-
-	productMetadata := metadata.Products[v1.AcceleratorProduct(product)]
-	if productMetadata == nil {
-		return 0, false
-	}
-
-	return productMetadata.MemoryTotalMiB, true
-}
-
-func requestedVGPUCoreUnits(resources *v1.ResourceSpec) (int64, error) {
-	corePercent := resources.GetAcceleratorVirtualizationCorePercent()
-	if corePercent == "" {
-		return 0, nil
-	}
-
-	return parseRequiredPositiveInteger(corePercent, "virtualization.core_percent")
-}
-
-func countSatisfiableVGPUDevices(
-	resourceInfo *v1.ClusterResources,
-	product string,
-	requestedMemoryMiB int64,
-	requestedCoreUnits int64,
-) (int64, int64, bool, bool) {
-	if resourceInfo == nil || resourceInfo.NodeResources == nil {
-		return 0, 0, false, false
-	}
-
-	var (
-		satisfiableDevices int64
-		matchingDevices    int64
-	)
-	telemetryReady := true
-
-	for _, node := range resourceInfo.NodeResources {
-		if node == nil {
-			continue
-		}
-
-		for _, device := range node.Devices {
-			if device == nil || !device.Health || device.Product != product {
-				continue
-			}
-
-			matchingDevices++
-
-			if device.Available == nil {
-				telemetryReady = false
-				continue
-			}
-
-			if requestedMemoryMiB > 0 && device.Available.MemoryMiB < requestedMemoryMiB {
-				continue
-			}
-
-			if requestedCoreUnits > 0 && device.Available.CoreUnits < requestedCoreUnits {
-				continue
-			}
-
-			satisfiableDevices++
-		}
-	}
-
-	return satisfiableDevices, matchingDevices, true, telemetryReady
-}
-
 func parsePositiveIntegerResource(value *string, field string) (int64, error) {
 	if value == nil || *value == "" {
 		return 0, fmt.Errorf("%s must be a positive integer", field)
 	}
 
 	return parseRequiredPositiveInteger(*value, field)
-}
-
-func parseOptionalPositiveInteger(value string, field string) (int64, error) {
-	if value == "" {
-		return 0, nil
-	}
-
-	return parseRequiredPositiveInteger(value, field)
 }
 
 func parseRequiredPositiveInteger(value string, field string) (int64, error) {
@@ -730,18 +588,14 @@ func parseRequiredPositiveInteger(value string, field string) (int64, error) {
 	return parsed, nil
 }
 
-func validatePercentResource(value string, field string) error {
+func validateZeroToHundredPercentResource(value string, field string) error {
 	if value == "" {
 		return nil
 	}
 
-	parsed, err := parseOptionalPositiveInteger(value, field)
-	if err != nil {
-		return err
-	}
-
-	if parsed > 100 {
-		return fmt.Errorf("%s must be between 1 and 100", field)
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || parsed < 0 || parsed > 100 {
+		return fmt.Errorf("%s must be between 0 and 100", field)
 	}
 
 	return nil
@@ -760,14 +614,6 @@ func endpointResourceValueError(err error) *validationError {
 		Code:    "10216",
 		Message: "invalid endpoint accelerator virtualization resources",
 		Hint:    err.Error(),
-	}
-}
-
-func endpointVGPUCapacityError(hint string) *validationError {
-	return &validationError{
-		Code:    "10220",
-		Message: "endpoint accelerator virtualization resources exceed cluster availability",
-		Hint:    hint,
 	}
 }
 

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -51,16 +51,42 @@ func TestValidateEndpointVGPUResourceShape(t *testing.T) {
 		assert.Equal(t, "10218", err.Code)
 	})
 
-	t.Run("rejects mutually exclusive memory fields", func(t *testing.T) {
+	t.Run("rejects unsupported memory percent", func(t *testing.T) {
 		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:     "8192",
 			v1.AcceleratorVirtualizationMemoryPercentKey: "50",
+			v1.AcceleratorVirtualizationCorePercentKey:   "50",
 		})
 
 		err := validateEndpointVGPUResourceShape(resources)
 
 		assert.NotNil(t, err)
 		assert.Equal(t, "10219", err.Code)
+		assert.Contains(t, err.Hint, "virtualization.memory_mib")
+	})
+
+	t.Run("rejects memory percent even when memory mib is set", func(t *testing.T) {
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:     "8192",
+			v1.AcceleratorVirtualizationMemoryPercentKey: "50",
+			v1.AcceleratorVirtualizationCorePercentKey:   "50",
+		})
+
+		err := validateEndpointVGPUResourceShape(resources)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10219", err.Code)
+	})
+
+	t.Run("rejects missing vGPU memory mib", func(t *testing.T) {
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationCorePercentKey: "50",
+		})
+
+		err := validateEndpointVGPUResourceShape(resources)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "10216", err.Code)
+		assert.Contains(t, err.Hint, "virtualization.memory_mib")
 	})
 
 	t.Run("rejects invalid vGPU numeric resources", func(t *testing.T) {
@@ -101,7 +127,18 @@ func TestValidateEndpointVGPUResourceShape(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Equal(t, "10216", err.Code)
 		assert.Contains(t, err.Hint, "virtualization.core_percent")
-		assert.Contains(t, err.Hint, "positive integer")
+		assert.Contains(t, err.Hint, "between 0 and 100")
+	})
+
+	t.Run("allows zero vGPU core resource", func(t *testing.T) {
+		resources := vgpuResources("1", "Tesla-T4", map[string]string{
+			v1.AcceleratorVirtualizationMemoryMiBKey:   "8192",
+			v1.AcceleratorVirtualizationCorePercentKey: "0",
+		})
+
+		err := validateEndpointVGPUResourceShape(resources)
+
+		assert.Nil(t, err)
 	})
 
 	t.Run("allows vGPU endpoint resource shape without cluster availability lookup", func(t *testing.T) {
@@ -118,7 +155,7 @@ func TestValidateEndpointVGPUResourceShape(t *testing.T) {
 	t.Run("skips patch that does not touch resources", func(t *testing.T) {
 		endpoint, err := parseEndpointBody([]byte(`{
 			"spec": {
-				"replicas": {"num": 2}
+				"variables": {"foo": "bar"}
 			}
 		}`))
 
@@ -128,253 +165,29 @@ func TestValidateEndpointVGPUResourceShape(t *testing.T) {
 	})
 }
 
-func TestValidateEndpointVGPUCapacity(t *testing.T) {
-	t.Run("skips when cluster resource info is unavailable", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
+func TestMergeEndpointResourceSpec(t *testing.T) {
+	t.Run("clears virtualization keys and preserves custom keys when switching to whole GPU", func(t *testing.T) {
+		existing := vgpuResources("1", "Tesla-T4", map[string]string{
 			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
 			v1.AcceleratorVirtualizationCorePercentKey: "50",
+			"nvidia.com/gpucores":                      "50",
 		})
-		cluster := &v1.Cluster{
-			Status: &v1.ClusterStatus{},
-		}
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("skips when available accelerator telemetry is incomplete", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		cluster := &v1.Cluster{
-			Status: &v1.ClusterStatus{
-				ResourceInfo: &v1.ClusterResources{},
+		patch := &v1.ResourceSpec{
+			Accelerator: map[string]string{
+				v1.AcceleratorTypeKey:    string(v1.AcceleratorTypeNVIDIAGPU),
+				v1.AcceleratorProductKey: "Tesla-T4",
 			},
 		}
 
-		err := validateEndpointVGPUCapacity(resources, cluster)
+		merged := mergeEndpointResourceSpec(existing, patch)
 
-		assert.Nil(t, err)
-	})
-
-	t.Run("rejects request that exceeds per device memory availability", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "8193",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10220", err.Code)
-		assert.Contains(t, err.Hint, "Tesla-T4")
-		assert.Contains(t, err.Hint, "satisfiable")
-	})
-
-	t.Run("rejects product absent from cluster resource info", func(t *testing.T) {
-		resources := vgpuResources("1", "Missing-GPU", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10220", err.Code)
-		assert.Contains(t, err.Hint, "Missing-GPU")
-	})
-
-	t.Run("skips when product exists but virtualization telemetry is missing", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
-		})
-		cluster.Status.ResourceInfo.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU].
-			Products[v1.AcceleratorProduct("Tesla-T4")].Virtualization = nil
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("rejects fragmented capacity that cannot satisfy each requested virtual card", func(t *testing.T) {
-		resources := vgpuResources("2", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "8193",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 32768, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
-			healthyDevice("gpu-1", "Tesla-T4", 8192, 100),
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10220", err.Code)
-		assert.Contains(t, err.Hint, "requested_gpu=2")
-	})
-
-	t.Run("rejects request that exceeds per device core availability", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "51",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 8192, 50),
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		if assert.NotNil(t, err) {
-			assert.Equal(t, "10220", err.Code)
-			assert.Contains(t, err.Hint, "requested_core_units=51")
-			assert.Contains(t, err.Hint, "satisfiable_devices=0")
-		}
-	})
-
-	t.Run("rejects request that needs more healthy matching devices than available", func(t *testing.T) {
-		resources := vgpuResources("2", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10220", err.Code)
-		assert.Contains(t, err.Hint, "requested_gpu=2")
-		assert.Contains(t, err.Hint, "satisfiable_devices=1")
-	})
-
-	t.Run("ignores unhealthy matching devices", func(t *testing.T) {
-		resources := vgpuResources("2", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 32768, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
-			unhealthyDevice("gpu-1", "Tesla-T4", 8192, 100),
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10220", err.Code)
-		assert.Contains(t, err.Hint, "satisfiable_devices=1")
-	})
-
-	t.Run("allows request when enough healthy matching devices fit", func(t *testing.T) {
-		resources := vgpuResources("2", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 8192, 50),
-			healthyDevice("gpu-1", "Tesla-T4", 8192, 50),
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("derives memory from memory percent using product metadata", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
-			v1.AcceleratorVirtualizationCorePercentKey:   "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 10001, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 5101, 100),
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("skips memory percent precheck when product memory metadata is missing", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
-			v1.AcceleratorVirtualizationCorePercentKey:   "50",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 10001, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 5101, 100),
-		})
-		cluster.Status.ResourceInfo.AcceleratorMetadata = nil
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("rejects core overuse when memory percent metadata is missing", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryPercentKey: "51",
-			v1.AcceleratorVirtualizationCorePercentKey:   "51",
-		})
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 10001, []*v1.DeviceResource{
-			healthyDevice("gpu-0", "Tesla-T4", 5101, 50),
-		})
-		cluster.Status.ResourceInfo.AcceleratorMetadata = nil
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		if err == nil {
-			t.Fatal("expected capacity error")
-		}
-		assert.Equal(t, "10220", err.Code)
-		assert.Contains(t, err.Hint, "requested_core_units=51")
-		assert.Contains(t, err.Hint, "satisfiable_devices=0")
-	})
-
-	t.Run("skips when matching device availability telemetry is incomplete", func(t *testing.T) {
-		resources := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		device := healthyDevice("gpu-0", "Tesla-T4", 8192, 100)
-		device.Available = nil
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			device,
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("skips matching device count rejection when availability telemetry is incomplete", func(t *testing.T) {
-		resources := vgpuResources("2", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-		})
-		device := healthyDevice("gpu-0", "Tesla-T4", 8192, 100)
-		device.Available = nil
-		cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-			device,
-		})
-
-		err := validateEndpointVGPUCapacity(resources, cluster)
-
-		assert.Nil(t, err)
+		assert.Equal(t, "50", merged.Accelerator["nvidia.com/gpucores"])
+		assert.Empty(t, merged.Accelerator[v1.AcceleratorVirtualizationMemoryMiBKey])
+		assert.Empty(t, merged.Accelerator[v1.AcceleratorVirtualizationCorePercentKey])
 	})
 }
 
-func TestEndpointVGPUValidationRejectsUnsatisfiablePost(t *testing.T) {
+func TestEndpointVGPUValidationAllowsPostWithoutCapacityPrecheck(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
 	})
@@ -400,14 +213,11 @@ func TestEndpointVGPUValidationRejectsUnsatisfiablePost(t *testing.T) {
 
 	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
 
-	var response validationError
-	assert.Equal(t, http.StatusBadRequest, recorder.Code)
-	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, "10220", response.Code)
-	assert.False(t, handlerCalled)
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationRejectsNoGPUClusterPost(t *testing.T) {
+func TestEndpointVGPUValidationRejectsPostWhenProductMemorySpecIsMissing(t *testing.T) {
 	cluster := clusterWithoutNVIDIAGPUProducts()
 	markClusterVGPUReady(cluster, "cluster-a", "team-a")
 	clusterStorage := &fakeClusterStorage{
@@ -434,8 +244,42 @@ func TestEndpointVGPUValidationRejectsNoGPUClusterPost(t *testing.T) {
 	var response validationError
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, "10220", response.Code)
-	assert.Contains(t, response.Hint, "product=Tesla-T4 has no available")
+	assert.Equal(t, "10216", response.Code)
+	assert.Contains(t, response.Hint, "physical GPU memory_mib")
+	assert.False(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationRejectsPostWhenMemoryMIBExceedsPhysicalCardSpec(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 2048, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 2048, 100),
+	})
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
+
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10216", response.Code)
+	assert.Contains(t, response.Hint, "less than or equal to physical GPU memory_mib 2048")
 	assert.False(t, handlerCalled)
 }
 
@@ -504,6 +348,68 @@ func TestEndpointVGPUValidationRejectsNotReadyPost(t *testing.T) {
 	assert.False(t, handlerCalled)
 }
 
+func TestEndpointVGPUValidationAllowsMultiReplicaTotalDemandPost(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+	})
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"replicas": {"num": 3},
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationAllowsPausedPostWhenVirtualizationNotReady(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+	})
+	markClusterVGPUNotReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+	}
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a"},
+		"spec": {
+			"cluster": "cluster-a",
+			"replicas": {"num": 0},
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
 func TestEndpointVGPUValidationRejectsPatchWithoutEndpointFilters(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
@@ -538,7 +444,7 @@ func TestEndpointVGPUValidationRejectsPatchWithoutEndpointFilters(t *testing.T) 
 	assert.False(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationResolvesEndpointAndRejectsUnsatisfiablePatch(t *testing.T) {
+func TestEndpointVGPUValidationResolvesEndpointAndAllowsPatchWithoutCapacityPrecheck(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 1024, 100),
 	})
@@ -570,15 +476,12 @@ func TestEndpointVGPUValidationResolvesEndpointAndRejectsUnsatisfiablePatch(t *t
 		clusterStorage,
 	)
 
-	var response validationError
-	assert.Equal(t, http.StatusBadRequest, recorder.Code)
-	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, "10220", response.Code)
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
 	assert.Equal(t, 1, clusterStorage.endpointListCalls)
-	assert.False(t, handlerCalled)
+	assert.True(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationRejectsMergedPatchWhenOnlyGPUChanges(t *testing.T) {
+func TestEndpointVGPUValidationAllowsMergedPatchWhenOnlyGPUChanges(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 4096, 50),
 	})
@@ -604,15 +507,209 @@ func TestEndpointVGPUValidationRejectsMergedPatchWhenOnlyGPUChanges(t *testing.T
 		clusterStorage,
 	)
 
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, 1, clusterStorage.endpointListCalls)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationAllowsMergedPatchWhenOnlyReplicasChange(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+	})
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+		endpoints: []v1.Endpoint{
+			*endpointWithVGPU("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"replicas": {"num": 3}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationAllowsPausePatchWhenVirtualizationNotReady(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		healthyDevice("gpu-0", "Tesla-T4", 8192, 100),
+	})
+	markClusterVGPUNotReady(cluster, "cluster-a", "team-a")
+	clusterStorage := &fakeClusterStorage{
+		clusters: []v1.Cluster{*cluster},
+		endpoints: []v1.Endpoint{
+			*endpointWithVGPU("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"replicas": {"num": 0}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationAllowsPausePatchWithMissingCluster(t *testing.T) {
+	clusterStorage := &fakeClusterStorage{
+		endpoints: []v1.Endpoint{
+			*endpointWithVGPU("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"cluster": "missing-cluster",
+			"replicas": {"num": 0}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationAllowsPausePatchWithInvalidVGPUResourceShape(t *testing.T) {
+	clusterStorage := &fakeClusterStorage{
+		endpoints: []v1.Endpoint{
+			*endpointWithVGPU("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"replicas": {"num": 0},
+			"resources": {
+				"accelerator": {
+					"virtualization.memory_mib": "4096",
+					"virtualization.memory_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationRejectsNegativeReplicaPatch(t *testing.T) {
+	clusterStorage := &fakeClusterStorage{
+		endpoints: []v1.Endpoint{
+			*endpointWithVGPU("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"replicas": {"num": -1}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
 	var response validationError
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, "10220", response.Code)
-	assert.Equal(t, 1, clusterStorage.endpointListCalls)
+	assert.Equal(t, "10216", response.Code)
+	assert.Contains(t, response.Hint, "spec.replicas.num")
 	assert.False(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationRejectsMergedPatchWhenOnlyProductChanges(t *testing.T) {
+func TestEndpointVGPUValidationAllowsNonVGPUPatchWhenReplicasChange(t *testing.T) {
+	gpu := "1"
+	endpoint := endpointWithVGPU("cluster-a", "team-a")
+	endpoint.Spec.Resources = &v1.ResourceSpec{
+		GPU: &gpu,
+		Accelerator: map[string]string{
+			v1.AcceleratorTypeKey:    string(v1.AcceleratorTypeNVIDIAGPU),
+			v1.AcceleratorProductKey: "Tesla-T4",
+		},
+	}
+	clusterStorage := &fakeClusterStorage{
+		endpoints: []v1.Endpoint{*endpoint},
+	}
+	body := `{
+		"spec": {
+			"replicas": {"num": 3}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationAllowsPatchFromVGPUToWholeGPU(t *testing.T) {
+	clusterStorage := &fakeClusterStorage{
+		endpoints: []v1.Endpoint{
+			*endpointWithVGPU("cluster-a", "team-a"),
+		},
+	}
+	body := `{
+		"spec": {
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, 1, clusterStorage.endpointListCalls)
+	assert.Equal(t, 0, clusterStorage.listCalls)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationRejectsMergedPatchWhenOnlyProductChangesToMissingMemorySpec(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 4096, 50),
 	})
@@ -643,14 +740,15 @@ func TestEndpointVGPUValidationRejectsMergedPatchWhenOnlyProductChanges(t *testi
 	var response validationError
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, "10220", response.Code)
+	assert.Equal(t, "10216", response.Code)
+	assert.Contains(t, response.Hint, "physical GPU memory_mib")
 	assert.Equal(t, 1, clusterStorage.endpointListCalls)
 	assert.False(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationAddsBackCurrentPatchAllocation(t *testing.T) {
+func TestEndpointVGPUValidationAllowsPatchWhenCurrentAvailableCapacityIsZero(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
-		healthyDevice("gpu-0", "Tesla-T4", 0, 0),
+		occupiedDevice("gpu-0", "Tesla-T4", 8192, 100),
 	})
 	markClusterVGPUReady(cluster, "cluster-a", "team-a")
 	endpoint := endpointWithVGPU("cluster-a", "team-a")
@@ -702,7 +800,67 @@ func TestEndpointVGPUValidationAddsBackCurrentPatchAllocation(t *testing.T) {
 	assert.True(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationDoesNotAddBackAllocationWhenPatchMovesCluster(t *testing.T) {
+func TestEndpointVGPUValidationAllowsWholeGPUToVGPUPatchWhenCurrentAvailableCapacityIsZero(t *testing.T) {
+	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
+		occupiedDevice("gpu-0", "Tesla-T4", 16384, 100),
+	})
+	markClusterVGPUReady(cluster, "cluster-a", "team-a")
+
+	gpu := "1"
+	endpoint := endpointWithVGPU("cluster-a", "team-a")
+	endpoint.Spec.Resources = &v1.ResourceSpec{
+		GPU: &gpu,
+		Accelerator: map[string]string{
+			v1.AcceleratorTypeKey:    string(v1.AcceleratorTypeNVIDIAGPU),
+			v1.AcceleratorProductKey: "Tesla-T4",
+		},
+	}
+	endpoint.Status = &v1.EndpointStatus{
+		Resources: &v1.EndpointResourceStatus{
+			Replicas: []v1.ReplicaDeviceAllocation{
+				{
+					NodeID: "node-0",
+					Devices: []v1.DeviceAllocation{
+						{
+							UUID:    "gpu-0",
+							Product: "Tesla-T4",
+							NodeID:  "node-0",
+						},
+					},
+				},
+			},
+		},
+	}
+	clusterStorage := &fakeClusterStorage{
+		clusters:  []v1.Cluster{*cluster},
+		endpoints: []v1.Endpoint{*endpoint},
+	}
+	body := `{
+		"spec": {
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "16384",
+					"virtualization.core_percent": "100"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationAllowsPatchWhenTargetDeviceCannotPhysicallyFitVGPU(t *testing.T) {
 	cluster := clusterWithNVIDIAGPUProduct("Tesla-T4", 16384, []*v1.DeviceResource{
 		healthyDevice("gpu-0", "Tesla-T4", 0, 0),
 	})
@@ -752,11 +910,8 @@ func TestEndpointVGPUValidationDoesNotAddBackAllocationWhenPatchMovesCluster(t *
 		clusterStorage,
 	)
 
-	var response validationError
-	assert.Equal(t, http.StatusBadRequest, recorder.Code)
-	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, "10220", response.Code)
-	assert.False(t, handlerCalled)
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
 }
 
 func endpointWithVGPU(cluster string, workspace string) *v1.Endpoint {
@@ -850,6 +1005,21 @@ func clusterWithNVIDIAGPUProduct(product string, productMemoryMiB float64, devic
 							},
 						},
 					},
+					Allocatable: &v1.ResourceInfo{
+						AcceleratorGroups: map[v1.AcceleratorType]*v1.AcceleratorGroup{
+							v1.AcceleratorTypeNVIDIAGPU: {
+								Products: map[v1.AcceleratorProduct]*v1.AcceleratorProductResource{
+									v1.AcceleratorProduct(product): {
+										Quantity: 1,
+										Virtualization: &v1.AcceleratorVirtualizationResource{
+											MemoryMiB: productMemoryMiB,
+											CoreUnits: 100,
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				AcceleratorMetadata: map[v1.AcceleratorType]*v1.AcceleratorMetadata{
 					v1.AcceleratorTypeNVIDIAGPU: {
@@ -875,6 +1045,9 @@ func clusterWithoutNVIDIAGPUProducts() *v1.Cluster {
 		Status: &v1.ClusterStatus{
 			ResourceInfo: &v1.ClusterResources{
 				ResourceStatus: v1.ResourceStatus{
+					Allocatable: &v1.ResourceInfo{
+						AcceleratorGroups: map[v1.AcceleratorType]*v1.AcceleratorGroup{},
+					},
 					Available: &v1.ResourceInfo{
 						AcceleratorGroups: map[v1.AcceleratorType]*v1.AcceleratorGroup{},
 					},
@@ -921,10 +1094,27 @@ func healthyDevice(uuid string, product string, memoryMiB int64, coreUnits int64
 		UUID:    uuid,
 		Product: product,
 		Health:  true,
+		Allocatable: &v1.DeviceResourcePool{
+			MemoryMiB: memoryMiB,
+			CoreUnits: coreUnits,
+		},
 		Available: &v1.DeviceResourcePool{
 			MemoryMiB: memoryMiB,
 			CoreUnits: coreUnits,
 		},
+	}
+}
+
+func occupiedDevice(uuid string, product string, memoryMiB int64, coreUnits int64) *v1.DeviceResource {
+	return &v1.DeviceResource{
+		UUID:    uuid,
+		Product: product,
+		Health:  true,
+		Allocatable: &v1.DeviceResourcePool{
+			MemoryMiB: memoryMiB,
+			CoreUnits: coreUnits,
+		},
+		Available: &v1.DeviceResourcePool{},
 	}
 }
 


### PR DESCRIPTION
## Issue

n/a

## Summary

vGPU endpoint validation now follows a target-resource preflight flow: build the target endpoint for POST/PATCH, skip non-vGPU and paused requests, validate cluster accelerator-virtualization readiness, then validate vGPU resource shape and physical GPU memory specification.

Backend dynamic capacity hard rejects remain removed because cluster resource availability snapshots can be stale by the time the request is scheduled. Capacity placement is left to scheduler/runtime status instead of API admission.

## Changes

- Refactor vGPU preflight around a merged target endpoint for POST/PATCH validation.
- Re-run vGPU validation for PATCH requests that change `resources`, `cluster`, or `replicas.num`.
- Let paused vGPU requests (`replicas.num == 0`) pass after rejecting negative replica counts.
- Support only `virtualization.memory_mib`; reject `virtualization.memory_percent`.
- Validate `virtualization.core_percent` as 0-100 when set.
- Validate `virtualization.memory_mib` as 1 through the target GPU product's physical card memory size.
- Remove backend dynamic capacity hard rejects for current available/allocatable resource state.

## Test Plan

Unit test
- [x] `git diff --check origin/main...HEAD`
- [x] `go vet ./internal/routes/proxies`
- [x] `go test ./internal/routes/proxies -count=1`

DB test
- [x] Verified forwarded non-vGPU and valid vGPU requests reach PostgREST instead of being rejected by vGPU preflight; duplicate-name requests returned DB unique-constraint errors as expected.
- [x] Verified temporary endpoint cleanup through soft-delete PATCH after backend request E2E.
- [x] No DB schema or migration changes.

E2E test
- [x] Hot-updated neutree-api/neutree-core on `10.255.1.54` from PR head `f0cacf9` using isolated worktree `/home/neutree/e2e-test/neutree-pr470-hot`.
- [x] Verified API health with `GET /health` returning 200.
- [x] Verified POST preflight branches through backend requests: non-vGPU skip, `replicas.num == 0` pause skip, missing cluster `10221`, non-virtualized cluster `10222`, unsupported `virtualization.memory_percent` `10219`, missing `virtualization.memory_mib` `10216`, `core_percent > 100` `10216`, `memory_mib` above physical `NVIDIA-L20` card size `10216`, and negative replicas `10216`.
- [x] Verified dynamic capacity is no longer a hard admission gate: `l20-2` currently reports zero available vGPU memory, while valid vGPU requests are forwarded instead of rejected by preflight.
- [x] Verified PATCH target handling through backend requests: missing lookup filters `10221`, whole GPU -> vGPU succeeds with merged target, vGPU -> whole GPU succeeds and clears virtualization, and `replicas.num == 0` PATCH skips invalid vGPU shape.

## Risk & Rollback

Risk is limited to endpoint vGPU validation. Rollback by reverting this commit to restore the previous API admission behavior.