### PR TITLE
fix: include HAMi status reason in cluster errors

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestClusterController(s *storagemocks.MockStorage,
@@ -461,6 +463,45 @@ func TestClusterController_UpdateClusterStatus(t *testing.T) {
 					obj := args.Get(1).(*v1.Cluster)
 					assert.Equal(t, v1.ClusterPhaseFailed, obj.Status.Phase)
 					assert.NotEmpty(t, obj.Status.ErrorMessage)
+				}).Return(nil)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Failed: HAMi reconcile status reason is preserved in error message",
+			input: &v1.Cluster{
+				ID:       1,
+				Metadata: &v1.Metadata{Name: "test"},
+				Spec:     specV2,
+				Status: &v1.ClusterStatus{
+					Phase:            v1.ClusterPhaseRunning,
+					Initialized:      true,
+					ObservedSpecHash: specV2Hash,
+				},
+			},
+			mockSetup: func(s *storagemocks.MockStorage, o *clustermocks.MockClusterReconcile) {
+				reconcileErr := errors.New(
+					"accelerator virtualization component is not ready: DaemonSetNotReady daemonset hami-device-plugin ready 0/1",
+				)
+				o.On("Reconcile", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					c := args.Get(1).(*v1.Cluster)
+					c.Status.ComponentStatus = map[string]*v1.ComponentStatus{
+						v1.ComponentStatusAcceleratorVirtualizationKey: {
+							Phase:   v1.ComponentPhaseNotReady,
+							Managed: true,
+							Version: "v2.6.0",
+							Reason:  "DaemonSetNotReady",
+							Message: "daemonset hami-device-plugin ready 0/1",
+						},
+					}
+				}).Return(reconcileErr)
+				s.On("UpdateCluster", "1", mock.Anything).Run(func(args mock.Arguments) {
+					obj := args.Get(1).(*v1.Cluster)
+					assert.Equal(t, v1.ClusterPhaseFailed, obj.Status.Phase)
+					assert.Contains(t, obj.Status.ErrorMessage, reconcileErr.Error())
+					require.NotNil(t, obj.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey])
+					assert.Equal(t, "DaemonSetNotReady", obj.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey].Reason)
+					assert.Equal(t, "daemonset hami-device-plugin ready 0/1", obj.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey].Message)
 				}).Return(nil)
 			},
 			wantErr: true,

--- a/internal/cluster/component/hami/hami.go
+++ b/internal/cluster/component/hami/hami.go
@@ -95,7 +95,7 @@ func (h *HAMiComponent) Reconcile() error {
 
 	if !status.Ready {
 		h.setNotReadyStatus(status.Reason, status.Message)
-		return fmt.Errorf("accelerator virtualization component is not fully ready: %s", status.Message)
+		return hamiStatusError(status)
 	}
 
 	h.writeStatus(status.ComponentStatus())
@@ -154,6 +154,15 @@ func (h *HAMiComponent) setNotReadyStatus(reason, message string) {
 		Reason:  reason,
 		Message: message,
 	})
+}
+
+func hamiStatusError(status *HAMiStatus) error {
+	if status == nil {
+		return fmt.Errorf("accelerator virtualization component is not ready")
+	}
+
+	return fmt.Errorf("accelerator virtualization component is not ready: %s %s",
+		status.Reason, status.Message)
 }
 
 func (h *HAMiComponent) writeStatus(status *v1.ComponentStatus) {

--- a/internal/cluster/component/hami/hami.go
+++ b/internal/cluster/component/hami/hami.go
@@ -3,6 +3,7 @@ package hami
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -161,8 +162,12 @@ func hamiStatusError(status *HAMiStatus) error {
 		return fmt.Errorf("accelerator virtualization component is not ready")
 	}
 
-	return fmt.Errorf("accelerator virtualization component is not ready: %s %s",
-		status.Reason, status.Message)
+	detail := strings.TrimSpace(strings.Join([]string{status.Reason, status.Message}, " "))
+	if detail == "" {
+		return fmt.Errorf("accelerator virtualization component is not ready")
+	}
+
+	return fmt.Errorf("accelerator virtualization component is not ready: %s", detail)
 }
 
 func (h *HAMiComponent) writeStatus(status *v1.ComponentStatus) {

--- a/internal/cluster/component/hami/hami_test.go
+++ b/internal/cluster/component/hami/hami_test.go
@@ -244,6 +244,19 @@ func TestHAMiComponentReconcileWritesNotReadyStatusWhenDaemonSetMissing(t *testi
 	assert.Equal(t, "DaemonSetNotReady", cluster.Status.ComponentStatus[v1.ComponentStatusAcceleratorVirtualizationKey].Reason)
 }
 
+func TestHAMiStatusErrorMessageIncludesReason(t *testing.T) {
+	err := hamiStatusError(&HAMiStatus{
+		Reason:  "DaemonSetNotReady",
+		Message: "daemonset hami-device-plugin ready 0/1",
+	})
+
+	require.Error(t, err)
+	assert.Equal(t,
+		"accelerator virtualization component is not ready: DaemonSetNotReady daemonset hami-device-plugin ready 0/1",
+		err.Error(),
+	)
+}
+
 func TestHAMiComponentNodeScopeUsesPluginVirtualizationConfig(t *testing.T) {
 	fakeClient := newHAMiFakeClient(t,
 		newHAMiNode("plugin-candidate", map[string]string{}),

--- a/internal/cluster/component/hami/hami_test.go
+++ b/internal/cluster/component/hami/hami_test.go
@@ -257,6 +257,13 @@ func TestHAMiStatusErrorMessageIncludesReason(t *testing.T) {
 	)
 }
 
+func TestHAMiStatusErrorMessageOmitsEmptyDetails(t *testing.T) {
+	err := hamiStatusError(&HAMiStatus{})
+
+	require.Error(t, err)
+	assert.Equal(t, "accelerator virtualization component is not ready", err.Error())
+}
+
 func TestHAMiComponentNodeScopeUsesPluginVirtualizationConfig(t *testing.T) {
 	fakeClient := newHAMiFakeClient(t,
 		newHAMiNode("plugin-candidate", map[string]string{}),


### PR DESCRIPTION
## Issue

n/a

## Summary

This change keeps the existing `component_status` backend handling while making HAMi not-ready cluster errors include both the component status reason and message. The enriched error is propagated through the existing cluster `status.error_message` path.

## Changes

- Include HAMi component status `Reason` in not-ready reconcile errors.
- Keep writing `status.component_status` for existing backend consumers.
- Avoid appending empty HAMi status details when reason/message are unavailable.
- Add unit and controller-level coverage for the enriched HAMi status error message.

## Test Plan

### Unit test
- [x] `go test ./api/... ./controllers ./internal/... -count=1`

### DB test
- [x] Not required. No database schema, migration, or query behavior changes.

### E2E test
- [x] Not required. Backend change only enriches HAMi not-ready error messages while preserving existing `component_status` processing.

## Risk & Rollback

Low risk. The change only modifies the HAMi not-ready error string and does not change reconciliation state transitions, persisted status shape, or endpoint validation gates. Roll back by reverting this commit.