### PR TITLE
fix: restore llama.cpp embedding flag value

### DIFF
--- a/internal/engine/llama-cpp/v0.3.7/templates/kubernetes/default.yaml
+++ b/internal/engine/llama-cpp/v0.3.7/templates/kubernetes/default.yaml
@@ -101,7 +101,7 @@ spec:
               python3 -m llama_cpp.server
               --model $(find {{ .ModelArgs.path }} -path "*/{{ .ModelArgs.file }}" | head -n 1)
               --host 0.0.0.0 --port 8000 --model_alias {{ .ModelArgs.serve_name }}
-              {{- if eq .ModelArgs.task "text-embedding" }} --embedding{{- end }}
+              {{- if eq .ModelArgs.task "text-embedding" }} --embedding true{{- end }}
               {{- if .EngineArgs }}{{- range $key, $value := .EngineArgs }} --{{ $key }} "{{ $value }}" {{- end }}{{- end }}
           resources:
             limits:

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -80,6 +80,49 @@ func TestVLLMTemplateTaskTranslation(t *testing.T) {
 	}
 }
 
+func TestLlamaCppTemplateEmbeddingMode(t *testing.T) {
+	tests := []struct {
+		name                string
+		task                string
+		wantEmbeddingValue  string
+		wantEmbeddingAbsent bool
+	}{
+		{
+			name:               "text-embedding enables llama.cpp embedding mode",
+			task:               "text-embedding",
+			wantEmbeddingValue: "true",
+		},
+		{
+			name:                "text-generation leaves llama.cpp embedding mode disabled",
+			task:                "text-generation",
+			wantEmbeddingAbsent: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vars := newTestVLLMVars("v0.3.7", tc.task)
+			vars["EngineName"] = "llama-cpp-engine"
+			vars["ImageRepo"] = "neutree/engine-llama-cpp"
+
+			objs, err := util.RenderKubernetesManifest(llamaCppDefaultDeployTemplate, vars)
+			require.NoError(t, err)
+			require.NotEmpty(t, objs.Items)
+
+			deploy := mustFindRenderedObject(t, objs.Items, "Deployment", "ep-test")
+			args := mustExtractContainerArgs(t, deploy.Object, "llama-cpp-engine")
+			tokens := strings.Fields(strings.Join(args, " "))
+
+			if tc.wantEmbeddingAbsent {
+				assert.NotContains(t, tokens, "--embedding", "full args=%v", args)
+				return
+			}
+
+			assert.Equal(t, tc.wantEmbeddingValue, flagValue(tokens, "--embedding"), "full args=%v", args)
+		})
+	}
+}
+
 func TestBuiltInKubernetesTemplatesPreserveNumericEndpointName(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -235,6 +278,34 @@ func assertAntiAffinityEndpointValue(t *testing.T, obj map[string]any, want stri
 	}
 
 	require.Fail(t, "endpoint anti-affinity match expression not found")
+}
+
+// mustExtractContainerArgs pulls the named container's args list out of a
+// rendered unstructured Deployment object.
+func mustExtractContainerArgs(t *testing.T, obj map[string]any, containerName string) []string {
+	t.Helper()
+	spec := requireMap(t, obj["spec"], "spec")
+	tmpl := requireMap(t, spec["template"], "spec.template")
+	pod := requireMap(t, tmpl["spec"], "spec.template.spec")
+	containers := requireSlice(t, pod["containers"], "spec.template.spec.containers")
+
+	for _, c := range containers {
+		cm := requireMap(t, c, "container")
+		name, ok := cm["name"].(string)
+		if ok && name == containerName {
+			args := requireSlice(t, cm["args"], "container.args")
+			out := make([]string, 0, len(args))
+
+			for i, s := range args {
+				out = append(out, mustString(t, s, "args", i))
+			}
+
+			return out
+		}
+	}
+	require.Failf(t, "container not found in rendered deployment", "%q", containerName)
+
+	return nil
 }
 
 // mustExtractContainerCommand pulls the named container's command list out of


### PR DESCRIPTION
## Issue

n/a

## Summary

Restore the llama.cpp Kubernetes template contract for embedding endpoints so text-embedding deployments pass `--embedding true` to `llama_cpp.server` instead of a bare `--embedding` flag.

## Changes

- Render `--embedding true` for llama.cpp K8s deployments when `ModelArgs.task` is `text-embedding`.
- Add a render regression test that verifies embedding endpoints include the value and generation endpoints omit the flag.

## Test Plan

Unit test:
- [x] `git diff --check`
- [x] `go vet ./internal/engine/...`
- [x] `go test ./internal/engine -run TestLlamaCppTemplateEmbeddingMode -count=1 -v`
- [x] `go test ./internal/engine/... -count=1`
- [x] `go test ./internal/orchestrator -run 'TestBuildDeployment_BooleanEngineArgs|TestBuildDeployment_VLLMListEngineArgs' -count=1`

DB test:
- [x] Not affected. No database or migration changes.

E2E test:
- [x] Not required for this Trivial template rendering fix; regression coverage is at the embedded template render layer.

## Risk & Rollback

Risk is limited to llama.cpp Kubernetes text-embedding endpoints. Rollback by reverting this commit; text-generation rendering remains unchanged.