### PR TITLE
fix: use node-agent GPU view for K8s resources

### DIFF
--- a/internal/cluster/component/metrics/manifests.go
+++ b/internal/cluster/component/metrics/manifests.go
@@ -16,7 +16,8 @@ const (
 	MinManagedMetricsExporterClusterVersion = "v1.1.0"
 )
 
-var metricsManifestTemplate = `
+const (
+	vmagentRBACMetricsManifestTemplate = `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -103,7 +104,9 @@ roleRef:
   kind: ClusterRole
   name: vmagent-node-reader-{{ .HashSuffix }}
   apiGroup: rbac.authorization.k8s.io
-{{ if .EnableKubeStateMetrics }}
+`
+
+	kubeStateMetricsManifestTemplate = `
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -207,8 +210,9 @@ spec:
             {{- range $key, $value := .KubeStateMetricsResources }}
             {{ $key }}: {{ $value }}
             {{- end }}
-{{ end }}
-{{ if .EnableNeutreeNodeAgentMetrics }}
+`
+
+	neutreeNodeAgentRBACMetricsManifestTemplate = `
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -253,8 +257,9 @@ roleRef:
   kind: ClusterRole
   name: {{ .NeutreeNodeAgentMetricsName }}-{{ .HashSuffix }}
   apiGroup: rbac.authorization.k8s.io
-{{ end }}
-{{ if .EnableNodeExporter }}
+`
+
+	nodeExporterMetricsManifestTemplate = `
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -301,8 +306,9 @@ spec:
       - name: host-root
         hostPath:
           path: /
-{{ end }}
-{{ if .EnableNeutreeNodeAgentMetrics }}
+`
+
+	neutreeNodeAgentDaemonSetMetricsManifestTemplate = `
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -384,7 +390,9 @@ spec:
         hostPath:
           path: /var/lib/kubelet/pod-resources
           type: DirectoryOrCreate
-{{ end }}
+`
+
+	acceleratorExporterMetricsManifestTemplate = `
 {{ range .AcceleratorExporters }}
 {{ if .ConfigFileData }}
 ---
@@ -467,6 +475,9 @@ spec:
 {{ .Volumes | toYaml | indent 6 }}
 {{ end }}
 {{ end }}
