### PR TITLE
fix: avoid static node restarts from sudo warnings

### DIFF
--- a/internal/cluster/staticnode/reconciler.go
+++ b/internal/cluster/staticnode/reconciler.go
@@ -533,12 +533,11 @@ func (r *Reconciler) reconcileComponent(
 
 	restarted := configChanged || !containerMatches
 	if restarted {
-		workspace, nodeName, cluster := staticNodeLogIdentity(node)
 		klog.Infof(
 			"Restarting static node component: workspace=%q node=%q cluster=%q component=%q image=%q desired_hash=%q config_changed=%t container_matches=%t reason=%q",
-			workspace,
-			nodeName,
-			cluster,
+			node.Metadata.Workspace,
+			node.Metadata.Name,
+			node.Spec.Cluster,
 			component.Name,
 			component.Image,
 			status.ObservedHash,
@@ -569,31 +568,6 @@ func (r *Reconciler) reconcileComponent(
 	status.Reason = componentReasonRunning
 
 	return status, nil
-}
-
-func staticNodeLogIdentity(node *v1.StaticNode) (string, string, string) {
-	if node == nil {
-		return "", "", ""
-	}
-
-	workspace := ""
-	nodeName := ""
-	cluster := ""
-
-	if node.Metadata != nil {
-		workspace = node.Metadata.Workspace
-		nodeName = node.Metadata.Name
-	}
-
-	if node.Spec != nil {
-		cluster = node.Spec.Cluster
-	}
-
-	if nodeName == "" && node.Spec != nil {
-		nodeName = node.Spec.IP
-	}
-
-	return workspace, nodeName, cluster
 }
 
 func componentRestartReason(configChanged bool, containerMatches bool, inspectErr error) string {

--- a/internal/cluster/staticnode/reconciler.go
+++ b/internal/cluster/staticnode/reconciler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/cluster/staticcomponent"
@@ -520,7 +521,7 @@ func (r *Reconciler) reconcileComponent(
 		return status, err
 	}
 
-	running, err := dockerRuntime.ComponentContainerMatches(
+	containerMatches, err := dockerRuntime.ComponentContainerMatches(
 		ctx,
 		componentContainerName(node, component),
 		status.ObservedHash,
@@ -530,8 +531,22 @@ func (r *Reconciler) reconcileComponent(
 		status.Reason = dockerReason(err, componentReasonInspectFailed)
 	}
 
-	restarted := configChanged || !running
+	restarted := configChanged || !containerMatches
 	if restarted {
+		workspace, nodeName, cluster := staticNodeLogIdentity(node)
+		klog.Infof(
+			"Restarting static node component: workspace=%q node=%q cluster=%q component=%q image=%q desired_hash=%q config_changed=%t container_matches=%t reason=%q",
+			workspace,
+			nodeName,
+			cluster,
+			component.Name,
+			component.Image,
+			status.ObservedHash,
+			configChanged,
+			containerMatches,
+			componentRestartReason(configChanged, containerMatches, err),
+		)
+
 		if err := dockerRuntime.RestartComponentContainer(ctx, node, component, status.ObservedHash); err != nil {
 			status.Phase = v1.NodeComponentPhaseFailed
 			status.Reason = dockerReason(err, componentReasonRunFailed)
@@ -554,6 +569,48 @@ func (r *Reconciler) reconcileComponent(
 	status.Reason = componentReasonRunning
 
 	return status, nil
+}
+
+func staticNodeLogIdentity(node *v1.StaticNode) (string, string, string) {
+	if node == nil {
+		return "", "", ""
+	}
+
+	workspace := ""
+	nodeName := ""
+	cluster := ""
+
+	if node.Metadata != nil {
+		workspace = node.Metadata.Workspace
+		nodeName = node.Metadata.Name
+	}
+
+	if node.Spec != nil {
+		cluster = node.Spec.Cluster
+	}
+
+	if nodeName == "" && node.Spec != nil {
+		nodeName = node.Spec.IP
+	}
+
+	return workspace, nodeName, cluster
+}
+
+func componentRestartReason(configChanged bool, containerMatches bool, inspectErr error) string {
+	reasons := []string{}
+	if configChanged {
+		reasons = append(reasons, "config changed")
+	}
+
+	if !containerMatches && inspectErr == nil {
+		reasons = append(reasons, "container does not match desired state")
+	}
+
+	if inspectErr != nil {
+		reasons = append(reasons, "container inspect failed: "+inspectErr.Error())
+	}
+
+	return strings.Join(reasons, "; ")
 }
 
 func stopStaleComponents(

--- a/internal/cluster/staticnode/reconciler_test.go
+++ b/internal/cluster/staticnode/reconciler_test.go
@@ -29,6 +29,10 @@ const (
 	testRayFileSDPath             = "/etc/neutree/ray/file_sd/ray.json"
 )
 
+func testStaticNodeMetadata(name string) *v1.Metadata {
+	return &v1.Metadata{Workspace: "default", Name: name}
+}
+
 func TestReconcilerReconcileWarmImages(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -675,59 +679,9 @@ func TestComponentRestartReason(t *testing.T) {
 	}
 }
 
-func TestStaticNodeLogIdentity(t *testing.T) {
-	tests := []struct {
-		name          string
-		node          *v1.StaticNode
-		wantWorkspace string
-		wantNode      string
-		wantCluster   string
-	}{
-		{
-			name: "metadata and spec",
-			node: &v1.StaticNode{
-				Metadata: &v1.Metadata{
-					Workspace: "default",
-					Name:      "172.21.151.131",
-				},
-				Spec: &v1.StaticNodeSpec{
-					Cluster: "docker-t4",
-					IP:      "172.21.151.131",
-				},
-			},
-			wantWorkspace: "default",
-			wantNode:      "172.21.151.131",
-			wantCluster:   "docker-t4",
-		},
-		{
-			name: "missing metadata falls back to ip",
-			node: &v1.StaticNode{
-				Spec: &v1.StaticNodeSpec{
-					Cluster: "docker-t4",
-					IP:      "172.21.151.131",
-				},
-			},
-			wantNode:    "172.21.151.131",
-			wantCluster: "docker-t4",
-		},
-		{
-			name: "nil node",
-			node: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			workspace, nodeName, cluster := staticNodeLogIdentity(tt.node)
-			assert.Equal(t, tt.wantWorkspace, workspace)
-			assert.Equal(t, tt.wantNode, nodeName)
-			assert.Equal(t, tt.wantCluster, cluster)
-		})
-	}
-}
-
 func TestReconcilerReconcileComponentsFailsWhenImageMissing(t *testing.T) {
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("node-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			Components: []v1.NodeComponentSpec{
@@ -773,6 +727,7 @@ func TestBuildDockerRunCommandQuotesDockerRunOptions(t *testing.T) {
 func TestReconcilerReconcileComponentsStartsContainer(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, testDefaultPrometheusHTTPPath, `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("worker-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,
@@ -833,6 +788,7 @@ func TestReconcilerReconcileComponentsStartsContainer(t *testing.T) {
 func TestReconcilerReconcileComponentsContinuesAfterIndependentFailure(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, testDefaultPrometheusHTTPPath, `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("head-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,
@@ -906,6 +862,7 @@ func TestReconcilerReconcileComponentsContinuesAfterIndependentFailure(t *testin
 func TestReconcilerReconcileComponentsUsesLocalImageWithoutPull(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, testDefaultPrometheusHTTPPath, `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("worker-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,
@@ -957,6 +914,7 @@ func TestReconcilerReconcileComponentsUsesLocalImageWithoutPull(t *testing.T) {
 func TestReconcilerReconcileComponentsRestartsWhenConfigChanged(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, testDefaultHealthHTTPPath, `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("head-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,
@@ -1033,6 +991,7 @@ func TestReconcilerReconcileComponentsRestartsWhenConfigChanged(t *testing.T) {
 func TestReconcilerReconcileComponentsDoesNotRestartWhenOnlySkipRestartConfigChanged(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, testDefaultHealthHTTPPath, `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("head-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,
@@ -1087,6 +1046,7 @@ func TestReconcilerReconcileComponentsDoesNotRestartWhenOnlySkipRestartConfigCha
 
 func TestReconcilerReconcileComponentsStopsRemovedComponent(t *testing.T) {
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("node-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster:    "static-a",
 			IP:         "10.0.0.11",
@@ -1178,6 +1138,7 @@ func TestReconcilerDeleteRemovesDesiredAndObservedComponents(t *testing.T) {
 func TestReconcilerReconcileComponentsChecksRayWorkerHTTPProbe(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, testDefaultHealthHTTPPath, `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("worker-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,
@@ -1214,7 +1175,7 @@ func TestReconcilerReconcileComponentsChecksRayWorkerHTTPProbe(t *testing.T) {
 
 func TestReconcilerReconcileComponentsWaitsForHeadBeforeWorkerComponent(t *testing.T) {
 	node := &v1.StaticNode{
-		Metadata: &v1.Metadata{Workspace: "default", Name: "worker-0"},
+		Metadata: testStaticNodeMetadata("worker-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      "10.0.0.11",
@@ -1257,7 +1218,7 @@ func TestClusterHeadReadyCheckerReadsHeadStatusFromClusterNodes(t *testing.T) {
 	}
 	checker := &ClusterHeadReadyChecker{Storage: store}
 	node := &v1.StaticNode{
-		Metadata: &v1.Metadata{Workspace: "default", Name: "worker-0"},
+		Metadata: testStaticNodeMetadata("worker-0"),
 		Spec:     &v1.StaticNodeSpec{Cluster: "static-a", Role: v1.StaticNodeRoleWorker},
 	}
 
@@ -1272,6 +1233,7 @@ func TestClusterHeadReadyCheckerReadsHeadStatusFromClusterNodes(t *testing.T) {
 func TestReconcilerReconcileComponentsChecksRayHeadHTTPProbe(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, testDefaultHealthHTTPPath, `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("head-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,
@@ -1309,6 +1271,7 @@ func TestReconcilerReconcileComponentsChecksRayHeadHTTPProbe(t *testing.T) {
 func TestReconcilerReconcileComponentsChecksHTTPRootWhenHTTPPathEmpty(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, "/", `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("head-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,
@@ -1344,6 +1307,7 @@ func TestReconcilerReconcileComponentsChecksHTTPRootWhenHTTPPathEmpty(t *testing
 func TestReconcilerReconcileComponentsReportsHealthCheckFailureWithoutRestart(t *testing.T) {
 	healthHost, healthPort := newStaticNodeHealthServer(t, "/health", `ok`)
 	node := &v1.StaticNode{
+		Metadata: testStaticNodeMetadata("head-0"),
 		Spec: &v1.StaticNodeSpec{
 			Cluster: "static-a",
 			IP:      healthHost,

--- a/internal/cluster/staticnode/reconciler_test.go
+++ b/internal/cluster/staticnode/reconciler_test.go
@@ -622,6 +622,110 @@ func TestComponentContainerMatchesIgnoresSSHWarning(t *testing.T) {
 	assert.True(t, matches)
 }
 
+func TestComponentRestartReason(t *testing.T) {
+	tests := []struct {
+		name             string
+		configChanged    bool
+		containerMatches bool
+		inspectErr       error
+		want             string
+	}{
+		{
+			name:             "config changed",
+			configChanged:    true,
+			containerMatches: true,
+			want:             "config changed",
+		},
+		{
+			name:             "container mismatch",
+			configChanged:    false,
+			containerMatches: false,
+			want:             "container does not match desired state",
+		},
+		{
+			name:             "config changed and container mismatch",
+			configChanged:    true,
+			containerMatches: false,
+			want:             "config changed; container does not match desired state",
+		},
+		{
+			name:             "inspect error",
+			configChanged:    false,
+			containerMatches: false,
+			inspectErr:       errors.New("docker inspect failed"),
+			want:             "container inspect failed: docker inspect failed",
+		},
+		{
+			name:             "config changed and inspect error",
+			configChanged:    true,
+			containerMatches: false,
+			inspectErr:       errors.New("docker inspect failed"),
+			want:             "config changed; container inspect failed: docker inspect failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				tt.want,
+				componentRestartReason(tt.configChanged, tt.containerMatches, tt.inspectErr),
+			)
+		})
+	}
+}
+
+func TestStaticNodeLogIdentity(t *testing.T) {
+	tests := []struct {
+		name          string
+		node          *v1.StaticNode
+		wantWorkspace string
+		wantNode      string
+		wantCluster   string
+	}{
+		{
+			name: "metadata and spec",
+			node: &v1.StaticNode{
+				Metadata: &v1.Metadata{
+					Workspace: "default",
+					Name:      "172.21.151.131",
+				},
+				Spec: &v1.StaticNodeSpec{
+					Cluster: "docker-t4",
+					IP:      "172.21.151.131",
+				},
+			},
+			wantWorkspace: "default",
+			wantNode:      "172.21.151.131",
+			wantCluster:   "docker-t4",
+		},
+		{
+			name: "missing metadata falls back to ip",
+			node: &v1.StaticNode{
+				Spec: &v1.StaticNodeSpec{
+					Cluster: "docker-t4",
+					IP:      "172.21.151.131",
+				},
+			},
+			wantNode:    "172.21.151.131",
+			wantCluster: "docker-t4",
+		},
+		{
+			name: "nil node",
+			node: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace, nodeName, cluster := staticNodeLogIdentity(tt.node)
+			assert.Equal(t, tt.wantWorkspace, workspace)
+			assert.Equal(t, tt.wantNode, nodeName)
+			assert.Equal(t, tt.wantCluster, cluster)
+		})
+	}
+}
+
 func TestReconcilerReconcileComponentsFailsWhenImageMissing(t *testing.T) {
 	node := &v1.StaticNode{
 		Spec: &v1.StaticNodeSpec{

--- a/pkg/command_runner/file_client.go
+++ b/pkg/command_runner/file_client.go
@@ -117,7 +117,40 @@ func (f *sshFileClient) remoteSha256(ctx context.Context, remotePath string, sud
 		return "", errors.Wrap(err, "failed to calculate remote file hash")
 	}
 
-	return strings.TrimSpace(output), nil
+	return remoteSHA256FromOutput(output), nil
+}
+
+func remoteSHA256FromOutput(output string) string {
+	hash := ""
+
+	for _, line := range strings.Split(output, "\n") {
+		for _, field := range strings.Fields(line) {
+			if isSHA256Hex(field) {
+				hash = strings.ToLower(field)
+				break
+			}
+		}
+	}
+
+	return hash
+}
+
+func isSHA256Hex(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+
+	for _, char := range value {
+		if (char >= '0' && char <= '9') ||
+			(char >= 'a' && char <= 'f') ||
+			(char >= 'A' && char <= 'F') {
+			continue
+		}
+
+		return false
+	}
+
+	return true
 }
 
 func (f *sshFileClient) upload(ctx context.Context, localPath, remotePath string) error {

--- a/pkg/command_runner/file_client_test.go
+++ b/pkg/command_runner/file_client_test.go
@@ -40,6 +40,113 @@ func TestSSHFileClient_WriteFileIfChanged_SkipsWhenContentMatches(t *testing.T) 
 	mockExec.AssertExpectations(t)
 }
 
+func TestSSHFileClient_WriteFileIfChanged_SkipsWhenRemoteHashOutputHasWarnings(t *testing.T) {
+	mockExec := new(commandmocks.MockExecutor)
+	runner := newSSHCommandRunner(mockExec)
+	content := []byte("scrape_configs: []\n")
+
+	mockExec.On("Execute", mock.Anything, "ssh", sshArgsContaining("uptime")).
+		Return([]byte("success"), nil).
+		Once()
+	mockExec.On("Execute", mock.Anything, "ssh", mock.MatchedBy(func(args []string) bool {
+		joined := strings.Join(args, " ")
+		return strings.Contains(joined, "sha256sum") &&
+			strings.Contains(joined, "/etc/vmagent/config.yaml")
+	})).
+		Return([]byte(strings.Join([]string{
+			"sudo: unable to resolve host x86-2204: Name or service not known",
+			strings.ToUpper(sha256Hex(content)) + "  /etc/vmagent/config.yaml",
+			"sudo: unable to resolve host x86-2204: Name or service not known",
+			"",
+		}, "\n")), nil).
+		Once()
+
+	changed, err := runner.Files().WriteFileIfChanged(
+		context.Background(),
+		"/etc/vmagent/config.yaml",
+		content,
+		WriteFileOptions{Sudo: true},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, changed)
+	mockExec.AssertNotCalled(t, "Execute", mock.Anything, "scp", mock.Anything)
+	mockExec.AssertExpectations(t)
+}
+
+func TestRemoteSHA256FromOutput(t *testing.T) {
+	firstHash := strings.Repeat("a", 64)
+	secondHash := strings.Repeat("b", 64)
+
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "clean hash",
+			output: firstHash + "\n",
+			want:   firstHash,
+		},
+		{
+			name:   "sha256sum default output",
+			output: firstHash + "  /etc/neutree/config.yaml\n",
+			want:   firstHash,
+		},
+		{
+			name:   "warning before hash",
+			output: "sudo: unable to resolve host x86-2204: Name or service not known\n" + firstHash + "\n",
+			want:   firstHash,
+		},
+		{
+			name:   "warning after hash",
+			output: firstHash + "\nsudo: unable to resolve host x86-2204: Name or service not known\n",
+			want:   firstHash,
+		},
+		{
+			name:   "uppercase hash is normalized",
+			output: strings.ToUpper(firstHash) + "\n",
+			want:   firstHash,
+		},
+		{
+			name:   "last valid hash wins",
+			output: firstHash + "\n" + secondHash + "\n",
+			want:   secondHash,
+		},
+		{
+			name:   "hash-looking path does not override line hash",
+			output: firstHash + "  /etc/neutree/" + secondHash + "\n",
+			want:   firstHash,
+		},
+		{
+			name:   "warning only",
+			output: "sudo: unable to resolve host x86-2204: Name or service not known\n",
+			want:   "",
+		},
+		{
+			name:   "truncated hash",
+			output: strings.Repeat("c", 63) + "\n",
+			want:   "",
+		},
+		{
+			name:   "same length non-hex token",
+			output: strings.Repeat("g", 64) + "\n",
+			want:   "",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, remoteSHA256FromOutput(tt.output))
+		})
+	}
+}
+
 func TestSSHFileClient_WriteFile_UploadsAndInstallsAtomically(t *testing.T) {
 	mockExec := new(commandmocks.MockExecutor)
 	runner := newSSHCommandRunner(mockExec)


### PR DESCRIPTION
## Issue

NEU-515

TestRail: C2728950

## Summary

Static node config hash checks can receive stderr text together with stdout because SSH command execution uses combined output. On nodes where sudo prints hostname warnings, unchanged config files were misdetected as changed, causing restart-sensitive components such as accelerator-exporter and vmagent to be recreated every reconcile. This PR parses only valid SHA-256 tokens from successful remote hash output and logs the exact reason whenever a static node component is restarted.

## Changes

- Parse remote SHA-256 output defensively in `pkg/command_runner.FileClient`, ignoring sudo/SSH warning text while preserving command failure behavior.
- Cover edge cases for warning-before/after-hash output, uppercase hashes, hash-looking path fields, empty output, and invalid/truncated hashes.
- Add static-node restart logging before `RestartComponentContainer`, including component identity, desired hash, image, `config_changed`, `container_matches`, and reason.
- Add tests for restart reason composition and remote SHA-256 parsing edge cases.

## Test Plan

### Unit test

- [x] `go test ./pkg/command_runner ./internal/cluster/staticnode`
- [x] `git diff --check`
- [x] GitHub `pr-check` passed on head `90ce00136ba9956bffe87f5c0ce545e7f6432dc4`

### DB test

- [x] Not affected. No DB schema, migration, storage query, or persisted contract changes.

### E2E test

- [x] Not required. The root cause is deterministic remote hash output parsing; sudo warning and Docker restart effects are covered by unit tests around `WriteFileIfChanged` and static-node restart reason construction. Manual E2E is intentionally not required because it depends on host-specific sudo/hostname warning state and Docker event timing.

## Risk & Rollback

Risk is limited to static-node remote config comparison and restart observability. Invalid or missing remote hash output remains conservative and writes the file. Rollback by reverting this PR; no DB or public API rollback required.