### PR TITLE
fix: shorten usage aggregation cron from 5min to 30s

### DIFF
--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -18,7 +18,10 @@ func StartCrons(ctx context.Context, storage storage.Storage) error {
 		return errors.Wrapf(err, "failed to init cron scheduler")
 	}
 
-	_, err = s.NewJob(gocron.DurationJob(time.Minute*5), gocron.NewTask(func() {
+	// Runs frequently (vs. the other jobs below) to bound how long an API key's
+	// token_quota usage can lag actual consumption, since get_api_key_remaining
+	// reads from the aggregated api_daily_usage table, not the raw usage records.
+	_, err = s.NewJob(gocron.DurationJob(time.Second*30), gocron.NewTask(func() {
 		klog.V(4).Infof("Start to aggregate usage records")
 
 		jobErr := storage.CallDatabaseFunction("aggregate_usage_records", map[string]interface{}{


### PR DESCRIPTION
## Summary
- Shortens the `aggregate_usage_records` cron interval from 5 minutes to 30 seconds (`internal/cron/cron.go`).
- `cleanup_aggregated_records` and `sync_api_key_usage` are left at 5 minutes — unchanged.
- No change to batching: `aggregate_usage_records` still has no `p_batch_size` cap. Scope intentionally kept to the interval only.

## Why
`get_api_key_remaining` computes an API key's remaining `token_quota` from the aggregated `api.api_daily_usage` table, not from the raw `api.api_usage_records` rows that get written per-request. Those raw rows only get folded into `api_daily_usage` by the `aggregate_usage_records` cron job. At the previous 5-minute interval, a burst of usage could take up to ~5 minutes to be reflected in the quota check, i.e. up to ~5 minutes of over-use before enforcement catches up. Dropping the interval to 30s bounds that window to ~30s (worst case), ~15s on average.

This only touches `aggregate_usage_records` because it's the one job on the enforcement read path — `sync_api_key_usage` only refreshes the display-only `status.usage` field on the API key resource, not something `get_api_key_remaining` reads, so it doesn't need to run any more often. `cleanup_aggregated_records` is unrelated garbage collection.

## Known follow-up (out of scope here)
`aggregate_usage_records` processes all unaggregated rows in a single unbounded loop per invocation (unlike `cleanup_aggregated_records`, which already has a `p_batch_size` cap). Each job run is serialized against itself via `gocron.WithSingletonMode(LimitModeWait)`, so under sustained load or after a backlog (e.g. DB was briefly unavailable), a slow run can cause subsequent runs to queue rather than overlap — this pre-existing gap gets a lower trigger threshold at 30s and would benefit from a `p_batch_size` cap in a follow-up, but is left out of this PR to keep the change minimal and reviewable.

## Validation
- `go build ./internal/... ./api/... ./cmd/... ./pkg/... ./controllers/...`
- `bin/golangci-lint run ./internal/cron/...`
- No existing tests reference the cron interval; not modified.