### PR TITLE
feat: scope API key model allowlist by IE/EE endpoint (NEU-540)

### DIFF
--- a/api/v1/api_key_types.go
+++ b/api/v1/api_key_types.go
@@ -17,8 +17,22 @@ type ApiKeyLimits struct {
 	RPS           int               `json:"rps,omitempty"`
 	RPM           int               `json:"rpm,omitempty"`
 	Concurrency   int               `json:"concurrency,omitempty"`
-	AllowedModels []string          `json:"allowed_models,omitempty"`
+	AllowedModels []AllowedModel    `json:"allowed_models,omitempty"`
 	Disabled      bool              `json:"disabled,omitempty"`
+}
+
+// AllowedModel is one entry of an API key's model allowlist, scoped to the
+// IE/EE (internal/external endpoint) dimension. A request is permitted when its
+// client-facing model equals Model AND — for each of Type / EndpointName that is
+// set — the endpoint the request actually hit matches it. Empty Type and
+// EndpointName mean "any endpoint serving this model" (the legacy name-only
+// semantics old keys are migrated to). A fully pinned entry (Type + EndpointName
+// set) restricts to one specific endpoint, so the same model name exposed by a
+// different IE/EE is not allowed.
+type AllowedModel struct {
+	Model        string `json:"model"`
+	Type         string `json:"type,omitempty"`          // "internal" | "external" | "" (any source)
+	EndpointName string `json:"endpoint_name,omitempty"` // "" = any endpoint of this model
 }
 
 type ApiKeyTokenQuota struct {

--- a/api/v1/api_key_types.go
+++ b/api/v1/api_key_types.go
@@ -30,8 +30,13 @@ type ApiKeyLimits struct {
 // set) restricts to one specific endpoint, so the same model name exposed by a
 // different IE/EE is not allowed.
 type AllowedModel struct {
-	Model        string `json:"model"`
-	Type         string `json:"type,omitempty"`          // "internal" | "external" | "" (any source)
+	Model string `json:"model"`
+	// Type is the IE/EE token "internal" | "external" (or "" for any source).
+	// Note this is NOT the DB `source` that get_workspace_models returns
+	// ("endpoint" | "external_endpoint"); the UI maps source -> type when it
+	// builds this entry. The gateway enforces against the same "internal" /
+	// "external" tokens (see endpointTypeInternal/External in internal/gateway).
+	Type         string `json:"type,omitempty"`
 	EndpointName string `json:"endpoint_name,omitempty"` // "" = any endpoint of this model
 }
 

--- a/api/v1/api_key_types.go
+++ b/api/v1/api_key_types.go
@@ -29,6 +29,16 @@ type ApiKeyLimits struct {
 // semantics old keys are migrated to). A fully pinned entry (Type + EndpointName
 // set) restricts to one specific endpoint, so the same model name exposed by a
 // different IE/EE is not allowed.
+//
+// EndpointName is deliberately not workspace-qualified. An API key is bound to a
+// single workspace (Metadata.Workspace) and its Kong ACL groups are derived only
+// from that workspace's endpoints (see desiredAPIKeyACLGroups), so a request
+// through the key can only ever reach endpoints in its own workspace — the ACL
+// plugin rejects anything else before this allowlist is consulted. Endpoint
+// names are unique within a workspace, so (Type, EndpointName) is unambiguous
+// here. This relies on that invariant: if a key could ever access endpoints
+// across workspaces, EndpointName would need a workspace qualifier to avoid
+// same-name collisions.
 type AllowedModel struct {
 	Model string `json:"model"`
 	// Type is the IE/EE token "internal" | "external" (or "" for any source).

--- a/db/dbtest/api_key_limits_test.go
+++ b/db/dbtest/api_key_limits_test.go
@@ -18,7 +18,7 @@ func TestApiKeyLimits(t *testing.T) {
 	user := CreateTestUser(t, "limitsuser", "limits@example.com", "testpassword")
 	other := CreateTestUser(t, "limitsother", "limitsother@example.com", "testpassword")
 
-	const limits = `{"token_quota":{"limit":300,"period":"monthly"},"rps":10,"rpm":600,"concurrency":8,"allowed_models":["gpt-4"],"disabled":false}`
+	const limits = `{"token_quota":{"limit":300,"period":"monthly"},"rps":10,"rpm":600,"concurrency":8,"allowed_models":[{"model":"gpt-4","type":"internal","endpoint_name":"ep-a"}],"disabled":false}`
 
 	// Create a key carrying limits in one call.
 	var apiKeyID string
@@ -44,7 +44,7 @@ func TestApiKeyLimits(t *testing.T) {
 		if err := db.QueryRowContext(ctx, `
 			SELECT (spec).limits #>> '{token_quota,limit}',
 			       (spec).limits #>> '{disabled}',
-			       (spec).limits #>> '{allowed_models,0}',
+			       (spec).limits #>> '{allowed_models,0,model}',
 			       (spec).quota::text
 			FROM api.api_keys WHERE id = $1`, apiKeyID).Scan(&lim, &disabled, &model, &quota); err != nil {
 			t.Fatalf("read spec.limits: %v", err)
@@ -229,6 +229,39 @@ func TestApiKeyLimits(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatalf("expected empty allowed_models to be accepted, got %v", err)
+		}
+	})
+
+	t.Run("set_api_key_limits accepts endpoint-scoped and unpinned allowed_models entries", func(t *testing.T) {
+		// A pinned entry (type + endpoint_name) and an unpinned one (model only,
+		// = any endpoint of that model) are both valid post-NEU-540.
+		const v = `{"allowed_models":[{"model":"gpt-4","type":"external","endpoint_name":"ee-a"},{"model":"llama"}]}`
+		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+			_, e := tx.ExecContext(ctx, `SELECT api.set_api_key_limits($1, $2::jsonb)`, apiKeyID, v)
+			return e
+		})
+		if err != nil {
+			t.Fatalf("expected endpoint-scoped allowed_models to be accepted, got %v", err)
+		}
+	})
+
+	t.Run("set_api_key_limits rejects malformed allowed_models entries", func(t *testing.T) {
+		// The legacy bare-string shape and objects missing a non-empty model must
+		// now fail validation (they can no longer reach the gateway as-is).
+		cases := []string{
+			`{"allowed_models":["gpt-4"]}`,                // legacy bare string
+			`{"allowed_models":[{"type":"external"}]}`,    // no model
+			`{"allowed_models":[{"model":""}]}`,           // empty model
+			`{"allowed_models":[{"model":"x","type":5}]}`, // non-string type
+		}
+		for _, c := range cases {
+			err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+				_, e := tx.ExecContext(ctx, `SELECT api.set_api_key_limits($1, $2::jsonb)`, apiKeyID, c)
+				return e
+			})
+			if err == nil {
+				t.Fatalf("expected malformed allowed_models %q to be rejected, got nil", c)
+			}
 		}
 	})
 }