+`
+
+	vmagentDeploymentMetricsManifestTemplate = `
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -530,6 +541,7 @@ spec:
         configMap:
           name: vmagent-config
 `
+)
 
 // MetricsManifestVariables holds the variables for rendering metrics manifests
 type MetricsManifestVariables struct {
@@ -556,12 +568,45 @@ type MetricsManifestVariables struct {
 	KubeStateMetricsResources        map[string]string
 	HashSuffix                       string
 	EnableHAMiMonitorScrape          bool
+	EnableVMAgent                    bool
 	EnableKubeStateMetrics           bool
 	EnableNeutreeNodeAgentMetrics    bool
 	EnableNodeExporter               bool
 	EnableExternalDCGMScrape         bool
 	AcceleratorExporters             []metricsAcceleratorExporter
 	VMAgentConfig                    string
+}
+
+func buildMetricsManifestTemplate(variables MetricsManifestVariables) string {
+	var templates []string
+
+	if variables.EnableVMAgent {
+		templates = append(templates,
+			vmagentRBACMetricsManifestTemplate,
+			vmagentDeploymentMetricsManifestTemplate,
+		)
+	}
+
+	if variables.EnableKubeStateMetrics {
+		templates = append(templates, kubeStateMetricsManifestTemplate)
+	}
+
+	if variables.EnableNeutreeNodeAgentMetrics {
+		templates = append(templates,
+			neutreeNodeAgentRBACMetricsManifestTemplate,
+			neutreeNodeAgentDaemonSetMetricsManifestTemplate,
+		)
+	}
+
+	if variables.EnableNodeExporter {
+		templates = append(templates, nodeExporterMetricsManifestTemplate)
+	}
+
+	if len(variables.AcceleratorExporters) > 0 {
+		templates = append(templates, acceleratorExporterMetricsManifestTemplate)
+	}
+
+	return strings.Join(templates, "\n")
 }
 
 // buildManifestVariables creates the data structure for rendering manifests

--- a/internal/cluster/component/metrics/metrics_apply.go
+++ b/internal/cluster/component/metrics/metrics_apply.go
@@ -15,6 +15,7 @@ import (
 // GetMetricsResources returns all Kubernetes resources for the metrics component.
 func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructured.UnstructuredList, error) {
 	variables := m.buildManifestVariables()
+	enableMetricsPipeline := util.IsHTTPOrHTTPSURL(m.metricsRemoteWriteURL)
 
 	enableKubeStateMetrics, err := m.supportsKubeStateMetrics()
 	if err != nil {
@@ -23,8 +24,9 @@ func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructur
 	// HAMi monitor scraping depends on virtualization being enabled. The
 	// kube-state-metrics sidecar is a cluster-version capability and is not
 	// HAMi-specific.
-	variables.EnableHAMiMonitorScrape = m.cluster.Spec.AcceleratorVirtualizationEnabled()
-	variables.EnableKubeStateMetrics = enableKubeStateMetrics
+	variables.EnableVMAgent = enableMetricsPipeline
+	variables.EnableHAMiMonitorScrape = enableMetricsPipeline && m.cluster.Spec.AcceleratorVirtualizationEnabled()
+	variables.EnableKubeStateMetrics = enableMetricsPipeline && enableKubeStateMetrics
 
 	enableManagedMetricsExporters, err := m.supportsManagedMetricsExporters()
 	if err != nil {
@@ -33,7 +35,7 @@ func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructur
 
 	variables.EnableNodeExporter = enableManagedMetricsExporters
 	variables.EnableNeutreeNodeAgentMetrics = enableManagedMetricsExporters
-	variables.EnableExternalDCGMScrape = m.acceleratorExporterMode() == v1.ClusterAcceleratorExporterModeExternal
+	variables.EnableExternalDCGMScrape = enableMetricsPipeline && m.acceleratorExporterMode() == v1.ClusterAcceleratorExporterModeExternal
 
 	acceleratorExporters, err := m.planAcceleratorExporters(ctx)
 	if err != nil {
@@ -43,6 +45,10 @@ func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructur
 	variables.AcceleratorExporters = acceleratorExporters
 	variables.NeutreeNodeAgentMetricsEnv = nodeAgentEnvFromAcceleratorExporters(acceleratorExporters)
 
+	if !variables.EnableVMAgent && !variables.EnableNeutreeNodeAgentMetrics {
+		return &unstructured.UnstructuredList{}, nil
+	}
+
 	vmagentConfig, err := renderKubernetesVMAgentConfig(variables)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to render vmagent config for cluster %s", m.cluster.Metadata.Name)
@@ -50,7 +56,7 @@ func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructur
 
 	variables.VMAgentConfig = vmagentConfig
 
-	objs, err := util.RenderKubernetesManifest(metricsManifestTemplate, variables)
+	objs, err := util.RenderKubernetesManifest(buildMetricsManifestTemplate(variables), variables)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to render metrics manifest for cluster %s", m.cluster.Metadata.Name)
 	}

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/neutree-ai/neutree/internal/accelerator"
 	acceleratormocks "github.com/neutree-ai/neutree/internal/accelerator/mocks"
 	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
+	"github.com/neutree-ai/neutree/internal/util"
 	"github.com/stretchr/testify/mock"
 	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/assert"
@@ -95,9 +96,10 @@ func TestBuildVMAgentDeployment(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -141,9 +143,10 @@ func TestBuildVMAgentConfigIncludesHAMiMonitorScrape(t *testing.T) {
 				},
 			},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -178,9 +181,10 @@ func TestBuildVMAgentConfigNormalizesSGLangMetricNames(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -225,9 +229,10 @@ func TestBuildMetricsResourcesSkipsKubeStateMetricsBeforeV110(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.0.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -258,9 +263,10 @@ func TestBuildVMAgentConfigSkipsHAMiMonitorScrapeWhenAcceleratorVirtualizationDi
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -293,9 +299,10 @@ func TestBuildVMAgentConfigIncludesHAMiMonitorScrapeBeforeV110WhenAcceleratorVir
 				},
 			},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -324,9 +331,10 @@ func TestBuildMetricsResourcesIncludesKubeStateMetrics(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -385,9 +393,10 @@ func TestBuildMetricsResourcesIncludesNodeExporterDaemonSet(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -428,9 +437,10 @@ func TestBuildMetricsResourcesIncludesNodeAgentDaemonSet(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v9.9.9"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -471,8 +481,285 @@ func TestBuildMetricsResourcesIncludesNodeAgentDaemonSet(t *testing.T) {
 	assert.Assert(t, strings.Contains(vmagentConfig, "replacement: $1:19101"))
 }
 
-func TestBuildMetricsResourcesDoesNotSupportManagedExportersBeforeV110(t *testing.T) {
+func TestBuildMetricsResourcesDefaultsToNodeAgentWithoutRemoteWrite(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	metricsCmpt := &MetricsComponent{
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{
+				Name:      "test-cluster",
+				Workspace: "test-workspace",
+			},
+			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
+		},
+		namespace:       "test-namespace",
+		imagePrefix:     "test-image-prefix",
+		imagePullSecret: "test-image-pull-secret",
+		acceleratorMgr:  accelerator.NewManager(gin.New()),
+		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
+			"nvidia.com/gpu.present": "true",
+		})).Build(),
+	}
+
+	objs, err := metricsCmpt.GetMetricsResources(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to build metrics resources: %v", err)
+	}
+
+	findMetricsDaemonSet(t, objs, "neutree-node-agent")
+	findMetricsDaemonSet(t, objs, "neutree-node-exporter")
+	findMetricsDaemonSet(t, objs, "nvidia-gpu-dcgm-exporter")
+	for _, obj := range objs.Items {
+		assert.Assert(t, !(obj.GetKind() == "Deployment" && obj.GetName() == "vmagent"))
+		assert.Assert(t, !(obj.GetKind() == "ConfigMap" && obj.GetName() == "vmagent-config"))
+		assert.Assert(t, !(obj.GetKind() == "Deployment" && obj.GetName() == "neutree-kube-state-metrics"))
+	}
+}
+
+func TestBuildMetricsResourcesSelectsSubComponentManifests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name                  string
+		clusterVersion        string
+		metricsRemoteWriteURL string
+		ctrlClient            client.Client
+		wantObjects           []metricsObjectRef
+		forbiddenObjects      []metricsObjectRef
+	}{
+		{
+			name:           "local metrics mode renders node-agent node-exporter and accelerator-exporter",
+			clusterVersion: "v1.1.0",
+			ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
+				"nvidia.com/gpu.present": "true",
+			})).Build(),
+			wantObjects: []metricsObjectRef{
+				{kind: "ServiceAccount", name: "neutree-node-agent"},
+				{kind: "DaemonSet", name: "neutree-node-agent"},
+				{kind: "DaemonSet", name: "neutree-node-exporter"},
+				{kind: "DaemonSet", name: "nvidia-gpu-dcgm-exporter"},
+			},
+			forbiddenObjects: []metricsObjectRef{
+				{kind: "Deployment", name: "vmagent"},
+				{kind: "ConfigMap", name: "vmagent-config"},
+				{kind: "Deployment", name: "neutree-kube-state-metrics"},
+			},
+		},
+		{
+			name:                  "full pipeline renders all managed subcomponents",
+			clusterVersion:        "v1.1.0",
+			metricsRemoteWriteURL: "http://example.com/write",
+			ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
+				"nvidia.com/gpu.present": "true",
+			})).Build(),
+			wantObjects: []metricsObjectRef{
+				{kind: "ConfigMap", name: "vmagent-config"},
+				{kind: "Deployment", name: "vmagent"},
+				{kind: "Deployment", name: "neutree-kube-state-metrics"},
+				{kind: "DaemonSet", name: "neutree-node-exporter"},
+				{kind: "DaemonSet", name: "neutree-node-agent"},
+				{kind: "DaemonSet", name: "nvidia-gpu-dcgm-exporter"},
+			},
+		},
+		{
+			name:                  "old version full pipeline skips managed subcomponents",
+			clusterVersion:        "v1.0.0",
+			metricsRemoteWriteURL: "http://example.com/write",
+			ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
+				"nvidia.com/gpu.present": "true",
+			})).Build(),
+			wantObjects: []metricsObjectRef{
+				{kind: "ConfigMap", name: "vmagent-config"},
+				{kind: "Deployment", name: "vmagent"},
+			},
+			forbiddenObjects: []metricsObjectRef{
+				{kind: "Deployment", name: "neutree-kube-state-metrics"},
+				{kind: "DaemonSet", name: "neutree-node-exporter"},
+				{kind: "DaemonSet", name: "neutree-node-agent"},
+				{kind: "DaemonSet", name: "nvidia-gpu-dcgm-exporter"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrlClient := tc.ctrlClient
+			if ctrlClient == nil {
+				ctrlClient = fake.NewClientBuilder().Build()
+			}
+
+			metricsCmpt := &MetricsComponent{
+				cluster: &v1.Cluster{
+					Metadata: &v1.Metadata{
+						Name:      "test-cluster",
+						Workspace: "test-workspace",
+					},
+					Spec: &v1.ClusterSpec{Version: tc.clusterVersion},
+				},
+				namespace:             "test-namespace",
+				imagePrefix:           "test-image-prefix",
+				imagePullSecret:       "test-image-pull-secret",
+				metricsRemoteWriteURL: tc.metricsRemoteWriteURL,
+				acceleratorMgr:        accelerator.NewManager(gin.New()),
+				ctrlClient:            ctrlClient,
+			}
+
+			objs, err := metricsCmpt.GetMetricsResources(context.Background())
+			assert.NilError(t, err)
+
+			for _, want := range tc.wantObjects {
+				assert.Assert(t, hasMetricsObject(objs, want.kind, want.name), "missing %s/%s", want.kind, want.name)
+			}
+
+			for _, forbidden := range tc.forbiddenObjects {
+				assert.Assert(t, !hasMetricsObject(objs, forbidden.kind, forbidden.name), "unexpected %s/%s", forbidden.kind, forbidden.name)
+			}
+		})
+	}
+}
+
+func TestBuildMetricsManifestTemplateRendersLegacyFullPipelineObjects(t *testing.T) {
+	variables := metricsManifestTestVariables()
+	variables.EnableVMAgent = true
+	variables.EnableKubeStateMetrics = true
+	variables.EnableNeutreeNodeAgentMetrics = true
+	variables.EnableNodeExporter = true
+	variables.VMAgentConfig = "global:\n  scrape_interval: 15s\n"
+	variables.AcceleratorExporters = []metricsAcceleratorExporter{
+		{
+			Name:            "nvidia-gpu-dcgm-exporter",
+			AcceleratorType: string(v1.AcceleratorTypeNVIDIAGPU),
+			ExporterName:    "dcgm-exporter",
+			Image:           "test-image-prefix/nvidia/dcgm-exporter:latest",
+			Port:            9400,
+			MetricsPath:     "/metrics",
+			ConfigFileData: map[string]string{
+				"dcgm-exporter.csv": "DCGM_FI_DEV_GPU_TEMP,gauge,temperature",
+			},
+		},
+	}
+
+	objs, err := util.RenderKubernetesManifest(buildMetricsManifestTemplate(variables), variables)
+	assert.NilError(t, err)
+
+	hashSuffix := variables.HashSuffix
+	assert.DeepEqual(t, metricsObjectRefStrings(objs), []string{
+		"ConfigMap/vmagent-config",
+		"ServiceAccount/vmagent-service-account",
+		"Role/vmagent-pod-reader",
+		"RoleBinding/vmagent-rolebinding",
+		"ClusterRole/vmagent-node-reader-" + hashSuffix,
+		"ClusterRoleBinding/vmagent-node-reader-" + hashSuffix,
+		"Deployment/vmagent",
+		"ServiceAccount/neutree-kube-state-metrics",
+		"Role/neutree-kube-state-metrics",
+		"RoleBinding/neutree-kube-state-metrics",
+		"Service/neutree-kube-state-metrics",
+		"Deployment/neutree-kube-state-metrics",
+		"ServiceAccount/neutree-node-agent",
+		"ClusterRole/neutree-node-agent-" + hashSuffix,
+		"ClusterRoleBinding/neutree-node-agent-" + hashSuffix,
+		"DaemonSet/neutree-node-agent",
+		"DaemonSet/neutree-node-exporter",
+		"ConfigMap/nvidia-gpu-dcgm-exporter-config",
+		"DaemonSet/nvidia-gpu-dcgm-exporter",
+	})
+}
+
+func TestBuildMetricsManifestTemplateFiltersSubComponentManifests(t *testing.T) {
+	cases := []struct {
+		name      string
+		variables MetricsManifestVariables
+		want      []string
+	}{
+		{
+			name: "remote write disabled renders local metrics components without vmagent pipeline",
+			variables: func() MetricsManifestVariables {
+				variables := metricsManifestTestVariables()
+				variables.EnableNeutreeNodeAgentMetrics = true
+				variables.EnableNodeExporter = true
+				variables.AcceleratorExporters = []metricsAcceleratorExporter{
+					{
+						Name:            "nvidia-gpu-dcgm-exporter",
+						AcceleratorType: string(v1.AcceleratorTypeNVIDIAGPU),
+						ExporterName:    "dcgm-exporter",
+						Image:           "test-image-prefix/nvidia/dcgm-exporter:latest",
+						Port:            9400,
+						MetricsPath:     "/metrics",
+					},
+				}
+				return variables
+			}(),
+			want: []string{
+				"ServiceAccount/neutree-node-agent",
+				"ClusterRole/neutree-node-agent-{{hash}}",
+				"ClusterRoleBinding/neutree-node-agent-{{hash}}",
+				"DaemonSet/neutree-node-agent",
+				"DaemonSet/neutree-node-exporter",
+				"DaemonSet/nvidia-gpu-dcgm-exporter",
+			},
+		},
+		{
+			name: "remote pipeline without managed exporters renders vmagent only",
+			variables: func() MetricsManifestVariables {
+				variables := metricsManifestTestVariables()
+				variables.EnableVMAgent = true
+				variables.VMAgentConfig = "global:\n  scrape_interval: 15s\n"
+				return variables
+			}(),
+			want: []string{
+				"ConfigMap/vmagent-config",
+				"ServiceAccount/vmagent-service-account",
+				"Role/vmagent-pod-reader",
+				"RoleBinding/vmagent-rolebinding",
+				"ClusterRole/vmagent-node-reader-{{hash}}",
+				"ClusterRoleBinding/vmagent-node-reader-{{hash}}",
+				"Deployment/vmagent",
+			},
+		},
+		{
+			name: "remote pipeline without accelerator exporters omits exporter manifests",
+			variables: func() MetricsManifestVariables {
+				variables := metricsManifestTestVariables()
+				variables.EnableVMAgent = true
+				variables.EnableKubeStateMetrics = true
+				variables.EnableNeutreeNodeAgentMetrics = true
+				variables.EnableNodeExporter = true
+				variables.VMAgentConfig = "global:\n  scrape_interval: 15s\n"
+				return variables
+			}(),
+			want: []string{
+				"ConfigMap/vmagent-config",
+				"ServiceAccount/vmagent-service-account",
+				"Role/vmagent-pod-reader",
+				"RoleBinding/vmagent-rolebinding",
+				"ClusterRole/vmagent-node-reader-{{hash}}",
+				"ClusterRoleBinding/vmagent-node-reader-{{hash}}",
+				"Deployment/vmagent",
+				"ServiceAccount/neutree-kube-state-metrics",
+				"Role/neutree-kube-state-metrics",
+				"RoleBinding/neutree-kube-state-metrics",
+				"Service/neutree-kube-state-metrics",
+				"Deployment/neutree-kube-state-metrics",
+				"ServiceAccount/neutree-node-agent",
+				"ClusterRole/neutree-node-agent-{{hash}}",
+				"ClusterRoleBinding/neutree-node-agent-{{hash}}",
+				"DaemonSet/neutree-node-agent",
+				"DaemonSet/neutree-node-exporter",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs, err := util.RenderKubernetesManifest(buildMetricsManifestTemplate(tc.variables), tc.variables)
+			assert.NilError(t, err)
+
+			assert.DeepEqual(t, metricsObjectRefStrings(objs), expandMetricsObjectRefHashes(tc.want, tc.variables.HashSuffix))
+		})
+	}
+}
+
+func TestBuildMetricsResourcesSkipsAllResourcesWhenUnsupportedWithoutRemoteWrite(t *testing.T) {
 	metricsCmpt := &MetricsComponent{
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{
@@ -484,7 +771,31 @@ func TestBuildMetricsResourcesDoesNotSupportManagedExportersBeforeV110(t *testin
 		namespace:       "test-namespace",
 		imagePrefix:     "test-image-prefix",
 		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  accelerator.NewManager(gin.New()),
+	}
+
+	objs, err := metricsCmpt.GetMetricsResources(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to build metrics resources: %v", err)
+	}
+
+	assert.Equal(t, len(objs.Items), 0)
+}
+
+func TestBuildMetricsResourcesDoesNotSupportManagedExportersBeforeV110(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	metricsCmpt := &MetricsComponent{
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{
+				Name:      "test-cluster",
+				Workspace: "test-workspace",
+			},
+			Spec: &v1.ClusterSpec{Version: "v1.0.0"},
+		},
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
 			"nvidia.com/gpu.present": "true",
 		})).Build(),
@@ -528,10 +839,11 @@ func TestBuildMetricsResourcesUsesExternalDCGMScrapeWhenConfigured(t *testing.T)
 				},
 			},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  accelerator.NewManager(gin.New()),
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
 			"nvidia.com/gpu.present": "true",
 		})).Build(),
@@ -589,9 +901,10 @@ func TestBuildMetricsResourcesDoesNotGrantNodeAgentExternalNodeExporterAccess(t 
 				},
 			},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -648,10 +961,11 @@ func TestBuildMetricsResourcesIncludesAcceleratorExporterFromPluginProfile(t *te
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  accelerator.NewManager(gin.New()),
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
 			"nvidia.com/gpu.present": "true",
 		})).Build(),
@@ -767,10 +1081,11 @@ func TestBuildMetricsResourcesSkipsAcceleratorExporterChecksumForRuntimeConfigFi
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  acceleratorMgr,
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        acceleratorMgr,
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("custom-node", map[string]string{
 			"accelerator.example.com/custom": "true",
 		})).Build(),
@@ -814,10 +1129,11 @@ func TestBuildMetricsResourcesProjectsDuplicateAcceleratorExporterConfigBasename
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  acceleratorMgr,
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        acceleratorMgr,
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("custom-node", map[string]string{
 			"accelerator.example.com/custom": "true",
 		})).Build(),
@@ -874,10 +1190,11 @@ func TestBuildMetricsResourcesDoesNotParseDockerRunOptions(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  acceleratorMgr,
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        acceleratorMgr,
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("custom-node", map[string]string{
 			"accelerator.example.com/custom": "true",
 		})).Build(),
@@ -921,10 +1238,11 @@ func TestBuildMetricsResourcesSkipsAcceleratorExporterWithoutMatchingNode(t *tes
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  acceleratorMgr,
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        acceleratorMgr,
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("cpu-node", map[string]string{
 			"kubernetes.io/os": "linux",
 		})).Build(),
@@ -965,10 +1283,11 @@ func TestBuildMetricsResourcesSkipsAcceleratorExporterWithoutName(t *testing.T) 
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  acceleratorMgr,
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        acceleratorMgr,
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -1009,10 +1328,11 @@ func TestBuildMetricsResourcesSkipsAcceleratorExporterProfileErrors(t *testing.T
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  acceleratorMgr,
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        acceleratorMgr,
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("custom-node", map[string]string{
 			"accelerator.example.com/custom": "true",
 		})).Build(),
@@ -1066,10 +1386,11 @@ func TestBuildMetricsResourcesIncludesMultipleMatchingAcceleratorExporters(t *te
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  acceleratorMgr,
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        acceleratorMgr,
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("accelerator-node", map[string]string{
 			"accelerator.example.com/enabled": "true",
 		})).Build(),
@@ -1093,9 +1414,10 @@ func TestBuildMetricsResourcesSkipsAcceleratorExporterWithoutProvider(t *testing
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -1118,9 +1440,10 @@ func TestBuildVMAgentConfigIncludesKubeStateMetricsScrape(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -1169,6 +1492,55 @@ func envValue(env []corev1.EnvVar, name string) string {
 	}
 
 	return ""
+}
+
+type metricsObjectRef struct {
+	kind string
+	name string
+}
+
+func hasMetricsObject(objs *unstructured.UnstructuredList, kind, name string) bool {
+	for _, obj := range objs.Items {
+		if obj.GetKind() == kind && obj.GetName() == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func metricsObjectRefStrings(objs *unstructured.UnstructuredList) []string {
+	refs := make([]string, 0, len(objs.Items))
+	for _, obj := range objs.Items {
+		refs = append(refs, obj.GetKind()+"/"+obj.GetName())
+	}
+
+	return refs
+}
+
+func expandMetricsObjectRefHashes(refs []string, hashSuffix string) []string {
+	expanded := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		expanded = append(expanded, strings.ReplaceAll(ref, "{{hash}}", hashSuffix))
+	}
+
+	return expanded
+}
+
+func metricsManifestTestVariables() MetricsManifestVariables {
+	return (&MetricsComponent{
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{
+				Name:      "test-cluster",
+				Workspace: "test-workspace",
+			},
+			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
+		},
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "http://example.com/write",
+	}).buildManifestVariables()
 }
 
 func findMetricsDaemonSet(t *testing.T, objs *unstructured.UnstructuredList, name string) *appsv1.DaemonSet {

--- a/internal/cluster/component/metrics/metrics_status.go
+++ b/internal/cluster/component/metrics/metrics_status.go
@@ -14,6 +14,7 @@ import (
 
 // MetricsStatus represents the status of metrics component resources
 type MetricsStatus struct {
+	DeploymentRequired                    bool
 	DeploymentReady                       bool
 	NodeExporterRequired                  bool
 	NodeExporterDaemonSetReady            bool
@@ -39,13 +40,13 @@ type MetricsStatus struct {
 
 func (m MetricsStatus) String() string {
 	base := fmt.Sprintf(
-		"DeploymentReady: %v, PodsReady: %d/%d, NodeExporterDaemonSetReady: %v, "+
+		"DeploymentRequired: %v, DeploymentReady: %v, PodsReady: %d/%d, NodeExporterDaemonSetReady: %v, "+
 			"NodeExporterRequired: %v, NodeExporterPodsReady: %d/%d, NeutreeNodeAgentMetricsRequired: %v, "+
 			"NeutreeNodeAgentMetricsDaemonSetReady: %v, NeutreeNodeAgentMetricsPodsReady: %d/%d, KubeStateMetricsRequired: %v, "+
 			"KubeStateMetricsDeploymentReady: %v, KubeStateMetricsPodsReady: %d/%d, "+
 			"AcceleratorExporterRequired: %v, AcceleratorExporterDaemonSetsReady: %v, "+
 			"AcceleratorExporterPodsReady: %d/%d, Errors: %v",
-		m.DeploymentReady, m.PodsReady, m.TotalPods,
+		m.DeploymentRequired, m.DeploymentReady, m.PodsReady, m.TotalPods,
 		m.NodeExporterDaemonSetReady, m.NodeExporterRequired, m.NodeExporterPodsReady, m.NodeExporterTotalPods,
 		m.NeutreeNodeAgentMetricsRequired, m.NeutreeNodeAgentMetricsDaemonSetReady,
 		m.NeutreeNodeAgentMetricsPodsReady, m.NeutreeNodeAgentMetricsTotalPods,
@@ -63,7 +64,7 @@ func (m MetricsStatus) Ready() bool {
 		return false
 	}
 
-	return m.DeploymentReady &&
+	return (!m.DeploymentRequired || m.DeploymentReady) &&
 		(!m.NodeExporterRequired || m.NodeExporterDaemonSetReady) &&
 		(!m.NeutreeNodeAgentMetricsRequired || m.NeutreeNodeAgentMetricsDaemonSetReady) &&
 		(!m.KubeStateMetricsRequired || m.KubeStateMetricsDeploymentReady) &&
@@ -73,21 +74,23 @@ func (m MetricsStatus) Ready() bool {
 // CheckResourcesStatus checks the status of all metrics resources
 func (m *MetricsComponent) CheckResourcesStatus(ctx context.Context) (*MetricsStatus, error) {
 	status := &MetricsStatus{
-		Errors: []string{},
+		DeploymentRequired: util.IsHTTPOrHTTPSURL(m.metricsRemoteWriteURL),
+		Errors:             []string{},
 	}
 
-	// Check Deployment status
-	deploymentReady, podsReady, totalPods, err := m.checkDeploymentStatus(ctx)
-	if err != nil {
-		status.Errors = append(status.Errors, fmt.Sprintf("deployment check failed: %v", err))
-		status.Diagnostics = append(status.Diagnostics, component.DeploymentDiagnostics(ctx, m.ctrlClient, m.namespace, "vmagent", m.metricsPodLabels())...)
-	} else {
-		status.DeploymentReady = deploymentReady
-		status.PodsReady = podsReady
-		status.TotalPods = totalPods
-
-		if !deploymentReady {
+	if status.DeploymentRequired {
+		deploymentReady, podsReady, totalPods, err := m.checkDeploymentStatus(ctx)
+		if err != nil {
+			status.Errors = append(status.Errors, fmt.Sprintf("deployment check failed: %v", err))
 			status.Diagnostics = append(status.Diagnostics, component.DeploymentDiagnostics(ctx, m.ctrlClient, m.namespace, "vmagent", m.metricsPodLabels())...)
+		} else {
+			status.DeploymentReady = deploymentReady
+			status.PodsReady = podsReady
+			status.TotalPods = totalPods
+
+			if !deploymentReady {
+				status.Diagnostics = append(status.Diagnostics, component.DeploymentDiagnostics(ctx, m.ctrlClient, m.namespace, "vmagent", m.metricsPodLabels())...)
+			}
 		}
 	}
 
@@ -100,7 +103,7 @@ func (m *MetricsComponent) CheckResourcesStatus(ctx context.Context) (*MetricsSt
 	status.NodeExporterRequired = nodeExporterRequired
 	status.NeutreeNodeAgentMetricsRequired = nodeExporterRequired
 
-	if nodeExporterRequired {
+	if status.NodeExporterRequired {
 		nodeExporterReady, nodeExporterPodsReady, nodeExporterTotalPods, err := m.checkDaemonSetStatus(ctx, nodeExporterDaemonSetName)
 		if err != nil {
 			status.Errors = append(status.Errors, fmt.Sprintf("node-exporter daemonset check failed: %v", err))
@@ -109,7 +112,9 @@ func (m *MetricsComponent) CheckResourcesStatus(ctx context.Context) (*MetricsSt
 			status.NodeExporterPodsReady = nodeExporterPodsReady
 			status.NodeExporterTotalPods = nodeExporterTotalPods
 		}
+	}
 
+	if status.NeutreeNodeAgentMetricsRequired {
 		neutreeNodeAgentMetricsReady, neutreeNodeAgentMetricsPodsReady, neutreeNodeAgentMetricsTotalPods, err := m.checkDaemonSetStatus(ctx, neutreeNodeAgentMetricsName)
 		if err != nil {
 			status.Errors = append(status.Errors, fmt.Sprintf("%s daemonset check failed: %v", neutreeNodeAgentMetricsName, err))
@@ -152,9 +157,9 @@ func (m *MetricsComponent) CheckResourcesStatus(ctx context.Context) (*MetricsSt
 		return status, nil
 	}
 
-	status.KubeStateMetricsRequired = kubeStateMetricsRequired
+	status.KubeStateMetricsRequired = status.DeploymentRequired && kubeStateMetricsRequired
 
-	if kubeStateMetricsRequired {
+	if status.KubeStateMetricsRequired {
 		kubeStateMetricsReady, kubeStateMetricsPodsReady, kubeStateMetricsTotalPods, err := m.checkKubeStateMetricsDeploymentStatus(ctx)
 		kubeStateMetricsDiagnostics := func() []string {
 			return component.DeploymentDiagnostics(ctx, m.ctrlClient, m.namespace, "neutree-kube-state-metrics", m.kubeStateMetricsPodLabels())

--- a/internal/cluster/component/metrics/metrics_status_test.go
+++ b/internal/cluster/component/metrics/metrics_status_test.go
@@ -155,8 +155,9 @@ func Test_checkDeploymentStatus(t *testing.T) {
 				Build()
 
 			metricsCmpt := &MetricsComponent{
-				ctrlClient: fakeClient,
-				namespace:  "default",
+				ctrlClient:            fakeClient,
+				namespace:             "default",
+				metricsRemoteWriteURL: "http://example.com/write",
 				cluster: &v1.Cluster{
 					Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
 					Spec:     &v1.ClusterSpec{},
@@ -185,8 +186,9 @@ func TestCheckResourcesStatusIncludesKubeStateMetrics(t *testing.T) {
 		Build()
 
 	metricsCmpt := &MetricsComponent{
-		ctrlClient: fakeClient,
-		namespace:  "default",
+		ctrlClient:            fakeClient,
+		namespace:             "default",
+		metricsRemoteWriteURL: "http://example.com/write",
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
 			Spec:     &v1.ClusterSpec{Version: "v1.1.0"},
@@ -216,8 +218,9 @@ func TestCheckResourcesStatusSkipsKubeStateMetricsBeforeV110(t *testing.T) {
 		Build()
 
 	metricsCmpt := &MetricsComponent{
-		ctrlClient: fakeClient,
-		namespace:  "default",
+		ctrlClient:            fakeClient,
+		namespace:             "default",
+		metricsRemoteWriteURL: "http://example.com/write",
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
 			Spec:     &v1.ClusterSpec{Version: "v1.0.0"},
@@ -233,6 +236,49 @@ func TestCheckResourcesStatusSkipsKubeStateMetricsBeforeV110(t *testing.T) {
 	assert.False(t, status.KubeStateMetricsDeploymentReady)
 	assert.False(t, status.NodeExporterRequired)
 	assert.False(t, status.NodeExporterDaemonSetReady)
+}
+
+func TestCheckResourcesStatusRequiresLocalMetricsComponentsWithoutRemoteWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(
+			readyMetricsDaemonSet("neutree-node-agent", 1),
+			readyMetricsDaemonSet("neutree-node-exporter", 1),
+			readyMetricsDaemonSet("nvidia-gpu-dcgm-exporter", 1),
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu-node",
+					Labels: map[string]string{
+						"nvidia.com/gpu.present": "true",
+					},
+				},
+			},
+		).
+		Build()
+
+	metricsCmpt := &MetricsComponent{
+		ctrlClient:     fakeClient,
+		namespace:      "default",
+		acceleratorMgr: accelerator.NewManager(gin.New()),
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
+			Spec:     &v1.ClusterSpec{Version: "v1.1.0"},
+		},
+	}
+
+	status, err := metricsCmpt.CheckResourcesStatus(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, status.Ready())
+	assert.False(t, status.DeploymentRequired)
+	assert.False(t, status.DeploymentReady)
+	assert.True(t, status.NodeExporterRequired)
+	assert.True(t, status.NodeExporterDaemonSetReady)
+	assert.True(t, status.NeutreeNodeAgentMetricsRequired)
+	assert.True(t, status.NeutreeNodeAgentMetricsDaemonSetReady)
+	assert.False(t, status.KubeStateMetricsRequired)
+	assert.True(t, status.AcceleratorExporterRequired)
+	assert.True(t, status.AcceleratorExporterDaemonSetsReady)
 }
 
 func TestCheckResourcesStatusIncludesAcceleratorExporterDaemonSet(t *testing.T) {
@@ -256,9 +302,10 @@ func TestCheckResourcesStatusIncludesAcceleratorExporterDaemonSet(t *testing.T) 
 		Build()
 
 	metricsCmpt := &MetricsComponent{
-		ctrlClient:     fakeClient,
-		namespace:      "default",
-		acceleratorMgr: accelerator.NewManager(gin.New()),
+		ctrlClient:            fakeClient,
+		namespace:             "default",
+		metricsRemoteWriteURL: "http://example.com/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
 			Spec:     &v1.ClusterSpec{Version: "v1.1.0"},

--- a/internal/cluster/kubernetes_cluster.go
+++ b/internal/cluster/kubernetes_cluster.go
@@ -209,15 +209,10 @@ func (c *NativeKubernetesClusterReconciler) ComputeAdditionalComponents(reconcil
 	reconcileComps := []component.Component{}
 	reconcileDeleteComps := []component.Component{}
 
-	// Only install metrics component when metrics remote write url is valid.
 	metricsComp := metrics.NewMetricsComponent(reconcileCtx.Cluster,
 		reconcileCtx.clusterNamespace, imagePrefix, ImagePullSecretName,
 		c.metricsRemoteWriteURL, *reconcileCtx.kubernetesClusterConfig, reconcileCtx.ctrClient, c.acceleratorMgr)
-	if util.IsHTTPOrHTTPSURL(c.metricsRemoteWriteURL) {
-		reconcileComps = append(reconcileComps, metricsComp)
-	} else {
-		reconcileDeleteComps = append(reconcileDeleteComps, metricsComp)
-	}
+	reconcileComps = append(reconcileComps, metricsComp)
 
 	hamiComp := hami.NewHAMiComponent(reconcileCtx.Cluster,
 		reconcileCtx.clusterNamespace, imagePrefix, ImagePullSecretName,

--- a/internal/cluster/kubernetes_cluster_test.go
+++ b/internal/cluster/kubernetes_cluster_test.go
@@ -589,14 +589,14 @@ func TestComputeAdditionalComponents_Metrics(t *testing.T) {
 		{
 			name:                   "URL without HTTP/HTTPS scheme for metrics",
 			metricsRemoteWriteURL:  "invalid-url",
-			expectedReconcileCount: 0,
-			expectedDeleteCount:    2,
+			expectedReconcileCount: 1,
+			expectedDeleteCount:    1,
 		},
 		{
 			name:                   "Empty URL for metrics",
 			metricsRemoteWriteURL:  "",
-			expectedReconcileCount: 0,
-			expectedDeleteCount:    2,
+			expectedReconcileCount: 1,
+			expectedDeleteCount:    1,
 		},
 	}
 
@@ -636,11 +636,11 @@ func TestComputeAdditionalComponents_HAMi(t *testing.T) {
 
 	reconcileComps, deleteComps := reconciler.ComputeAdditionalComponents(reconcileCtx, "test-prefix/")
 
-	if len(reconcileComps) != 1 {
-		t.Fatalf("expected accelerator virtualization component to be reconciled, got %d components", len(reconcileComps))
+	if len(reconcileComps) != 2 {
+		t.Fatalf("expected metrics and accelerator virtualization components to be reconciled, got %d components", len(reconcileComps))
 	}
-	if len(deleteComps) != 1 {
-		t.Fatalf("expected metrics component to be deleted when metrics URL is empty, got %d components", len(deleteComps))
+	if len(deleteComps) != 0 {
+		t.Fatalf("expected no components to be deleted when virtualization needs node-agent annotations, got %d components", len(deleteComps))
 	}
 }
 

--- a/internal/cluster/staticcluster/metrics_components.go
+++ b/internal/cluster/staticcluster/metrics_components.go
@@ -85,10 +85,6 @@ func buildMetricsComponents(
 	profile *v1.AcceleratorProfile,
 	metricsRemoteWriteURL string,
 ) []v1.NodeComponentSpec {
-	if !util.IsHTTPOrHTTPSURL(metricsRemoteWriteURL) {
-		return nil
-	}
-
 	components := []v1.NodeComponentSpec{buildNodeExporterComponent(cluster)}
 
 	if acceleratorExporterMode(cluster) == v1.ClusterAcceleratorExporterModeManaged {
@@ -99,7 +95,7 @@ func buildMetricsComponents(
 
 	components = append(components, buildNodeAgentComponent(cluster, node, profile))
 
-	if role == v1.StaticNodeRoleHead {
+	if role == v1.StaticNodeRoleHead && util.IsHTTPOrHTTPSURL(metricsRemoteWriteURL) {
 		components = append(components, buildVMAgentComponent(cluster, metricsRemoteWriteURL))
 	}
 

--- a/internal/cluster/staticcluster/planner_test.go
+++ b/internal/cluster/staticcluster/planner_test.go
@@ -381,6 +381,71 @@ func TestPlannerIncludesMetricsComponentsForStaticFlowVersion(t *testing.T) {
 	assert.NotNil(t, findConfigFile(vmagentComponent.ConfigFiles, vmagentNodeExporterFileSDPath))
 }
 
+func TestPlannerKeepsStaticNodeAgentAndNodeExporterWhenAcceleratorExporterMissing(t *testing.T) {
+	cluster := testStaticNodeCluster()
+	currentNodes := []*v1.StaticNode{
+		staticNodeStatusWithAccelerator(
+			"head-0",
+			v1.StaticNodeRoleHead,
+			v1.StaticNodePhaseReady,
+			true,
+			nvidiaAcceleratorStatus(),
+			nil,
+		),
+		staticNodeStatusWithAccelerator(
+			"worker-0",
+			v1.StaticNodeRoleWorker,
+			v1.StaticNodePhaseReady,
+			true,
+			cpuAcceleratorStatus(),
+			nil,
+		),
+	}
+
+	nodes := plannedStaticNodes(t, &Planner{
+		AcceleratorProfileProvider: fakeAcceleratorProfileProvider{
+			profiles: map[string]*v1.AcceleratorProfile{
+				v1.AcceleratorTypeNVIDIAGPU.String(): {
+					AcceleratorType: v1.AcceleratorTypeNVIDIAGPU.String(),
+				},
+			},
+		},
+		MetricsRemoteWriteURL: "http://vm:8480/insert/0/prometheus/",
+	}, cluster, currentNodes)
+
+	head := findStaticNode(nodes, "head-0")
+	require.NotNil(t, head)
+	assertNodeComponentNames(t, head.Spec.Components, []string{
+		"ray-head",
+		nodeExporterComponentName,
+		nodeAgentComponentName,
+		vmagentComponentName,
+	})
+	assert.NotEqual(t, "", warmImageRef(head.Spec.Warm.Images, nodeExporterComponentName))
+	assert.NotEqual(t, "", warmImageRef(head.Spec.Warm.Images, nodeAgentComponentName))
+	assert.Equal(t, "", warmImageRef(head.Spec.Warm.Images, acceleratorExporterComponentName))
+
+	vmagentComponent := findComponent(head.Spec.Components, vmagentComponentName)
+	require.NotNil(t, vmagentComponent)
+	vmagentConfig := findConfigFile(vmagentComponent.ConfigFiles, vmagentConfigPath)
+	require.NotNil(t, vmagentConfig)
+	assert.Contains(t, vmagentConfig.Content, `job_name: static-node-node-exporter`)
+	assert.Contains(t, vmagentConfig.Content, `job_name: static-node-node-agent`)
+	assert.NotContains(t, vmagentConfig.Content, `accelerator-exporter`)
+	assert.NotNil(t, findConfigFile(vmagentComponent.ConfigFiles, vmagentNodeExporterFileSDPath))
+	assert.NotNil(t, findConfigFile(vmagentComponent.ConfigFiles, vmagentNodeAgentFileSDPath))
+	assert.Nil(t, findConfigFile(vmagentComponent.ConfigFiles, "/etc/neutree/vmagent/file_sd/accelerator-exporter-nvidia-gpu.json"))
+
+	worker := findStaticNode(nodes, "worker-0")
+	require.NotNil(t, worker)
+	assertNodeComponentNames(t, worker.Spec.Components, []string{
+		"ray-worker",
+		nodeExporterComponentName,
+		nodeAgentComponentName,
+	})
+	assert.Nil(t, findComponent(worker.Spec.Components, acceleratorExporterComponentName))
+}
+
 func TestPlannerUsesExternalAcceleratorExporterTargets(t *testing.T) {
 	cluster := testStaticNodeCluster()
 	cluster.Spec.Metrics = &v1.ClusterMetricsConfig{
@@ -443,7 +508,7 @@ func TestPlannerUsesExternalAcceleratorExporterTargets(t *testing.T) {
 	assert.NotContains(t, acceleratorTargets.Content, `"10.0.0.11:9400"`)
 }
 
-func TestPlannerSkipsMetricsComponentsWithoutValidRemoteWriteURL(t *testing.T) {
+func TestPlannerSkipsOnlyVMAgentWithoutValidRemoteWriteURL(t *testing.T) {
 	tests := []struct {
 		name                  string
 		metricsRemoteWriteURL string
@@ -462,7 +527,7 @@ func TestPlannerSkipsMetricsComponentsWithoutValidRemoteWriteURL(t *testing.T) {
 					v1.StaticNodeRoleHead,
 					v1.StaticNodePhaseReady,
 					true,
-					cpuAcceleratorStatus(),
+					nvidiaAcceleratorStatus(),
 					nil,
 				),
 				staticNodeStatusWithAccelerator(
@@ -476,21 +541,48 @@ func TestPlannerSkipsMetricsComponentsWithoutValidRemoteWriteURL(t *testing.T) {
 			}
 
 			nodes := plannedStaticNodes(t, &Planner{
+				AcceleratorProfileProvider: fakeAcceleratorProfileProvider{
+					profiles: map[string]*v1.AcceleratorProfile{
+						v1.AcceleratorTypeNVIDIAGPU.String(): {
+							AcceleratorType: v1.AcceleratorTypeNVIDIAGPU.String(),
+							MetricsExporter: &v1.AcceleratorExporterProfile{
+								Name:  "dcgm-exporter",
+								Image: "nvcr.io/nvidia/k8s/dcgm-exporter:test",
+								Port:  19400,
+							},
+						},
+					},
+				},
 				MetricsRemoteWriteURL: tt.metricsRemoteWriteURL,
 			}, cluster, currentNodes)
 
 			head := findStaticNode(nodes, "head-0")
 			require.NotNil(t, head)
-			assertNodeComponentNames(t, head.Spec.Components, []string{"ray-head"})
-			assertWarmImages(t, head.Spec.Warm.Images, map[string]string{
-				"ray-runtime": "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+			assertNodeComponentNames(t, head.Spec.Components, []string{
+				"ray-head",
+				nodeExporterComponentName,
+				acceleratorExporterComponentName,
+				nodeAgentComponentName,
 			})
+			assertWarmImages(t, head.Spec.Warm.Images, map[string]string{
+				"ray-runtime":                    "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+				nodeExporterComponentName:        "registry.example.com/neutree/prometheus/node-exporter:v1.8.2",
+				nodeAgentComponentName:           "registry.example.com/neutree/neutree/neutree-node-agent:v1.1.0-rc.1",
+				acceleratorExporterComponentName: "registry.example.com/neutree/nvidia/k8s/dcgm-exporter:test",
+			})
+			assert.Nil(t, findComponent(head.Spec.Components, vmagentComponentName))
 
 			worker := findStaticNode(nodes, "worker-0")
 			require.NotNil(t, worker)
-			assertNodeComponentNames(t, worker.Spec.Components, []string{"ray-worker"})
+			assertNodeComponentNames(t, worker.Spec.Components, []string{
+				"ray-worker",
+				nodeExporterComponentName,
+				nodeAgentComponentName,
+			})
 			assertWarmImages(t, worker.Spec.Warm.Images, map[string]string{
-				"ray-runtime": "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+				"ray-runtime":             "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+				nodeExporterComponentName: "registry.example.com/neutree/prometheus/node-exporter:v1.8.2",
+				nodeAgentComponentName:    "registry.example.com/neutree/neutree/neutree-node-agent:v1.1.0-rc.1",
 			})
 		})
 	}

--- a/internal/deploy/kubernetes_deployer_test.go
+++ b/internal/deploy/kubernetes_deployer_test.go
@@ -309,6 +309,76 @@ func TestKubernetesDeployer_DeleteCleansConfigMapOnSecondPass(t *testing.T) {
 	}
 }
 
+func TestKubernetesDeployer_ApplyWaitsForPrunedResourcesToDisappearBeforeSavingConfig(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := &fakeApplyClient{Client: baseClient}
+	ctx := context.Background()
+
+	resourceName := "test-cluster"
+	componentName := "metrics"
+	store := NewConfigStore(fakeClient)
+	oldCM := createTestConfigMap("old-cm", "default", "key", "old")
+	lastApplied := []unstructured.Unstructured{*oldCM}
+	lastConfigBytes, err := json.Marshal(lastApplied)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	lastConfig := string(lastConfigBytes)
+	if err := store.Set(ctx, "default", resourceName, componentName, lastConfig, nil); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if err := fakeClient.Create(ctx, oldCM); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	newCM := createTestConfigMap("new-cm", "default", "key", "new")
+	newObjects := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{*newCM},
+	}
+	applier := NewKubernetesDeployer(fakeClient, "default", resourceName, componentName).
+		WithNewObjects(newObjects).
+		WithLogger(klog.Background())
+
+	_, err = applier.Apply(ctx)
+	if err == nil {
+		t.Fatalf("First Apply() error = nil, want pending prune error")
+	}
+
+	configAfterFirstApply, err := store.Get(ctx, "default", resourceName, componentName)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if configAfterFirstApply != lastConfig {
+		t.Fatalf("config after first Apply() = %s, want old config %s", configAfterFirstApply, lastConfig)
+	}
+
+	staleCM := &corev1.ConfigMap{}
+	if err := fakeClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "old-cm"}, staleCM); err == nil {
+		if deleteErr := fakeClient.Delete(ctx, staleCM); deleteErr != nil {
+			t.Fatalf("Delete stale old ConfigMap error = %v", deleteErr)
+		}
+	} else if !apierrors.IsNotFound(err) {
+		t.Fatalf("Get stale old ConfigMap error = %v", err)
+	}
+
+	_, err = applier.Apply(ctx)
+	if err != nil {
+		t.Fatalf("Second Apply() error = %v", err)
+	}
+
+	configAfterSecondApply, err := store.Get(ctx, "default", resourceName, componentName)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if configAfterSecondApply == lastConfig {
+		t.Fatalf("config after second Apply() still old: %s", configAfterSecondApply)
+	}
+}
+
 func TestKubernetesDeployer_ConfigSaved(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/internal/deploy/manifest_apply.go
+++ b/internal/deploy/manifest_apply.go
@@ -20,6 +20,8 @@ import (
 // Mutate is a callback function to modify objects before applying
 type Mutate func(obj *unstructured.Unstructured) error
 
+var ErrManifestDeletePending = errors.New("manifest resources are still deleting")
+
 // ManifestApply handles Kubernetes manifest lifecycle operations
 // It focuses on comparing, applying, and deleting manifests
 type ManifestApply struct {
@@ -225,26 +227,64 @@ func (m *ManifestApply) ApplyManifests(
 			"namespace", obj.GetNamespace())
 	}
 
-	deleteObjects := diff.DeletedObjects
+	deleteCount, deleteFinished, err := m.deleteRemovedObjects(ctx, diff.DeletedObjects)
+	if err != nil {
+		return 0, err
+	}
+
+	if !deleteFinished {
+		return len(objects) + deleteCount, ErrManifestDeletePending
+	}
+
+	return len(objects) + deleteCount, nil
+}
+
+func (m *ManifestApply) deleteRemovedObjects(ctx context.Context,
+	deleteObjects []unstructured.Unstructured) (int, bool, error) {
+	deleteFinished := true
 
 	for i := range deleteObjects {
 		obj := &deleteObjects[i]
+		liveObj := &unstructured.Unstructured{}
+		liveObj.SetAPIVersion(obj.GetAPIVersion())
+		liveObj.SetKind(obj.GetKind())
+
+		err := m.ctrlClient.Get(ctx, client.ObjectKey{
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+		}, liveObj)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
+			return 0, false, errors.Wrapf(err, "failed to get removed object %s/%s/%s",
+				obj.GetKind(), obj.GetNamespace(), obj.GetName())
+		}
+
+		deleteFinished = false
+
+		if liveObj.GetDeletionTimestamp() != nil {
+			continue
+		}
+
 		m.logger.Info("Deleting resource",
 			"kind", obj.GetKind(),
 			"name", obj.GetName(),
-			"namespace", m.namespace)
+			"namespace", obj.GetNamespace())
 
-		if err := m.ctrlClient.Delete(ctx, obj); err != nil {
-			if !apierrors.IsNotFound(err) {
-				klog.ErrorS(err, "Failed to delete resource",
-					"kind", obj.GetKind(),
-					"name", obj.GetName())
-				// Continue with other resources
+		if err := m.ctrlClient.Delete(ctx, liveObj); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
 			}
+
+			klog.ErrorS(err, "Failed to delete resource",
+				"kind", obj.GetKind(),
+				"name", obj.GetName())
 		}
 	}
 
-	return len(objects) + len(deleteObjects), nil
+	return len(deleteObjects), deleteFinished, nil
 }
 
 func (m *ManifestApply) addLiveDriftedObjects(ctx context.Context, diff *ManifestDiff) error {

--- a/internal/resource/resource_client_test.go
+++ b/internal/resource/resource_client_test.go
@@ -411,6 +411,81 @@ func TestK8sResourceClientListNodesUsesNeutreeDeviceAnnotations(t *testing.T) {
 	require.Equal(t, float64(15360), available.Products["Tesla-T4"].Virtualization.MemoryMiB)
 }
 
+func TestK8sResourceClientListNodesUsesNeutreeDeviceAnnotationsForTimeSlicingQuantity(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node",
+			Labels: map[string]string{
+				plugin.NvidiaGPUKubernetesNodeSelectorKey: "NVIDIA-L20",
+				plugin.NvidiaGPUMemoryNodeLabelKey:        "46068",
+			},
+			Annotations: map[string]string{
+				resourceparser.NeutreeAcceleratorDevicesAnnotation: `[
+					{"uuid":"GPU-1","product_model":"Annotation-L20","product_name":"NVIDIA L20","memory_mib":46068,"healthy":true,"minor_number":0},
+					{"uuid":"GPU-2","product_model":"Annotation-L20","product_name":"NVIDIA L20","memory_mib":46068,"healthy":true,"minor_number":1}
+				]`,
+			},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:                 k8sresource.MustParse("8"),
+				corev1.ResourceMemory:              k8sresource.MustParse("32Gi"),
+				plugin.NvidiaGPUKubernetesResource: k8sresource.MustParse("20"),
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "infer-1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				resourceparser.NeutreeAcceleratorAllocationsAnnotation: `[
+					{"uuid":"GPU-1","product":"NVIDIA-L20","memory_mib":46068,"core_units":100}
+				]`,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "gpu-node",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	ctrClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node, pod).
+		Build()
+	client := resourceview.NewK8sResourceClient(ctrClient, map[string]resourceparser.ResourceParser{
+		string(v1.AcceleratorTypeNVIDIAGPU): &plugin.GPUResourceParser{},
+	})
+
+	nodes, err := client.ListNodes(context.Background(), nil)
+
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	require.Len(t, nodes[0].Status.Devices, 2)
+	require.Equal(t, "NVIDIA-L20", nodes[0].Status.Devices[0].Product)
+	require.Equal(t, "NVIDIA-L20", nodes[0].Status.Devices[1].Product)
+	require.Equal(t, int64(0), nodes[0].Status.Devices[0].Available.MemoryMiB)
+	require.Equal(t, int64(46068), nodes[0].Status.Devices[1].Available.MemoryMiB)
+
+	allocatable := nodes[0].Status.Allocatable.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
+	require.Equal(t, float64(2), allocatable.Quantity)
+	require.Equal(t, float64(2), allocatable.ProductGroups["NVIDIA-L20"])
+	require.Equal(t, float64(2), allocatable.Products["NVIDIA-L20"].Quantity)
+	require.NotContains(t, allocatable.ProductGroups, v1.AcceleratorProduct("Annotation-L20"))
+	require.NotContains(t, allocatable.Products, v1.AcceleratorProduct("Annotation-L20"))
+
+	available := nodes[0].Status.Available.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
+	require.Equal(t, float64(1), available.Quantity)
+	require.Equal(t, float64(1), available.ProductGroups["NVIDIA-L20"])
+	require.Equal(t, float64(1), available.Products["NVIDIA-L20"].Quantity)
+}
+
 func TestK8sResourceClientListNodesUsesNeutreeDeviceAvailabilityForAvailableGPUQuantity(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))


### PR DESCRIPTION
## Issue

NEU-532

## Summary

This change keeps Neutree's local metrics and GPU-device view components deployed independently from the remote metrics pipeline. Supported Kubernetes and static-node clusters now keep `neutree-node-agent`, `node-exporter`, and managed `accelerator-exporter` even when `metricsRemoteWriteURL` is empty or invalid. The existing Kubernetes resource-client annotation-first GPU quantity behavior is also locked with an explicit time-slicing regression test.

## Changes

- Gate only the remote metrics pipeline on a valid remote write URL: `vmagent`, kube-state-metrics, HAMi monitor scraping, and external DCGM scrape config.
- Keep local collectors deployed by default for supported Kubernetes clusters: `neutree-node-agent`, `node-exporter`, and managed `accelerator-exporter`.
- Keep static-node local collectors and warm images when remote write is absent; skip only the head-node `vmagent` component.
- Split Kubernetes metrics manifests by subcomponent and add render/selection coverage for local-only, vmagent-only, full-pipeline, missing-exporter, and legacy full-pipeline object sets.
- Preserve apply-and-prune lifecycle visibility by keeping the old desired manifest config until pruned Kubernetes resources are confirmed gone.
- Add a time-slicing resource-client regression: annotation device count drives physical GPU quantity and availability while product identity remains sourced from `GPUResourceParser`.

## Test Plan

### Unit test
- `go vet ./internal/resource ./internal/cluster ./internal/cluster/component/metrics ./internal/cluster/staticcluster ./internal/deploy ./internal/observability/neutreemetrics ./internal/observability/neutreemetrics/devicesnapshot ./internal/observability/neutreemetrics/hardware ./cmd/neutree-node-agent`
- `go test ./internal/resource ./internal/cluster ./internal/cluster/component/metrics ./internal/cluster/staticcluster ./internal/deploy ./internal/observability/neutreemetrics ./internal/observability/neutreemetrics/devicesnapshot ./internal/observability/neutreemetrics/hardware ./cmd/neutree-node-agent -count=1`
- `./bin/golangci-lint run ./internal/resource ./internal/cluster ./internal/cluster/component/metrics ./internal/cluster/staticcluster ./internal/deploy ./internal/observability/neutreemetrics ./internal/observability/neutreemetrics/devicesnapshot ./internal/observability/neutreemetrics/hardware ./cmd/neutree-node-agent`
- `git diff --check`

### DB test
- Not affected by this change.

### E2E test
- Skipped per user instruction for this iteration.
- Planned coverage remains documented in NEU-532 cases C2732036-C2732043 for the K8s GPU virtualization environment.

## Risk & Rollback

- Risk: clusters without remote write will run more local collector components than before. This is intentional so node/device views remain available.
- Risk: disabling remote write prunes stale remote-pipeline resources asynchronously; this PR keeps retry visibility by not saving the new desired manifest config until removed resources disappear.
- Rollback: revert this PR to restore remote-write-gated metrics component deployment.
- DB/API compatibility: no schema, migration, or API shape changes.