### PR TITLE
fix: clean stale HAMi and Neutree node annotations

### DIFF
--- a/internal/cluster/component/hami/hami_test.go
+++ b/internal/cluster/component/hami/hami_test.go
@@ -26,6 +26,13 @@ import (
 	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
 )
 
+var testHAMiNodeAnnotations = []string{
+	"hami.io/node-nvidia-register",
+	"hami.io/node-nvidia-score",
+	"hami.io/node-handshake",
+	"hami.io/mutex.lock",
+}
+
 func TestHAMiComponentResources(t *testing.T) {
 	component := NewHAMiComponent(newTestCluster(), "neutree-system", "registry.example.com/neutree/",
 		"image-pull-secret", v1.KubernetesClusterConfig{}, newHAMiFakeClient(t))
@@ -545,21 +552,27 @@ func TestHAMiDeleteRemovesComponentStatus(t *testing.T) {
 	assert.NotContains(t, cluster.Status.ComponentStatus, v1.ComponentStatusAcceleratorVirtualizationKey)
 }
 
-func TestHAMiDeleteRemovesEnabledNodeScopeLabels(t *testing.T) {
+func TestHAMiDeleteRemovesOwnedNodeScopeState(t *testing.T) {
 	enabledNode := newHAMiNode("gpu-enabled", map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "true",
 	})
 	enabledNode.Annotations = map[string]string{
+		"hami.io/node-nvidia-register":                     `[{"id":"GPU-enabled"}]`,
+		"hami.io/node-nvidia-score":                        `[{"uuid":"GPU-enabled"}]`,
+		"hami.io/node-handshake":                           "Reported",
+		"hami.io/mutex.lock":                               "lock-values,default,pod-gpu",
 		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-enabled"}]`,
 	}
 	disabledNode := newHAMiNode("gpu-disabled", map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "false",
 	})
 	disabledNode.Annotations = map[string]string{
+		"hami.io/node-nvidia-register":                     `[{"id":"GPU-disabled"}]`,
 		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-disabled"}]`,
 	}
 	unlabeledNode := newHAMiNode("gpu-unlabeled", map[string]string{})
 	unlabeledNode.Annotations = map[string]string{
+		"hami.io/node-nvidia-register":                     `[{"id":"GPU-unlabeled"}]`,
 		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-unlabeled"}]`,
 	}
 	fakeClient := newHAMiFakeClient(t, enabledNode, disabledNode, unlabeledNode)
@@ -575,17 +588,20 @@ func TestHAMiDeleteRemovesEnabledNodeScopeLabels(t *testing.T) {
 	gotEnabled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-enabled"}, gotEnabled))
 	assert.NotContains(t, gotEnabled.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
-	assert.NotContains(t, gotEnabled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+	assertHAMiNodeAnnotationsRemoved(t, gotEnabled.Annotations)
+	assert.Contains(t, gotEnabled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 
 	gotDisabled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-disabled"}, gotDisabled))
 	assert.Equal(t, "false", gotDisabled.Labels[plugin.NvidiaGPUVirtualizationLabelKey])
-	assert.NotContains(t, gotDisabled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+	assertHAMiNodeAnnotationsRemoved(t, gotDisabled.Annotations)
+	assert.Contains(t, gotDisabled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 
 	gotUnlabeled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-unlabeled"}, gotUnlabeled))
 	assert.NotContains(t, gotUnlabeled.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
-	assert.NotContains(t, gotUnlabeled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+	assertHAMiNodeAnnotationsRemoved(t, gotUnlabeled.Annotations)
+	assert.Contains(t, gotUnlabeled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 }
 
 func TestHAMiDeleteSkipsNodeScopeCleanupWhenClusterDoesNotOwnVirtualization(t *testing.T) {
@@ -593,6 +609,7 @@ func TestHAMiDeleteSkipsNodeScopeCleanupWhenClusterDoesNotOwnVirtualization(t *t
 		plugin.NvidiaGPUVirtualizationLabelKey: "true",
 	})
 	enabledNode.Annotations = map[string]string{
+		"hami.io/node-nvidia-register":                     `[{"id":"GPU-owned-by-other"}]`,
 		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-owned-by-other"}]`,
 	}
 	fakeClient := newHAMiFakeClient(t, enabledNode)
@@ -608,6 +625,7 @@ func TestHAMiDeleteSkipsNodeScopeCleanupWhenClusterDoesNotOwnVirtualization(t *t
 	gotEnabled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-enabled"}, gotEnabled))
 	assert.Equal(t, "true", gotEnabled.Labels[plugin.NvidiaGPUVirtualizationLabelKey])
+	assert.Contains(t, gotEnabled.Annotations, "hami.io/node-nvidia-register")
 	assert.Contains(t, gotEnabled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 }
 
@@ -666,6 +684,14 @@ func TestHAMiDeleteUsesPluginNodeScopeLabel(t *testing.T) {
 	gotDefaultEnabled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "default-enabled"}, gotDefaultEnabled))
 	assert.Equal(t, "true", gotDefaultEnabled.Labels[plugin.NvidiaGPUVirtualizationLabelKey])
+}
+
+func assertHAMiNodeAnnotationsRemoved(t *testing.T, annotations map[string]string) {
+	t.Helper()
+
+	for _, key := range testHAMiNodeAnnotations {
+		assert.NotContains(t, annotations, key)
+	}
 }
 
 func assertHasObject(t *testing.T, items []unstructured.Unstructured, kind, name string) {

--- a/internal/cluster/component/hami/hami_test.go
+++ b/internal/cluster/component/hami/hami_test.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
+	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
 )
 
 func TestHAMiComponentResources(t *testing.T) {
@@ -548,10 +549,19 @@ func TestHAMiDeleteRemovesEnabledNodeScopeLabels(t *testing.T) {
 	enabledNode := newHAMiNode("gpu-enabled", map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "true",
 	})
+	enabledNode.Annotations = map[string]string{
+		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-enabled"}]`,
+	}
 	disabledNode := newHAMiNode("gpu-disabled", map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "false",
 	})
+	disabledNode.Annotations = map[string]string{
+		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-disabled"}]`,
+	}
 	unlabeledNode := newHAMiNode("gpu-unlabeled", map[string]string{})
+	unlabeledNode.Annotations = map[string]string{
+		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-unlabeled"}]`,
+	}
 	fakeClient := newHAMiFakeClient(t, enabledNode, disabledNode, unlabeledNode)
 	cluster := newTestCluster()
 	markHAMiOwned(cluster)
@@ -565,20 +575,26 @@ func TestHAMiDeleteRemovesEnabledNodeScopeLabels(t *testing.T) {
 	gotEnabled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-enabled"}, gotEnabled))
 	assert.NotContains(t, gotEnabled.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
+	assert.NotContains(t, gotEnabled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 
 	gotDisabled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-disabled"}, gotDisabled))
 	assert.Equal(t, "false", gotDisabled.Labels[plugin.NvidiaGPUVirtualizationLabelKey])
+	assert.NotContains(t, gotDisabled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 
 	gotUnlabeled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-unlabeled"}, gotUnlabeled))
 	assert.NotContains(t, gotUnlabeled.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
+	assert.NotContains(t, gotUnlabeled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 }
 
 func TestHAMiDeleteSkipsNodeScopeCleanupWhenClusterDoesNotOwnVirtualization(t *testing.T) {
 	enabledNode := newHAMiNode("gpu-enabled", map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "true",
 	})
+	enabledNode.Annotations = map[string]string{
+		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-owned-by-other"}]`,
+	}
 	fakeClient := newHAMiFakeClient(t, enabledNode)
 	cluster := newTestCluster()
 	cluster.Spec.AcceleratorVirtualization = nil
@@ -592,6 +608,7 @@ func TestHAMiDeleteSkipsNodeScopeCleanupWhenClusterDoesNotOwnVirtualization(t *t
 	gotEnabled := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-enabled"}, gotEnabled))
 	assert.Equal(t, "true", gotEnabled.Labels[plugin.NvidiaGPUVirtualizationLabelKey])
+	assert.Contains(t, gotEnabled.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 }
 
 func TestHAMiDeleteRemovesNodeScopeWhenSpecStillEnablesVirtualization(t *testing.T) {

--- a/internal/cluster/component/hami/scope.go
+++ b/internal/cluster/component/hami/scope.go
@@ -9,8 +9,21 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
-	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
 )
+
+const (
+	hamiNodeNVIDIARegisterAnnotation  = "hami.io/node-nvidia-register"
+	hamiNodeNVIDIAScoreAnnotation     = "hami.io/node-nvidia-score"
+	hamiNodeNVIDIAHandshakeAnnotation = "hami.io/node-handshake"
+	hamiNodeLockAnnotation            = "hami.io/mutex.lock"
+)
+
+var hamiNodeAnnotations = []string{
+	hamiNodeNVIDIARegisterAnnotation,
+	hamiNodeNVIDIAScoreAnnotation,
+	hamiNodeNVIDIAHandshakeAnnotation,
+	hamiNodeLockAnnotation,
+}
 
 func (h *HAMiComponent) ReconcileNodeScope(ctx context.Context) (NodeScopePlan, error) {
 	nodeList := &corev1.NodeList{}
@@ -56,11 +69,9 @@ func (h *HAMiComponent) DisableNodeScope(ctx context.Context) error {
 		return errors.Wrap(err, "failed to list nodes")
 	}
 
-	// Remove only the enabled scope label written while HAMi is active.
-	// Existing disabled labels are preserved because users can set them
-	// explicitly to keep a node out of virtualization. The Neutree device
-	// annotation is HAMi/vGPU state and is removed from every node while the
-	// cluster still owns HAMi scope, including retries after labels are gone.
+	// Remove only HAMi-owned node scope state. Existing disabled labels are
+	// preserved because users can set them explicitly to keep a node out of
+	// virtualization.
 	label := nodeScopeLabelFromPlugin(config.NodeScopeLabel)
 	for _, item := range nodeList.Items {
 		if !nodeNeedsScopeCleanup(item, label) {
@@ -89,14 +100,12 @@ func nodeNeedsScopeCleanup(node corev1.Node, label NodeScopeLabel) bool {
 		return true
 	}
 
-	_, ok := node.Annotations[resourceparser.NeutreeAcceleratorDevicesAnnotation]
-
-	return ok
+	return hasHAMiNodeAnnotation(node.Annotations)
 }
 
 func cleanupNodeScope(node *corev1.Node, label NodeScopeLabel) bool {
 	changed := cleanupEnabledNodeScopeLabel(node, label)
-	if cleanupDeviceAnnotation(node) {
+	if cleanupHAMiNodeAnnotations(node) {
 		changed = true
 	}
 
@@ -113,18 +122,32 @@ func cleanupEnabledNodeScopeLabel(node *corev1.Node, label NodeScopeLabel) bool 
 	return true
 }
 
-func cleanupDeviceAnnotation(node *corev1.Node) bool {
+func cleanupHAMiNodeAnnotations(node *corev1.Node) bool {
 	if node.Annotations == nil {
 		return false
 	}
 
-	if _, ok := node.Annotations[resourceparser.NeutreeAcceleratorDevicesAnnotation]; !ok {
-		return false
+	changed := false
+
+	for _, key := range hamiNodeAnnotations {
+		if _, ok := node.Annotations[key]; ok {
+			delete(node.Annotations, key)
+
+			changed = true
+		}
 	}
 
-	delete(node.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+	return changed
+}
 
-	return true
+func hasHAMiNodeAnnotation(annotations map[string]string) bool {
+	for _, key := range hamiNodeAnnotations {
+		if _, ok := annotations[key]; ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (h *HAMiComponent) planNodeScope(ctx context.Context, nodes []corev1.Node, enabled bool) (NodeScopePlan, error) {

--- a/internal/cluster/component/hami/scope.go
+++ b/internal/cluster/component/hami/scope.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
+	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
 )
 
 func (h *HAMiComponent) ReconcileNodeScope(ctx context.Context) (NodeScopePlan, error) {
@@ -57,10 +58,12 @@ func (h *HAMiComponent) DisableNodeScope(ctx context.Context) error {
 
 	// Remove only the enabled scope label written while HAMi is active.
 	// Existing disabled labels are preserved because users can set them
-	// explicitly to keep a node out of virtualization.
+	// explicitly to keep a node out of virtualization. The Neutree device
+	// annotation is HAMi/vGPU state and is removed from every node while the
+	// cluster still owns HAMi scope, including retries after labels are gone.
 	label := nodeScopeLabelFromPlugin(config.NodeScopeLabel)
 	for _, item := range nodeList.Items {
-		if item.Labels[label.Key] != label.EnabledValue {
+		if !nodeNeedsScopeCleanup(item, label) {
 			continue
 		}
 
@@ -69,11 +72,9 @@ func (h *HAMiComponent) DisableNodeScope(ctx context.Context) error {
 			return errors.Wrapf(err, "failed to get node %s", item.Name)
 		}
 
-		if node.Labels == nil || node.Labels[label.Key] != label.EnabledValue {
+		if !cleanupNodeScope(node, label) {
 			continue
 		}
-
-		delete(node.Labels, label.Key)
 
 		if err := h.ctrlClient.Update(ctx, node); err != nil {
 			return errors.Wrapf(err, "failed to patch node %s", item.Name)
@@ -81,6 +82,49 @@ func (h *HAMiComponent) DisableNodeScope(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func nodeNeedsScopeCleanup(node corev1.Node, label NodeScopeLabel) bool {
+	if node.Labels[label.Key] == label.EnabledValue {
+		return true
+	}
+
+	_, ok := node.Annotations[resourceparser.NeutreeAcceleratorDevicesAnnotation]
+
+	return ok
+}
+
+func cleanupNodeScope(node *corev1.Node, label NodeScopeLabel) bool {
+	changed := cleanupEnabledNodeScopeLabel(node, label)
+	if cleanupDeviceAnnotation(node) {
+		changed = true
+	}
+
+	return changed
+}
+
+func cleanupEnabledNodeScopeLabel(node *corev1.Node, label NodeScopeLabel) bool {
+	if node.Labels == nil || node.Labels[label.Key] != label.EnabledValue {
+		return false
+	}
+
+	delete(node.Labels, label.Key)
+
+	return true
+}
+
+func cleanupDeviceAnnotation(node *corev1.Node) bool {
+	if node.Annotations == nil {
+		return false
+	}
+
+	if _, ok := node.Annotations[resourceparser.NeutreeAcceleratorDevicesAnnotation]; !ok {
+		return false
+	}
+
+	delete(node.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+
+	return true
 }
 
 func (h *HAMiComponent) planNodeScope(ctx context.Context, nodes []corev1.Node, enabled bool) (NodeScopePlan, error) {

--- a/internal/cluster/component/metrics/cleanup.go
+++ b/internal/cluster/component/metrics/cleanup.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
+)
+
+func (m *MetricsComponent) cleanupNodeAnnotations(ctx context.Context) error {
+	nodeList := &corev1.NodeList{}
+	if err := m.ctrlClient.List(ctx, nodeList); err != nil {
+		return errors.Wrap(err, "failed to list nodes")
+	}
+
+	for _, item := range nodeList.Items {
+		if !hasNeutreeAcceleratorDevicesAnnotation(item.Annotations) {
+			continue
+		}
+
+		node := &corev1.Node{}
+		if err := m.ctrlClient.Get(ctx, types.NamespacedName{Name: item.Name}, node); err != nil {
+			return errors.Wrapf(err, "failed to get node %s", item.Name)
+		}
+
+		if !cleanupNeutreeAcceleratorDevicesAnnotation(node) {
+			continue
+		}
+
+		if err := m.ctrlClient.Update(ctx, node); err != nil {
+			return errors.Wrapf(err, "failed to patch node %s", item.Name)
+		}
+	}
+
+	return nil
+}
+
+func cleanupNeutreeAcceleratorDevicesAnnotation(node *corev1.Node) bool {
+	if !hasNeutreeAcceleratorDevicesAnnotation(node.Annotations) {
+		return false
+	}
+
+	delete(node.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+
+	return true
+}
+
+func hasNeutreeAcceleratorDevicesAnnotation(annotations map[string]string) bool {
+	_, ok := annotations[resourceparser.NeutreeAcceleratorDevicesAnnotation]
+
+	return ok
+}

--- a/internal/cluster/component/metrics/metrics.go
+++ b/internal/cluster/component/metrics/metrics.go
@@ -67,10 +67,15 @@ func (m *MetricsComponent) Reconcile() error {
 }
 
 func (m *MetricsComponent) Delete() error {
-	// Implement the logic to delete the metrics component from the cluster
-	deleted, err := m.DeleteResources(context.Background())
+	ctx := context.Background()
+
+	deleted, err := m.DeleteResources(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete metrics resources")
+	}
+
+	if err := m.cleanupNodeAnnotations(ctx); err != nil {
+		return errors.Wrap(err, "failed to cleanup metrics node annotations")
 	}
 
 	if !deleted {

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/accelerator"
 	acceleratormocks "github.com/neutree-ai/neutree/internal/accelerator/mocks"
+	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
 	"github.com/stretchr/testify/mock"
 	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/assert"
@@ -21,6 +22,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -31,6 +33,57 @@ func metricsTestNode(name string, labels map[string]string) *corev1.Node {
 			Labels: labels,
 		},
 	}
+}
+
+func metricsTestNodeWithAnnotations(name string, annotations map[string]string) *corev1.Node {
+	node := metricsTestNode(name, nil)
+	node.Annotations = annotations
+
+	return node
+}
+
+func TestMetricsDeleteRemovesNeutreeAcceleratorDevicesAnnotation(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithObjects(
+		metricsTestNodeWithAnnotations("gpu-node", map[string]string{
+			resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-metrics"}]`,
+			"hami.io/node-nvidia-register":                     `[{"id":"GPU-hami"}]`,
+			"example.com/keep":                                 "value",
+		}),
+		metricsTestNodeWithAnnotations("cpu-node", map[string]string{
+			"example.com/keep": "value",
+		}),
+	).Build()
+	metricsCmpt := &MetricsComponent{
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{
+				Name:      "test-cluster",
+				Workspace: "test-workspace",
+			},
+			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
+		},
+		namespace:  "test-namespace",
+		ctrlClient: fakeClient,
+	}
+
+	err := metricsCmpt.Delete()
+
+	assert.NilError(t, err)
+
+	gotGPUNode := &corev1.Node{}
+	assert.NilError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "gpu-node"}, gotGPUNode))
+	assert.Assert(t, !hasKey(gotGPUNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation))
+	assert.Equal(t, gotGPUNode.Annotations["hami.io/node-nvidia-register"], `[{"id":"GPU-hami"}]`)
+	assert.Equal(t, gotGPUNode.Annotations["example.com/keep"], "value")
+
+	gotCPUNode := &corev1.Node{}
+	assert.NilError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: "cpu-node"}, gotCPUNode))
+	assert.Equal(t, gotCPUNode.Annotations["example.com/keep"], "value")
+}
+
+func hasKey(values map[string]string, key string) bool {
+	_, ok := values[key]
+
+	return ok
 }
 
 func TestBuildVMAgentDeployment(t *testing.T) {

--- a/internal/cluster/kubernetes_cluster_test.go
+++ b/internal/cluster/kubernetes_cluster_test.go
@@ -696,7 +696,7 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScope(t *te
 	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: "gpu-node"}, gotNode))
 	require.NotContains(t, gotNode.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
 	require.NotContains(t, gotNode.Annotations, "hami.io/node-nvidia-register")
-	require.Contains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+	require.NotContains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 
 	gotClusterRole := newUnstructuredObject("rbac.authorization.k8s.io/v1", "ClusterRole",
 		"", "vmagent-node-reader-test")
@@ -771,7 +771,7 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScopeFromSt
 	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: "gpu-node"}, gotNode))
 	require.NotContains(t, gotNode.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
 	require.NotContains(t, gotNode.Annotations, "hami.io/node-nvidia-register")
-	require.Contains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+	require.NotContains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 }
 
 func newUnstructuredObject(apiVersion, kind, namespace, name string) *unstructured.Unstructured {

--- a/internal/cluster/kubernetes_cluster_test.go
+++ b/internal/cluster/kubernetes_cluster_test.go
@@ -659,8 +659,10 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScope(t *te
 			Name: util.ClusterNamespace(cluster),
 		},
 	}
-	gpuNode := newNode("gpu-node", true, nil, map[string]string{
+	gpuNode := newNodeWithAnnotations("gpu-node", true, nil, map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "true",
+	}, map[string]string{
+		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-delete-path"}]`,
 	})
 	metricsClusterRole := newUnstructuredObject("rbac.authorization.k8s.io/v1", "ClusterRole",
 		"", "vmagent-node-reader-test")
@@ -692,6 +694,7 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScope(t *te
 	gotNode := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: "gpu-node"}, gotNode))
 	require.NotContains(t, gotNode.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
+	require.NotContains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 
 	gotClusterRole := newUnstructuredObject("rbac.authorization.k8s.io/v1", "ClusterRole",
 		"", "vmagent-node-reader-test")
@@ -729,8 +732,10 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScopeFromSt
 			Name: util.ClusterNamespace(cluster),
 		},
 	}
-	gpuNode := newNode("gpu-node", true, nil, map[string]string{
+	gpuNode := newNodeWithAnnotations("gpu-node", true, nil, map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "true",
+	}, map[string]string{
+		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-delete-status"}]`,
 	})
 	metricsClusterRole := newUnstructuredObject("rbac.authorization.k8s.io/v1", "ClusterRole",
 		"", "vmagent-node-reader-test")
@@ -762,6 +767,7 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScopeFromSt
 	gotNode := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: "gpu-node"}, gotNode))
 	require.NotContains(t, gotNode.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
+	require.NotContains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 }
 
 func newUnstructuredObject(apiVersion, kind, namespace, name string) *unstructured.Unstructured {

--- a/internal/cluster/kubernetes_cluster_test.go
+++ b/internal/cluster/kubernetes_cluster_test.go
@@ -662,6 +662,7 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScope(t *te
 	gpuNode := newNodeWithAnnotations("gpu-node", true, nil, map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "true",
 	}, map[string]string{
+		"hami.io/node-nvidia-register":                     `[{"id":"GPU-delete-path"}]`,
 		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-delete-path"}]`,
 	})
 	metricsClusterRole := newUnstructuredObject("rbac.authorization.k8s.io/v1", "ClusterRole",
@@ -694,7 +695,8 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScope(t *te
 	gotNode := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: "gpu-node"}, gotNode))
 	require.NotContains(t, gotNode.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
-	require.NotContains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+	require.NotContains(t, gotNode.Annotations, "hami.io/node-nvidia-register")
+	require.Contains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 
 	gotClusterRole := newUnstructuredObject("rbac.authorization.k8s.io/v1", "ClusterRole",
 		"", "vmagent-node-reader-test")
@@ -735,6 +737,7 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScopeFromSt
 	gpuNode := newNodeWithAnnotations("gpu-node", true, nil, map[string]string{
 		plugin.NvidiaGPUVirtualizationLabelKey: "true",
 	}, map[string]string{
+		"hami.io/node-nvidia-register":                     `[{"id":"GPU-delete-status"}]`,
 		resourceparser.NeutreeAcceleratorDevicesAnnotation: `[{"uuid":"GPU-delete-status"}]`,
 	})
 	metricsClusterRole := newUnstructuredObject("rbac.authorization.k8s.io/v1", "ClusterRole",
@@ -767,7 +770,8 @@ func TestKubernetesReconcileDeleteCleansAcceleratorVirtualizationNodeScopeFromSt
 	gotNode := &corev1.Node{}
 	require.NoError(t, fakeClient.Get(context.TODO(), client.ObjectKey{Name: "gpu-node"}, gotNode))
 	require.NotContains(t, gotNode.Labels, plugin.NvidiaGPUVirtualizationLabelKey)
-	require.NotContains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
+	require.NotContains(t, gotNode.Annotations, "hami.io/node-nvidia-register")
+	require.Contains(t, gotNode.Annotations, resourceparser.NeutreeAcceleratorDevicesAnnotation)
 }
 
 func newUnstructuredObject(apiVersion, kind, namespace, name string) *unstructured.Unstructured {

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"time"
@@ -178,30 +177,6 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 			assertK8sEndpointAcceleratorAllocationAnnotations(clusterName, fullCardEndpointName)
 		})
 
-		It("should clean node device annotations when deleting the virtualized cluster", Label("C2729471"), func() {
-			ctx := context.Background()
-			k8sH := NewK8sHelper(kubeconfig)
-
-			By("Capturing GPU nodes with Neutree device annotations")
-			nodeNames := expectK8sNodeAcceleratorDeviceAnnotations(ctx, k8sH)
-
-			if endpointName != "" {
-				deleteEndpoint(endpointName)
-				endpointName = ""
-			}
-
-			if fullCardEndpointName != "" {
-				deleteEndpoint(fullCardEndpointName)
-				fullCardEndpointName = ""
-			}
-
-			By("Deleting virtualized cluster")
-			teardownCluster(clusterName)
-			clusterName = ""
-
-			By("Verifying HAMi cleanup removed Neutree device annotations")
-			assertK8sNodeAcceleratorDeviceAnnotationsRemoved(ctx, k8sH, nodeNames)
-		})
 	})
 
 func requireAcceleratorVirtualizationProfile() {

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -26,13 +26,12 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 			clusterName          string
 			endpointName         string
 			fullCardEndpointName string
-			kubeconfig           string
 			productName          string
 		)
 
 		BeforeAll(func() {
 			requireAcceleratorVirtualizationProfile()
-			kubeconfig = requireK8sProfile()
+			kubeconfig := requireK8sProfile()
 
 			By("Setting up image registry")
 			SetupImageRegistry()

--- a/tests/e2e/accelerator_virtualization_test.go
+++ b/tests/e2e/accelerator_virtualization_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -26,12 +27,13 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 			clusterName          string
 			endpointName         string
 			fullCardEndpointName string
+			kubeconfig           string
 			productName          string
 		)
 
 		BeforeAll(func() {
 			requireAcceleratorVirtualizationProfile()
-			kubeconfig := requireK8sProfile()
+			kubeconfig = requireK8sProfile()
 
 			By("Setting up image registry")
 			SetupImageRegistry()
@@ -174,6 +176,31 @@ var _ = Describe("K8s Accelerator Virtualization", Ordered,
 
 			By("Verifying node-agent writes full-card endpoint allocation annotations")
 			assertK8sEndpointAcceleratorAllocationAnnotations(clusterName, fullCardEndpointName)
+		})
+
+		It("should clean node device annotations when deleting the virtualized cluster", Label("C2729471"), func() {
+			ctx := context.Background()
+			k8sH := NewK8sHelper(kubeconfig)
+
+			By("Capturing GPU nodes with Neutree device annotations")
+			nodeNames := expectK8sNodeAcceleratorDeviceAnnotations(ctx, k8sH)
+
+			if endpointName != "" {
+				deleteEndpoint(endpointName)
+				endpointName = ""
+			}
+
+			if fullCardEndpointName != "" {
+				deleteEndpoint(fullCardEndpointName)
+				fullCardEndpointName = ""
+			}
+
+			By("Deleting virtualized cluster")
+			teardownCluster(clusterName)
+			clusterName = ""
+
+			By("Verifying HAMi cleanup removed Neutree device annotations")
+			assertK8sNodeAcceleratorDeviceAnnotationsRemoved(ctx, k8sH, nodeNames)
 		})
 	})
 

--- a/tests/e2e/node_agent_observability_helper.go
+++ b/tests/e2e/node_agent_observability_helper.go
@@ -477,6 +477,59 @@ func assertK8sNodeAcceleratorDeviceAnnotations(ctx context.Context, k8sH *K8sHel
 	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
 }
 
+func expectK8sNodeAcceleratorDeviceAnnotations(ctx context.Context, k8sH *K8sHelper) []string {
+	var nodeNames []string
+
+	EventuallyWithOffset(1, func(g Gomega) {
+		nodes, err := k8sH.ListNodes(ctx, "nvidia.com/gpu.present=true")
+		g.Expect(err).NotTo(HaveOccurred(), "should list NVIDIA GPU nodes")
+		g.Expect(nodes).NotTo(BeEmpty(), "GPU nodes should exist")
+
+		nodeNames = nodeNames[:0]
+		var missing []string
+		for _, node := range nodes {
+			nodeNames = append(nodeNames, node.Name)
+			if err := validateNodeDeviceAnnotation(node.Annotations); err != nil {
+				missing = append(missing, fmt.Sprintf("%s: %v", node.Name, err))
+			}
+		}
+
+		g.Expect(missing).To(BeEmpty(), "all GPU nodes should have accelerator device annotations")
+	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
+
+	return nodeNames
+}
+
+func assertK8sNodeAcceleratorDeviceAnnotationsRemoved(
+	ctx context.Context,
+	k8sH *K8sHelper,
+	nodeNames []string,
+) {
+	ExpectWithOffset(1, nodeNames).NotTo(BeEmpty(), "captured GPU nodes should not be empty")
+
+	EventuallyWithOffset(1, func(g Gomega) {
+		nodes, err := k8sH.ListNodes(ctx, "")
+		g.Expect(err).NotTo(HaveOccurred(), "should list cluster nodes")
+
+		nodeByName := make(map[string]corev1.Node, len(nodes))
+		for _, node := range nodes {
+			nodeByName[node.Name] = node
+		}
+
+		var remaining []string
+		for _, name := range nodeNames {
+			node, ok := nodeByName[name]
+			g.Expect(ok).To(BeTrue(), "captured node %s should still exist", name)
+
+			if _, ok := node.Annotations[resourceparser.NeutreeAcceleratorDevicesAnnotation]; ok {
+				remaining = append(remaining, name)
+			}
+		}
+
+		g.Expect(remaining).To(BeEmpty(), "Neutree device annotations should be removed")
+	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
+}
+
 func k8sClusterNamespace(clusterName string) string {
 	cluster := getClusterFullJSON(clusterName)
 	ExpectWithOffset(1, cluster.Metadata).NotTo(BeNil())

--- a/tests/e2e/node_agent_observability_helper.go
+++ b/tests/e2e/node_agent_observability_helper.go
@@ -477,59 +477,6 @@ func assertK8sNodeAcceleratorDeviceAnnotations(ctx context.Context, k8sH *K8sHel
 	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
 }
 
-func expectK8sNodeAcceleratorDeviceAnnotations(ctx context.Context, k8sH *K8sHelper) []string {
-	var nodeNames []string
-
-	EventuallyWithOffset(1, func(g Gomega) {
-		nodes, err := k8sH.ListNodes(ctx, "nvidia.com/gpu.present=true")
-		g.Expect(err).NotTo(HaveOccurred(), "should list NVIDIA GPU nodes")
-		g.Expect(nodes).NotTo(BeEmpty(), "GPU nodes should exist")
-
-		nodeNames = nodeNames[:0]
-		var missing []string
-		for _, node := range nodes {
-			nodeNames = append(nodeNames, node.Name)
-			if err := validateNodeDeviceAnnotation(node.Annotations); err != nil {
-				missing = append(missing, fmt.Sprintf("%s: %v", node.Name, err))
-			}
-		}
-
-		g.Expect(missing).To(BeEmpty(), "all GPU nodes should have accelerator device annotations")
-	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
-
-	return nodeNames
-}
-
-func assertK8sNodeAcceleratorDeviceAnnotationsRemoved(
-	ctx context.Context,
-	k8sH *K8sHelper,
-	nodeNames []string,
-) {
-	ExpectWithOffset(1, nodeNames).NotTo(BeEmpty(), "captured GPU nodes should not be empty")
-
-	EventuallyWithOffset(1, func(g Gomega) {
-		nodes, err := k8sH.ListNodes(ctx, "")
-		g.Expect(err).NotTo(HaveOccurred(), "should list cluster nodes")
-
-		nodeByName := make(map[string]corev1.Node, len(nodes))
-		for _, node := range nodes {
-			nodeByName[node.Name] = node
-		}
-
-		var remaining []string
-		for _, name := range nodeNames {
-			node, ok := nodeByName[name]
-			g.Expect(ok).To(BeTrue(), "captured node %s should still exist", name)
-
-			if _, ok := node.Annotations[resourceparser.NeutreeAcceleratorDevicesAnnotation]; ok {
-				remaining = append(remaining, name)
-			}
-		}
-
-		g.Expect(remaining).To(BeEmpty(), "Neutree device annotations should be removed")
-	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
-}
-
 func k8sClusterNamespace(clusterName string) string {
 	cluster := getClusterFullJSON(clusterName)
 	ExpectWithOffset(1, cluster.Metadata).NotTo(BeNil())


### PR DESCRIPTION
## Issue

NEU-517

## Summary

Deleting a Kubernetes cluster with GPU annotations could leave stale node annotations behind. This change splits cleanup ownership by annotation semantics: HAMi cleanup removes HAMi virtualization annotations and node-scope labels, while metrics cleanup removes Neutree's default accelerator device annotation.

## Changes

- Remove HAMi-owned node annotations during HAMi node-scope cleanup:
  - `hami.io/node-nvidia-register`
  - `hami.io/node-nvidia-score`
  - `hami.io/node-handshake`
  - `hami.io/mutex.lock`
- Preserve `neutree.ai/accelerator-devices` during HAMi cleanup because it is the current default Neutree device annotation semantics, not HAMi virtualization semantics.
- Remove `neutree.ai/accelerator-devices` during metrics component deletion so cluster deletion cleans the Neutree device annotation after metrics no longer owns it.
- Extend HAMi, metrics, and Kubernetes cluster deletion tests for the split cleanup behavior.

## Test Plan

### Unit test

- [x] `go vet ./internal/cluster/component/metrics ./internal/cluster/component/hami ./internal/cluster`
- [x] `go test -count=1 ./internal/cluster/component/metrics ./internal/cluster/component/hami ./internal/cluster`
- [x] `go test -count=1 ./tests/e2e -run '^$'`
- [x] `./bin/golangci-lint run ./internal/cluster/component/metrics ./internal/cluster/component/hami ./internal/cluster ./tests/e2e`
- [x] `git diff --check`
- [x] PR checks passed for head `542c31fc`.
- [ ] `go vet ./...` and `go test ./...`: blocked in this local workspace by missing embedded `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`; scoped affected-package gates passed.

### DB test

- [x] Not affected. No DB schema, storage, or migration changes.

### E2E test

- [x] Manual E2E on a hot-updated L20 Kubernetes accelerator virtualization environment with runtime commit `96cc7411`; latest head `542c31fc` only removes an unused E2E variable-scope change and does not change runtime cleanup behavior.
- [x] Virtualization enabled: verified HAMi annotations and `neutree.ai/accelerator-devices` were present on the actual L20 GPU node.
- [x] Virtualization disabled: verified HAMi annotations were removed while `neutree.ai/accelerator-devices` remained present.
- [x] Virtualization re-enabled: verified HAMi annotations returned and `neutree.ai/accelerator-devices` remained present.
- [x] Cluster deletion after deleting the L20 inference endpoints: verified the cluster namespace was removed and both HAMi annotations and `neutree.ai/accelerator-devices` were removed from the L20 GPU node.
- [ ] Code-backed Ginkgo E2E was not run per request to skip automated E2E in this round.
- Manual testing outside E2E is not required.

## Risk & Rollback

Risk is limited to Kubernetes node annotation cleanup during HAMi and metrics component deletion. Rollback is to revert this PR; stale node annotations can still be removed manually from affected nodes if needed.