### PR TITLE
fix: normalize endpoint resource product

### DIFF
--- a/internal/resource/kubernetes_resource_client.go
+++ b/internal/resource/kubernetes_resource_client.go
@@ -211,7 +211,7 @@ func (c *K8sResourceClient) ListEndpointInstances(
 		EndpointName: endpoint.Metadata.Name,
 		Namespace:    namespace,
 		Pods:         pods,
-	})
+	}, endpointAcceleratorProduct(endpoint))
 
 	if len(instances) == 0 {
 		return nil, nil
@@ -324,6 +324,7 @@ func kubernetesNeutreeAcceleratorResourcesFromAnnotations(
 
 func endpointInstancesFromNeutreeAnnotations(
 	input resourceparser.KubernetesEndpointResourceContext,
+	product string,
 ) []EndpointInstanceResource {
 	instances := make([]EndpointInstanceResource, 0, len(input.Pods))
 
@@ -340,6 +341,12 @@ func endpointInstancesFromNeutreeAnnotations(
 
 		if len(devices) == 0 {
 			continue
+		}
+
+		if product != "" {
+			for i := range devices {
+				devices[i].Product = product
+			}
 		}
 
 		instances = append(instances, EndpointInstanceResource{

--- a/internal/resource/resource_client_test.go
+++ b/internal/resource/resource_client_test.go
@@ -89,6 +89,9 @@ func TestK8sResourceClientListEndpointInstancesReportsEndpointProduct(t *testing
 
 	require.NoError(t, err)
 	require.NotNil(t, resources)
+	require.Len(t, resources.Replicas, 1)
+	require.Len(t, resources.Replicas[0].Devices, 1)
+	require.Equal(t, "NVIDIA-L20", resources.Replicas[0].Devices[0].Product)
 	require.NotNil(t, resources.Summary)
 	require.Contains(t, resources.Summary.Products, v1.AcceleratorProduct("NVIDIA-L20"))
 	require.NotContains(t, resources.Summary.Products, v1.AcceleratorProduct("raw-device-product"))
@@ -146,8 +149,9 @@ func TestK8sResourceClientListEndpointInstancesWithNeutreeAllocation(t *testing.
 		WithObjects(pod).
 		Build()
 	client := resourceview.NewK8sResourceClient(ctrClient, nil)
+	endpoint := endpointForTest("chat")
 
-	instances, err := client.ListEndpointInstances(context.Background(), k8sClusterForTest(), endpointForTest("chat"))
+	instances, err := client.ListEndpointInstances(context.Background(), k8sClusterForTest(), endpoint)
 
 	require.NoError(t, err)
 	require.Len(t, instances, 1)
@@ -162,6 +166,15 @@ func TestK8sResourceClientListEndpointInstancesWithNeutreeAllocation(t *testing.
 	require.Equal(t, int64(4096), instances[0].Devices[0].UsedMemoryMiB)
 	require.Equal(t, int64(100), instances[0].Devices[0].CoreUnits)
 	require.Equal(t, "gpu-node", instances[0].Devices[0].NodeID)
+
+	resources, err := resourceview.NewResourceViewBuilder(client).
+		BuildEndpointResources(context.Background(), k8sClusterForTest(), endpoint)
+
+	require.NoError(t, err)
+	require.NotNil(t, resources)
+	require.Len(t, resources.Replicas, 1)
+	require.Len(t, resources.Replicas[0].Devices, 1)
+	require.Equal(t, "Tesla-T4", resources.Replicas[0].Devices[0].Product)
 }
 
 func TestK8sResourceClientListEndpointInstancesSkipsMalformedNeutreeAllocation(t *testing.T) {

--- a/internal/resource/resource_client_test.go
+++ b/internal/resource/resource_client_test.go
@@ -25,10 +25,74 @@ func endpointForTest(name string) *v1.Endpoint {
 	}
 }
 
+func endpointForTestWithProduct(name, product string) *v1.Endpoint {
+	endpoint := endpointForTest(name)
+	endpoint.Spec.Resources = &v1.ResourceSpec{}
+	endpoint.Spec.Resources.SetAcceleratorProduct(product)
+
+	return endpoint
+}
+
 func k8sClusterForTest() *v1.Cluster {
 	return &v1.Cluster{
 		Metadata: &v1.Metadata{Name: "cluster", Workspace: "default"},
 	}
+}
+
+func TestK8sResourceClientListEndpointInstancesReportsEndpointProduct(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "chat-abc",
+			Namespace: k8sClusterNamespaceForTest(),
+			UID:       types.UID("uid-1"),
+			Labels: map[string]string{
+				"app":      "inference",
+				"endpoint": "chat",
+			},
+			Annotations: map[string]string{
+				resourceparser.NeutreeAcceleratorAllocationsAnnotation: `[
+					{"uuid":"GPU-1","product":"raw-device-product","memory_mib":15360,"core_units":100}
+				]`,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "gpu-node",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	ctrClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pod).
+		Build()
+	client := resourceview.NewK8sResourceClient(ctrClient, nil)
+	endpoint := endpointForTestWithProduct("chat", "NVIDIA-L20")
+
+	instances, err := client.ListEndpointInstances(
+		context.Background(),
+		k8sClusterForTest(),
+		endpoint,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+	require.Len(t, instances[0].Devices, 1)
+	require.Equal(t, "NVIDIA-L20", instances[0].Devices[0].Product)
+
+	resources, err := resourceview.NewResourceViewBuilder(client).
+		BuildEndpointResources(context.Background(), k8sClusterForTest(), endpoint)
+
+	require.NoError(t, err)
+	require.NotNil(t, resources)
+	require.NotNil(t, resources.Summary)
+	require.Contains(t, resources.Summary.Products, v1.AcceleratorProduct("NVIDIA-L20"))
+	require.NotContains(t, resources.Summary.Products, v1.AcceleratorProduct("raw-device-product"))
+	require.Equal(t, int64(15360), resources.Summary.Products["NVIDIA-L20"].MemoryMiB)
 }
 
 func k8sClusterNamespaceForTest() string {


### PR DESCRIPTION
## Issue

n/a

## Summary

K8s endpoint resource status used the product copied from node-agent allocation annotations. That could differ from the cluster/endpoint accelerator product key and made `status.resources.replicas[].devices[].product` and `status.resources.summary.products` inconsistent with cluster-level resources. This change normalizes K8s endpoint status resources to the product requested by the endpoint spec, matching the existing static-node behavior.

## Changes

- Normalize K8s endpoint resource device product to the endpoint accelerator product when building endpoint instances.
- Keep raw pod allocation annotations and observability metric labels unchanged.
- Add regression coverage for both final status replicas and summary aggregation.

## Test Plan

### Unit test

- [x] `go test -count=1 ./internal/resource ./internal/orchestrator`
- [x] `go test ./internal/resource -run 'TestK8sResourceClientListEndpointInstances(ReportsEndpointProduct|WithNeutreeAllocation)' -count=1 -v`
- [x] RED verified before implementation: `TestK8sResourceClientListEndpointInstancesReportsEndpointProduct` failed with expected `NVIDIA-L20`, actual `raw-device-product`.
- [x] PR CI `pr-check` and `codecov/patch` passed on head `21f93fb58c6c5a2e56a54086027fb17e2f0c1b1c`.

Note: full-repo `go vet ./...` and `go test ./...` are currently blocked locally by the existing missing embedded artifact `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`. Scoped package tests passed fresh.

### DB test

- [x] Not affected. No DB schema, migration, RLS, or validation trigger changes.

### E2E test

- [x] Deployed production code for manual regression on `10.255.1.54`, branch `fix-endpoint-resource-product`, commit `d614a27`. Current PR head `21f93fb5` adds tests only; no runtime redeploy required.
- [x] Control-plane health check passed: `curl -sf http://localhost:3000/health` returned `{"status":"ok"}`.
- [x] User confirmed manual endpoint resource product regression passed on `10.255.1.54`.

## Risk & Rollback

Risk is limited to endpoint status resource reporting for K8s clusters. Pod annotations and metrics remain unchanged, so rollback is reverting this commit and hot-updating `neutree-core` / `neutree-api` to the previous branch or `main`.