### PR TITLE
feat: CLI access log export (NEU-544)

### DIFF
--- a/cmd/neutree-cli/app/cmd/cmd.go
+++ b/cmd/neutree-cli/app/cmd/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/cleanup"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/delete"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/engine"
+	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/export"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/get"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/launch"
@@ -53,6 +54,7 @@ Examples:
 	neutreeCliCmd.AddCommand(cleanup.NewCleanupCmd())
 	neutreeCliCmd.AddCommand(delete.NewDeleteCmd())
 	neutreeCliCmd.AddCommand(engine.NewEngineCmd())
+	neutreeCliCmd.AddCommand(export.NewExportCmd())
 	neutreeCliCmd.AddCommand(get.NewGetCmd())
 	neutreeCliCmd.AddCommand(launch.NewLaunchCmd())
 	neutreeCliCmd.AddCommand(model.NewModelCmd())

--- a/cmd/neutree-cli/app/cmd/export/export.go
+++ b/cmd/neutree-cli/app/cmd/export/export.go
@@ -1,0 +1,228 @@
+package export
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+// NewExportCmd creates the `export` parent command.
+func NewExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export data from Neutree",
+		Long:  "Export data from Neutree for archival or offline analysis.",
+	}
+
+	cmd.AddCommand(newAccessLogCmd())
+
+	return cmd
+}
+
+// accessLogOptions holds the flags for `export access-log`.
+type accessLogOptions struct {
+	workspace string
+	format    string
+	file      string
+	limit     int
+	withBody  bool
+
+	since  string
+	until  string
+	filter client.TraceListFilters
+}
+
+func newAccessLogCmd() *cobra.Command {
+	opts := &accessLogOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "access-log",
+		Short: "Export access logs (AI traces)",
+		Long: `Export access logs (AI inference traces) for a workspace.
+
+Records are streamed page by page to the output, so exporting large histories
+never buffers the full result set in memory. Data is written to stdout by
+default (redirect with --file); all progress and diagnostics go to stderr, so
+the data stream stays clean for pipes and redirection.
+
+Use --since/--until to bound the time window for large exports. Pass the
+special workspace _all_ to aggregate across every workspace you may read.
+
+Examples:
+  # Stream the last records as JSON Lines to stdout
+  neutree-cli export access-log -w default
+
+  # Export a time window to a CSV file
+  neutree-cli export access-log -w default --since 2026-07-01 --until 2026-07-14 --format csv -f traces.csv
+
+  # Aggregate across all workspaces, filter by status, pipe to jq
+  neutree-cli export access-log -w _all_ --status 500 | jq -c .
+
+  # Include full request/response bodies (slow: one extra request per record)
+  neutree-cli export access-log -w default --limit 100 --with-body`,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAccessLogExport(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.workspace, "workspace", "w", "default", "Workspace name (use _all_ to aggregate across all readable workspaces)")
+	f.StringVar(&opts.format, "format", "jsonl", "Output format: jsonl, json, csv")
+	f.StringVarP(&opts.file, "file", "f", "", "Output file path (default: stdout)")
+	f.IntVar(&opts.limit, "limit", 0, "Maximum number of records to export (0 = no limit)")
+	f.BoolVar(&opts.withBody, "with-body", false, "Fetch full request/response bodies (one extra request per record; slow)")
+	f.StringVar(&opts.since, "since", "", "Only export records at or after this time (RFC3339 or YYYY-MM-DD)")
+	f.StringVar(&opts.until, "until", "", "Only export records before this time (RFC3339 or YYYY-MM-DD)")
+	f.StringVar(&opts.filter.EndpointName, "endpoint", "", "Filter by endpoint name")
+	f.StringVar(&opts.filter.EndpointType, "endpoint-type", "", "Filter by endpoint type (endpoint or external-endpoint)")
+	f.StringVar(&opts.filter.Model, "model", "", "Filter by request or response model")
+	f.StringVar(&opts.filter.Status, "status", "", "Filter by HTTP response status")
+	f.StringVar(&opts.filter.APIKeyID, "api-key-id", "", "Filter by API key ID")
+	f.StringVar(&opts.filter.FinishReason, "finish-reason", "", "Filter by finish reason")
+
+	return cmd
+}
+
+// perPageMax is the server's maximum page size.
+const perPageMax = client.MaxTracePageSize
+
+func runAccessLogExport(opts *accessLogOptions) error {
+	c, err := global.NewClient()
+	if err != nil {
+		return err
+	}
+
+	// Resolve output. A file is buffered; stdout is written directly. Progress
+	// always goes to stderr so it never corrupts the data stream.
+	var out *os.File
+
+	if opts.file != "" {
+		out, err = os.Create(opts.file)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer out.Close()
+	} else {
+		out = os.Stdout
+	}
+
+	bw := bufio.NewWriter(out)
+	defer bw.Flush() //nolint:errcheck
+
+	writer, err := newTraceWriter(opts.format, bw)
+	if err != nil {
+		return err
+	}
+
+	filters := opts.filter
+	filters.Start = opts.since
+	filters.End = opts.until
+
+	total, err := exportLoop(c, opts, filters, writer)
+	if err != nil {
+		return err
+	}
+
+	if err := writer.Close(); err != nil {
+		return err
+	}
+
+	if err := bw.Flush(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "done: exported %d access log record(s)\n", total)
+
+	return nil
+}
+
+// exportLoop pages through the trace store, deduplicating by request id and
+// stopping on stall, limit, or exhaustion. It returns the number of records
+// written.
+func exportLoop(c *client.Client, opts *accessLogOptions, filters client.TraceListFilters, writer traceWriter) (int, error) {
+	seen := make(map[string]struct{})
+
+	var (
+		before string
+		total  int
+	)
+
+	for {
+		perPage := perPageMax
+		if opts.limit > 0 && opts.limit-total < perPage {
+			perPage = opts.limit - total
+		}
+
+		items, nextBefore, err := c.Traces.ListPage(opts.workspace, filters, before, perPage)
+		if err != nil {
+			return total, err
+		}
+
+		if len(items) == 0 {
+			break
+		}
+
+		newInPage := 0
+
+		for i := range items {
+			t := items[i]
+
+			if _, dup := seen[t.RequestID]; dup {
+				continue
+			}
+
+			seen[t.RequestID] = struct{}{}
+			newInPage++
+
+			if opts.withBody {
+				detail, derr := c.Traces.GetDetail(opts.workspace, t.RequestID)
+				if derr != nil {
+					fmt.Fprintf(os.Stderr, "warning: failed to fetch body for %s: %v\n", t.RequestID, derr)
+				} else {
+					t = *detail
+				}
+			}
+
+			if err := writer.Write(t); err != nil {
+				return total, err
+			}
+
+			total++
+
+			if opts.limit > 0 && total >= opts.limit {
+				return total, nil
+			}
+		}
+
+		fmt.Fprintf(os.Stderr, "exported %d access log record(s)...\n", total)
+
+		// Termination: the server reports no more pages, the cursor stops
+		// advancing, or the whole page was records we already wrote (a
+		// timestamp-boundary stall caused by the inclusive cursor).
+		if nextBefore == "" {
+			break
+		}
+
+		if nextBefore == before {
+			fmt.Fprintf(os.Stderr, "warning: pagination cursor stopped advancing at %s; stopping early\n", nextBefore)
+			break
+		}
+
+		if newInPage == 0 {
+			fmt.Fprintf(os.Stderr, "warning: pagination stalled on duplicate records at %s; stopping early\n", nextBefore)
+			break
+		}
+
+		before = nextBefore
+	}
+
+	return total, nil
+}

--- a/cmd/neutree-cli/app/cmd/export/export.go
+++ b/cmd/neutree-cli/app/cmd/export/export.go
@@ -42,9 +42,10 @@ type accessLogOptions struct {
 	limit         int
 	withBody      bool
 
-	since  string
-	until  string
-	filter client.TraceListFilters
+	since   string
+	until   string
+	timeout time.Duration
+	filter  client.TraceListFilters
 }
 
 // withBodyDefaultLimit caps a body-carrying export that did not set an explicit
@@ -101,6 +102,7 @@ Examples:
 	f.StringVarP(&opts.file, "file", "f", "", "Output file path (default: stdout)")
 	f.IntVar(&opts.limit, "limit", 0, "Maximum number of records to export (0 = no limit)")
 	f.BoolVar(&opts.withBody, "with-body", true, "Include full request/response bodies")
+	f.DurationVar(&opts.timeout, "timeout", 0, "Per-request HTTP timeout (0 = no timeout); a body-carrying page can exceed a short timeout")
 	f.StringVar(&opts.since, "since", "", "Only export records at or after this time (RFC3339, or YYYY-MM-DD = start of that day)")
 	f.StringVar(&opts.until, "until", "", "Only export records before this time (RFC3339, or YYYY-MM-DD = through the end of that day)")
 	f.StringVar(&opts.filter.EndpointName, "endpoint", "", "Filter by endpoint name")
@@ -164,8 +166,26 @@ func effectiveLimit(withBody, limitSet bool, limit int) (int, bool) {
 	return limit, false
 }
 
