### PR TITLE
fix(serve-metrics): inject Serve labels into PerfMetricsProm too

### DIFF
--- a/cluster-image-builder/serve/_metrics/ray_stat_logger.py
+++ b/cluster-image-builder/serve/_metrics/ray_stat_logger.py
@@ -14,6 +14,7 @@ RayKVConnectorProm = getattr(
     "RayKVConnectorPrometheus",
     getattr(_ray_wrappers, "RayKVConnectorProm", None),
 )
+RayPerfMetricsProm = getattr(_ray_wrappers, "RayPerfMetricsProm", None)
 
 logger = logging.getLogger("ray.serve")
 
@@ -57,6 +58,15 @@ def _make_extended_kv_connector_cls(base_cls, extra_labels):
     return Extended
 
 
+def _make_extended_perf_metrics_cls(base_cls, extra_labels):
+    """Extend PerfMetricsProm counters with custom labels via its _cls vars."""
+
+    class Extended(base_cls):
+        _counter_cls = _make_extended_metric_cls(RayCounterWrapper, extra_labels)
+
+    return Extended
+
+
 class NeutreeRayStatLogger(RayPrometheusStatLogger):
     """RayPrometheusStatLogger with Ray Serve context labels injected.
 
@@ -94,6 +104,9 @@ class NeutreeRayStatLogger(RayPrometheusStatLogger):
             if RayKVConnectorProm is not None:
                 self._kv_connector_cls = _make_extended_kv_connector_cls(
                     RayKVConnectorProm, extra_labels)
+            if RayPerfMetricsProm is not None:
+                self._perf_metrics_cls = _make_extended_perf_metrics_cls(
+                    RayPerfMetricsProm, extra_labels)
 
         super().__init__(vllm_config, engine_indexes)
 


### PR DESCRIPTION
## Problem

`NeutreeRayStatLogger` extends vLLM metrics with Ray Serve context labels (`deployment`, `replica`, `application`, `engine`, `engine_version`) by overriding the metric-wrapper classes that vLLM's `PrometheusStatLogger` uses.

vLLM's `PrometheusStatLogger` instantiates **three** overridable sub-metric groups:

```python
_spec_decoding_cls = SpecDecodingProm
_kv_connector_cls  = KVConnectorProm
_perf_metrics_cls  = PerfMetricsProm
```

`NeutreeRayStatLogger` overrides `_spec_decoding_cls` and `_kv_connector_cls`, but **not** `_perf_metrics_cls`. As a result the PerfMetricsProm counters — `vllm:estimated_flops_per_gpu_total`, `vllm:estimated_read_bytes_per_gpu_total`, `vllm:estimated_write_bytes_per_gpu_total` — are emitted **without** the Serve context labels, unlike every other metric. That contradicts the logger's own docstring ("Transparently extends all vLLM metrics ...") and leaves those series unable to be filtered by `application` on the per-endpoint dashboards.

## Change

Add a `_perf_metrics_cls` override, symmetric with the existing spec-decoding / kv-connector overrides. It is guarded by `getattr(_ray_wrappers, "RayPerfMetricsProm", None)`, so it is a no-op on engine versions that predate `PerfMetricsProm` — this file is shared across all vLLM engine versions via `COPY serve/_metrics`.

Verified against `engine-vllm:v0.24.0-neutree1-ray2.53.0`: `loggers.PrometheusStatLogger` carries `_spec_decoding_cls`, `_kv_connector_cls`, and `_perf_metrics_cls` (all instantiated in `__init__`), and `ray_wrappers` ships `RayPerfMetricsProm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
