### PR TITLE
feat: show resource ID column in `get` table output (NEU-545)

### DIFF
--- a/cmd/neutree-cli/app/cmd/get/get.go
+++ b/cmd/neutree-cli/app/cmd/get/get.go
@@ -3,6 +3,7 @@ package get
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -180,6 +181,18 @@ type resourcePrinter struct {
 	kind          string
 	format        string
 	headerPrinted bool
+	// out is the destination for rendered output; defaults to os.Stdout when nil
+	// (overridden in tests to capture output).
+	out io.Writer
+}
+
+// writer returns the printer's output destination, defaulting to os.Stdout.
+func (p *resourcePrinter) writer() io.Writer {
+	if p.out != nil {
+		return p.out
+	}
+
+	return os.Stdout
 }
 
 func (p *resourcePrinter) print(items []json.RawMessage) error {
@@ -196,13 +209,13 @@ func (p *resourcePrinter) print(items []json.RawMessage) error {
 }
 
 func (p *resourcePrinter) printTable(items []json.RawMessage) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	w := tabwriter.NewWriter(p.writer(), 0, 4, 2, ' ', 0)
 
 	if !p.headerPrinted {
 		if p.kind == "Workspace" {
-			fmt.Fprintln(w, "NAME\tPHASE\tAGE")
+			fmt.Fprintln(w, "NAME\tID\tPHASE\tAGE")
 		} else {
-			fmt.Fprintln(w, "NAME\tWORKSPACE\tPHASE\tAGE")
+			fmt.Fprintln(w, "NAME\tID\tWORKSPACE\tPHASE\tAGE")
 		}
 
 		p.headerPrinted = true
@@ -210,14 +223,15 @@ func (p *resourcePrinter) printTable(items []json.RawMessage) error {
 
 	for _, item := range items {
 		name := client.ExtractMetadataField(item, "name")
+		id := client.ExtractID(item)
 		workspace := client.ExtractMetadataField(item, "workspace")
 		phase := client.ExtractPhase(item)
 		age := formatAge(client.ExtractMetadataField(item, "creation_timestamp"))
 
 		if p.kind == "Workspace" {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", name, phase, age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, id, phase, age)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, workspace, phase, age)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", name, id, workspace, phase, age)
 		}
 	}
 

--- a/cmd/neutree-cli/app/cmd/get/get_test.go
+++ b/cmd/neutree-cli/app/cmd/get/get_test.go
@@ -1,10 +1,55 @@
 package get
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestPrintTableIncludesIDColumn(t *testing.T) {
+	var buf bytes.Buffer
+
+	p := &resourcePrinter{kind: "ApiKey", format: "table", out: &buf}
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"id":"721d6adc-6b32-46d1-b4bf-67cb0c576848","metadata":{"name":"tos-titlegen-provider","workspace":"default"},"status":{"phase":"ACTIVE"}}`),
+	}
+	require.NoError(t, p.printTable(items))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+
+	// Header carries an ID column between NAME and WORKSPACE.
+	assert.Equal(t, []string{"NAME", "ID", "WORKSPACE", "PHASE", "AGE"}, strings.Fields(lines[0]))
+	row := strings.Fields(lines[1])
+	assert.Equal(t, "tos-titlegen-provider", row[0])
+	assert.Equal(t, "721d6adc-6b32-46d1-b4bf-67cb0c576848", row[1])
+	assert.Equal(t, "default", row[2])
+	assert.Equal(t, "ACTIVE", row[3])
+}
+
+func TestPrintTableWorkspaceKindOmitsWorkspaceColumnButKeepsID(t *testing.T) {
+	var buf bytes.Buffer
+
+	p := &resourcePrinter{kind: "Workspace", format: "table", out: &buf}
+
+	items := []json.RawMessage{
+		json.RawMessage(`{"id":7,"metadata":{"name":"default"},"status":{"phase":"READY"}}`),
+	}
+	require.NoError(t, p.printTable(items))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, []string{"NAME", "ID", "PHASE", "AGE"}, strings.Fields(lines[0]))
+	row := strings.Fields(lines[1])
+	assert.Equal(t, "default", row[0])
+	assert.Equal(t, "7", row[1])
+	assert.Equal(t, "READY", row[2])
+}
 
 func TestFormatAge(t *testing.T) {
 	tests := []struct {

--- a/pkg/client/generic.go
+++ b/pkg/client/generic.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
@@ -274,6 +275,31 @@ func ExtractPhase(data json.RawMessage) string {
 	}
 
 	return holder.Status.Phase
+}
+
+// ExtractID extracts the top-level resource id from raw JSON resource data.
+// The id may be a JSON string (e.g. an api key's UUID) or a number (an integer
+// primary key); both are returned as their string form. Missing/unparseable
+// ids yield "".
+func ExtractID(data json.RawMessage) string {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ""
+	}
+
+	idRaw, ok := raw["id"]
+	if !ok {
+		return ""
+	}
+
+	// A UUID id arrives quoted; unmarshal into a string to strip the quotes.
+	var s string
+	if err := json.Unmarshal(idRaw, &s); err == nil {
+		return s
+	}
+
+	// A numeric id has no quotes to strip — use its literal form.
+	return strings.TrimSpace(string(idRaw))
 }
 
 // ExtractMetadataField extracts a field from metadata in raw JSON resource data.

--- a/pkg/client/generic_test.go
+++ b/pkg/client/generic_test.go
@@ -155,3 +155,38 @@ func TestExtractMetadataField(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractID(t *testing.T) {
+	tests := []struct {
+		name string
+		data json.RawMessage
+		want string
+	}{
+		{
+			name: "uuid string id",
+			data: json.RawMessage(`{"id":"721d6adc-6b32-46d1-b4bf-67cb0c576848","metadata":{"name":"k"}}`),
+			want: "721d6adc-6b32-46d1-b4bf-67cb0c576848",
+		},
+		{
+			name: "integer id",
+			data: json.RawMessage(`{"id":42,"metadata":{"name":"e"}}`),
+			want: "42",
+		},
+		{
+			name: "missing id",
+			data: json.RawMessage(`{"metadata":{"name":"n"}}`),
+			want: "",
+		},
+		{
+			name: "invalid JSON",
+			data: json.RawMessage(`not json`),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ExtractID(tt.data))
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds an **ID** column to `neutree-cli get` table output. Previously the table showed only NAME/WORKSPACE/PHASE/AGE, so getting a resource's id (e.g. an api key id to feed `export access-log --api-key-id`) meant `-o json` + jq. Now the id is visible directly.

Jira: [NEU-545](http://jira.smartx.com/browse/NEU-545)

## Before / after

```
# before
$ neutree-cli get apikey -w default
NAME                   WORKSPACE  PHASE    AGE
tos-titlegen-provider  default    Created  13d

# after
$ neutree-cli get apikey -w default
NAME                   ID                                    WORKSPACE  PHASE    AGE
tos-titlegen-provider  721d6adc-6b32-46d1-b4bf-67cb0c576848  default    Created  13d
```

Composition it unblocks:

```
neutree-cli get apikey -w default | awk '$1=="tos-titlegen-provider"{print $2}'
# -> feed to: neutree-cli export access-log --api-key-id <id>
```

## Design notes

- ID is placed between NAME and WORKSPACE so the two identity columns sit together.
- The id may be a **UUID string** (api keys) or an **integer primary key** (most tables). `client.ExtractID` returns both as their string form.
- Only the **table** output changes; `-o json` / `-o yaml` already carried the id and are untouched.
- This is the composition-friendly alternative decided in the NEU-544 review (rather than an `--api-key-name` flag on `export`, which would be ambiguous since api key names are only unique per `(workspace, name)`).

## Changes

- `pkg/client/generic.go`: `ExtractID` (handles UUID-string and integer ids)
- `cmd/neutree-cli/app/cmd/get/get.go`: ID column in `printTable`; printer output destination made injectable for testing

## Testing

- Unit tests: `ExtractID` (uuid / int / missing / invalid); `printTable` ID column for a normal kind and for the Workspace kind (which omits the WORKSPACE column but keeps ID).
- Verified live: `get apikey` shows UUID ids, `get workspace` shows integer id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)