+// validateLimit rejects a negative --limit. 0 means unlimited; a negative value
+// is meaningless and would otherwise slip past the with-body cap (which only
+// applies when --limit is unset) and be treated as unlimited.
+func validateLimit(limit int) error {
+	if limit < 0 {
+		return fmt.Errorf("--limit must be >= 0 (0 = no limit)")
+	}
+
+	return nil
+}
+
 func runAccessLogExport(cmd *cobra.Command, opts *accessLogOptions) error {
-	c, err := global.NewClient()
+	if err := validateLimit(opts.limit); err != nil {
+		return err
+	}
+
+	// Exports are long-running: a full page of inline bodies can exceed the
+	// client's default 30s timeout and abort a partial export. Default to no
+	// timeout; --timeout lets the user reinstate one.
+	c, err := global.NewClient(client.WithTimeout(opts.timeout))
 	if err != nil {
 		return err
 	}

--- a/cmd/neutree-cli/app/cmd/export/export.go
+++ b/cmd/neutree-cli/app/cmd/export/export.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -92,8 +93,8 @@ Examples:
 	f.StringVarP(&opts.file, "file", "f", "", "Output file path (default: stdout)")
 	f.IntVar(&opts.limit, "limit", 0, "Maximum number of records to export (0 = no limit)")
 	f.BoolVar(&opts.withBody, "with-body", true, "Include full request/response bodies")
-	f.StringVar(&opts.since, "since", "", "Only export records at or after this time (RFC3339 or YYYY-MM-DD)")
-	f.StringVar(&opts.until, "until", "", "Only export records before this time (RFC3339 or YYYY-MM-DD)")
+	f.StringVar(&opts.since, "since", "", "Only export records at or after this time (RFC3339, or YYYY-MM-DD = start of that day)")
+	f.StringVar(&opts.until, "until", "", "Only export records before this time (RFC3339, or YYYY-MM-DD = through the end of that day)")
 	f.StringVar(&opts.filter.EndpointName, "endpoint", "", "Filter by endpoint name")
 	f.StringVar(&opts.filter.EndpointType, "endpoint-type", "", "Filter by endpoint type (endpoint or external-endpoint)")
 	f.StringVar(&opts.filter.Model, "model", "", "Filter by request or response model")
@@ -108,6 +109,29 @@ Examples:
 
 // perPageMax is the server's maximum page size.
 const perPageMax = client.MaxTracePageSize
+
+// normalizeTimeBound converts a bare YYYY-MM-DD date to an RFC3339 instant so
+// the server (and VictoriaLogs behind it) reads it unambiguously. A date-only
+// lower bound becomes the start of that UTC day; a date-only upper bound
+// (endOfDay=true) becomes the start of the *next* UTC day, so `--until <date>`
+// includes the whole day. Values already carrying a time, or any other form,
+// are passed through unchanged.
+func normalizeTimeBound(v string, endOfDay bool) string {
+	if v == "" {
+		return ""
+	}
+
+	d, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		return v // not a bare date (RFC3339, unix, etc.) — leave as-is
+	}
+
+	if endOfDay {
+		d = d.AddDate(0, 0, 1)
+	}
+
+	return d.UTC().Format(time.RFC3339)
+}
 
 func runAccessLogExport(cmd *cobra.Command, opts *accessLogOptions) error {
 	c, err := global.NewClient()
@@ -155,8 +179,11 @@ func runAccessLogExport(cmd *cobra.Command, opts *accessLogOptions) error {
 	}
 
 	filters := opts.filter
-	filters.Start = opts.since
-	filters.End = opts.until
+	// A bare YYYY-MM-DD is normalized to an RFC3339 instant before being sent
+	// on to VictoriaLogs, which otherwise reads a date as that day's 00:00 —
+	// so an inclusive-looking `--until <date>` would drop the whole day.
+	filters.Start = normalizeTimeBound(opts.since, false)
+	filters.End = normalizeTimeBound(opts.until, true)
 
 	total, err := exportLoop(c, workspace, opts, filters, writer)
 	if err != nil {

--- a/cmd/neutree-cli/app/cmd/export/export.go
+++ b/cmd/neutree-cli/app/cmd/export/export.go
@@ -26,16 +26,23 @@ func NewExportCmd() *cobra.Command {
 
 // accessLogOptions holds the flags for `export access-log`.
 type accessLogOptions struct {
-	workspace string
-	format    string
-	file      string
-	limit     int
-	withBody  bool
+	workspace     string
+	allWorkspaces bool
+	format        string
+	file          string
+	limit         int
+	withBody      bool
 
 	since  string
 	until  string
 	filter client.TraceListFilters
 }
+
+// withBodyDefaultLimit caps a body-carrying export that did not set an explicit
+// --limit. Full request/response bodies are large, so an unbounded default
+// would produce enormous output; users who really want everything pass an
+// explicit --limit (0 for no cap).
+const withBodyDefaultLimit = 2000
 
 func newAccessLogCmd() *cobra.Command {
 	opts := &accessLogOptions{}
@@ -50,35 +57,41 @@ never buffers the full result set in memory. Data is written to stdout by
 default (redirect with --file); all progress and diagnostics go to stderr, so
 the data stream stays clean for pipes and redirection.
 
-Use --since/--until to bound the time window for large exports. Pass the
-special workspace _all_ to aggregate across every workspace you may read.
+Full request/response bodies are included by default. Because bodies are large,
+a body-carrying export without an explicit --limit is capped (pass --limit 0 to
+lift the cap); use --with-body=false to export metadata only.
+
+Use --since/--until to bound the time window for large exports. Pass
+--all-workspaces (-A) to aggregate across every workspace you may read.
 
 Examples:
-  # Stream the last records as JSON Lines to stdout
+  # Stream records (with bodies) as JSON Lines to stdout
   neutree-cli export access-log -w default
 
-  # Export a time window to a CSV file
-  neutree-cli export access-log -w default --since 2026-07-01 --until 2026-07-14 --format csv -f traces.csv
+  # Metadata only, a time window, to a CSV file
+  neutree-cli export access-log -w default --with-body=false \
+    --since 2026-07-01 --until 2026-07-14 --format csv -f traces.csv
 
   # Aggregate across all workspaces, filter by status, pipe to jq
-  neutree-cli export access-log -w _all_ --status 500 | jq -c .
+  neutree-cli export access-log -A --status 500 | jq -c .
 
-  # Include full request/response bodies (slow: one extra request per record)
-  neutree-cli export access-log -w default --limit 100 --with-body`,
+  # Export everything for one API key over the last week
+  neutree-cli export access-log -w default --api-key-id <uuid> --since 2026-07-07 --limit 0`,
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAccessLogExport(opts)
+			return runAccessLogExport(cmd, opts)
 		},
 	}
 
 	f := cmd.Flags()
-	f.StringVarP(&opts.workspace, "workspace", "w", "default", "Workspace name (use _all_ to aggregate across all readable workspaces)")
+	f.StringVarP(&opts.workspace, "workspace", "w", "default", "Workspace name")
+	f.BoolVarP(&opts.allWorkspaces, "all-workspaces", "A", false, "Aggregate across every workspace you may read (mutually exclusive with --workspace)")
 	f.StringVar(&opts.format, "format", "jsonl", "Output format: jsonl, json, csv")
 	f.StringVarP(&opts.file, "file", "f", "", "Output file path (default: stdout)")
 	f.IntVar(&opts.limit, "limit", 0, "Maximum number of records to export (0 = no limit)")
-	f.BoolVar(&opts.withBody, "with-body", false, "Fetch full request/response bodies (one extra request per record; slow)")
+	f.BoolVar(&opts.withBody, "with-body", true, "Include full request/response bodies")
 	f.StringVar(&opts.since, "since", "", "Only export records at or after this time (RFC3339 or YYYY-MM-DD)")
 	f.StringVar(&opts.until, "until", "", "Only export records before this time (RFC3339 or YYYY-MM-DD)")
 	f.StringVar(&opts.filter.EndpointName, "endpoint", "", "Filter by endpoint name")
@@ -88,16 +101,35 @@ Examples:
 	f.StringVar(&opts.filter.APIKeyID, "api-key-id", "", "Filter by API key ID")
 	f.StringVar(&opts.filter.FinishReason, "finish-reason", "", "Filter by finish reason")
 
+	cmd.MarkFlagsMutuallyExclusive("workspace", "all-workspaces")
+
 	return cmd
 }
 
 // perPageMax is the server's maximum page size.
 const perPageMax = client.MaxTracePageSize
 
-func runAccessLogExport(opts *accessLogOptions) error {
+func runAccessLogExport(cmd *cobra.Command, opts *accessLogOptions) error {
 	c, err := global.NewClient()
 	if err != nil {
 		return err
+	}
+
+	// --all-workspaces is exposed as a boolean so it never collides with a real
+	// workspace name; the server's cross-workspace aggregate is requested via
+	// the AllWorkspaces sentinel on the wire.
+	workspace := opts.workspace
+	if opts.allWorkspaces {
+		workspace = client.AllWorkspaces
+	}
+
+	// Bodies are large: a body-carrying export that did not set --limit is
+	// capped so a bare command cannot accidentally pull an unbounded volume.
+	if opts.withBody && !cmd.Flags().Changed("limit") {
+		opts.limit = withBodyDefaultLimit
+		fmt.Fprintf(os.Stderr,
+			"note: limiting to %d records because --with-body is on; pass --limit N (or --limit 0) to change\n",
+			withBodyDefaultLimit)
 	}
 
 	// Resolve output. A file is buffered; stdout is written directly. Progress
@@ -126,7 +158,7 @@ func runAccessLogExport(opts *accessLogOptions) error {
 	filters.Start = opts.since
 	filters.End = opts.until
 
-	total, err := exportLoop(c, opts, filters, writer)
+	total, err := exportLoop(c, workspace, opts, filters, writer)
 	if err != nil {
 		return err
 	}
@@ -147,7 +179,7 @@ func runAccessLogExport(opts *accessLogOptions) error {
 // exportLoop pages through the trace store, deduplicating by request id and
 // stopping on stall, limit, or exhaustion. It returns the number of records
 // written.
-func exportLoop(c *client.Client, opts *accessLogOptions, filters client.TraceListFilters, writer traceWriter) (int, error) {
+func exportLoop(c *client.Client, workspace string, opts *accessLogOptions, filters client.TraceListFilters, writer traceWriter) (int, error) {
 	seen := make(map[string]struct{})
 
 	var (
@@ -161,7 +193,9 @@ func exportLoop(c *client.Client, opts *accessLogOptions, filters client.TraceLi
 			perPage = opts.limit - total
 		}
 
-		items, nextBefore, err := c.Traces.ListPage(opts.workspace, filters, before, perPage)
+		// Bodies come inline via include_body, so a full-content export is still
+		// a single request per page — no per-record detail lookup.
+		items, nextBefore, err := c.Traces.ListPage(workspace, filters, before, perPage, opts.withBody)
 		if err != nil {
 			return total, err
 		}
@@ -181,15 +215,6 @@ func exportLoop(c *client.Client, opts *accessLogOptions, filters client.TraceLi
 
 			seen[t.RequestID] = struct{}{}
 			newInPage++
-
-			if opts.withBody {
-				detail, derr := c.Traces.GetDetail(opts.workspace, t.RequestID)
-				if derr != nil {
-					fmt.Fprintf(os.Stderr, "warning: failed to fetch body for %s: %v\n", t.RequestID, derr)
-				} else {
-					t = *detail
-				}
-			}
 
 			if err := writer.Write(t); err != nil {
 				return total, err

--- a/cmd/neutree-cli/app/cmd/export/export.go
+++ b/cmd/neutree-cli/app/cmd/export/export.go
@@ -3,6 +3,7 @@ package export
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -11,6 +12,13 @@ import (
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
 	"github.com/neutree-ai/neutree/pkg/client"
 )
+
+// traceLister fetches one page of traces. *client.TracesService satisfies it;
+// injecting it (rather than a concrete client) lets the export logic be unit
+// tested with an in-memory fake — no HTTP server, no filesystem.
+type traceLister interface {
+	ListPage(workspace string, filters client.TraceListFilters, before string, limit int, includeBody bool) ([]client.AITrace, string, error)
+}
 
 // NewExportCmd creates the `export` parent command.
 func NewExportCmd() *cobra.Command {
@@ -133,27 +141,40 @@ func normalizeTimeBound(v string, endOfDay bool) string {
 	return d.UTC().Format(time.RFC3339)
 }
 
+// resolveWorkspace maps the workspace flags to the value sent on the wire.
+// --all-workspaces is a boolean (never collides with a real workspace name);
+// it resolves to the server's cross-workspace sentinel.
+func resolveWorkspace(workspace string, allWorkspaces bool) string {
+	if allWorkspaces {
+		return client.AllWorkspaces
+	}
+
+	return workspace
+}
+
+// effectiveLimit applies the body-mode cap. Bodies are large, so a
+// body-carrying export that did not explicitly set --limit is capped to avoid
+// accidentally pulling an unbounded volume. Returns the limit to use and
+// whether the cap was applied.
+func effectiveLimit(withBody, limitSet bool, limit int) (int, bool) {
+	if withBody && !limitSet {
+		return withBodyDefaultLimit, true
+	}
+
+	return limit, false
+}
+
 func runAccessLogExport(cmd *cobra.Command, opts *accessLogOptions) error {
 	c, err := global.NewClient()
 	if err != nil {
 		return err
 	}
 
-	// --all-workspaces is exposed as a boolean so it never collides with a real
-	// workspace name; the server's cross-workspace aggregate is requested via
-	// the AllWorkspaces sentinel on the wire.
-	workspace := opts.workspace
-	if opts.allWorkspaces {
-		workspace = client.AllWorkspaces
-	}
-
-	// Bodies are large: a body-carrying export that did not set --limit is
-	// capped so a bare command cannot accidentally pull an unbounded volume.
-	if opts.withBody && !cmd.Flags().Changed("limit") {
-		opts.limit = withBodyDefaultLimit
+	if limit, capped := effectiveLimit(opts.withBody, cmd.Flags().Changed("limit"), opts.limit); capped {
+		opts.limit = limit
 		fmt.Fprintf(os.Stderr,
 			"note: limiting to %d records because --with-body is on; pass --limit N (or --limit 0) to change\n",
-			withBodyDefaultLimit)
+			limit)
 	}
 
 	// Resolve output. A file is buffered; stdout is written directly. Progress
@@ -173,24 +194,14 @@ func runAccessLogExport(cmd *cobra.Command, opts *accessLogOptions) error {
 	bw := bufio.NewWriter(out)
 	defer bw.Flush() //nolint:errcheck
 
-	writer, err := newTraceWriter(opts.format, bw)
+	total, err := runExport(exportRequest{
+		lister:    c.Traces,
+		dataOut:   bw,
+		progress:  os.Stderr,
+		workspace: resolveWorkspace(opts.workspace, opts.allWorkspaces),
+		opts:      opts,
+	})
 	if err != nil {
-		return err
-	}
-
-	filters := opts.filter
-	// A bare YYYY-MM-DD is normalized to an RFC3339 instant before being sent
-	// on to VictoriaLogs, which otherwise reads a date as that day's 00:00 —
-	// so an inclusive-looking `--until <date>` would drop the whole day.
-	filters.Start = normalizeTimeBound(opts.since, false)
-	filters.End = normalizeTimeBound(opts.until, true)
-
-	total, err := exportLoop(c, workspace, opts, filters, writer)
-	if err != nil {
-		return err
-	}
-
-	if err := writer.Close(); err != nil {
 		return err
 	}
 
@@ -203,10 +214,48 @@ func runAccessLogExport(cmd *cobra.Command, opts *accessLogOptions) error {
 	return nil
 }
 
+// exportRequest carries the fully-resolved inputs for a single export run. It
+// depends only on interfaces and io.Writers, so runExport is unit testable with
+// an in-memory lister and byte buffers.
+type exportRequest struct {
+	lister    traceLister
+	dataOut   io.Writer // record stream (stdout or a file)
+	progress  io.Writer // diagnostics (stderr)
+	workspace string
+	opts      *accessLogOptions
+}
+
+// runExport builds the output writer, streams every page through it, and
+// finalizes. It returns the number of records written.
+func runExport(req exportRequest) (int, error) {
+	writer, err := newTraceWriter(req.opts.format, req.dataOut)
+	if err != nil {
+		return 0, err
+	}
+
+	filters := req.opts.filter
+	// A bare YYYY-MM-DD is normalized to an RFC3339 instant before being sent
+	// on to VictoriaLogs, which otherwise reads a date as that day's 00:00 —
+	// so an inclusive-looking `--until <date>` would drop the whole day.
+	filters.Start = normalizeTimeBound(req.opts.since, false)
+	filters.End = normalizeTimeBound(req.opts.until, true)
+
+	total, err := exportLoop(req.lister, req.progress, req.workspace, req.opts, filters, writer)
+	if err != nil {
+		return total, err
+	}
+
+	if err := writer.Close(); err != nil {
+		return total, err
+	}
+
+	return total, nil
+}
+
 // exportLoop pages through the trace store, deduplicating by request id and
 // stopping on stall, limit, or exhaustion. It returns the number of records
 // written.
-func exportLoop(c *client.Client, workspace string, opts *accessLogOptions, filters client.TraceListFilters, writer traceWriter) (int, error) {
+func exportLoop(lister traceLister, progress io.Writer, workspace string, opts *accessLogOptions, filters client.TraceListFilters, writer traceWriter) (int, error) {
 	seen := make(map[string]struct{})
 
 	var (
@@ -222,7 +271,7 @@ func exportLoop(c *client.Client, workspace string, opts *accessLogOptions, filt
 
 		// Bodies come inline via include_body, so a full-content export is still
 		// a single request per page — no per-record detail lookup.
-		items, nextBefore, err := c.Traces.ListPage(workspace, filters, before, perPage, opts.withBody)
+		items, nextBefore, err := lister.ListPage(workspace, filters, before, perPage, opts.withBody)
 		if err != nil {
 			return total, err
 		}
@@ -254,7 +303,7 @@ func exportLoop(c *client.Client, workspace string, opts *accessLogOptions, filt
 			}
 		}
 
-		fmt.Fprintf(os.Stderr, "exported %d access log record(s)...\n", total)
+		fmt.Fprintf(progress, "exported %d access log record(s)...\n", total)
 
 		// Termination: the server reports no more pages, the cursor stops
 		// advancing, or the whole page was records we already wrote (a
@@ -264,12 +313,12 @@ func exportLoop(c *client.Client, workspace string, opts *accessLogOptions, filt
 		}
 
 		if nextBefore == before {
-			fmt.Fprintf(os.Stderr, "warning: pagination cursor stopped advancing at %s; stopping early\n", nextBefore)
+			fmt.Fprintf(progress, "warning: pagination cursor stopped advancing at %s; stopping early\n", nextBefore)
 			break
 		}
 
 		if newInPage == 0 {
-			fmt.Fprintf(os.Stderr, "warning: pagination stalled on duplicate records at %s; stopping early\n", nextBefore)
+			fmt.Fprintf(progress, "warning: pagination stalled on duplicate records at %s; stopping early\n", nextBefore)
 			break
 		}
 

--- a/cmd/neutree-cli/app/cmd/export/export_test.go
+++ b/cmd/neutree-cli/app/cmd/export/export_test.go
@@ -1,0 +1,174 @@
+package export
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+// fakeTraceStore serves a fixed, time-desc-sorted set of traces with an
+// inclusive cursor and a small server-side page cap — reproducing the real
+// endpoint's boundary behavior (the cursor record repeats on the next page).
+type fakeTraceStore struct {
+	traces  []client.AITrace // sorted by Time desc
+	pageCap int
+}
+
+func (f *fakeTraceStore) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	before := r.URL.Query().Get("before")
+
+	limit := f.pageCap
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, _ := strconv.Atoi(v); n > 0 && n < limit {
+			limit = n
+		}
+	}
+
+	// Inclusive filter: Time <= before (mimics passing the cursor as `end`).
+	var filtered []client.AITrace
+
+	for _, t := range f.traces {
+		if before == "" || t.Time <= before {
+			filtered = append(filtered, t)
+		}
+	}
+
+	page := filtered
+	next := ""
+
+	if len(filtered) > limit {
+		page = filtered[:limit]
+		next = page[len(page)-1].Time // inclusive cursor -> boundary repeats
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"items":       page,
+		"next_before": next,
+	})
+}
+
+func newTestClient(t *testing.T, store *fakeTraceStore) (*client.Client, func()) {
+	t.Helper()
+
+	server := httptest.NewServer(store)
+
+	return client.NewClient(server.URL, client.WithAPIKey("k")), server.Close
+}
+
+func makeTraces(n int) []client.AITrace {
+	traces := make([]client.AITrace, n)
+	for i := range n {
+		// Descending, zero-padded so string comparison matches recency order.
+		traces[i] = client.AITrace{
+			RequestID: fmt.Sprintf("r%03d", i),
+			Time:      fmt.Sprintf("2026-07-14T00:00:%05d", n-i),
+		}
+	}
+
+	return traces
+}
+
+func TestExportLoopPaginatesAndDeduplicates(t *testing.T) {
+	store := &fakeTraceStore{traces: makeTraces(12), pageCap: 5}
+	c, closeFn := newTestClient(t, store)
+	defer closeFn()
+
+	var buf bytes.Buffer
+
+	writer, err := newTraceWriter("jsonl", &buf)
+	require.NoError(t, err)
+
+	total, err := exportLoop(c, &accessLogOptions{workspace: "default"}, client.TraceListFilters{}, writer)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	// All 12 unique records exported exactly once despite the inclusive-cursor
+	// boundary repeats across the 3 pages.
+	require.Equal(t, 12, total)
+
+	seen := map[string]bool{}
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var rec client.AITrace
+		require.NoError(t, json.Unmarshal([]byte(line), &rec))
+		require.False(t, seen[rec.RequestID], "duplicate %s", rec.RequestID)
+		seen[rec.RequestID] = true
+	}
+
+	require.Len(t, seen, 12)
+}
+
+func TestExportLoopRespectsLimit(t *testing.T) {
+	store := &fakeTraceStore{traces: makeTraces(100), pageCap: 500}
+	c, closeFn := newTestClient(t, store)
+	defer closeFn()
+
+	writer, err := newTraceWriter("jsonl", &bytes.Buffer{})
+	require.NoError(t, err)
+
+	total, err := exportLoop(c, &accessLogOptions{workspace: "default", limit: 7}, client.TraceListFilters{}, writer)
+	require.NoError(t, err)
+	require.Equal(t, 7, total)
+}
+
+func TestExportLoopTerminatesOnStall(t *testing.T) {
+	// More same-timestamp records than a page holds: the inclusive cursor can
+	// never advance past them. The loop must detect the stall and stop rather
+	// than spin forever.
+	traces := make([]client.AITrace, 8)
+	for i := range traces {
+		traces[i] = client.AITrace{RequestID: fmt.Sprintf("r%d", i), Time: "2026-07-14T00:00:00Z"}
+	}
+
+	store := &fakeTraceStore{traces: traces, pageCap: 5}
+	c, closeFn := newTestClient(t, store)
+	defer closeFn()
+
+	writer, err := newTraceWriter("jsonl", &bytes.Buffer{})
+	require.NoError(t, err)
+
+	total, err := exportLoop(c, &accessLogOptions{workspace: "default"}, client.TraceListFilters{}, writer)
+	require.NoError(t, err)
+	// Only the first page's worth is recoverable; the loop terminates.
+	require.Equal(t, 5, total)
+}
+
+func TestExportLoopWithBodyFetchesDetail(t *testing.T) {
+	store := &fakeTraceStore{traces: makeTraces(2), pageCap: 5}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Detail lookups hit /ai-traces/default/<id> (5 slashes); list hits
+		// /ai-traces/default (4 slashes).
+		if strings.Count(r.URL.Path, "/") == 5 {
+			id := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+			_ = json.NewEncoder(w).Encode(client.AITrace{RequestID: id, RequestBody: "body-" + id})
+
+			return
+		}
+
+		store.ServeHTTP(w, r)
+	}))
+	defer server.Close()
+
+	c := client.NewClient(server.URL, client.WithAPIKey("k"))
+
+	var buf bytes.Buffer
+
+	writer, err := newTraceWriter("jsonl", &buf)
+	require.NoError(t, err)
+
+	total, err := exportLoop(c, &accessLogOptions{workspace: "default", withBody: true}, client.TraceListFilters{}, writer)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	require.Equal(t, 2, total)
+	require.Contains(t, buf.String(), "body-r000")
+}

--- a/cmd/neutree-cli/app/cmd/export/export_test.go
+++ b/cmd/neutree-cli/app/cmd/export/export_test.go
@@ -154,6 +154,27 @@ func TestExportLoopTerminatesOnStall(t *testing.T) {
 	require.Equal(t, 5, total)
 }
 
+func TestNormalizeTimeBound(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		endOfDay bool
+		want     string
+	}{
+		{"empty", "", false, ""},
+		{"date since -> start of day", "2026-07-07", false, "2026-07-07T00:00:00Z"},
+		{"date until -> next day start", "2026-07-14", true, "2026-07-15T00:00:00Z"},
+		{"rfc3339 passthrough", "2026-07-07T04:20:00Z", false, "2026-07-07T04:20:00Z"},
+		{"non-date passthrough", "5m", false, "5m"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, normalizeTimeBound(tc.in, tc.endOfDay))
+		})
+	}
+}
+
 func TestExportLoopWithBodyIncludesBodiesInline(t *testing.T) {
 	// With --with-body the loop asks for include_body=true and the store returns
 	// bodies inline in the same page — no per-record detail request.

--- a/cmd/neutree-cli/app/cmd/export/export_test.go
+++ b/cmd/neutree-cli/app/cmd/export/export_test.go
@@ -50,6 +50,18 @@ func (f *fakeTraceStore) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		next = page[len(page)-1].Time // inclusive cursor -> boundary repeats
 	}
 
+	// When include_body is requested the store returns bodies inline, mirroring
+	// the real endpoint's ?include_body=true projection.
+	if r.URL.Query().Get("include_body") == "true" {
+		withBodies := make([]client.AITrace, len(page))
+		for i, t := range page {
+			t.RequestBody = "body-" + t.RequestID
+			withBodies[i] = t
+		}
+
+		page = withBodies
+	}
+
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"items":       page,
 		"next_before": next,
@@ -87,7 +99,7 @@ func TestExportLoopPaginatesAndDeduplicates(t *testing.T) {
 	writer, err := newTraceWriter("jsonl", &buf)
 	require.NoError(t, err)
 
-	total, err := exportLoop(c, &accessLogOptions{workspace: "default"}, client.TraceListFilters{}, writer)
+	total, err := exportLoop(c, "default", &accessLogOptions{}, client.TraceListFilters{}, writer)
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
@@ -115,7 +127,7 @@ func TestExportLoopRespectsLimit(t *testing.T) {
 	writer, err := newTraceWriter("jsonl", &bytes.Buffer{})
 	require.NoError(t, err)
 
-	total, err := exportLoop(c, &accessLogOptions{workspace: "default", limit: 7}, client.TraceListFilters{}, writer)
+	total, err := exportLoop(c, "default", &accessLogOptions{limit: 7}, client.TraceListFilters{}, writer)
 	require.NoError(t, err)
 	require.Equal(t, 7, total)
 }
@@ -136,37 +148,25 @@ func TestExportLoopTerminatesOnStall(t *testing.T) {
 	writer, err := newTraceWriter("jsonl", &bytes.Buffer{})
 	require.NoError(t, err)
 
-	total, err := exportLoop(c, &accessLogOptions{workspace: "default"}, client.TraceListFilters{}, writer)
+	total, err := exportLoop(c, "default", &accessLogOptions{}, client.TraceListFilters{}, writer)
 	require.NoError(t, err)
 	// Only the first page's worth is recoverable; the loop terminates.
 	require.Equal(t, 5, total)
 }
 
-func TestExportLoopWithBodyFetchesDetail(t *testing.T) {
+func TestExportLoopWithBodyIncludesBodiesInline(t *testing.T) {
+	// With --with-body the loop asks for include_body=true and the store returns
+	// bodies inline in the same page — no per-record detail request.
 	store := &fakeTraceStore{traces: makeTraces(2), pageCap: 5}
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Detail lookups hit /ai-traces/default/<id> (5 slashes); list hits
-		// /ai-traces/default (4 slashes).
-		if strings.Count(r.URL.Path, "/") == 5 {
-			id := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
-			_ = json.NewEncoder(w).Encode(client.AITrace{RequestID: id, RequestBody: "body-" + id})
-
-			return
-		}
-
-		store.ServeHTTP(w, r)
-	}))
-	defer server.Close()
-
-	c := client.NewClient(server.URL, client.WithAPIKey("k"))
+	c, closeFn := newTestClient(t, store)
+	defer closeFn()
 
 	var buf bytes.Buffer
 
 	writer, err := newTraceWriter("jsonl", &buf)
 	require.NoError(t, err)
 
-	total, err := exportLoop(c, &accessLogOptions{workspace: "default", withBody: true}, client.TraceListFilters{}, writer)
+	total, err := exportLoop(c, "default", &accessLogOptions{withBody: true}, client.TraceListFilters{}, writer)
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 	require.Equal(t, 2, total)

--- a/cmd/neutree-cli/app/cmd/export/export_test.go
+++ b/cmd/neutree-cli/app/cmd/export/export_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"strconv"
+	"io"
 	"strings"
 	"testing"
 
@@ -15,23 +13,24 @@ import (
 	"github.com/neutree-ai/neutree/pkg/client"
 )
 
-// fakeTraceStore serves a fixed, time-desc-sorted set of traces with an
-// inclusive cursor and a small server-side page cap — reproducing the real
-// endpoint's boundary behavior (the cursor record repeats on the next page).
-type fakeTraceStore struct {
-	traces  []client.AITrace // sorted by Time desc
-	pageCap int
+// fakeLister is an in-memory traceLister. It reproduces the real endpoint's
+// inclusive cursor and server-side page cap (so a boundary record repeats on
+// the next page), letting the export logic be tested without an HTTP server.
+type fakeLister struct {
+	traces      []client.AITrace // sorted by Time desc
+	pageCap     int
+	calls       int
+	lastInclude bool
+	err         error
 }
 
-func (f *fakeTraceStore) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	before := r.URL.Query().Get("before")
-
-	limit := f.pageCap
-	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, _ := strconv.Atoi(v); n > 0 && n < limit {
-			limit = n
-		}
+func (f *fakeLister) ListPage(_ string, _ client.TraceListFilters, before string, limit int, includeBody bool) ([]client.AITrace, string, error) {
+	if f.err != nil {
+		return nil, "", f.err
 	}
+
+	f.calls++
+	f.lastInclude = includeBody
 
 	// Inclusive filter: Time <= before (mimics passing the cursor as `end`).
 	var filtered []client.AITrace
@@ -42,17 +41,20 @@ func (f *fakeTraceStore) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	pageLimit := f.pageCap
+	if limit > 0 && limit < pageLimit {
+		pageLimit = limit
+	}
+
 	page := filtered
 	next := ""
 
-	if len(filtered) > limit {
-		page = filtered[:limit]
+	if len(filtered) > pageLimit {
+		page = filtered[:pageLimit]
 		next = page[len(page)-1].Time // inclusive cursor -> boundary repeats
 	}
 
-	// When include_body is requested the store returns bodies inline, mirroring
-	// the real endpoint's ?include_body=true projection.
-	if r.URL.Query().Get("include_body") == "true" {
+	if includeBody {
 		withBodies := make([]client.AITrace, len(page))
 		for i, t := range page {
 			t.RequestBody = "body-" + t.RequestID
@@ -62,18 +64,7 @@ func (f *fakeTraceStore) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		page = withBodies
 	}
 
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"items":       page,
-		"next_before": next,
-	})
-}
-
-func newTestClient(t *testing.T, store *fakeTraceStore) (*client.Client, func()) {
-	t.Helper()
-
-	server := httptest.NewServer(store)
-
-	return client.NewClient(server.URL, client.WithAPIKey("k")), server.Close
+	return page, next, nil
 }
 
 func makeTraces(n int) []client.AITrace {
@@ -89,27 +80,36 @@ func makeTraces(n int) []client.AITrace {
 	return traces
 }
 
-func TestExportLoopPaginatesAndDeduplicates(t *testing.T) {
-	store := &fakeTraceStore{traces: makeTraces(12), pageCap: 5}
-	c, closeFn := newTestClient(t, store)
-	defer closeFn()
+// runLoop drives exportLoop with an in-memory lister and a jsonl writer,
+// returning the record count and the raw output.
+func runLoop(t *testing.T, lister traceLister, opts *accessLogOptions) (int, string) {
+	t.Helper()
 
 	var buf bytes.Buffer
 
 	writer, err := newTraceWriter("jsonl", &buf)
 	require.NoError(t, err)
 
-	total, err := exportLoop(c, "default", &accessLogOptions{}, client.TraceListFilters{}, writer)
+	total, err := exportLoop(lister, io.Discard, "default", opts, client.TraceListFilters{}, writer)
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
+
+	return total, buf.String()
+}
+
+func TestExportLoopPaginatesAndDeduplicates(t *testing.T) {
+	lister := &fakeLister{traces: makeTraces(12), pageCap: 5}
+
+	total, out := runLoop(t, lister, &accessLogOptions{})
 
 	// All 12 unique records exported exactly once despite the inclusive-cursor
 	// boundary repeats across the 3 pages.
 	require.Equal(t, 12, total)
+	require.Greater(t, lister.calls, 1) // actually paged
 
 	seen := map[string]bool{}
 
-	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		var rec client.AITrace
 		require.NoError(t, json.Unmarshal([]byte(line), &rec))
 		require.False(t, seen[rec.RequestID], "duplicate %s", rec.RequestID)
@@ -120,15 +120,9 @@ func TestExportLoopPaginatesAndDeduplicates(t *testing.T) {
 }
 
 func TestExportLoopRespectsLimit(t *testing.T) {
-	store := &fakeTraceStore{traces: makeTraces(100), pageCap: 500}
-	c, closeFn := newTestClient(t, store)
-	defer closeFn()
+	lister := &fakeLister{traces: makeTraces(100), pageCap: 500}
 
-	writer, err := newTraceWriter("jsonl", &bytes.Buffer{})
-	require.NoError(t, err)
-
-	total, err := exportLoop(c, "default", &accessLogOptions{limit: 7}, client.TraceListFilters{}, writer)
-	require.NoError(t, err)
+	total, _ := runLoop(t, lister, &accessLogOptions{limit: 7})
 	require.Equal(t, 7, total)
 }
 
@@ -141,17 +135,62 @@ func TestExportLoopTerminatesOnStall(t *testing.T) {
 		traces[i] = client.AITrace{RequestID: fmt.Sprintf("r%d", i), Time: "2026-07-14T00:00:00Z"}
 	}
 
-	store := &fakeTraceStore{traces: traces, pageCap: 5}
-	c, closeFn := newTestClient(t, store)
-	defer closeFn()
+	lister := &fakeLister{traces: traces, pageCap: 5}
 
-	writer, err := newTraceWriter("jsonl", &bytes.Buffer{})
-	require.NoError(t, err)
-
-	total, err := exportLoop(c, "default", &accessLogOptions{}, client.TraceListFilters{}, writer)
-	require.NoError(t, err)
+	total, _ := runLoop(t, lister, &accessLogOptions{})
 	// Only the first page's worth is recoverable; the loop terminates.
 	require.Equal(t, 5, total)
+}
+
+func TestExportLoopWithBodyIncludesBodiesInline(t *testing.T) {
+	// With --with-body the loop asks for include_body=true and the lister returns
+	// bodies inline in the same page — no per-record detail request.
+	lister := &fakeLister{traces: makeTraces(2), pageCap: 5}
+
+	total, out := runLoop(t, lister, &accessLogOptions{withBody: true})
+	require.Equal(t, 2, total)
+	require.True(t, lister.lastInclude)
+	require.Contains(t, out, "body-r000")
+}
+
+func TestExportLoopPropagatesListError(t *testing.T) {
+	lister := &fakeLister{err: fmt.Errorf("boom")}
+
+	writer, err := newTraceWriter("jsonl", io.Discard)
+	require.NoError(t, err)
+
+	_, err = exportLoop(lister, io.Discard, "default", &accessLogOptions{}, client.TraceListFilters{}, writer)
+	require.ErrorContains(t, err, "boom")
+}
+
+func TestResolveWorkspace(t *testing.T) {
+	require.Equal(t, "prod", resolveWorkspace("prod", false))
+	require.Equal(t, client.AllWorkspaces, resolveWorkspace("prod", true))
+	require.Equal(t, "default", resolveWorkspace("default", false))
+}
+
+func TestEffectiveLimit(t *testing.T) {
+	cases := []struct {
+		name       string
+		withBody   bool
+		limitSet   bool
+		limit      int
+		wantLimit  int
+		wantCapped bool
+	}{
+		{"body, no explicit limit -> capped", true, false, 0, withBodyDefaultLimit, true},
+		{"body, explicit limit -> respected", true, true, 50, 50, false},
+		{"body, explicit unlimited -> respected", true, true, 0, 0, false},
+		{"no body -> never capped", false, false, 0, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, capped := effectiveLimit(tc.withBody, tc.limitSet, tc.limit)
+			require.Equal(t, tc.wantLimit, got)
+			require.Equal(t, tc.wantCapped, capped)
+		})
+	}
 }
 
 func TestNormalizeTimeBound(t *testing.T) {
@@ -175,21 +214,35 @@ func TestNormalizeTimeBound(t *testing.T) {
 	}
 }
 
-func TestExportLoopWithBodyIncludesBodiesInline(t *testing.T) {
-	// With --with-body the loop asks for include_body=true and the store returns
-	// bodies inline in the same page — no per-record detail request.
-	store := &fakeTraceStore{traces: makeTraces(2), pageCap: 5}
-	c, closeFn := newTestClient(t, store)
-	defer closeFn()
+func TestRunExportCSVToBufferNormalizesUntil(t *testing.T) {
+	// End-to-end through runExport with byte buffers only: writer selection,
+	// the loop, and finalization — no HTTP server, no filesystem.
+	lister := &fakeLister{traces: makeTraces(3), pageCap: 500}
 
-	var buf bytes.Buffer
+	var data, progress bytes.Buffer
 
-	writer, err := newTraceWriter("jsonl", &buf)
+	total, err := runExport(exportRequest{
+		lister:    lister,
+		dataOut:   &data,
+		progress:  &progress,
+		workspace: "default",
+		opts:      &accessLogOptions{format: "csv", until: "2026-07-14"},
+	})
 	require.NoError(t, err)
+	require.Equal(t, 3, total)
 
-	total, err := exportLoop(c, "default", &accessLogOptions{withBody: true}, client.TraceListFilters{}, writer)
-	require.NoError(t, err)
-	require.NoError(t, writer.Close())
-	require.Equal(t, 2, total)
-	require.Contains(t, buf.String(), "body-r000")
+	lines := strings.Split(strings.TrimSpace(data.String()), "\n")
+	require.Len(t, lines, 4) // header + 3 rows
+	require.Equal(t, strings.Join(csvHeader, ","), lines[0])
+}
+
+func TestRunExportUnsupportedFormat(t *testing.T) {
+	_, err := runExport(exportRequest{
+		lister:    &fakeLister{},
+		dataOut:   io.Discard,
+		progress:  io.Discard,
+		workspace: "default",
+		opts:      &accessLogOptions{format: "xml"},
+	})
+	require.Error(t, err)
 }

--- a/cmd/neutree-cli/app/cmd/export/export_test.go
+++ b/cmd/neutree-cli/app/cmd/export/export_test.go
@@ -169,6 +169,12 @@ func TestResolveWorkspace(t *testing.T) {
 	require.Equal(t, "default", resolveWorkspace("default", false))
 }
 
+func TestValidateLimit(t *testing.T) {
+	require.NoError(t, validateLimit(0))  // 0 = unlimited
+	require.NoError(t, validateLimit(10)) // positive is fine
+	require.Error(t, validateLimit(-1))   // negative must be rejected
+}
+
 func TestEffectiveLimit(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/cmd/neutree-cli/app/cmd/export/writer.go
+++ b/cmd/neutree-cli/app/cmd/export/writer.go
@@ -1,0 +1,137 @@
+package export
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+// traceWriter streams AI trace records to an output in a specific format.
+// Records are written one at a time so exports never buffer the full result
+// set in memory. Close finalizes the stream (e.g. the closing JSON bracket).
+type traceWriter interface {
+	Write(t client.AITrace) error
+	Close() error
+}
+
+// newTraceWriter builds a writer for the given format. Supported formats:
+// "jsonl" (default), "json", "csv".
+func newTraceWriter(format string, w io.Writer) (traceWriter, error) {
+	switch format {
+	case "jsonl", "":
+		return &jsonlWriter{enc: json.NewEncoder(w)}, nil
+	case "json":
+		return &jsonArrayWriter{w: w}, nil
+	case "csv":
+		cw := &csvWriter{cw: csv.NewWriter(w)}
+		if err := cw.cw.Write(csvHeader); err != nil {
+			return nil, err
+		}
+
+		return cw, nil
+	default:
+		return nil, fmt.Errorf("unsupported format %q (want jsonl, json, or csv)", format)
+	}
+}
+
+// jsonlWriter emits one JSON object per line (newline-delimited JSON).
+type jsonlWriter struct {
+	enc *json.Encoder
+}
+
+func (jw *jsonlWriter) Write(t client.AITrace) error { return jw.enc.Encode(t) }
+func (jw *jsonlWriter) Close() error                 { return nil }
+
+// jsonArrayWriter emits a single well-formed JSON array, streamed element by
+// element so the whole slice never lives in memory at once.
+type jsonArrayWriter struct {
+	w       io.Writer
+	started bool
+	failed  bool
+}
+
+func (aw *jsonArrayWriter) Write(t client.AITrace) error {
+	sep := "[\n  "
+	if aw.started {
+		sep = ",\n  "
+	}
+
+	if _, err := io.WriteString(aw.w, sep); err != nil {
+		aw.failed = true
+		return err
+	}
+
+	aw.started = true
+
+	b, err := json.Marshal(t)
+	if err != nil {
+		aw.failed = true
+		return err
+	}
+
+	if _, err := aw.w.Write(b); err != nil {
+		aw.failed = true
+		return err
+	}
+
+	return nil
+}
+
+func (aw *jsonArrayWriter) Close() error {
+	if aw.failed {
+		return nil
+	}
+
+	if !aw.started {
+		_, err := io.WriteString(aw.w, "[]\n")
+		return err
+	}
+
+	_, err := io.WriteString(aw.w, "\n]\n")
+
+	return err
+}
+
+// csvHeader lists the columns in the order csvWriter emits them.
+var csvHeader = []string{
+	"request_id", "time", "workspace", "endpoint_type", "endpoint_name",
+	"api_key_id", "request_uri", "request_model", "response_model",
+	"response_status", "prompt_tokens", "completion_tokens", "total_tokens",
+	"finish_reason", "stream", "user_agent", "duration_ms",
+	"request_body", "response_body",
+}
+
+// csvWriter emits one CSV row per trace. Body columns are empty unless the
+// export was run with --with-body.
+type csvWriter struct {
+	cw *csv.Writer
+}
+
+func (cw *csvWriter) Write(t client.AITrace) error {
+	return cw.cw.Write([]string{
+		t.RequestID, t.Time, t.Workspace, t.EndpointType, t.EndpointName,
+		t.APIKeyID, t.RequestURI, t.RequestModel, t.ResponseModel,
+		strconv.Itoa(t.ResponseStatus),
+		intPtrStr(t.PromptTokens), intPtrStr(t.CompletionTokens), intPtrStr(t.TotalTokens),
+		t.FinishReason, strconv.FormatBool(t.Stream), t.UserAgent, intPtrStr(t.DurationMs),
+		t.RequestBody, t.ResponseBody,
+	})
+}
+
+func (cw *csvWriter) Close() error {
+	cw.cw.Flush()
+	return cw.cw.Error()
+}
+
+// intPtrStr renders a *int as its decimal string, or "" when nil.
+func intPtrStr(p *int) string {
+	if p == nil {
+		return ""
+	}
+
+	return strconv.Itoa(*p)
+}

--- a/cmd/neutree-cli/app/cmd/export/writer_test.go
+++ b/cmd/neutree-cli/app/cmd/export/writer_test.go
@@ -1,0 +1,82 @@
+package export
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+func intPtr(n int) *int { return &n }
+
+func TestJSONLWriter(t *testing.T) {
+	var buf bytes.Buffer
+
+	w, err := newTraceWriter("jsonl", &buf)
+	require.NoError(t, err)
+	require.NoError(t, w.Write(client.AITrace{RequestID: "a"}))
+	require.NoError(t, w.Write(client.AITrace{RequestID: "b"}))
+	require.NoError(t, w.Close())
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+
+	var rec client.AITrace
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &rec))
+	require.Equal(t, "b", rec.RequestID)
+}
+
+func TestJSONArrayWriterEmitsValidArray(t *testing.T) {
+	var buf bytes.Buffer
+
+	w, err := newTraceWriter("json", &buf)
+	require.NoError(t, err)
+	require.NoError(t, w.Write(client.AITrace{RequestID: "a"}))
+	require.NoError(t, w.Write(client.AITrace{RequestID: "b"}))
+	require.NoError(t, w.Close())
+
+	var recs []client.AITrace
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &recs))
+	require.Len(t, recs, 2)
+}
+
+func TestJSONArrayWriterEmptyIsValid(t *testing.T) {
+	var buf bytes.Buffer
+
+	w, err := newTraceWriter("json", &buf)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	var recs []client.AITrace
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &recs))
+	require.Empty(t, recs)
+}
+
+func TestCSVWriterHeaderAndPointerColumns(t *testing.T) {
+	var buf bytes.Buffer
+
+	w, err := newTraceWriter("csv", &buf)
+	require.NoError(t, err)
+	require.NoError(t, w.Write(client.AITrace{
+		RequestID:      "a",
+		ResponseStatus: 200,
+		TotalTokens:    intPtr(42),
+		// PromptTokens left nil -> empty column
+	}))
+	require.NoError(t, w.Close())
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	require.Equal(t, strings.Join(csvHeader, ","), lines[0])
+	require.Contains(t, lines[1], "a,")
+	require.Contains(t, lines[1], ",42,") // total_tokens rendered
+}
+
+func TestUnsupportedFormat(t *testing.T) {
+	_, err := newTraceWriter("xml", &bytes.Buffer{})
+	require.Error(t, err)
+}

--- a/cmd/neutree-cli/app/cmd/global/global.go
+++ b/cmd/neutree-cli/app/cmd/global/global.go
@@ -33,8 +33,10 @@ func ResolveEnv() {
 	}
 }
 
-// NewClient validates global flags and creates a new API client.
-func NewClient() (*client.Client, error) {
+// NewClient validates global flags and creates a new API client. Extra options
+// (e.g. client.WithTimeout for long-running exports) are appended after the
+// defaults, so they take precedence.
+func NewClient(extra ...client.ClientOption) (*client.Client, error) {
 	if ServerURL == "" {
 		return nil, fmt.Errorf("server URL is required: use --server-url or set NEUTREE_SERVER_URL")
 	}
@@ -47,6 +49,8 @@ func NewClient() (*client.Client, error) {
 	if Insecure {
 		opts = append(opts, client.WithInsecureSkipVerify())
 	}
+
+	opts = append(opts, extra...)
 
 	return client.NewClient(ServerURL, opts...), nil
 }

--- a/internal/routes/logs/ai_trace.go
+++ b/internal/routes/logs/ai_trace.go
@@ -53,6 +53,16 @@ const listProjection = "_time, request_id, workspace, endpoint_type, " +
 	"response_status, prompt_tokens, completion_tokens, total_tokens, " +
 	"finish_reason, stream, user_agent, duration_ms"
 
+// stringTrue is the literal a boolean-valued string (a query flag, or a
+// stringified VictoriaLogs field) must equal to be considered on.
+const stringTrue = "true"
+
+// fullProjection extends listProjection with the large request/response body
+// columns. The list endpoint uses it only when the caller passes
+// ?include_body=true — chiefly the CLI export, which fetches bodies inline to
+// avoid an N+1 per-record detail lookup.
+const fullProjection = listProjection + ", request_body, response_body"
+
 // AITraceListResponse is the wire format for GET /api/v1/ai-traces/:workspace.
 //
 // NextBefore is the cursor for the next page: passing it as ?before=<ts> on
@@ -383,10 +393,17 @@ func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
 		}
 
 		// The list view never renders request/response bodies — project them
-		// out so VictoriaLogs returns only the small metadata columns.
+		// out so VictoriaLogs returns only the small metadata columns. Callers
+		// exporting the full record (?include_body=true) opt into the larger
+		// projection so bodies come back inline, avoiding a per-record lookup.
+		projection := listProjection
+		if c.Query("include_body") == stringTrue {
+			projection = fullProjection
+		}
+
 		query := strings.Join(queryParts, " ") +
 			" | sort by (_time) desc | limit " + strconv.Itoa(limit) +
-			" | fields " + listProjection
+			" | fields " + projection
 
 		params := url.Values{}
 
@@ -905,7 +922,7 @@ func decodeVLRecord(line []byte) (AITrace, bool) {
 		RequestModel:  r.RequestModel,
 		ResponseModel: r.ResponseModel,
 		FinishReason:  r.FinishReason,
-		Stream:        r.IsStream == "true",
+		Stream:        r.IsStream == stringTrue,
 		UserAgent:     r.UserAgent,
 		RequestBody:   r.RequestBody,
 		ResponseBody:  r.ResponseBody,

--- a/internal/routes/logs/ai_trace_test.go
+++ b/internal/routes/logs/ai_trace_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -505,6 +506,44 @@ func TestAITraceHandlers_StoreNotConfigured(t *testing.T) {
 		h(c)
 		assert.Equalf(t, http.StatusServiceUnavailable, w.Code, "handler %s", name)
 		assert.Containsf(t, w.Body.String(), "not configured", "handler %s", name)
+	}
+}
+
+func TestHandleListAITraces_IncludeBodyProjection(t *testing.T) {
+	// The list projection omits the large body columns by default and includes
+	// them only when the caller passes ?include_body=true.
+	cases := []struct {
+		name        string
+		rawQuery    string
+		wantInQuery bool
+	}{
+		{"default omits bodies", "", false},
+		{"include_body adds bodies", "include_body=true", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotQuery string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotQuery = r.URL.Query().Get("query")
+				w.Header().Set("Content-Type", "application/x-ndjson")
+			}))
+			defer server.Close()
+
+			deps := &Dependencies{AITraceStoreURL: server.URL, HTTPClient: &util.DefaultHTTPClient{}}
+
+			c, w := traceCtx("user-1", "ws1")
+			c.Request = httptest.NewRequest("GET", "/?"+tc.rawQuery, nil)
+
+			handleListAITraces(deps)(c)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, gotQuery, "| fields ")
+
+			hasBodies := strings.Contains(gotQuery, "request_body, response_body")
+			assert.Equal(t, tc.wantInQuery, hasBodies, "query: %s", gotQuery)
+		})
 	}
 }
 

