### PR TITLE
fix: remove NvSwitch link status from default collectors

### DIFF
--- a/internal/accelerator/plugin/gpu.go
+++ b/internal/accelerator/plugin/gpu.go
@@ -53,7 +53,6 @@ DCGM_FI_DEV_PCIE_MAX_LINK_WIDTH, gauge, PCIe max link width.
 DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe current link generation.
 DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe current link width.
 DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL, counter, Total NVLink bandwidth counter.
-DCGM_FI_DEV_NVSWITCH_LINK_STATUS, gauge, NVSwitch link status.
 DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics or compute engine is active.
 DCGM_FI_PROF_SM_ACTIVE, gauge, Ratio of cycles an SM has at least one active warp.
 DCGM_FI_PROF_SM_OCCUPANCY, gauge, Ratio of resident warps on an SM.

--- a/internal/accelerator/plugin/gpu_test.go
+++ b/internal/accelerator/plugin/gpu_test.go
@@ -355,7 +355,7 @@ func TestGPUAcceleratorPlugin_GetAcceleratorProfile(t *testing.T) {
 		"DCGM_FI_DEV_PCIE_MAX_LINK_WIDTH",
 		"DCGM_FI_DEV_PCIE_LINK_GEN",
 		"DCGM_FI_DEV_PCIE_LINK_WIDTH",
-		"DCGM_FI_DEV_NVSWITCH_LINK_STATUS",
+		"DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL",
 		"DCGM_FI_DEV_XID_ERRORS",
 		"DCGM_FI_DEV_ECC_DBE_VOL_TOTAL",
 		"DCGM_FI_DEV_RETIRED_PENDING",
@@ -378,6 +378,7 @@ func TestGPUAcceleratorPlugin_GetAcceleratorProfile(t *testing.T) {
 		assert.Contains(t, collectors, metric)
 	}
 	assert.NotContains(t, collectors, "DCGM_CUSTOM_")
+	assert.NotContains(t, collectors, "DCGM_FI_DEV_NVSWITCH_LINK_STATUS")
 	assert.NotContains(t, collectors, "DCGM_FI_DEV_NAME")
 	assert.NotContains(t, collectors, "DCGM_FI_DEV_BRAND")
 	assert.NotContains(t, collectors, "DCGM_FI_DEV_GPU_UUID")

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -693,7 +693,7 @@ func TestBuildMetricsResourcesIncludesAcceleratorExporterFromPluginProfile(t *te
 		"DCGM_FI_DEV_PCIE_MAX_LINK_WIDTH",
 		"DCGM_FI_DEV_PCIE_LINK_GEN",
 		"DCGM_FI_DEV_PCIE_LINK_WIDTH",
-		"DCGM_FI_DEV_NVSWITCH_LINK_STATUS",
+		"DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL",
 		"DCGM_FI_DEV_FB_USED_PERCENT",
 		"DCGM_FI_DEV_ECC_DBE_VOL_TOTAL",
 		"DCGM_FI_DEV_RETIRED_PENDING",
@@ -716,6 +716,7 @@ func TestBuildMetricsResourcesIncludesAcceleratorExporterFromPluginProfile(t *te
 		assert.Assert(t, strings.Contains(collectors, metric))
 	}
 	assert.Assert(t, !strings.Contains(collectors, "DCGM_CUSTOM_"))
+	assert.Assert(t, !strings.Contains(collectors, "DCGM_FI_DEV_NVSWITCH_LINK_STATUS"))
 	assert.Assert(t, !strings.Contains(collectors, "DCGM_FI_DEV_NAME"))
 	assert.Assert(t, !strings.Contains(collectors, "DCGM_FI_DEV_BRAND"))
 	assert.Assert(t, !strings.Contains(collectors, "DCGM_FI_DEV_GPU_UUID"))

--- a/tests/e2e/cluster_metrics_helper.go
+++ b/tests/e2e/cluster_metrics_helper.go
@@ -113,6 +113,7 @@ func assertK8sMetricsResources(
 
 		dcgmConfig, err := k8sH.GetConfigMap(ctx, namespace, "nvidia-gpu-dcgm-exporter-config")
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "DCGM exporter config should exist")
+
 		collectors := dcgmConfig.Data["default-counters.csv"]
 		ExpectWithOffset(1, collectors).NotTo(ContainSubstring("DCGM_FI_DEV_NVSWITCH_LINK_STATUS"))
 		ExpectWithOffset(1, collectors).To(ContainSubstring("DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"))

--- a/tests/e2e/cluster_metrics_helper.go
+++ b/tests/e2e/cluster_metrics_helper.go
@@ -111,6 +111,14 @@ func assertK8sMetricsResources(
 		))
 		ExpectWithOffset(1, vmagentConfig.Data["prometheus.yml"]).To(ContainSubstring("job_name: 'accelerator-exporter-nvidia-gpu'"))
 
+		dcgmConfig, err := k8sH.GetConfigMap(ctx, namespace, "nvidia-gpu-dcgm-exporter-config")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "DCGM exporter config should exist")
+		collectors := dcgmConfig.Data["default-counters.csv"]
+		ExpectWithOffset(1, collectors).NotTo(ContainSubstring("DCGM_FI_DEV_NVSWITCH_LINK_STATUS"))
+		ExpectWithOffset(1, collectors).To(ContainSubstring("DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"))
+		ExpectWithOffset(1, collectors).To(ContainSubstring("DCGM_FI_PROF_NVLINK_RX_BYTES"))
+		ExpectWithOffset(1, collectors).To(ContainSubstring("DCGM_FI_PROF_NVLINK_TX_BYTES"))
+
 		By("Checking node-agent writes node accelerator device annotations")
 		assertK8sNodeAcceleratorDeviceAnnotations(ctx, k8sH)
 	}


