### PR TITLE
test(e2e): reuse an existing cluster for K8s-scoped tests

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1191,6 +1191,15 @@ func setupK8sCluster(prefix string) (clusterName string) {
 	By("Setting up image registry")
 	SetupImageRegistry()
 
+	// Reuse an existing Running cluster when configured (shared GPU envs where
+	// a second cluster on the same nodes would conflict on host ports / GPU).
+	if existing := profile.Kubernetes.ExistingCluster; existing != "" {
+		By("Reusing existing K8s cluster: " + existing)
+		ch := NewClusterHelper()
+		ch.EventuallyInPhase(existing, v1.ClusterPhaseRunning, "", TerminalPhaseTimeout)
+		return existing
+	}
+
 	kubeconfig := requireK8sProfile()
 	clusterName = prefix + Cfg.RunID
 
@@ -1216,7 +1225,10 @@ func setupK8sCluster(prefix string) (clusterName string) {
 func teardownCluster(clusterName string) {
 	ch := NewClusterHelper()
 
-	ch.EnsureDeleted(clusterName)
+	// Never delete a reused pre-existing cluster — it is shared infrastructure.
+	if clusterName != profile.Kubernetes.ExistingCluster {
+		ch.EnsureDeleted(clusterName)
+	}
 
 	TeardownImageRegistry()
 }

--- a/tests/e2e/profile.go
+++ b/tests/e2e/profile.go
@@ -51,6 +51,11 @@ type Profile struct {
 	Kubernetes struct {
 		Kubeconfig       string `yaml:"kubeconfig"`
 		RouterAccessMode string `yaml:"router_access_mode"`
+		// ExistingCluster, when set, makes K8s-cluster-scoped tests reuse an
+		// already-Running Neutree cluster of that name instead of enrolling a
+		// fresh one. Needed for shared GPU environments where creating a second
+		// cluster on the same k8s nodes conflicts on host ports / GPU DCGM.
+		ExistingCluster string `yaml:"existing_cluster"`
 	} `yaml:"kubernetes"`
 
 	ImageRegistry struct {


### PR DESCRIPTION
## What

Add an optional `kubernetes.existing_cluster` field to the E2E test profile. When set:

- `setupK8sCluster` skips enrolling a fresh cluster — it waits for the named cluster to be `Running` and returns it.
- `teardownCluster` never deletes a reused cluster (it is shared infrastructure).

When the field is empty, behaviour is unchanged (a fresh cluster is enrolled and torn down per suite).

## Why

The endpoint / lifecycle suites call `setupK8sCluster`, which enrolls a brand-new Neutree cluster onto the k8s nodes in `kubernetes.kubeconfig`. On a **shared GPU environment** where a Neutree cluster is already provisioned on those nodes, enrolling a second cluster conflicts at the node level:

- `neutree-node-exporter` binds host port `19100` — the second DaemonSet stays `Pending` (`didn't have free ports`).
- `nvidia-gpu-dcgm-exporter` needs exclusive GPU DCGM profiling — the second copy `CrashLoopBackOff`s.

So the fresh-cluster path never reaches `Running` there. Pointing `existing_cluster` at the already-Running cluster lets the endpoint deploy/inference/lifecycle tests run (each test still creates and tears down its own endpoints in that cluster).

## Test

- `go vet ./tests/e2e/...` and `go test -c ./tests/e2e/` compile clean.
- Verified end-to-end against a shared vGPU cluster: endpoints deploy into the reused cluster, reach `Running`, and serve inference; the reused cluster is left intact on teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)