### PR TITLE
fix: avoid SGLang versioned served model names

### DIFF
--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -358,12 +358,7 @@ func (k *kubernetesOrchestrator) setModelArgs(data *DeploymentManifestVariables,
 		"registry_type": string(modelRegistry.Spec.Type),
 	}
 
-	modelArgs["serve_name"] = endpoint.Spec.Model.Name
-
-	// only set serve_name with version when version is specified and not latest for non-huggingface model registry
-	if endpoint.Spec.Model.Version != "" && endpoint.Spec.Model.Version != v1.LatestVersion && modelRegistry.Spec.Type != v1.HuggingFaceModelRegistryType {
-		modelArgs["serve_name"] = endpoint.Spec.Model.Name + ":" + endpoint.Spec.Model.Version
-	}
+	modelArgs["serve_name"] = endpointModelServeName(endpoint, modelRegistry)
 
 	maps.Copy(data.ModelArgs, modelArgs)
 }

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -1986,6 +1986,9 @@ func TestKubernetesOrchestrator_setModelArgs(t *testing.T) {
 			name: "serve_name with version when registry is BentoML",
 			endpoint: &v1.Endpoint{
 				Spec: &v1.EndpointSpec{
+					Engine: &v1.EndpointEngineSpec{
+						Engine: v1.EngineNameVLLM,
+					},
 					Model: &v1.ModelSpec{
 						Name:     "gpt-model",
 						Version:  "v2.0",
@@ -2011,6 +2014,40 @@ func TestKubernetesOrchestrator_setModelArgs(t *testing.T) {
 				"path":          "gpt-model",
 				"registry_type": string(v1.BentoMLModelRegistryType),
 				"serve_name":    "gpt-model:v2.0",
+			},
+		},
+		{
+			name: "sglang serve_name omits version when registry is BentoML",
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Engine: &v1.EndpointEngineSpec{
+						Engine: v1.EngineNameSGLang,
+					},
+					Model: &v1.ModelSpec{
+						Name:     "gpt-model",
+						Version:  "v2.0",
+						Task:     "text-generation",
+						Registry: "bentoml",
+					},
+				},
+			},
+			modelRegistry: &v1.ModelRegistry{
+				Metadata: &v1.Metadata{
+					Name: "bentoml-registry",
+				},
+				Spec: &v1.ModelRegistrySpec{
+					Type: v1.BentoMLModelRegistryType,
+					Url:  "nfs://192.168.1.100/bentoml",
+				},
+			},
+			expectedModelArgs: map[string]interface{}{
+				"name":          "gpt-model",
+				"version":       "v2.0",
+				"file":          "",
+				"task":          "text-generation",
+				"path":          "gpt-model",
+				"registry_type": string(v1.BentoMLModelRegistryType),
+				"serve_name":    "gpt-model",
 			},
 		},
 	}

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -893,10 +893,7 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 		"task":          endpoint.Spec.Model.Task,
 	}
 
-	modelArgs["serve_name"] = endpoint.Spec.Model.Name
-	if endpoint.Spec.Model.Version != "" && endpoint.Spec.Model.Version != v1.LatestVersion && modelRegistry.Spec.Type != v1.HuggingFaceModelRegistryType {
-		modelArgs["serve_name"] = endpoint.Spec.Model.Name + ":" + endpoint.Spec.Model.Version
-	}
+	modelArgs["serve_name"] = endpointModelServeName(endpoint, modelRegistry)
 
 	modelCacheRelativePath := v1.DefaultModelCacheRelativePath
 

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -1045,7 +1045,7 @@ func TestEndpointToApplication_setModelArgs(t *testing.T) {
 						Task:    v1.TextGenerationModelTask,
 					},
 					Resources:         &v1.ResourceSpec{},
-					Engine:            &v1.EndpointEngineSpec{},
+					Engine:            &v1.EndpointEngineSpec{Engine: v1.EngineNameVLLM},
 					DeploymentOptions: map[string]interface{}{},
 				},
 			},
@@ -1220,6 +1220,49 @@ func TestEndpointToApplication_setModelArgs(t *testing.T) {
 				v1.HFTokenEnv: "test-token",
 			},
 			wantErr: false,
