### PR TITLE
fix: keep llama.cpp request annotations eager

### DIFF
--- a/cluster-image-builder/serve/llama_cpp/v0_3_7/app.py
+++ b/cluster-image-builder/serve/llama_cpp/v0_3_7/app.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import os
 import enum
 import json

--- a/cluster-image-builder/serve/llama_cpp/v0_3_7/test_app_annotations.py
+++ b/cluster-image-builder/serve/llama_cpp/v0_3_7/test_app_annotations.py
@@ -1,0 +1,43 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+APP_PATH = Path(__file__).with_name("app.py")
+
+
+class TestFastAPIRequestAnnotations(unittest.TestCase):
+    def test_class_based_fastapi_routes_do_not_defer_request_annotations(self):
+        tree = ast.parse(APP_PATH.read_text())
+
+        has_future_annotations = any(
+            isinstance(node, ast.ImportFrom)
+            and node.module == "__future__"
+            and any(alias.name == "annotations" for alias in node.names)
+            for node in tree.body
+        )
+
+        request_route_methods = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.args.args:
+                continue
+            if node.args.args[0].arg != "self":
+                continue
+            for arg in node.args.args[1:]:
+                if arg.arg != "request":
+                    continue
+                if isinstance(arg.annotation, ast.Name) and arg.annotation.id == "Request":
+                    request_route_methods.append(node.name)
+
+        self.assertTrue(request_route_methods)
+        self.assertFalse(
+            has_future_annotations,
+            "Ray Serve class-based FastAPI routes must keep request: Request "
+            f"annotations eager; affected methods: {request_route_methods}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue

n/a

## Summary

Fix the llama.cpp Ray Serve ingress path so FastAPI keeps `request: Request` as an eager runtime annotation. With postponed annotations enabled, Ray Serve's class-based FastAPI route wrapping can re-analyze the endpoint with `request` as a string annotation and classify it as a required query parameter instead of the injected ASGI request object.

## Changes

- Remove postponed annotation evaluation from the llama.cpp v0.3.7 Ray Serve app.
- Add a co-located regression test that prevents `from __future__ import annotations` from being reintroduced while class-based FastAPI routes use `request: Request`.

## Test Plan

Unit test:
- [x] `PYTHONPATH=cluster-image-builder python3 -m unittest discover -s cluster-image-builder/serve/llama_cpp/v0_3_7 -p 'test_*.py'` passed.
- [x] RED verified before the fix: the new regression test failed while `from __future__ import annotations` was present.
- [x] `python3 -m py_compile cluster-image-builder/serve/llama_cpp/v0_3_7/app.py cluster-image-builder/serve/llama_cpp/v0_3_7/test_app_annotations.py` passed.

DB test:
- [x] Not affected. This change does not touch database schema, migrations, storage, or RLS behavior.

E2E test:
- [x] Not affected for this Trivial change. The diff is limited to a single llama.cpp serve app annotation behavior plus a local regression test; no deployed control-plane, API, DB, chart, or E2E flow changes are required.

## Risk & Rollback

Risk is low. The change only restores eager runtime annotation evaluation in one llama.cpp serve app file. Rollback is reverting this PR, but doing so can reintroduce FastAPI 422 responses where `request` is treated as a missing query parameter on Ray Serve class-based routes.