### PR DESCRIPTION
## Issue

NEU-531

## Summary

Remove `DCGM_FI_DEV_NVSWITCH_LINK_STATUS` from the built-in managed NVIDIA `dcgm-exporter` default collector list. This avoids enabling the NvSwitch-specific collector by default on non-NvSwitch GPU nodes while keeping GPU-side NVLink collectors enabled.

## Changes

- Remove `DCGM_FI_DEV_NVSWITCH_LINK_STATUS` from the NVIDIA GPU accelerator profile default collector CSV.
- Add regression assertions in the accelerator profile and rendered metrics resource tests.
- Extend the existing K8s metrics E2E helper to check the rendered DCGM exporter ConfigMap omits the NvSwitch link-status collector and keeps NVLink collectors.

## Test Plan

### Unit test

- [x] `go test ./internal/accelerator/plugin -run TestGPUAcceleratorPlugin_GetAcceleratorProfile -count=1`
- [x] `go test ./internal/cluster/component/metrics -run TestBuildMetricsResourcesIncludesAcceleratorExporterFromPluginProfile -count=1`
- [x] `go test ./internal/observability/neutreemetrics/... -count=1`
- [x] `go test ./internal/accelerator/plugin ./internal/cluster/component/metrics ./internal/cluster/staticcluster -count=1`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v 'e2e\|mocks\|db/dbtest')`
- [x] `bin/golangci-lint run ./internal/accelerator/plugin/... ./internal/cluster/component/metrics/...`

### DB test

- [x] Not affected. No DB schema, migration, storage, or RBAC behavior changed.

### E2E test

- [x] `go test ./tests/e2e -run TestNonExistent -count=0`
- [x] Deployment prep: CP baseline `v1.1.0-nightly-20260713` was deployed, then branch head `81d56353` was hot-updated on `10.255.1.54` and admin login probe passed.
- [x] Manual E2E: passed on the `k8s-t4` cluster; after deploying Neutree there, the managed `dcgm-exporter` ran normally.
- [ ] Code-backed E2E was not run separately after the manual `k8s-t4` verification.

## Risk & Rollback

Risk is limited to the default managed NVIDIA exporter collector set. Default managed deployments will no longer collect the NvSwitch link-status metric unless a user supplies a custom/external collector configuration. Rollback is to re-add `DCGM_FI_DEV_NVSWITCH_LINK_STATUS` to the default collector CSV.