--- a/pkg/client/ai_trace.go
+++ b/pkg/client/ai_trace.go
@@ -1,0 +1,180 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// TracesService handles communication with the AI trace (access log) endpoints.
+//
+// Access logs are modeled server-side as AI traces, stored in VictoriaLogs and
+// exposed under /api/v1/ai-traces/:workspace. These are custom routes (not
+// PostgREST tables), so they cannot go through GenericService.
+type TracesService struct {
+	client *Client
+}
+
+// NewTracesService creates a new traces service.
+func NewTracesService(client *Client) *TracesService {
+	return &TracesService{client: client}
+}
+
+// AllWorkspaces is the sentinel workspace value that aggregates traces across
+// every workspace the caller may read. Mirrors the server's allWorkspacesSentinel.
+const AllWorkspaces = "_all_"
+
+// MaxTracePageSize is the largest page the list endpoint accepts per request.
+const MaxTracePageSize = 500
+
+// AITrace is one inference trace (access log) record. Mirrors the server-side
+// shape in internal/routes/logs/ai_trace.go. The list endpoint leaves
+// RequestBody/ResponseBody empty; the detail endpoint populates them.
+type AITrace struct {
+	RequestID        string `json:"request_id"`
+	Time             string `json:"time"`
+	Workspace        string `json:"workspace"`
+	EndpointType     string `json:"endpoint_type"`
+	EndpointName     string `json:"endpoint_name"`
+	APIKeyID         string `json:"api_key_id,omitempty"`
+	RequestURI       string `json:"request_uri,omitempty"`
+	RequestModel     string `json:"request_model,omitempty"`
+	ResponseModel    string `json:"response_model,omitempty"`
+	ResponseStatus   int    `json:"response_status"`
+	PromptTokens     *int   `json:"prompt_tokens,omitempty"`
+	CompletionTokens *int   `json:"completion_tokens,omitempty"`
+	TotalTokens      *int   `json:"total_tokens,omitempty"`
+	FinishReason     string `json:"finish_reason,omitempty"`
+	Stream           bool   `json:"stream"`
+	UserAgent        string `json:"user_agent,omitempty"`
+	DurationMs       *int   `json:"duration_ms,omitempty"`
+	RequestBody      string `json:"request_body,omitempty"`
+	ResponseBody     string `json:"response_body,omitempty"`
+}
+
+// TraceListFilters are the optional server-side filters for a list query. Empty
+// fields are omitted from the request.
+type TraceListFilters struct {
+	EndpointName string
+	EndpointType string
+	Status       string
+	APIKeyID     string
+	FinishReason string
+	Model        string
+	Start        string // RFC3339 lower time bound (inclusive)
+	End          string // RFC3339 upper time bound
+}
+
+// aiTraceListResponse is the wire format for GET /api/v1/ai-traces/:workspace.
+type aiTraceListResponse struct {
+	Items      []AITrace `json:"items"`
+	NextBefore string    `json:"next_before"`
+}
+
+// ListPage fetches a single page of traces for the workspace, applying the
+// filters. `before` is the pagination cursor from the previous page's
+// NextBefore (empty for the first page); `limit` is capped at MaxTracePageSize.
+// It returns the page's items and the cursor for the next (older) page, which
+// is empty when the server signals there are no more records.
+//
+// Callers exporting the full history must deduplicate by RequestID across
+// pages: the server's cursor is timestamp-based and inclusive, so the boundary
+// record can repeat on the next page.
+func (s *TracesService) ListPage(workspace string, filters TraceListFilters, before string, limit int) (items []AITrace, nextBefore string, err error) {
+	if workspace == "" {
+		return nil, "", fmt.Errorf("workspace is required")
+	}
+
+	if limit <= 0 || limit > MaxTracePageSize {
+		limit = MaxTracePageSize
+	}
+
+	params := url.Values{}
+	params.Set("limit", strconv.Itoa(limit))
+
+	setIfNotEmpty(params, "endpoint_name", filters.EndpointName)
+	setIfNotEmpty(params, "endpoint_type", filters.EndpointType)
+	setIfNotEmpty(params, "status", filters.Status)
+	setIfNotEmpty(params, "api_key_id", filters.APIKeyID)
+	setIfNotEmpty(params, "finish_reason", filters.FinishReason)
+	setIfNotEmpty(params, "model", filters.Model)
+	setIfNotEmpty(params, "start", filters.Start)
+
+	// `before` (cursor) takes precedence over an explicit End: it is the upper
+	// bound for the next older page.
+	if before != "" {
+		params.Set("before", before)
+	} else {
+		setIfNotEmpty(params, "end", filters.End)
+	}
+
+	reqURL := fmt.Sprintf("%s/api/v1/ai-traces/%s?%s", s.client.baseURL, url.PathEscape(workspace), params.Encode())
+
+	var resp aiTraceListResponse
+	if err := s.getJSON(reqURL, &resp); err != nil {
+		return nil, "", err
+	}
+
+	return resp.Items, resp.NextBefore, nil
+}
+
+// GetDetail fetches a single trace including request/response bodies, looked up
+// by request id within the workspace scope.
+func (s *TracesService) GetDetail(workspace, requestID string) (*AITrace, error) {
+	if workspace == "" {
+		return nil, fmt.Errorf("workspace is required")
+	}
+
+	if requestID == "" {
+		return nil, fmt.Errorf("request id is required")
+	}
+
+	reqURL := fmt.Sprintf("%s/api/v1/ai-traces/%s/%s",
+		s.client.baseURL, url.PathEscape(workspace), url.PathEscape(requestID))
+
+	var trace AITrace
+	if err := s.getJSON(reqURL, &trace); err != nil {
+		return nil, err
+	}
+
+	return &trace, nil
+}
+
+// getJSON performs an authenticated GET and decodes the JSON body into out,
+// translating the common trace-store error statuses into readable messages.
+func (s *TracesService) getJSON(reqURL string, out any) error {
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.client.do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+
+		switch resp.StatusCode {
+		case http.StatusServiceUnavailable:
+			return fmt.Errorf("access log store is not configured on the server (set --ai-trace-store-url)")
+		case http.StatusForbidden:
+			return fmt.Errorf("permission denied: the API key needs endpoint:trace-read or external_endpoint:trace-read")
+		default:
+			return fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		}
+	}
+
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func setIfNotEmpty(params url.Values, key, value string) {
+	if value != "" {
+		params.Set(key, value)
+	}
+}

