### PR TITLE
fix: prevent cluster version downgrades

### DIFF
--- a/api/v1/cluster_types.go
+++ b/api/v1/cluster_types.go
@@ -26,6 +26,10 @@ const (
 // backed lifecycle.
 const StaticNodeClusterFlowVersionGate = "v1.0.1"
 
+// MinimumSelectableClusterVersionGate is the highest cluster version hidden
+// from version selection and available-version responses.
+const MinimumSelectableClusterVersionGate = StaticNodeClusterFlowVersionGate
+
 type Cluster struct {
 	ID         int            `json:"id,omitempty"`
 	APIVersion string         `json:"api_version,omitempty"`

--- a/internal/routes/clusters/cluster_versions.go
+++ b/internal/routes/clusters/cluster_versions.go
@@ -112,6 +112,12 @@ func getAvailableClusterVersions(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
+		minClusterVersion, err := semver.NewVersion(v1.MinimumSelectableClusterVersionGate)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("invalid minimum cluster version: %v", err)})
+			return
+		}
+
 		// Fetch labels concurrently for all tags
 		type tagResult struct {
 			version *semver.Version
@@ -148,6 +154,10 @@ func getAvailableClusterVersions(deps *Dependencies) gin.HandlerFunc {
 
 				v, parseErr := semver.NewVersion(versionStr)
 				if parseErr != nil {
+					return
+				}
+
+				if !minClusterVersion.LessThan(v) {
 					return
 				}
 

--- a/internal/routes/clusters/cluster_versions_test.go
+++ b/internal/routes/clusters/cluster_versions_test.go
@@ -54,15 +54,19 @@ func TestGetAvailableClusterVersions(t *testing.T) {
 					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
 				}, nil)
 				imgSvc.On("ListImageTags", mock.Anything, mock.Anything).Return([]string{
-					"v1.0.0", "v1.0.0-rocm", "v1.0.1-rc.1", "v1.1.0",
+					"v1.0.0", "v1.0.0-rocm", "v1.0.1", "v1.0.1-rc.1", "v1.0.2", "v1.1.0",
 					"v1.0.1-nightly-20260313", "latest",
 				}, nil)
 				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0" }), mock.Anything).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0-rocm" }), mock.Anything).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1" }), mock.Anything).
+					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1-rc.1" }), mock.Anything).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1-rc.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2" }), mock.Anything).
+					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.1.0" }), mock.Anything).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.1.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 				// Unlabeled tags — skipped
@@ -73,11 +77,11 @@ func TestGetAvailableClusterVersions(t *testing.T) {
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedResponse: &availableClusterVersionsResponse{
-				AvailableVersions: []string{"v1.0.0", "v1.0.1-rc.1", "v1.1.0"},
+				AvailableVersions: []string{"v1.0.2", "v1.1.0"},
 			},
 		},
 		{
-			name: "success - no accelerator_type deduplicates shared versions",
+			name: "success - no accelerator_type deduplicates shared versions after minimum filter",
 			queryParams: map[string]string{
 				"workspace":      "default",
 				"image_registry": "my-registry",
@@ -88,16 +92,20 @@ func TestGetAvailableClusterVersions(t *testing.T) {
 					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
 				}, nil)
 				imgSvc.On("ListImageTags", mock.Anything, mock.Anything).Return([]string{
-					"v1.0.0", "v1.0.0-rocm",
+					"v1.0.0", "v1.0.0-rocm", "v1.0.2", "v1.0.2-rocm",
 				}, nil)
 				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0" }), mock.Anything).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0-rocm" }), mock.Anything).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2" }), mock.Anything).
+					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2-rocm" }), mock.Anything).
+					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedResponse: &availableClusterVersionsResponse{
-				AvailableVersions: []string{"v1.0.0"},
+				AvailableVersions: []string{"v1.0.2"},
 			},
 		},
 		{
@@ -113,16 +121,18 @@ func TestGetAvailableClusterVersions(t *testing.T) {
 					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
 				}, nil)
 				imgSvc.On("ListImageTags", "registry.example.com/"+v1.NeutreeRouterImageName, mock.Anything).Return([]string{
-					"v1.0.0", "v1.1.0",
+					"v1.0.0", "v1.0.1", "v1.1.0",
 				}, nil)
 				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.0.0" }), mock.Anything).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.0.1" }), mock.Anything).