+		},
+		{
+			name: "SGLang BentoML modelRegistry - specific version omits version from serve_name",
+			modelRegistry: &v1.ModelRegistry{
+				Metadata: &v1.Metadata{
+					Name: "bentoml-registry",
+				},
+				Spec: &v1.ModelRegistrySpec{
+					Type: v1.BentoMLModelRegistryType,
+					Url:  "nfs://192.168.1.100/bentoml",
+				},
+			},
+			endpoint: &v1.Endpoint{
+				Metadata: &v1.Metadata{
+					Workspace: "default",
+					Name:      "sglang-endpoint",
+				},
+				Spec: &v1.EndpointSpec{
+					Model: &v1.ModelSpec{
+						Name:    "qwen",
+						Version: "v1.0",
+						Task:    v1.TextGenerationModelTask,
+					},
+					Resources: &v1.ResourceSpec{},
+					Engine: &v1.EndpointEngineSpec{
+						Engine: v1.EngineNameSGLang,
+					},
+					DeploymentOptions: map[string]interface{}{},
+				},
+			},
+			cluster: &v1.Cluster{},
+			expectedModelArgs: map[string]string{
+				"registry_type": "bentoml",
+				"name":          "qwen",
+				"version":       "v1.0",
+				"file":          "",
+				"task":          v1.TextGenerationModelTask,
+				"serve_name":    "qwen",
+				"path":          filepath.Join(v1.DefaultSSHClusterModelCacheMountPath, v1.DefaultModelCacheRelativePath, "qwen", "v1.0"),
+				"registry_path": filepath.Join("/mnt", "default", "sglang-endpoint", "models", "qwen", "v1.0"),
+			},
+			expectedEnvs: map[string]string{},
+			wantErr:      false,
 		},
 		{
 			name: "HuggingFace modelRegistry - without specific version",

--- a/internal/orchestrator/util.go
+++ b/internal/orchestrator/util.go
@@ -34,6 +34,19 @@ func engineTPArgKey(engineName string) string {
 	}
 }
 
+func endpointModelServeName(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistry) string {
+	serveName := endpoint.Spec.Model.Name
+	if endpoint.Spec.Engine != nil && endpoint.Spec.Engine.Engine == v1.EngineNameSGLang {
+		return serveName
+	}
+
+	if endpoint.Spec.Model.Version != "" && endpoint.Spec.Model.Version != v1.LatestVersion && modelRegistry.Spec.Type != v1.HuggingFaceModelRegistryType {
+		serveName = endpoint.Spec.Model.Name + ":" + endpoint.Spec.Model.Version
+	}
+
+	return serveName
+}
+
 func getEndpointDeployCluster(s storage.Storage, endpoint *v1.Endpoint) (*v1.Cluster, error) { //nolint:unparam
 	clusterFilter := []storage.Filter{
 		{


### PR DESCRIPTION
## Issue

n/a

## Summary

SGLang does not support served model names containing a colon, but Neutree previously reused the BentoML versioned served-name rule for all non-HuggingFace engines. This change keeps SGLang served model names equal to `spec.model.name` while preserving the existing `name:version` behavior for other engines.

## Changes

- Add a shared orchestrator helper for deriving endpoint model `serve_name`.
- Use the helper in both Kubernetes and Ray/SSH endpoint generation paths.
- Cover SGLang BentoML specific-version endpoints in both K8s and Ray/SSH unit tests.

## Test Plan

Unit test:
- [x] `git diff --check`
- [x] `go vet ./internal/orchestrator`
- [x] `go test ./internal/orchestrator -count=1`

DB test:
- [x] Not affected. No DB schema, migration, storage, or query changes.

E2E test:
- [x] Not required for this Trivial control-plane argument-generation fix. Unit tests cover both deployed generation paths: Kubernetes manifests and Ray/SSH serve application args.

Additional verification notes:
- `go vet ./...` and `go test ./...` are blocked in this worktree by missing embedded artifact `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`.
- `golangci-lint run ./internal/orchestrator/...` is not a valid local signal here because the installed `golangci-lint v1.53.3` typechecks this repo with Go 1.20-era assumptions and reports unrelated stdlib/current mock errors.

## Risk & Rollback

Risk is low and limited to served model alias generation. Rollback by reverting this PR restores the previous non-HuggingFace `name:version` served-name behavior for all engines.