--- a/pkg/client/ai_trace.go
+++ b/pkg/client/ai_trace.go
@@ -83,7 +83,10 @@ type aiTraceListResponse struct {
 // Callers exporting the full history must deduplicate by RequestID across
 // pages: the server's cursor is timestamp-based and inclusive, so the boundary
 // record can repeat on the next page.
-func (s *TracesService) ListPage(workspace string, filters TraceListFilters, before string, limit int) (items []AITrace, nextBefore string, err error) {
+//
+// When includeBody is true the page carries the full request/response bodies
+// inline (?include_body=true), so exports need no per-record detail lookup.
+func (s *TracesService) ListPage(workspace string, filters TraceListFilters, before string, limit int, includeBody bool) (items []AITrace, nextBefore string, err error) {
 	if workspace == "" {
 		return nil, "", fmt.Errorf("workspace is required")
 	}
@@ -94,6 +97,10 @@ func (s *TracesService) ListPage(workspace string, filters TraceListFilters, bef
 
 	params := url.Values{}
 	params.Set("limit", strconv.Itoa(limit))
+
+	if includeBody {
+		params.Set("include_body", "true")
+	}
 
 	setIfNotEmpty(params, "endpoint_name", filters.EndpointName)
 	setIfNotEmpty(params, "endpoint_type", filters.EndpointType)

--- a/pkg/client/ai_trace_test.go
+++ b/pkg/client/ai_trace_test.go
@@ -23,6 +23,7 @@ func TestTracesListPageBuildsQueryAndParsesResponse(t *testing.T) {
 		// before takes precedence over the filter's End.
 		require.Equal(t, "2026-07-14T00:00:00Z", q.Get("before"))
 		require.Empty(t, q.Get("end"))
+		require.Equal(t, "true", q.Get("include_body"))
 
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(aiTraceListResponse{
@@ -39,7 +40,7 @@ func TestTracesListPageBuildsQueryAndParsesResponse(t *testing.T) {
 		Model:        "qwen",
 		Start:        "2026-07-01T00:00:00Z",
 		End:          "2026-07-10T00:00:00Z", // must be ignored when before is set
-	}, "2026-07-14T00:00:00Z", 100)
+	}, "2026-07-14T00:00:00Z", 100, true)
 
 	require.NoError(t, err)
 	require.Equal(t, "2026-07-13T00:00:00Z", next)
@@ -53,6 +54,7 @@ func TestTracesListPageUsesEndWhenNoCursor(t *testing.T) {
 		require.Empty(t, q.Get("before"))
 		require.Equal(t, "2026-07-10T00:00:00Z", q.Get("end"))
 		require.Equal(t, "500", q.Get("limit")) // limit>max clamps to max
+		require.Empty(t, q.Get("include_body")) // omitted when false
 
 		_ = json.NewEncoder(w).Encode(aiTraceListResponse{})
 	}))
@@ -60,7 +62,7 @@ func TestTracesListPageUsesEndWhenNoCursor(t *testing.T) {
 
 	c := NewClient(server.URL, WithAPIKey("k"))
 
-	_, _, err := c.Traces.ListPage("default", TraceListFilters{End: "2026-07-10T00:00:00Z"}, "", 9999)
+	_, _, err := c.Traces.ListPage("default", TraceListFilters{End: "2026-07-10T00:00:00Z"}, "", 9999, false)
 	require.NoError(t, err)
 }
 
@@ -79,7 +81,7 @@ func TestTracesErrorStatusMapping(t *testing.T) {
 		}))
 
 		c := NewClient(server.URL, WithAPIKey("k"))
