### PR TITLE
feat: default VictoriaLogs retention to 30d with deploy-time override

### DIFF
--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -26,7 +26,14 @@ type neutreeCoreInstallOptions struct {
 	grafanaURL            string
 	version               string
 	adminPassword         string
+
+	victorialogsRetentionPeriod string
 }
+
+// defaultVictoriaLogsRetentionPeriod is the default VictoriaLogs log retention
+// period rendered into the neutree-core compose file. Overridable at deploy time
+// via --victorialogs-retention-period.
+const defaultVictoriaLogsRetentionPeriod = "30d"
 
 func NewNeutreeCoreInstallCmd(exector command.Executor, commonOptions *commonOptions) *cobra.Command {
 	options := neutreeCoreInstallOptions{
@@ -48,6 +55,7 @@ Configuration Options:
   --metrics-remote-write-url Remote metrics storage URL
   --grafana-url            Grafana dashboard URL for system info API
   --version                Component version (default: CLI release version, or v0.0.1 for non-release/local builds)
+  --victorialogs-retention-period VictoriaLogs log retention period (default: 30d; e.g. 30d, 90d, 1y)
 
 Examples:
   # Basic installation
@@ -77,6 +85,8 @@ Examples:
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.metricsRemoteWriteURL, "metrics-remote-write-url", "", "metrics remote write url")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.grafanaURL, "grafana-url", "", "grafana dashboard url for system info API")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.version, "version", defaultNeutreeCoreVersion(), "neutree core version")
+	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.victorialogsRetentionPeriod, "victorialogs-retention-period",
+		defaultVictoriaLogsRetentionPeriod, "VictoriaLogs log retention period (e.g. 30d, 90d, 1y)")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.adminPassword, "admin-password", "", "the password for the neutree admin user."+
 		"it is valid when starting neutree core for the first time. "+
 		"It is recommended to change it quickly after installation.")
@@ -176,19 +186,27 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 		return errors.Wrap(err, "create jwt token failed")
 	}
 
+	// Fall back to the default when unset (e.g. options constructed directly
+	// rather than via the CLI flag) so the compose never renders an empty
+	// -retentionPeriod= argument.
+	if options.victorialogsRetentionPeriod == "" {
+		options.victorialogsRetentionPeriod = defaultVictoriaLogsRetentionPeriod
+	}
+
 	templateParams := map[string]string{
-		"NeutreeCoreWorkDir":     coreWorkDir,
-		"JwtSecret":              options.jwtSecret,
-		"DbPassword":             options.dbPassword,
-		"MetricsRemoteWriteURL":  options.metricsRemoteWriteURL,
-		"GrafanaURL":             options.grafanaURL,
-		"VictoriaMetricsVersion": componentversion.VictoriaMetrics,
-		"NeutreeVersion":         options.version,
-		"JwtToken":               *jwtToken,
-		"VectorVersion":          componentversion.Vector,
-		"KongVersion":            componentversion.Kong,
-		"NodeIP":                 options.nodeIP,
-		"AdminPassword":          options.adminPassword,
+		"NeutreeCoreWorkDir":          coreWorkDir,
+		"JwtSecret":                   options.jwtSecret,
+		"DbPassword":                  options.dbPassword,
+		"MetricsRemoteWriteURL":       options.metricsRemoteWriteURL,
+		"GrafanaURL":                  options.grafanaURL,
+		"VictoriaMetricsVersion":      componentversion.VictoriaMetrics,
+		"VictoriaLogsRetentionPeriod": options.victorialogsRetentionPeriod,
+		"NeutreeVersion":              options.version,
+		"JwtToken":                    *jwtToken,
+		"VectorVersion":               componentversion.Vector,
+		"KongVersion":                 componentversion.Kong,
+		"NodeIP":                      options.nodeIP,
+		"AdminPassword":               options.adminPassword,
 	}
 
 	err = util.BatchParseTemplateFiles(tempplateFiles, templateParams)

--- a/deploy/chart/neutree/templates/victorialogs-deployment.yaml
+++ b/deploy/chart/neutree/templates/victorialogs-deployment.yaml
@@ -27,6 +27,9 @@ spec:
           imagePullPolicy: {{ .Values.victorialogs.image.pullPolicy }}
           args:
             - -storageDataPath=/victoria-logs-data
+            # Log retention period. Defaults to 30d; override with
+            # `--set victorialogs.retentionPeriod=<period>`.
+            - -retentionPeriod={{ .Values.victorialogs.retentionPeriod }}
             # AI-trace request/response bodies can be large; raise the per-line
             # ingest limit so VictoriaLogs does not drop them.
             - -insert.maxLineSizeBytes={{ int64 .Values.victorialogs.maxLineSizeBytes }}

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -267,6 +267,9 @@ victorialogs:
     repository: victoriametrics/victoria-logs
     tag: "v1.50.0"
     pullPolicy: IfNotPresent
+  # Log retention period. Override at deploy time with
+  # `--set victorialogs.retentionPeriod=<period>` (e.g. 30d, 90d, 1y).
+  retentionPeriod: 30d
   # AI-trace request/response bodies can be large; raise the per-line ingest
   # limit (bytes) so VictoriaLogs does not drop them. Matches docker-compose.
   maxLineSizeBytes: 16777216

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -319,6 +319,9 @@ services:
     image: victoriametrics/victoria-logs:v1.50.0
     command:
       - -storageDataPath=/victoria-logs-data
+      # Log retention period. Defaults to 30d; override at deploy time with
+      # `neutree-cli launch neutree-core --victorialogs-retention-period <period>`.
+      - -retentionPeriod={{ .VictoriaLogsRetentionPeriod }}
       # AI-trace request/response bodies can be large; raise the per-line
       # ingest limit to 16MiB so VictoriaLogs does not drop them.
       - -insert.maxLineSizeBytes=16777216


### PR DESCRIPTION
## What

VictoriaLogs previously ran without an explicit `-retentionPeriod`, falling back to its built-in **7d** default in both deploy paths. This sets the default to **30d** and makes it overridable at deploy time, for both compose and Helm.

## Changes

**docker-compose (`neutree-cli launch neutree-core`)**
- `deploy/docker/neutree-core/docker-compose.yml`: render `-retentionPeriod` from a new template var.
- `cmd/neutree-cli/.../launch/core.go`: new `--victorialogs-retention-period` flag (default `30d`) wired into the compose template params, with an empty-value fallback to the default.

**Helm chart**
- `deploy/chart/neutree/values.yaml`: add `victorialogs.retentionPeriod: 30d`.
- `deploy/chart/neutree/templates/victorialogs-deployment.yaml`: render `-retentionPeriod` from that value.

## Override at deploy time

Compose:
```
neutree-cli launch neutree-core --victorialogs-retention-period 90d
```

Helm (either `--set` or a values file):
```
helm upgrade --install neutree deploy/chart/neutree --set victorialogs.retentionPeriod=90d
```

## Verification

- CLI dry-run renders `-retentionPeriod=30d` by default, `-retentionPeriod=90d` with the flag.
- `helm template` renders `-retentionPeriod=30d` by default, and honors both `--set` and `-f values.yaml` overrides.
- `go build`, launch-package unit tests, `go vet`, `helm lint`, and `git diff --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)