### PR TITLE
fix: preserve empty arrays in tool schema round-trip (NEU-551)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,12 +63,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install LuaJIT + busted
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            luajit luarocks lua5.1 liblua5.1-0-dev build-essential
-          sudo luarocks install lua-cjson
-          sudo luarocks install busted
       - name: Run neutree-ai-gateway Lua unit tests
-        run: sh gateway/kong/plugins/neutree-ai-gateway/spec/run.sh
+        run: make gateway-lua-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,3 +58,17 @@ jobs:
         with:
           token: ${{secrets.CODECOV_UPLOAD_TOKEN}}
           file: ./coverage.out
+
+  gateway-lua-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install LuaJIT + busted
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            luajit luarocks lua5.1 liblua5.1-0-dev build-essential
+          sudo luarocks install lua-cjson
+          sudo luarocks install busted
+      - name: Run neutree-ai-gateway Lua unit tests
+        run: sh gateway/kong/plugins/neutree-ai-gateway/spec/run.sh

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,21 @@ e2e-test: ## Run E2E tests (requires NEUTREE_SERVER_URL and NEUTREE_API_KEY)
 	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 6h ./tests/e2e/... \
 		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips --ginkgo.timeout=$(E2E_TIMEOUT) $(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")
 
+##@ Gateway Lua Testing
+
+GATEWAY_PLUGIN_DIR ?= gateway/kong/plugins/neutree-ai-gateway
+
+.PHONY: gateway-lua-test
+gateway-lua-test: ## Run neutree-ai-gateway Lua unit tests (LuaJIT + busted, in Docker)
+	docker run --rm -v $(CURDIR)/$(GATEWAY_PLUGIN_DIR):/plugin -w /plugin debian:bookworm-slim sh -c '\
+		set -e; \
+		export DEBIAN_FRONTEND=noninteractive; \
+		apt-get update >/dev/null; \
+		apt-get install -y --no-install-recommends luajit luarocks lua5.1 liblua5.1-0-dev build-essential unzip ca-certificates >/dev/null; \
+		luarocks install lua-cjson >/dev/null; \
+		luarocks install busted >/dev/null; \
+		sh spec/run.sh'
+
 ##@ Database Testing
 
 .PHONY: db-test

--- a/Makefile
+++ b/Makefile
@@ -215,17 +215,12 @@ e2e-test: ## Run E2E tests (requires NEUTREE_SERVER_URL and NEUTREE_API_KEY)
 ##@ Gateway Lua Testing
 
 GATEWAY_PLUGIN_DIR ?= gateway/kong/plugins/neutree-ai-gateway
+GATEWAY_LUA_TEST_IMAGE ?= neutree-gateway-lua-test:latest
 
 .PHONY: gateway-lua-test
 gateway-lua-test: ## Run neutree-ai-gateway Lua unit tests (LuaJIT + busted, in Docker)
-	docker run --rm -v $(CURDIR)/$(GATEWAY_PLUGIN_DIR):/plugin -w /plugin debian:bookworm-slim sh -c '\
-		set -e; \
-		export DEBIAN_FRONTEND=noninteractive; \
-		apt-get update >/dev/null; \
-		apt-get install -y --no-install-recommends luajit luarocks lua5.1 liblua5.1-0-dev build-essential unzip ca-certificates >/dev/null; \
-		luarocks install lua-cjson >/dev/null; \
-		luarocks install busted >/dev/null; \
-		sh spec/run.sh'
+	docker build -q -t $(GATEWAY_LUA_TEST_IMAGE) $(GATEWAY_PLUGIN_DIR)/spec >/dev/null
+	docker run --rm -v $(CURDIR)/$(GATEWAY_PLUGIN_DIR):/plugin -w /plugin $(GATEWAY_LUA_TEST_IMAGE) sh spec/run.sh
 
 ##@ Database Testing
 

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -1,21 +1,32 @@
 local cjson = require("cjson.safe")
 local buffer = require("string.buffer")
-
--- Preserve the array/object distinction across a decode -> encode round-trip.
--- Plain lua-cjson decodes both JSON `[]` and `{}` into the same empty Lua table,
--- and re-encodes every empty table as `{}`. That silently rewrites a client's
--- `"required": []` (and any other empty array inside a tool schema) into
--- `"required": {}`, which upstreams reject with 400 ({} is not of type "array")
--- when we forward a model-mapped request (see access(): cjson.decode at the
--- anthropic and OpenAI passthrough paths, re-encoded before set_raw_body).
--- Enabling array_mt on decode tags decoded arrays so encode preserves `[]`,
--- while genuine empty objects (`{}`) still encode as `{}`. This is a per-worker
--- setting; the OpenResty cjson fork shares it between `cjson` and `cjson.safe`.
--- See NEU-551.
-cjson.decode_array_with_array_mt(true)
 local ai_shared = require("kong.llm.drivers.shared")
 local ai_driver = require("kong.llm.drivers.openai")
 local strip = require("kong.tools.string").strip
+
+-- JSON array/object policy (NEU-551).
+--
+-- An empty Lua table is ambiguous: plain lua-cjson decodes both JSON `[]` and
+-- `{}` into one empty table, and encodes every empty table back as `{}`. That
+-- silently turns a client's `"required": []` (or any empty array in a tool
+-- schema) into `"required": {}`, which upstreams reject with 400
+-- ({} is not of type "array"). Two rules resolve it, one per direction:
+--
+--   1. Tables decoded FROM the client body: enable array_mt on decode so
+--      decoded JSON arrays stay arrays across a re-encode (see access(), which
+--      decodes/re-encodes the body on the model-mapping paths). Genuine empty
+--      objects still encode as `{}`. This one setting covers every decode path.
+--      It is per-worker; the OpenResty cjson fork shares it with `cjson.safe`.
+--
+--   2. Lists we build OURSELVES and then encode: rule 1 cannot help these, so
+--      construct them with json_array() below. It tags the table with array_mt
+--      so it serialises as `[]` even when empty. Use it for ANY list this
+--      plugin emits that could be empty (stream events, model lists, ...).
+cjson.decode_array_with_array_mt(true)
+
+local function json_array(t)
+    return setmetatable(t or {}, cjson.array_mt)
+end
 
 local AIGatewayHandler = {
     PRIORITY = 900,
@@ -250,10 +261,7 @@ local function maybe_return_model_list(conf, suffix)
 
     if is_models_path(suffix) and kong.request.get_method() == "GET" then
         kong.ctx.plugin.skip = true
-        -- `data` must serialise as a JSON array even when no models are mapped;
-        -- a plain empty table would encode to `{}`. Tag with array_mt so an
-        -- empty list still becomes `[]`. See NEU-551.
-        local models = setmetatable({}, cjson.array_mt)
+        local models = json_array()
         for _, entry in ipairs(conf.upstreams) do
             for model_name, _ in pairs(entry.model_mapping) do
                 models[#models + 1] = {
@@ -273,8 +281,7 @@ local function maybe_return_model_list(conf, suffix)
 
     if is_anthropic_models_path(suffix) and kong.request.get_method() == "GET" then
         kong.ctx.plugin.skip = true
-        -- See the /v1/models path above: array_mt keeps an empty list as `[]`.
-        local models = setmetatable({}, cjson.array_mt)
+        local models = json_array()
         for _, entry in ipairs(conf.upstreams) do
             for model_name, _ in pairs(entry.model_mapping) do
                 models[#models + 1] = {
@@ -710,12 +717,8 @@ local function make_message_start(request_model, input_tokens)
             role = "assistant",
             model = request_model or "unknown",
             -- Anthropic's message_start always carries content as an empty JSON
-            -- array `[]`; a bare `{}` here (what an empty Lua table encodes to)
-            -- can break strict clients that treat content as a list. Use the
-            -- cjson sentinel that always serialises as `[]`. This is a
-            -- constructed table, so the module-level decode_array_with_array_mt
-            -- setting does not apply. See NEU-551.
-            content = cjson.empty_array,
+            -- array `[]`, never `{}`. json_array() keeps it an array.
+            content = json_array(),
             stop_reason = cjson.null,
             stop_sequence = cjson.null,
             usage = {

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -250,7 +250,10 @@ local function maybe_return_model_list(conf, suffix)
 
     if is_models_path(suffix) and kong.request.get_method() == "GET" then
         kong.ctx.plugin.skip = true
-        local models = {}
+        -- `data` must serialise as a JSON array even when no models are mapped;
+        -- a plain empty table would encode to `{}`. Tag with array_mt so an
+        -- empty list still becomes `[]`. See NEU-551.
+        local models = setmetatable({}, cjson.array_mt)
         for _, entry in ipairs(conf.upstreams) do
             for model_name, _ in pairs(entry.model_mapping) do
                 models[#models + 1] = {
@@ -270,7 +273,8 @@ local function maybe_return_model_list(conf, suffix)
 
     if is_anthropic_models_path(suffix) and kong.request.get_method() == "GET" then
         kong.ctx.plugin.skip = true
-        local models = {}
+        -- See the /v1/models path above: array_mt keeps an empty list as `[]`.
+        local models = setmetatable({}, cjson.array_mt)
         for _, entry in ipairs(conf.upstreams) do
             for model_name, _ in pairs(entry.model_mapping) do
                 models[#models + 1] = {
@@ -705,7 +709,13 @@ local function make_message_start(request_model, input_tokens)
             type = "message",
             role = "assistant",
             model = request_model or "unknown",
-            content = {},
+            -- Anthropic's message_start always carries content as an empty JSON
+            -- array `[]`; a bare `{}` here (what an empty Lua table encodes to)
+            -- can break strict clients that treat content as a list. Use the
+            -- cjson sentinel that always serialises as `[]`. This is a
+            -- constructed table, so the module-level decode_array_with_array_mt
+            -- setting does not apply. See NEU-551.
+            content = cjson.empty_array,
             stop_reason = cjson.null,
             stop_sequence = cjson.null,
             usage = {

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -1542,4 +1542,18 @@ function AIGatewayHandler:log(conf)
     kong.log.set_serialize_value("ai.statistics.usage", usage)
 end
 
+-- Internal helpers exposed for unit tests only (spec/handler_spec.lua). Not part
+-- of the plugin's runtime contract; do not use from other modules.
+AIGatewayHandler._TEST = {
+    json_array = json_array,
+    is_empty_table = is_empty_table,
+    convert_tool_choice = convert_tool_choice,
+    convert_tools = convert_tools,
+    convert_messages = convert_messages,
+    convert_request = convert_request,
+    convert_response = convert_response,
+    make_message_start = make_message_start,
+    anthropic_usage_from_openai = anthropic_usage_from_openai,
+}
+
 return AIGatewayHandler

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -1,5 +1,18 @@
 local cjson = require("cjson.safe")
 local buffer = require("string.buffer")
+
+-- Preserve the array/object distinction across a decode -> encode round-trip.
+-- Plain lua-cjson decodes both JSON `[]` and `{}` into the same empty Lua table,
+-- and re-encodes every empty table as `{}`. That silently rewrites a client's
+-- `"required": []` (and any other empty array inside a tool schema) into
+-- `"required": {}`, which upstreams reject with 400 ({} is not of type "array")
+-- when we forward a model-mapped request (see access(): cjson.decode at the
+-- anthropic and OpenAI passthrough paths, re-encoded before set_raw_body).
+-- Enabling array_mt on decode tags decoded arrays so encode preserves `[]`,
+-- while genuine empty objects (`{}`) still encode as `{}`. This is a per-worker
+-- setting; the OpenResty cjson fork shares it between `cjson` and `cjson.safe`.
+-- See NEU-551.
+cjson.decode_array_with_array_mt(true)
 local ai_shared = require("kong.llm.drivers.shared")
 local ai_driver = require("kong.llm.drivers.openai")
 local strip = require("kong.tools.string").strip

--- a/gateway/kong/plugins/neutree-ai-gateway/spec/Dockerfile
+++ b/gateway/kong/plugins/neutree-ai-gateway/spec/Dockerfile
@@ -1,0 +1,22 @@
+# Test image for the neutree-ai-gateway Lua unit tests.
+#
+# Bakes the toolchain (LuaJIT + luarocks + lua-cjson + busted) into cached
+# layers so `make gateway-lua-test` only pays the install cost on first build;
+# later runs are just `docker run`. LuaJIT is required because the plugin uses
+# goto/labels + string.buffer, which PUC Lua 5.1 cannot parse. The luarocks
+# `lua-cjson` is the OpenResty fork (array_mt / decode_array_with_array_mt),
+# matching the gateway's runtime cjson behaviour.
+#
+# The plugin source is NOT baked in — it is bind-mounted at run time so tests
+# always exercise the working tree. See Makefile: gateway-lua-test.
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        luajit luarocks lua5.1 liblua5.1-0-dev build-essential unzip ca-certificates \
+    && luarocks install lua-cjson \
+    && luarocks install busted \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /plugin

--- a/gateway/kong/plugins/neutree-ai-gateway/spec/handler_spec.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/spec/handler_spec.lua
@@ -1,0 +1,167 @@
+-- Unit tests for the neutree-ai-gateway plugin's pure helpers, focused on the
+-- JSON array/object handling policy (NEU-551).
+--
+-- These tests run under plain LuaJIT/Lua 5.1 with the luarocks `lua-cjson`
+-- (the OpenResty fork, which ships array_mt / decode_array_with_array_mt /
+-- empty_array) and `busted`. The handler pulls in a few OpenResty- and
+-- Kong-only modules; we stub them via package.loaded/globals BEFORE requiring
+-- it, since the helpers under test never touch them at call time.
+--
+-- Run: make gateway-lua-test   (or, with deps installed: busted spec/)
+
+-- Stub OpenResty / Kong dependencies so the handler loads outside Kong. Must be
+-- registered before the handler is required.
+package.loaded["string.buffer"] = {
+    new = function()
+        return {
+            put = function() end,
+            get = function() return "" end,
+            tostring = function() return "" end,
+        }
+    end,
+}
+package.loaded["kong.llm.drivers.shared"] = {
+    calculate_cost = function() return 0 end,
+    frame_to_events = function() return {} end,
+    from_format = function() return nil end,
+    _CONST = { SSE_TERMINATOR = "[DONE]" },
+}
+package.loaded["kong.llm.drivers.openai"] = {
+    from_format = function() return nil end,
+}
+package.loaded["kong.tools.string"] = {
+    strip = function(s) return s end,
+}
+
+_G.ngx = { now = function() return 0 end }
+_G.kong = { log = { warn = function() end, err = function() end } }
+
+-- Make `require("kong.plugins.neutree-ai-gateway.handler")` resolve to the
+-- handler next to this spec, regardless of the working directory busted is run
+-- from. The gateway root is four levels up from spec/.
+local spec_dir = (debug.getinfo(1, "S").source:sub(2)):match("(.*/)") or "./"
+local gateway_root = spec_dir .. "../../../../"
+package.path = gateway_root .. "?.lua;" .. gateway_root .. "?/init.lua;" .. package.path
+
+local cjson = require("cjson.safe")
+local handler = require("kong.plugins.neutree-ai-gateway.handler")
+local T = handler._TEST
+
+-- plain-substring find helpers (cjson emits no spaces, and a key and its value
+-- are always contiguous, so `"required":[]` is a reliable literal probe).
+local function has(str, needle)
+    return str:find(needle, 1, true) ~= nil
+end
+
+describe("json_array()", function()
+    it("encodes an empty list as [] rather than {}", function()
+        assert.are.equal("[]", cjson.encode(T.json_array()))
+    end)
+
+    it("wraps and encodes a populated list as an array", function()
+        local a = T.json_array()
+        a[#a + 1] = { id = "x" }
+        assert.are.equal('[{"id":"x"}]', cjson.encode(a))
+    end)
+end)
+
+describe("cjson array/object round-trip policy", function()
+    -- The handler enables decode_array_with_array_mt(true) at module load; this
+    -- is the mechanism access() relies on when it decodes and re-encodes the
+    -- client body on the model-mapping paths.
+    it("preserves empty arrays and empty objects distinctly", function()
+        local body = [[{"required":[],"enum":[],"properties":{}}]]
+        local out = cjson.encode(cjson.decode(body))
+        assert.is_true(has(out, '"required":[]'))
+        assert.is_true(has(out, '"enum":[]'))
+        assert.is_true(has(out, '"properties":{}'))
+        assert.is_false(has(out, '"required":{}'))
+    end)
+
+    it("simulates the OpenAI passthrough re-encode of a tool schema", function()
+        -- goose sends fully-optional tools with required:[]; access() decodes,
+        -- rewrites model, and re-encodes. The empty array must survive.
+        local body = [[{"model":"deepseek-v4-pro[1m]","tools":[{"type":"function",]]
+            .. [["function":{"name":"create_browser","parameters":]]
+            .. [[{"type":"object","properties":{},"required":[]}}}]}]]
+        local req = cjson.decode(body)
+        req.model = "deepseek-v4-pro" -- the only mutation access() makes here
+        local out = cjson.encode(req)
+        assert.is_true(has(out, '"required":[]'))
+        assert.is_true(has(out, '"properties":{}'))
+        assert.is_false(has(out, '"required":{}'))
+    end)
+end)
+
+describe("convert_tools()", function()
+    it("returns nil for nil, non-table, and empty input", function()
+        assert.is_nil(T.convert_tools(nil))
+        assert.is_nil(T.convert_tools("nope"))
+        assert.is_nil(T.convert_tools({}))
+    end)
+
+    it("maps anthropic tools to OpenAI function tools", function()
+        local tools = T.convert_tools({
+            { name = "t", description = "d", input_schema = { type = "object" } },
+        })
+        assert.are.equal(1, #tools)
+        assert.are.equal("function", tools[1].type)
+        assert.are.equal("t", tools[1]["function"].name)
+        assert.are.equal("d", tools[1]["function"].description)
+        assert.are.same({ type = "object" }, tools[1]["function"].parameters)
+    end)
+end)
+
+describe("convert_request()", function()
+    it("keeps an empty required array through the anthropic->openai path", function()
+        local anthropic = cjson.decode([[{"model":"deepseek","max_tokens":16,]]
+            .. [["messages":[{"role":"user","content":"hi"}],]]
+            .. [["tools":[{"name":"create_browser","input_schema":]]
+            .. [[{"type":"object","properties":{},"required":[]}}]}]])
+        local openai = T.convert_request(anthropic)
+        local enc = cjson.encode(openai)
+        assert.is_true(has(enc, '"required":[]'))
+        assert.is_true(has(enc, '"properties":{}'))
+        assert.is_false(has(enc, '"required":{}'))
+    end)
+
+    it("omits an empty stop_sequences list", function()
+        local openai = T.convert_request(cjson.decode(
+            [[{"model":"m","max_tokens":1,"messages":[{"role":"user","content":"hi"}],"stop_sequences":[]}]]))
+        assert.is_nil(openai.stop)
+    end)
+
+    it("forwards a non-empty stop_sequences list as stop", function()
+        local openai = T.convert_request(cjson.decode(
+            [[{"model":"m","max_tokens":1,"messages":[{"role":"user","content":"hi"}],"stop_sequences":["X"]}]]))
+        assert.are.same({ "X" }, openai.stop)
+    end)
+end)
+
+describe("convert_response()", function()
+    it("emits content as a non-empty array even when the model returns nothing", function()
+        local resp = T.convert_response({ choices = { { message = {} } } }, "m")
+        -- content must serialise as a JSON array, never {}
+        assert.is_true(cjson.encode(resp.content):sub(1, 1) == "[")
+        assert.are.equal("text", resp.content[1].type)
+        assert.are.equal("", resp.content[1].text)
+    end)
+
+    it("represents tool_use.input as a JSON object", function()
+        local resp = T.convert_response({
+            choices = { { message = { tool_calls = {
+                { id = "c1", ["function"] = { name = "f" } },
+            } } } },
+        }, "m")
+        local tool_use = resp.content[#resp.content]
+        assert.are.equal("tool_use", tool_use.type)
+        assert.are.equal("{}", cjson.encode(tool_use.input))
+    end)
+end)
+
+describe("make_message_start()", function()
+    it("carries content as an empty JSON array, not {}", function()
+        local ev = T.make_message_start("m", 5)
+        assert.are.equal("[]", cjson.encode(ev.message.content))
+    end)
+end)

--- a/gateway/kong/plugins/neutree-ai-gateway/spec/handler_spec.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/spec/handler_spec.lua
@@ -36,15 +36,13 @@ package.loaded["kong.tools.string"] = {
 _G.ngx = { now = function() return 0 end }
 _G.kong = { log = { warn = function() end, err = function() end } }
 
--- Make `require("kong.plugins.neutree-ai-gateway.handler")` resolve to the
--- handler next to this spec, regardless of the working directory busted is run
--- from. The gateway root is four levels up from spec/.
+-- Load the handler by file path (relative to this spec) rather than by module
+-- name, so the tests do not depend on the kong.plugins.* directory nesting
+-- being present — the plugin dir is often bind-mounted on its own.
 local spec_dir = (debug.getinfo(1, "S").source:sub(2)):match("(.*/)") or "./"
-local gateway_root = spec_dir .. "../../../../"
-package.path = gateway_root .. "?.lua;" .. gateway_root .. "?/init.lua;" .. package.path
 
 local cjson = require("cjson.safe")
-local handler = require("kong.plugins.neutree-ai-gateway.handler")
+local handler = assert(loadfile(spec_dir .. "../handler.lua"))()
 local T = handler._TEST
 
 -- plain-substring find helpers (cjson emits no spaces, and a key and its value

--- a/gateway/kong/plugins/neutree-ai-gateway/spec/run.sh
+++ b/gateway/kong/plugins/neutree-ai-gateway/spec/run.sh
@@ -7,8 +7,8 @@
 # invoke busted's Lua entry point directly under `luajit`.
 #
 # Requires on PATH: luajit, luarocks, and the rocks `lua-cjson` + `busted`
-# installed. `make gateway-lua-test` provisions these in a container; CI installs
-# them on the runner. See ci.yaml (gateway-lua-test job).
+# installed. `make gateway-lua-test` builds spec/Dockerfile (which bakes those
+# into cached layers) and runs this script inside it; CI runs the same target.
 set -e
 
 plugin_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)

--- a/gateway/kong/plugins/neutree-ai-gateway/spec/run.sh
+++ b/gateway/kong/plugins/neutree-ai-gateway/spec/run.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Run the neutree-ai-gateway Lua unit tests.
+#
+# The tests must run under LuaJIT (the OpenResty/Kong runtime), not PUC Lua 5.1:
+# handler.lua uses `goto`/labels and `string.buffer`, which PUC 5.1 cannot even
+# parse. The luarocks `busted` wrapper hard-execs `lua5.1`, so we bypass it and
+# invoke busted's Lua entry point directly under `luajit`.
+#
+# Requires on PATH: luajit, luarocks, and the rocks `lua-cjson` + `busted`
+# installed. `make gateway-lua-test` provisions these in a container; CI installs
+# them on the runner. See ci.yaml (gateway-lua-test job).
+set -e
+
+plugin_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$plugin_dir"
+
+# Put the luarocks trees on Lua's module path so luajit can find busted + cjson.
+eval "$(luarocks path)"
+
+busted_bin=$(ls /usr/local/lib/luarocks/rocks-*/busted/*/bin/busted 2>/dev/null | head -1)
+if [ -z "$busted_bin" ]; then
+    busted_bin=$(ls "$HOME"/.luarocks/lib/luarocks/rocks-*/busted/*/bin/busted 2>/dev/null | head -1)
+fi
+if [ -z "$busted_bin" ]; then
+    echo "busted not found — install it with: luarocks install busted" >&2
+    exit 1
+fi
+
+exec luajit "$busted_bin" spec/ "$@"


### PR DESCRIPTION
## Problem (NEU-551)

Any OpenAI-compatible client (e.g. goose) that sends tool calls through an external-endpoint model mapping gets a 400 from the upstream when a tool's JSON Schema contains an empty array (most commonly `"required": []`):

```
Invalid schema for function 'create_browser': {} is not of type "array"
```

The client sends `[]`, but the upstream sees `{}` — something in the middle collapses the empty array into an empty object.

## Root cause

`access()` in `gateway/kong/plugins/neutree-ai-gateway/handler.lua` decodes the whole body, rewrites `model`, and re-encodes it before forwarding upstream on the model-mapping paths (anthropic / OpenAI passthrough). Plain lua-cjson decodes JSON `[]` and `{}` into the same empty Lua table — the array/object distinction is lost at decode time — and `cjson.encode` re-encodes every empty table as `{}`. So each `"required": []` becomes `"required": {}`, and the upstream's JSON-Schema validation rejects it with a 400.

Impact: any request that goes through a model mapping and carries an empty array anywhere in a tool schema will 400.

## Fix

The bug is one concept — "an empty Lua table has an ambiguous JSON type" — with two directions, centralised into a single policy block at the top of the plugin:

1. **Tables decoded FROM the client body** (the round-trip case): `cjson.decode_array_with_array_mt(true)` at module load tags decoded arrays so a re-encode preserves `[]`, while genuine empty objects still encode as `{}`. One setting covers every decode path. (A global `encode_empty_table_as_object(false)` was rejected — a body can hold both an empty array and an empty object, so it would just move the bug.)
2. **Lists the plugin builds ITSELF** (rule 1 can't help these): one `json_array()` helper that tags a table with `array_mt`. Used at the three sites that needed it — the streaming `message_start` content and the two model-list endpoints — replacing the earlier scattered `cjson.empty_array` / `setmetatable(...)` idioms.

Sibling plugins (`neutree-ai-access`, `-quota`, `-statistics`) only decode bodies to read fields and never re-encode them onto the wire, so they are unaffected.

## Tests (first Lua UT in the repo)

`spec/handler_spec.lua` — 12 busted cases covering `json_array()`, the decode round-trip (`required:[]` stays an array, `properties:{}` stays an object), `convert_tools`/`convert_request` preserving empty tool-schema arrays end to end, `convert_response` emitting `content` as an array and `tool_use.input` as an object, and `make_message_start` content being `[]`. Internal helpers are exposed via a test-only `_TEST` table.

Runner details:
- Tests run under **LuaJIT** (the OpenResty/Kong runtime) — the plugin uses `goto`/labels + `string.buffer`, which PUC Lua 5.1 cannot parse. OpenResty/Kong deps are stubbed in the spec, so the suite runs on a plain `luajit + luarocks(lua-cjson, busted)` toolchain — no OpenResty image needed.
- `make gateway-lua-test` provisions the toolchain in a Docker container.
- New `gateway-lua-test` CI job runs the suite on every PR.

All 12 pass locally (verified under LuaJIT 2.1).

## Verification

Reproduced and fix-verified in a Kong 3.9 (OpenResty) container: `required:[]`/`stop:[]` round-trip as `[]`; `properties:{}` stays `{}`; `json_array()`/`make_message_start` content encode as `[]`; modified handler parses under `resty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)