-		_, _, err := c.Traces.ListPage("default", TraceListFilters{}, "", 50)
+		_, _, err := c.Traces.ListPage("default", TraceListFilters{}, "", 50, false)
 		require.EqualError(t, err, tc.want)
 
 		server.Close()
@@ -103,6 +105,6 @@ func TestTracesGetDetail(t *testing.T) {
 
 func TestTracesListPageRequiresWorkspace(t *testing.T) {
 	c := NewClient("http://example.com", WithAPIKey("k"))
-	_, _, err := c.Traces.ListPage("", TraceListFilters{}, "", 50)
+	_, _, err := c.Traces.ListPage("", TraceListFilters{}, "", 50, false)
 	require.Error(t, err)
 }

--- a/pkg/client/ai_trace_test.go
+++ b/pkg/client/ai_trace_test.go
@@ -1,0 +1,108 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracesListPageBuildsQueryAndParsesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/ai-traces/default", r.URL.Path)
+		require.Equal(t, "api-key", r.Header.Get("Authorization"))
+
+		q := r.URL.Query()
+		require.Equal(t, "100", q.Get("limit"))
+		require.Equal(t, "my-ep", q.Get("endpoint_name"))
+		require.Equal(t, "qwen", q.Get("model"))
+		require.Equal(t, "2026-07-01T00:00:00Z", q.Get("start"))
+		// before takes precedence over the filter's End.
+		require.Equal(t, "2026-07-14T00:00:00Z", q.Get("before"))
+		require.Empty(t, q.Get("end"))
+
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(aiTraceListResponse{
+			Items:      []AITrace{{RequestID: "a"}, {RequestID: "b"}},
+			NextBefore: "2026-07-13T00:00:00Z",
+		})
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+
+	items, next, err := c.Traces.ListPage("default", TraceListFilters{
+		EndpointName: "my-ep",
+		Model:        "qwen",
+		Start:        "2026-07-01T00:00:00Z",
+		End:          "2026-07-10T00:00:00Z", // must be ignored when before is set
+	}, "2026-07-14T00:00:00Z", 100)
+
+	require.NoError(t, err)
+	require.Equal(t, "2026-07-13T00:00:00Z", next)
+	require.Len(t, items, 2)
+	require.Equal(t, "a", items[0].RequestID)
+}
+
+func TestTracesListPageUsesEndWhenNoCursor(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		require.Empty(t, q.Get("before"))
+		require.Equal(t, "2026-07-10T00:00:00Z", q.Get("end"))
+		require.Equal(t, "500", q.Get("limit")) // limit>max clamps to max
+
+		_ = json.NewEncoder(w).Encode(aiTraceListResponse{})
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("k"))
+
+	_, _, err := c.Traces.ListPage("default", TraceListFilters{End: "2026-07-10T00:00:00Z"}, "", 9999)
+	require.NoError(t, err)
+}
+
+func TestTracesErrorStatusMapping(t *testing.T) {
+	cases := []struct {
+		status int
+		want   string
+	}{
+		{http.StatusServiceUnavailable, "access log store is not configured on the server (set --ai-trace-store-url)"},
+		{http.StatusForbidden, "permission denied: the API key needs endpoint:trace-read or external_endpoint:trace-read"},
+	}
+
+	for _, tc := range cases {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.status)
+		}))
+
+		c := NewClient(server.URL, WithAPIKey("k"))
+		_, _, err := c.Traces.ListPage("default", TraceListFilters{}, "", 50)
+		require.EqualError(t, err, tc.want)
+
+		server.Close()
+	}
+}
+
+func TestTracesGetDetail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/ai-traces/default/req-1", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(AITrace{RequestID: "req-1", RequestBody: "hello", ResponseBody: "world"})
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("k"))
+
+	trace, err := c.Traces.GetDetail("default", "req-1")
+	require.NoError(t, err)
+	require.Equal(t, "hello", trace.RequestBody)
+	require.Equal(t, "world", trace.ResponseBody)
+}
+
+func TestTracesListPageRequiresWorkspace(t *testing.T) {
+	c := NewClient("http://example.com", WithAPIKey("k"))
+	_, _, err := c.Traces.ListPage("", TraceListFilters{}, "", 50)
+	require.Error(t, err)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,6 +19,7 @@ type Client struct {
 	ImageRegistries *ImageRegistriesService
 	ModelRegistries *ModelRegistriesService
 	Generic         *GenericService
+	Traces          *TracesService
 }
 
 // ClientOption is a function that configures a Client
@@ -101,6 +102,7 @@ func NewClient(baseURL string, options ...ClientOption) *Client {
 	client.Engines = NewEnginesService(client)
 	client.ImageRegistries = NewImageRegistriesService(client)
 	client.ModelRegistries = NewModelRegistriesService(client)
+	client.Traces = NewTracesService(client)
 
 	s, err := BuildScheme()
 	if err == nil {


### PR DESCRIPTION
## What

Adds `neutree-cli export access-log` to export AI inference traces (access logs) for a workspace, plus a small backend optimization so full-content exports don't do N+1 requests.

Jira: [NEU-544](http://jira.smartx.com/browse/NEU-544)

## Usage

```
# With bodies (default), JSON Lines to stdout — capped when no --limit is set
neutree-cli export access-log -w default

# Metadata only, time window, CSV file
neutree-cli export access-log -w default --with-body=false \
  --since 2026-07-01 --until 2026-07-14 --format csv -f traces.csv

# Aggregate across all workspaces, filter, pipe
neutree-cli export access-log -A --status 500 | jq -c .

# Everything for one API key over the last week (uncapped)
neutree-cli export access-log -w default --api-key-id <uuid> --since 2026-07-07 --limit 0
```

Flags: `-w/--workspace`, `-A/--all-workspaces` (mutually exclusive with `-w`), `--format` (jsonl/json/csv), `-f/--file`, `--with-body` (default **true**), `--since/--until`, `--limit`, and `--endpoint/--endpoint-type/--model/--status/--api-key-id/--finish-reason` filters.

## Design notes

- **Streaming**: records are written page by page; the full result set is never buffered in memory. jsonl is the default (pipe/stream friendly).
- **stdout vs stderr**: data goes to stdout/`--file`; all progress and diagnostics go to stderr, so redirects and pipes stay clean.
- **`-A` instead of a magic `_all_` value**: "all workspaces" is a boolean flag, so it can never collide with a real workspace name (even one literally named `all`). The CLI translates it to the server's `_all_` sentinel on the wire.
- **Bodies inline, no N+1**: the ai-traces list endpoint gains `?include_body=true`. Bodies already live in VictoriaLogs and were only projected out; opting in returns them in the same paged query. `--with-body` (default on) uses this — one request per page, not one per record.
- **Body-mode limit cap**: a body-carrying export with no explicit `--limit` is capped (default 2000; `--limit 0` lifts it) so a bare command can't pull an unbounded volume of large bodies.
- **Large-volume correctness**: the list cursor is timestamp-based and inclusive, so a boundary record can repeat across pages. The export dedups by `request_id` and detects a non-advancing cursor (stall) to guarantee termination — no duplicates, no infinite loop.

## Changes

- `internal/routes/logs/ai_trace.go`: `?include_body=true` on the list endpoint (switches the LogsQL projection to include body columns)
- `pkg/client/ai_trace.go` (new): `TracesService` — `ListPage` (cursor pagination, `includeBody`) + `GetDetail` + readable 503/403 errors
- `pkg/client/client.go`: mount `Traces`
- `cmd/neutree-cli/app/cmd/export/{export,writer}.go` (new): command + jsonl/json/csv streaming writers
- `cmd/neutree-cli/app/cmd/cmd.go`: register command

## Related follow-up

- [NEU-545](http://jira.smartx.com/browse/NEU-545): surface resource `id` in `get` table output, to make `get apikey -> export --api-key-id` composition ergonomic (decided against an `--api-key-name` flag on export, since api key names are only unique per (workspace, name) and would be ambiguous across workspaces).

## Testing

- Unit tests: client query/cursor/error mapping + `include_body`; three writers; `exportLoop` pagination-dedup, `--limit`, stall termination, inline-body path; backend list `include_body` projection.
- Verified end-to-end against a live neutree control plane: jsonl/csv/json output, time-window and status filters, 1200-record multi-page export (no duplicates), `-A` aggregation, `-w/-A` mutual-exclusivity error, body-mode limit cap, `--with-body=false`. (Live server predates the `include_body` change, so inline-body content is covered by unit tests; CLI and server ship together.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)