+					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.1.0" }), mock.Anything).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.1.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedResponse: &availableClusterVersionsResponse{
-				AvailableVersions: []string{"v1.0.0", "v1.1.0"},
+				AvailableVersions: []string{"v1.1.0"},
 			},
 		},
 		{

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 
+	mastermindssemver "github.com/Masterminds/semver/v3"
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
@@ -165,7 +166,7 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		if err := validateStaticNodeClusterFlowVersionUpdate(current, desiredVersion); err != nil {
+		if err := validateClusterVersionNotDowngrade(current, desiredVersion); err != nil {
 			c.JSON(http.StatusBadRequest, &validationError{
 				Code:    "10212",
 				Message: "invalid cluster version update",
@@ -257,35 +258,59 @@ func resolveClusterForVersionUpdate(
 	return current, nil
 }
 
-func validateStaticNodeClusterFlowVersionUpdate(current *v1.Cluster, desiredVersion string) error {
-	if current.Spec.Type != v1.SSHClusterType {
-		return nil
-	}
-
-	currentUsesStaticFlow, err := semver.LessThan(v1.StaticNodeClusterFlowVersionGate, current.GetVersion())
+func validateClusterVersionNotDowngrade(current *v1.Cluster, desiredVersion string) error {
+	baseline, err := currentClusterSpecVersionBaseline(current)
 	if err != nil {
-		return fmt.Errorf("invalid current cluster version %q: %w", current.GetVersion(), err)
+		return err
 	}
 
-	if !currentUsesStaticFlow {
+	if baseline == "" {
+		if err := validateDesiredClusterVersion(desiredVersion); err != nil {
+			return err
+		}
+
 		return nil
 	}
 
-	desiredUsesStaticFlow, err := semver.LessThan(v1.StaticNodeClusterFlowVersionGate, desiredVersion)
+	desiredIsOlder, err := semver.LessThan(desiredVersion, baseline)
 	if err != nil {
 		return fmt.Errorf("invalid desired cluster version %q: %w", desiredVersion, err)
 	}
 
-	if desiredUsesStaticFlow {
-		return nil
+	if desiredIsOlder {
+		return fmt.Errorf(
+			"cluster version downgrade is not supported: current version is %s, desired version is %s",
+			baseline,
+			desiredVersion,
+		)
 	}
 
-	return fmt.Errorf(
-		"cluster version downgrade from static flow to legacy flow is not supported for %s clusters; "+
-			"keep spec.version greater than %s or recreate the cluster if legacy flow is required",
-		current.Spec.Type,
-		v1.StaticNodeClusterFlowVersionGate,
-	)
+	return nil
+}
+
+func validateDesiredClusterVersion(desiredVersion string) error {
+	if _, err := mastermindssemver.NewVersion(desiredVersion); err != nil {
+		return fmt.Errorf("invalid desired cluster version %q: %w", desiredVersion, err)
+	}
+
+	return nil
+}
+
+func currentClusterSpecVersionBaseline(current *v1.Cluster) (string, error) {
+	if current == nil || current.Spec == nil {
+		return "", fmt.Errorf("current cluster spec is required")
+	}
+
+	baseline := current.GetVersion()
+	if baseline == "" {
+		return "", nil
+	}
+
+	if _, err := mastermindssemver.NewVersion(baseline); err != nil {
+		return "", nil
+	}
+
+	return baseline, nil
 }
 
 func clusterAcceleratorVirtualizationDisableRequested(body []byte) (bool, error) {

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -507,7 +507,7 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("rejects SSH static flow downgrade to legacy flow before proxy handler", func(t *testing.T) {
+	t.Run("rejects SSH static flow downgrade before proxy handler", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
 		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
@@ -533,11 +533,11 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10212"`)
-		assert.Contains(t, recorder.Body.String(), "static flow to legacy flow is not supported")
+		assert.Contains(t, recorder.Body.String(), "cluster version downgrade is not supported")
 		mockStorage.AssertExpectations(t)
 	})
 
-	t.Run("allows SSH static flow version update", func(t *testing.T) {
+	t.Run("allows SSH static flow version upgrade", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
 		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
@@ -554,7 +554,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"version": "v1.0.2"}
+			"spec": {"version": "v1.2.0"}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -565,7 +565,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 	})
 
-	t.Run("rejects static flow downgrade using current cluster type even when patch changes type", func(t *testing.T) {
+	t.Run("rejects downgrade using current spec version even when patch changes type", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
 		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
@@ -590,7 +590,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		assert.Contains(t, recorder.Body.String(), "static flow to legacy flow is not supported")
+		assert.Contains(t, recorder.Body.String(), "cluster version downgrade is not supported")
 		mockStorage.AssertExpectations(t)
 	})
 
@@ -654,7 +654,7 @@ func (r *trackingReadCloser) Close() error {
 	return nil
 }
 
-func TestValidateStaticNodeClusterFlowVersionUpdate(t *testing.T) {
+func TestValidateClusterVersionNotDowngrade(t *testing.T) {
 	tests := []struct {
 		name            string
 		current         *v1.Cluster
@@ -667,31 +667,84 @@ func TestValidateStaticNodeClusterFlowVersionUpdate(t *testing.T) {
 			desiredVersion: "v1.1.0",
 		},
 		{
-			name:           "allows static flow version update",
+			name:           "allows static flow upgrade",
 			current:        &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.SSHClusterType, Version: "v1.1.0"}},
-			desiredVersion: "v1.0.2",
+			desiredVersion: "v1.2.0",
+		},
+		{
+			name:           "allows static flow same version",
+			current:        &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.SSHClusterType, Version: "v1.1.0"}},
+			desiredVersion: "v1.1.0",
+		},
+		{
+			name:            "rejects static flow downgrade within static flow",
+			current:         &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.SSHClusterType, Version: "v1.1.0"}},
+			desiredVersion:  "v1.0.2",
+			wantErrContains: "cluster version downgrade is not supported",
 		},
 		{
 			name:            "rejects static flow downgrade to legacy flow",
 			current:         &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.SSHClusterType, Version: "v1.1.0"}},
 			desiredVersion:  "v1.0.1",
-			wantErrContains: "static flow to legacy flow is not supported",
+			wantErrContains: "cluster version downgrade is not supported",
 		},
 		{
 			name:            "rejects static flow downgrade below legacy gate",
 			current:         &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.SSHClusterType, Version: "v1.1.0"}},
 			desiredVersion:  "v1.0.0",
-			wantErrContains: "static flow to legacy flow is not supported",
+			wantErrContains: "cluster version downgrade is not supported",
 		},
 		{
-			name:           "allows Kubernetes version downgrade",
+			name:           "allows Kubernetes version upgrade",
 			current:        &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.KubernetesClusterType, Version: "v1.1.0"}},
+			desiredVersion: "v1.2.0",
+		},
+		{
+			name:            "rejects Kubernetes version downgrade",
+			current:         &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.KubernetesClusterType, Version: "v1.1.0"}},
+			desiredVersion:  "v1.0.1",
+			wantErrContains: "cluster version downgrade is not supported",
+		},
+		{
+			name: "allows update equal to spec version when status version is newer",
+			current: &v1.Cluster{
+				Spec:   &v1.ClusterSpec{Type: v1.KubernetesClusterType, Version: "v1.1.0"},
+				Status: &v1.ClusterStatus{Version: "v1.2.0"},
+			},
+			desiredVersion: "v1.1.0",
+		},
+		{
+			name: "allows update when spec version is empty even if status version is newer",
+			current: &v1.Cluster{
+				Spec:   &v1.ClusterSpec{Type: v1.KubernetesClusterType},
+				Status: &v1.ClusterStatus{Version: "v1.2.0"},
+			},
+			desiredVersion: "v1.1.0",
+		},
+		{
+			name: "allows SSH update when spec version is empty even if status version is static flow",
+			current: &v1.Cluster{
+				Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
+				Status: &v1.ClusterStatus{Version: "v1.2.0"},
+			},
 			desiredVersion: "v1.0.1",
 		},
 		{
-			name:           "allows invalid desired version when current SSH cluster is legacy flow",
-			current:        &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.SSHClusterType, Version: "v1.0.1"}},
-			desiredVersion: "custom",
+			name:           "allows update when current spec version is invalid",
+			current:        &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.KubernetesClusterType, Version: "custom"}},
+			desiredVersion: "v1.1.0",
+		},
+		{
+			name:            "rejects invalid desired version when current spec version is invalid",
+			current:         &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.KubernetesClusterType, Version: "custom"}},
+			desiredVersion:  "also-custom",
+			wantErrContains: "invalid desired cluster version",
+		},
+		{
+			name:            "rejects invalid desired version when current SSH cluster is legacy flow",
+			current:         &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.SSHClusterType, Version: "v1.0.1"}},
+			desiredVersion:  "custom",
+			wantErrContains: "invalid desired cluster version",
 		},
 		{
 			name:            "rejects invalid desired version when current SSH cluster is static flow",
@@ -703,13 +756,15 @@ func TestValidateStaticNodeClusterFlowVersionUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateStaticNodeClusterFlowVersionUpdate(tt.current, tt.desiredVersion)
+			err := validateClusterVersionNotDowngrade(tt.current, tt.desiredVersion)
 			if tt.wantErrContains == "" {
 				assert.NoError(t, err)
 				return
 			}
 
-			assert.Error(t, err)
+			if !assert.Error(t, err) {
+				return
+			}
 			assert.Contains(t, err.Error(), tt.wantErrContains)
 		})
 	}


### PR DESCRIPTION
## Issue

NEU-519

## Summary

Disable cluster version downgrade paths in the backend. The available cluster version API now only returns versions strictly greater than the minimum selectable cluster version gate, and cluster version PATCH validation rejects downgrade attempts when the current spec version provides a comparable baseline.

## Changes

- Filter `GET /clusters/available_versions` results to exclude versions less than or equal to `v1.0.1` through `MinimumSelectableClusterVersionGate`.
- Reject `PATCH /clusters` `spec.version` downgrades for both SSH and Kubernetes clusters when current `spec.version` exists.
- Use one shared spec-version downgrade guard for SSH and Kubernetes version updates.
- Add focused unit coverage for version filtering, spec-version downgrade restrictions, empty-spec baseline behavior, and invalid version handling.

## Test Plan

- [x] Unit test: `go test ./internal/routes/clusters ./internal/routes/proxies -count=1`
- [x] DB test: not affected
- [x] E2E test: skipped per requested backend/unit-only scope

## Risk & Rollback

No database schema change. Roll back by reverting this commit to restore the previous available-version response and version PATCH behavior.