### PR TITLE
ci: bump nightly build base version to v1.1.1

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -21,7 +21,7 @@ jobs:
         id: create_nightly_tag
         run: |
           DATE=$(date +'%Y%m%d')
-          NIGHTLY_TAG="v1.1.0-nightly-${DATE}"
+          NIGHTLY_TAG="v1.1.1-nightly-${DATE}"
           git tag "${NIGHTLY_TAG}" -m "${NIGHTLY_TAG}"
           git push origin "${NIGHTLY_TAG}"
           echo "tag=${NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Issue

n/a

## Summary

Bump the community nightly tag base from v1.1.0 to v1.1.1 while retaining the existing release dispatch contract.

## Changes

- Update the Daily Build nightly tag constant only.

## Test Plan

### Unit test
- Not required: GitHub Actions workflow constant only.

### DB test
- Not required: no database surface.

### E2E test
- Local static validation passed (not exercised by PR CI): actionlint, YAML parse, tag/dispatch assertions, and diff scope check.
- PR CI passed: `pr-check` and `codecov/patch`.
- Scheduled GitHub Actions validation is pending after coordinated merge; no manual workflow dispatch is planned.

## Risk & Rollback

- Merge only as a coordinated set with UI #339 and Enterprise #89, then update both `NIGHTLY_CLUSTER_VERSION` repository secrets before the next 00:00 UTC chain. If the window cannot be met, defer all three PRs.
- If a scheduled run has created a tag or dispatched a release, preserve run/tag evidence and do not retag or manually dispatch. Revert all three workflow changes together and restore both secrets to their last recorded values before a controlled recovery.