--- a/db/dbtest/api_key_limits_test.go
+++ b/db/dbtest/api_key_limits_test.go
@@ -249,10 +249,11 @@ func TestApiKeyLimits(t *testing.T) {
 		// The legacy bare-string shape and objects missing a non-empty model must
 		// now fail validation (they can no longer reach the gateway as-is).
 		cases := []string{
-			`{"allowed_models":["gpt-4"]}`,                // legacy bare string
-			`{"allowed_models":[{"type":"external"}]}`,    // no model
-			`{"allowed_models":[{"model":""}]}`,           // empty model
-			`{"allowed_models":[{"model":"x","type":5}]}`, // non-string type
+			`{"allowed_models":["gpt-4"]}`,                   // legacy bare string
+			`{"allowed_models":[{"type":"external"}]}`,       // no model
+			`{"allowed_models":[{"model":""}]}`,              // empty model
+			`{"allowed_models":[{"model":"x","type":5}]}`,    // non-string type
+			`{"allowed_models":[{"model":"x","type":null}]}`, // null type (must be a string or absent)
 		}
 		for _, c := range cases {
 			err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {

--- a/db/migrations/078_apikey_allowed_models_endpoint_scope.down.sql
+++ b/db/migrations/078_apikey_allowed_models_endpoint_scope.down.sql
@@ -1,0 +1,74 @@
+-- Revert the endpoint-scoped API key model allowlist back to bare model-name
+-- strings. This is LOSSY: entries pinned to a specific IE/EE collapse to their
+-- model name (the endpoint dimension is dropped), and multiple pins of the same
+-- model dedupe to one string. An empty [] (deny-all) is left untouched.
+
+UPDATE api.api_keys k
+SET spec = ROW(
+        (k.spec).quota,
+        (k.spec).expires_in,
+        jsonb_set(
+            (k.spec).limits,
+            '{allowed_models}',
+            (
+                SELECT COALESCE(jsonb_agg(DISTINCT elem ->> 'model'), '[]'::jsonb)
+                FROM jsonb_array_elements((k.spec).limits -> 'allowed_models') AS elem
+                WHERE jsonb_typeof(elem) = 'object'
+                  AND jsonb_typeof(elem -> 'model') = 'string'
+            )
+        )
+    )::api.api_key_spec
+WHERE (k.spec).limits IS NOT NULL
+  AND jsonb_typeof((k.spec).limits -> 'allowed_models') = 'array'
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements((k.spec).limits -> 'allowed_models') AS elem
+      WHERE jsonb_typeof(elem) = 'object'
+  );
+
+-- Restore the migration-071 validator (without allowed_models validation).
+CREATE OR REPLACE FUNCTION api.validate_api_key_limits(p_limits JSONB)
+RETURNS VOID
+AS $$
+DECLARE
+    v_field TEXT;
+    v_node  JSONB;
+    v_num   NUMERIC;
+BEGIN
+    IF p_limits IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- token_quota.limit (nested)
+    v_node := p_limits #> '{token_quota,limit}';
+    IF v_node IS NOT NULL AND jsonb_typeof(v_node) <> 'null' THEN
+        IF jsonb_typeof(v_node) <> 'number' THEN
+            RAISE EXCEPTION 'Invalid token quota limit: must be a positive integer'
+                USING ERRCODE = '22023';
+        END IF;
+        v_num := v_node::text::numeric;
+        IF v_num <= 0 OR v_num <> trunc(v_num) THEN
+            RAISE EXCEPTION 'Invalid token quota limit: must be a positive integer'
+                USING ERRCODE = '22023';
+        END IF;
+    END IF;
+
+    -- top-level numeric limits: rps, rpm, concurrency
+    FOREACH v_field IN ARRAY ARRAY['rps', 'rpm', 'concurrency'] LOOP
+        IF p_limits ? v_field AND jsonb_typeof(p_limits -> v_field) <> 'null' THEN
+            v_node := p_limits -> v_field;
+            IF jsonb_typeof(v_node) <> 'number' THEN
+                RAISE EXCEPTION 'Invalid % limit: must be a positive integer', v_field
+                    USING ERRCODE = '22023';
+            END IF;
+            v_num := v_node::text::numeric;
+            IF v_num <= 0 OR v_num <> trunc(v_num) THEN
+                RAISE EXCEPTION 'Invalid % limit: must be a positive integer', v_field
+                    USING ERRCODE = '22023';
+            END IF;
+        END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+NOTIFY pgrst, 'reload schema';

--- a/db/migrations/078_apikey_allowed_models_endpoint_scope.up.sql
+++ b/db/migrations/078_apikey_allowed_models_endpoint_scope.up.sql
@@ -96,7 +96,10 @@ BEGIN
 
     -- allowed_models: optional array of endpoint-scoped entries. Each element must
     -- be an object with a non-empty string `model`; `type` / `endpoint_name`, when
-    -- present, must be strings. An empty array (deny-all) is valid.
+    -- present, must be strings (JSON null is rejected — Go unmarshals it to "" and
+    -- the Kong schema/enforcement treat "unset" as absent, not null, so a stored
+    -- null would be an ambiguous shape rather than a meaningful value). An empty
+    -- array (deny-all) is valid.
     IF p_limits ? 'allowed_models' AND jsonb_typeof(p_limits -> 'allowed_models') <> 'null' THEN
         IF jsonb_typeof(p_limits -> 'allowed_models') <> 'array' THEN
             RAISE EXCEPTION 'Invalid allowed_models: must be an array'
@@ -113,11 +116,11 @@ BEGIN
                 RAISE EXCEPTION 'Invalid allowed_models entry: each item needs a non-empty string model'
                     USING ERRCODE = '22023';
             END IF;
-            IF v_node ? 'type' AND jsonb_typeof(v_node -> 'type') NOT IN ('string', 'null') THEN
+            IF v_node ? 'type' AND jsonb_typeof(v_node -> 'type') <> 'string' THEN
                 RAISE EXCEPTION 'Invalid allowed_models entry: type must be a string'
                     USING ERRCODE = '22023';
             END IF;
-            IF v_node ? 'endpoint_name' AND jsonb_typeof(v_node -> 'endpoint_name') NOT IN ('string', 'null') THEN
+            IF v_node ? 'endpoint_name' AND jsonb_typeof(v_node -> 'endpoint_name') <> 'string' THEN
                 RAISE EXCEPTION 'Invalid allowed_models entry: endpoint_name must be a string'
                     USING ERRCODE = '22023';
             END IF;

--- a/db/migrations/078_apikey_allowed_models_endpoint_scope.up.sql
+++ b/db/migrations/078_apikey_allowed_models_endpoint_scope.up.sql
@@ -1,0 +1,129 @@
+-- Endpoint-scope the API key model allowlist (NEU-540).
+--
+-- Previously spec.limits.allowed_models was a flat array of bare model-name
+-- strings (["gpt-4", ...]), so a key could not distinguish the same model name
+-- exposed by different internal/external endpoints (IE/EE). It becomes an array
+-- of endpoint-scoped objects:
+--   [{ "model": "gpt-4", "type": "internal"|"external", "endpoint_name": "ep-a" }, ...]
+-- where `type` / `endpoint_name` are optional; when both are absent the entry
+-- means "any endpoint serving this model" — exactly the old name-only semantics.
+--
+-- Migration is a pure, lossless format change: each string element `s` becomes
+-- { "model": s } (an unpinned entry). We deliberately do NOT expand names into
+-- the endpoints that currently serve them: bare-name semantics include future
+-- endpoints of the same name, and expanding would silently pin existing keys to
+-- today's endpoint set (and turn a name with no current endpoint into deny-all).
+-- Existing keys therefore keep identical behavior. Idempotent (skips objects)
+-- and order-preserving; an empty [] (deny-all) is left untouched.
+
+UPDATE api.api_keys k
+SET spec = ROW(
+        (k.spec).quota,
+        (k.spec).expires_in,
+        jsonb_set(
+            (k.spec).limits,
+            '{allowed_models}',
+            (
+                SELECT COALESCE(
+                    jsonb_agg(
+                        CASE
+                            WHEN jsonb_typeof(t.elem) = 'string'
+                                THEN jsonb_build_object('model', t.elem #>> '{}')
+                            ELSE t.elem  -- already an object: leave as-is (idempotent)
+                        END
+                        ORDER BY t.ord
+                    ),
+                    '[]'::jsonb
+                )
+                FROM jsonb_array_elements((k.spec).limits -> 'allowed_models')
+                     WITH ORDINALITY AS t(elem, ord)
+            )
+        )
+    )::api.api_key_spec
+WHERE (k.spec).limits IS NOT NULL
+  AND jsonb_typeof((k.spec).limits -> 'allowed_models') = 'array'
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements((k.spec).limits -> 'allowed_models') AS elem
+      WHERE jsonb_typeof(elem) = 'string'
+  );
+
+-- Extend the limits validator to cover the new allowed_models shape. The numeric
+-- checks are unchanged from migration 071; the appended block validates each
+-- allowed_models entry. Callers (create_api_key / set_api_key_limits) resolve
+-- api.validate_api_key_limits by name, so replacing it here is enough.
+CREATE OR REPLACE FUNCTION api.validate_api_key_limits(p_limits JSONB)
+RETURNS VOID
+AS $$
+DECLARE
+    v_field TEXT;
+    v_node  JSONB;
+    v_num   NUMERIC;
+BEGIN
+    IF p_limits IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- token_quota.limit (nested)
+    v_node := p_limits #> '{token_quota,limit}';
+    IF v_node IS NOT NULL AND jsonb_typeof(v_node) <> 'null' THEN
+        IF jsonb_typeof(v_node) <> 'number' THEN
+            RAISE EXCEPTION 'Invalid token quota limit: must be a positive integer'
+                USING ERRCODE = '22023';
+        END IF;
+        v_num := v_node::text::numeric;
+        IF v_num <= 0 OR v_num <> trunc(v_num) THEN
+            RAISE EXCEPTION 'Invalid token quota limit: must be a positive integer'
+                USING ERRCODE = '22023';
+        END IF;
+    END IF;
+
+    -- top-level numeric limits: rps, rpm, concurrency
+    FOREACH v_field IN ARRAY ARRAY['rps', 'rpm', 'concurrency'] LOOP
+        IF p_limits ? v_field AND jsonb_typeof(p_limits -> v_field) <> 'null' THEN
+            v_node := p_limits -> v_field;
+            IF jsonb_typeof(v_node) <> 'number' THEN
+                RAISE EXCEPTION 'Invalid % limit: must be a positive integer', v_field
+                    USING ERRCODE = '22023';
+            END IF;
+            v_num := v_node::text::numeric;
+            IF v_num <= 0 OR v_num <> trunc(v_num) THEN
+                RAISE EXCEPTION 'Invalid % limit: must be a positive integer', v_field
+                    USING ERRCODE = '22023';
+            END IF;
+        END IF;
+    END LOOP;
+
+    -- allowed_models: optional array of endpoint-scoped entries. Each element must
+    -- be an object with a non-empty string `model`; `type` / `endpoint_name`, when
+    -- present, must be strings. An empty array (deny-all) is valid.
+    IF p_limits ? 'allowed_models' AND jsonb_typeof(p_limits -> 'allowed_models') <> 'null' THEN
+        IF jsonb_typeof(p_limits -> 'allowed_models') <> 'array' THEN
+            RAISE EXCEPTION 'Invalid allowed_models: must be an array'
+                USING ERRCODE = '22023';
+        END IF;
+        FOR v_node IN SELECT elem FROM jsonb_array_elements(p_limits -> 'allowed_models') AS elem LOOP
+            -- Explicit key-presence check: a missing `model` makes v_node -> 'model'
+            -- SQL NULL, so jsonb_typeof(...) <> 'string' would be NULL (not TRUE) and
+            -- silently pass. `NOT (v_node ? 'model')` catches that case.
+            IF jsonb_typeof(v_node) <> 'object'
+               OR NOT (v_node ? 'model')
+               OR jsonb_typeof(v_node -> 'model') <> 'string'
+               OR length(trim(v_node ->> 'model')) = 0 THEN
+                RAISE EXCEPTION 'Invalid allowed_models entry: each item needs a non-empty string model'
+                    USING ERRCODE = '22023';
+            END IF;
+            IF v_node ? 'type' AND jsonb_typeof(v_node -> 'type') NOT IN ('string', 'null') THEN
+                RAISE EXCEPTION 'Invalid allowed_models entry: type must be a string'
+                    USING ERRCODE = '22023';
+            END IF;
+            IF v_node ? 'endpoint_name' AND jsonb_typeof(v_node -> 'endpoint_name') NOT IN ('string', 'null') THEN
+                RAISE EXCEPTION 'Invalid allowed_models entry: endpoint_name must be a string'
+                    USING ERRCODE = '22023';
+            END IF;
+        END LOOP;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+NOTIFY pgrst, 'reload schema';

--- a/gateway/kong/plugins/neutree-ai-access/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-access/handler.lua
@@ -4,9 +4,11 @@
 -- consumer as this plugin's config (no per-request control-plane call).
 -- Enforced from local config:
 --   * disabled        -> 403 key_disabled
---   * allowed_models  -> 403 model_not_permitted (only when a non-empty list is
---                        set and the request model is missing/not in it; empty or
---                        unset means unrestricted)
+--   * allowed_models  -> 403 model_not_permitted. Each entry is endpoint-scoped
+--                        ({ model, type?, endpoint_name? }); the request model AND
+--                        the IE/EE endpoint it hit must match some entry. Empty
+--                        type/endpoint_name = any endpoint of that model. An unset
+--                        list means unrestricted; an empty [] means deny-all.
 --   * concurrency     -> 429 concurrency_exceeded (in-flight counter)
 --   * rate_limits     -> 429 rate_limit_exceeded (fixed window per window)
 -- The plugin is attached only when the key actually has access limits, so an
@@ -53,13 +55,23 @@ local function request_model()
     return nil
 end
 
-local function list_has(list, value)
+-- allow_match reports whether the request (model + the IE/EE endpoint it hit) is
+-- permitted by the endpoint-scoped allowlist. An entry permits the request when
+-- its `model` matches AND — for each of `type` / `endpoint_name` that the entry
+-- pins — the endpoint identity stashed by neutree-ai-gateway matches. An entry
+-- with empty type/endpoint_name is "any endpoint serving this model" (legacy
+-- name-only keys, migrated to this shape). An empty list permits nothing (deny-all).
+local function allow_match(list, model, ep_type, ep_name)
     if type(list) ~= "table" then
         return false
     end
-    for _, v in ipairs(list) do
-        if v == value then
-            return true
+    for _, entry in ipairs(list) do
+        if type(entry) == "table" and entry.model == model then
+            local type_ok = entry.type == nil or entry.type == "" or entry.type == ep_type
+            local name_ok = entry.endpoint_name == nil or entry.endpoint_name == "" or entry.endpoint_name == ep_name
+            if type_ok and name_ok then
+                return true
+            end
         end
     end
     return false
@@ -90,7 +102,9 @@ function AccessHandler:access(conf)
     --    stays unrestricted while [] enforces.
     if type(conf.allowed_models) == "table" then
         local model = request_model()
-        if not model or not list_has(conf.allowed_models, model) then
+        local ep_type = kong.ctx.shared and kong.ctx.shared.neutree_endpoint_type
+        local ep_name = kong.ctx.shared and kong.ctx.shared.neutree_endpoint_name
+        if not model or not allow_match(conf.allowed_models, model, ep_type, ep_name) then
             return deny403("model_not_permitted", "Model not permitted for this API key")
         end
     end

--- a/gateway/kong/plugins/neutree-ai-access/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-access/handler.lua
@@ -61,13 +61,17 @@ end
 -- pins — the endpoint identity stashed by neutree-ai-gateway matches. An entry
 -- with empty type/endpoint_name is "any endpoint serving this model" (legacy
 -- name-only keys, migrated to this shape). An empty list permits nothing (deny-all).
--- A pinned dimension matches when it is unset (nil/"" = any) or equals the
--- endpoint the request actually hit. endpoint_name is matched bare (not
--- workspace-qualified): an API key only reaches endpoints in its own workspace
--- (the route ACL rejects anything else before this plugin), and names are unique
--- within a workspace, so there is no cross-workspace collision to guard against.
+-- A pinned dimension matches when it is unset (= any) or equals the endpoint the
+-- request actually hit. "Unset" is anything that isn't a non-empty string: nil,
+-- or cjson.null (userdata) should a JSON null ever reach here — so a null
+-- type/endpoint_name reads as "any", never as a pin that can't match.
+--
+-- endpoint_name is matched bare (not workspace-qualified): an API key only
+-- reaches endpoints in its own workspace (the route ACL rejects anything else
+-- before this plugin), and names are unique within a workspace, so there is no
+-- cross-workspace collision to guard against.
 local function pin_ok(pin, actual)
-    return pin == nil or pin == "" or pin == actual
+    return type(pin) ~= "string" or pin == "" or pin == actual
 end
 
 local function allow_match(list, model, ep_type, ep_name)

--- a/gateway/kong/plugins/neutree-ai-access/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-access/handler.lua
@@ -62,7 +62,10 @@ end
 -- with empty type/endpoint_name is "any endpoint serving this model" (legacy
 -- name-only keys, migrated to this shape). An empty list permits nothing (deny-all).
 -- A pinned dimension matches when it is unset (nil/"" = any) or equals the
--- endpoint the request actually hit.
+-- endpoint the request actually hit. endpoint_name is matched bare (not
+-- workspace-qualified): an API key only reaches endpoints in its own workspace
+-- (the route ACL rejects anything else before this plugin), and names are unique
+-- within a workspace, so there is no cross-workspace collision to guard against.
 local function pin_ok(pin, actual)
     return pin == nil or pin == "" or pin == actual
 end

--- a/gateway/kong/plugins/neutree-ai-access/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-access/handler.lua
@@ -61,17 +61,21 @@ end
 -- pins — the endpoint identity stashed by neutree-ai-gateway matches. An entry
 -- with empty type/endpoint_name is "any endpoint serving this model" (legacy
 -- name-only keys, migrated to this shape). An empty list permits nothing (deny-all).
+-- A pinned dimension matches when it is unset (nil/"" = any) or equals the
+-- endpoint the request actually hit.
+local function pin_ok(pin, actual)
+    return pin == nil or pin == "" or pin == actual
+end
+
 local function allow_match(list, model, ep_type, ep_name)
     if type(list) ~= "table" then
         return false
     end
     for _, entry in ipairs(list) do
-        if type(entry) == "table" and entry.model == model then
-            local type_ok = entry.type == nil or entry.type == "" or entry.type == ep_type
-            local name_ok = entry.endpoint_name == nil or entry.endpoint_name == "" or entry.endpoint_name == ep_name
-            if type_ok and name_ok then
-                return true
-            end
+        if type(entry) == "table" and entry.model == model
+            and pin_ok(entry.type, ep_type)
+            and pin_ok(entry.endpoint_name, ep_name) then
+            return true
         end
     end
     return false

--- a/gateway/kong/plugins/neutree-ai-access/schema.lua
+++ b/gateway/kong/plugins/neutree-ai-access/schema.lua
@@ -25,7 +25,13 @@ return {
                 type = "record",
                 fields = {
                   { model = { type = "string", required = true } },
-                  { type = { type = "string", required = false } },
+                  {
+                    type = {
+                      type = "string",
+                      required = false,
+                      one_of = { "internal", "external" },
+                    },
+                  },
                   { endpoint_name = { type = "string", required = false } },
                 },
               },

--- a/gateway/kong/plugins/neutree-ai-access/schema.lua
+++ b/gateway/kong/plugins/neutree-ai-access/schema.lua
@@ -12,10 +12,23 @@ return {
         fields = {
           { disabled = { type = "boolean", default = false } },
           {
+            -- Endpoint-scoped model allowlist. Each entry is { model, type?,
+            -- endpoint_name? }: a request is permitted when its client-facing model
+            -- equals `model` AND, for each of `type` / `endpoint_name` that is set,
+            -- the endpoint the request hit (from kong.ctx.shared, stashed by
+            -- neutree-ai-gateway) matches. Empty type/endpoint_name = any endpoint
+            -- serving this model (legacy name-only semantics). An empty array = deny-all.
             allowed_models = {
               type = "array",
               required = false,
-              elements = { type = "string" },
+              elements = {
+                type = "record",
+                fields = {
+                  { model = { type = "string", required = true } },
+                  { type = { type = "string", required = false } },
+                  { endpoint_name = { type = "string", required = false } },
+                },
+              },
             },
           },
           { concurrency = { type = "integer", required = false } },

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -1191,10 +1191,12 @@ function AIGatewayHandler:access(conf)
     -- Expose the IE/EE identity this route serves to later consumer plugins
     -- (neutree-ai-access endpoint-level allowlist). It is static per route/config,
     -- so stash it unconditionally regardless of request format or upstream match.
-    if conf.endpoint_type and conf.endpoint_type ~= "" then
+    -- Require an actual non-empty string: a nil/cjson.null config value must not
+    -- be stashed, since the access plugin expects a plain string endpoint identity.
+    if type(conf.endpoint_type) == "string" and conf.endpoint_type ~= "" then
         kong.ctx.shared.neutree_endpoint_type = conf.endpoint_type
     end
-    if conf.endpoint_name and conf.endpoint_name ~= "" then
+    if type(conf.endpoint_name) == "string" and conf.endpoint_name ~= "" then
         kong.ctx.shared.neutree_endpoint_name = conf.endpoint_name
     end
 

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -1188,6 +1188,16 @@ function AIGatewayHandler:access(conf)
     local request_path = kong.request.get_path()
     local suffix = extract_suffix(request_path, conf.route_prefix or "")
 
+    -- Expose the IE/EE identity this route serves to later consumer plugins
+    -- (neutree-ai-access endpoint-level allowlist). It is static per route/config,
+    -- so stash it unconditionally regardless of request format or upstream match.
+    if conf.endpoint_type and conf.endpoint_type ~= "" then
+        kong.ctx.shared.neutree_endpoint_type = conf.endpoint_type
+    end
+    if conf.endpoint_name and conf.endpoint_name ~= "" then
+        kong.ctx.shared.neutree_endpoint_name = conf.endpoint_name
+    end
+
     if maybe_return_model_list(conf, suffix) then
         return
     end

--- a/gateway/kong/plugins/neutree-ai-gateway/schema.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/schema.lua
@@ -72,6 +72,21 @@ local schema = {
             },
           },
           {
+            -- IE/EE dimension this route serves ("internal" | "external"). Stashed
+            -- into kong.ctx.shared for the consumer-scoped neutree-ai-access plugin
+            -- to enforce endpoint-level model allowlists.
+            endpoint_type = {
+              type = "string",
+              required = false,
+            },
+          },
+          {
+            endpoint_name = {
+              type = "string",
+              required = false,
+            },
+          },
+          {
             upstreams = {
               type = "array",
               required = false,

--- a/gateway/kong/plugins/neutree-ai-gateway/schema.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/schema.lua
@@ -78,6 +78,7 @@ local schema = {
             endpoint_type = {
               type = "string",
               required = false,
+              one_of = { "internal", "external" },
             },
           },
           {

--- a/internal/gateway/kong.go
+++ b/internal/gateway/kong.go
@@ -458,6 +458,12 @@ func (k *Kong) generateAIGatewayPlugin(ep *v1.Endpoint, curRoute *kong.Route) *k
 			// endpoint behavior. Without it the suffix never matches and the raw
 			// Anthropic request is forwarded to the engine, which 404s.
 			"route_prefix": getEndpointRoutePath(ep),
+			// endpoint_type/endpoint_name identify the IE/EE this route serves so
+			// the consumer-scoped neutree-ai-access plugin can enforce endpoint-level
+			// model allowlists. The gateway plugin stashes these into kong.ctx.shared
+			// for the access plugin (which is not bound to a route) to read.
+			"endpoint_type": "internal",
+			"endpoint_name": ep.Metadata.Name,
 		},
 	}
 }
@@ -1110,6 +1116,13 @@ func (k *Kong) generateExternalEndpointAIGatewayPlugin(ee *v1.ExternalEndpoint, 
 		Config: map[string]interface{}{
 			"route_prefix": getExternalEndpointRoutePath(ee),
 			"upstreams":    upstreams,
+			// See generateAIGatewayPlugin: identify the EE this route serves so the
+			// access plugin can enforce endpoint-level allowlists. Note the per-upstream
+			// "internal" flag is a routing detail; from the API key's perspective the
+			// request entered through this external endpoint, so the dimension is fixed
+			// to (external, ee.name) regardless of which upstream the model resolves to.
+			"endpoint_type": "external",
+			"endpoint_name": ee.Metadata.Name,
 		},
 	}, nil
 }

--- a/internal/gateway/kong.go
+++ b/internal/gateway/kong.go
@@ -444,6 +444,20 @@ end`,
 	}
 }
 
+// Endpoint-type tokens for the IE/EE dimension of the API key model allowlist.
+// The gateway plugin stamps one of these into every endpoint route's config and
+// stashes it for neutree-ai-access to match against AllowedModel.Type.
+//
+// This is a distinct vocabulary from the ACL resource strings ("endpoint" /
+// "external-endpoint") and from the DB `source` labels that get_workspace_models
+// (migration 070) returns to populate the UI dropdown ("endpoint" /
+// "external_endpoint"). The UI maps that source to this type when it writes an
+// AllowedModel: source "endpoint" -> internal, "external_endpoint" -> external.
+const (
+	endpointTypeInternal = "internal"
+	endpointTypeExternal = "external"
+)
+
 func (k *Kong) generateAIGatewayPlugin(ep *v1.Endpoint, curRoute *kong.Route) *kong.Plugin {
 	return &kong.Plugin{
 		Name:         pointy.String("neutree-ai-gateway"),
@@ -462,7 +476,7 @@ func (k *Kong) generateAIGatewayPlugin(ep *v1.Endpoint, curRoute *kong.Route) *k
 			// the consumer-scoped neutree-ai-access plugin can enforce endpoint-level
 			// model allowlists. The gateway plugin stashes these into kong.ctx.shared
 			// for the access plugin (which is not bound to a route) to read.
-			"endpoint_type": "internal",
+			"endpoint_type": endpointTypeInternal,
 			"endpoint_name": ep.Metadata.Name,
 		},
 	}
@@ -1121,7 +1135,7 @@ func (k *Kong) generateExternalEndpointAIGatewayPlugin(ee *v1.ExternalEndpoint, 
 			// "internal" flag is a routing detail; from the API key's perspective the
 			// request entered through this external endpoint, so the dimension is fixed
 			// to (external, ee.name) regardless of which upstream the model resolves to.
-			"endpoint_type": "external",
+			"endpoint_type": endpointTypeExternal,
 			"endpoint_name": ee.Metadata.Name,
 		},
 	}, nil

--- a/internal/gateway/kong_apikey_limits_test.go
+++ b/internal/gateway/kong_apikey_limits_test.go
@@ -44,7 +44,7 @@ func TestGenerateAPIKeyAccessPlugin(t *testing.T) {
 		ID: "key-1",
 		Spec: &v1.ApiKeySpec{Limits: &v1.ApiKeyLimits{
 			Disabled:      true,
-			AllowedModels: []string{"gpt-4o"},
+			AllowedModels: []v1.AllowedModel{{Model: "gpt-4o", Type: "internal", EndpointName: "ep-a"}},
 			Concurrency:   8,
 			RPS:           10,
 			RPM:           600,
@@ -57,7 +57,7 @@ func TestGenerateAPIKeyAccessPlugin(t *testing.T) {
 	assert.Equal(t, cid, p.Consumer.ID)
 	assert.ElementsMatch(t, []*string{pointy.String("http"), pointy.String("https")}, p.Protocols)
 	assert.Equal(t, true, p.Config["disabled"])
-	assert.Equal(t, []string{"gpt-4o"}, p.Config["allowed_models"])
+	assert.Equal(t, []v1.AllowedModel{{Model: "gpt-4o", Type: "internal", EndpointName: "ep-a"}}, p.Config["allowed_models"])
 	assert.Equal(t, 8, p.Config["concurrency"])
 	rl, ok := p.Config["rate_limits"].([]map[string]interface{})
 	require.True(t, ok)
@@ -86,10 +86,10 @@ func TestGenerateAPIKeyAccessPlugin(t *testing.T) {
 	// (distinct from the unset case above which is nil/unrestricted).
 	p2d := k.generateAPIKeyAccessPlugin(cid, &v1.ApiKey{
 		ID:   "k2d",
-		Spec: &v1.ApiKeySpec{Limits: &v1.ApiKeyLimits{AllowedModels: []string{}}},
+		Spec: &v1.ApiKeySpec{Limits: &v1.ApiKeyLimits{AllowedModels: []v1.AllowedModel{}}},
 	})
 	require.NotNil(t, p2d)
-	assert.Equal(t, []string{}, p2d.Config["allowed_models"])
+	assert.Equal(t, []v1.AllowedModel{}, p2d.Config["allowed_models"])
 
 	// RPS only -> single second-window rate limit; disabled present and false
 	p3 := k.generateAPIKeyAccessPlugin(cid, &v1.ApiKey{


### PR DESCRIPTION
## Background

The API key model allowlist (`spec.limits.allowed_models`) enforced access **only by client-facing model name**. When the same model name is exposed by more than one internal/external endpoint (IE/EE), a key could not allow one entry while denying the other — the gateway matched the bare name and let every source through.

Jira: NEU-540.

## What changed

Each allowlist entry becomes **endpoint-scoped**: `{ model, type?, endpoint_name? }`. A request is permitted when its model matches **and**, for each of `type` / `endpoint_name` the entry pins, the endpoint the request actually hit matches. Empty `type`/`endpoint_name` means *"any endpoint serving this model"* — the legacy name-only semantics, which is what existing keys are migrated to.

- **`api/v1`** — `ApiKeyLimits.AllowedModels` `[]string` → `[]AllowedModel`.
- **DB migration `078`** — lossless format conversion of existing string entries to `{ "model": s }`. Deliberately **no** name→endpoint expansion: bare-name semantics include future endpoints of the same name, and expanding would silently pin existing keys to today's endpoint set (and turn a name with no current endpoint into deny-all). Existing keys keep identical behavior. `validate_api_key_limits` extended to check the new shape.
- **`neutree-ai-gateway`** (route-scoped plugin) — carries and stashes the IE/EE identity (`endpoint_type`/`endpoint_name`) into `kong.ctx.shared` for the consumer-scoped access plugin. Priority 900 > 895 guarantees the stash precedes the read.
- **`neutree-ai-access`** (consumer-scoped plugin) — `allowed_models` becomes a record array; matches the request model together with the stashed endpoint identity. Missing stash → pinned entries safely deny, wildcard entries still allow.

## Compatibility

- Old name-only keys → migrated to unpinned entries → behave exactly as before.
- Unset `allowed_models` = unrestricted; empty `[]` = deny-all (unchanged).
- Down migration reverts to bare names (lossy: pins collapse to model name).

## Testing

- `make db-test` green — real Postgres runs the migration + RPCs; new subtests cover accept (pinned + unpinned) and reject (legacy bare string, missing/empty `model`, non-string `type`) of the new shape.
- `internal/gateway` unit tests updated and passing; `build` / `vet` / `gofmt` / `golangci-lint` clean.
- Lua plugins have no in-repo test harness (verified on the dev box per existing workflow).

## Follow-up

UI changes live in the separate `neutree-ui` repo (`buildApiKeyLimits`/`limitsToForm`: emit/parse pinned entries, pass migrated wildcard entries through as read-only) — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)