### PR TITLE
fix: project matched exporter env to node-agent

### DIFF
--- a/internal/cluster/component/metrics/exporters.go
+++ b/internal/cluster/component/metrics/exporters.go
@@ -74,10 +74,6 @@ func (e metricsAcceleratorExporter) HasCustomMetricsPath() bool {
 }
 
 func (m *MetricsComponent) planAcceleratorExporters(ctx context.Context) ([]metricsAcceleratorExporter, error) {
-	if m.acceleratorExporterMode() != v1.ClusterAcceleratorExporterModeManaged {
-		return nil, nil
-	}
-
 	supported, err := m.supportsManagedMetricsExporters()
 	if err != nil {
 		return nil, err

--- a/internal/cluster/component/metrics/metrics_apply.go
+++ b/internal/cluster/component/metrics/metrics_apply.go
@@ -40,7 +40,9 @@ func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructur
 		return nil, errors.Wrapf(err, "failed to plan accelerator exporters for cluster %s", m.cluster.Metadata.Name)
 	}
 
-	variables.AcceleratorExporters = acceleratorExporters
+	if m.acceleratorExporterMode() == v1.ClusterAcceleratorExporterModeManaged {
+		variables.AcceleratorExporters = acceleratorExporters
+	}
 	variables.NeutreeNodeAgentMetricsEnv = nodeAgentEnvFromAcceleratorExporters(acceleratorExporters)
 
 	vmagentConfig, err := renderKubernetesVMAgentConfig(variables)

--- a/internal/cluster/component/metrics/metrics_apply.go
+++ b/internal/cluster/component/metrics/metrics_apply.go
@@ -43,6 +43,7 @@ func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructur
 	if m.acceleratorExporterMode() == v1.ClusterAcceleratorExporterModeManaged {
 		variables.AcceleratorExporters = acceleratorExporters
 	}
+
 	variables.NeutreeNodeAgentMetricsEnv = nodeAgentEnvFromAcceleratorExporters(acceleratorExporters)
 
 	vmagentConfig, err := renderKubernetesVMAgentConfig(variables)

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -571,6 +571,115 @@ func TestBuildMetricsResourcesUsesExternalDCGMScrapeWhenConfigured(t *testing.T)
 	assert.Assert(t, !strings.Contains(args, "--accelerator-exporter-url"))
 }
 
+func TestBuildMetricsResourcesProjectsMatchedExporterEnvToNodeAgent(t *testing.T) {
+	testCases := []struct {
+		name                string
+		mode                v1.ClusterAcceleratorExporterMode
+		nodeLabels          map[string]string
+		wantNodeAgentEnv    map[string]string
+		wantManagedExporter bool
+	}{
+		{
+			name: "managed mode",
+			mode: v1.ClusterAcceleratorExporterModeManaged,
+			nodeLabels: map[string]string{
+				"accelerator.example.com/nvidia": "true",
+			},
+			wantNodeAgentEnv: map[string]string{
+				"NVIDIA_VISIBLE_DEVICES":     "all",
+				"NVIDIA_DRIVER_CAPABILITIES": "utility,compute",
+			},
+			wantManagedExporter: true,
+		},
+		{
+			name: "external mode",
+			mode: v1.ClusterAcceleratorExporterModeExternal,
+			nodeLabels: map[string]string{
+				"accelerator.example.com/nvidia": "true",
+			},
+			wantNodeAgentEnv: map[string]string{
+				"NVIDIA_VISIBLE_DEVICES":     "all",
+				"NVIDIA_DRIVER_CAPABILITIES": "utility,compute",
+			},
+		},
+		{
+			name: "external mode without matching node",
+			mode: v1.ClusterAcceleratorExporterModeExternal,
+			nodeLabels: map[string]string{
+				"kubernetes.io/os": "linux",
+			},
+			wantNodeAgentEnv: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			acceleratorMgr := &acceleratormocks.MockManager{}
+			acceleratorMgr.On("SupportPlugins").Return([]string{v1.AcceleratorTypeNVIDIAGPU.String()}).Maybe()
+			acceleratorMgr.On("GetAcceleratorProfile", mock.Anything, v1.AcceleratorTypeNVIDIAGPU.String()).
+				Return(&v1.AcceleratorProfile{
+					AcceleratorType: v1.AcceleratorTypeNVIDIAGPU.String(),
+					MetricsExporter: &v1.AcceleratorExporterProfile{
+						Name:  "dcgm-exporter",
+						Image: "nvcr.io/nvidia/k8s/dcgm-exporter:test",
+						Port:  19400,
+						Env: map[string]string{
+							"NVIDIA_VISIBLE_DEVICES":     "all",
+							"NVIDIA_DRIVER_CAPABILITIES": "utility,compute",
+							"UNRELATED_EXPORTER_ENV":     "must-not-project",
+						},
+						Runtime: &v1.AcceleratorExporterRuntimeProfile{
+							NodeSelector: map[string]string{
+								"accelerator.example.com/nvidia": "true",
+							},
+						},
+					},
+				}, nil).Maybe()
+
+			metricsCmpt := &MetricsComponent{
+				cluster: &v1.Cluster{
+					Metadata: &v1.Metadata{Name: "test-cluster", Workspace: "test-workspace"},
+					Spec: &v1.ClusterSpec{
+						Version: "v1.1.0",
+						Config: &v1.ClusterConfig{Metrics: &v1.ClusterMetricsConfig{
+							AcceleratorExporter: &v1.ClusterAcceleratorExporterConfig{Mode: tc.mode},
+						}},
+					},
+				},
+				namespace:      "test-namespace",
+				acceleratorMgr: acceleratorMgr,
+				ctrlClient: fake.NewClientBuilder().WithObjects(
+					metricsTestNode("test-node", tc.nodeLabels),
+				).Build(),
+			}
+
+			objs, err := metricsCmpt.GetMetricsResources(context.Background())
+			assert.NilError(t, err)
+
+			nodeAgent := findMetricsDaemonSet(t, objs, "neutree-node-agent")
+			for name, want := range tc.wantNodeAgentEnv {
+				assert.Equal(t, want, envValue(nodeAgent.Spec.Template.Spec.Containers[0].Env, name))
+			}
+			for _, name := range []string{
+				"NVIDIA_VISIBLE_DEVICES",
+				"NVIDIA_DRIVER_CAPABILITIES",
+				"UNRELATED_EXPORTER_ENV",
+			} {
+				if _, ok := tc.wantNodeAgentEnv[name]; !ok {
+					assert.Assert(t, !hasEnv(nodeAgent.Spec.Template.Spec.Containers[0].Env, name))
+				}
+			}
+
+			managedExporterFound := false
+			for _, obj := range objs.Items {
+				isManagedExporter := obj.GetKind() == "DaemonSet" && obj.GetName() == "nvidia-gpu-dcgm-exporter"
+				managedExporterFound = managedExporterFound || isManagedExporter
+			}
+			assert.Equal(t, tc.wantManagedExporter, managedExporterFound)
+		})
+	}
+}
+
 func TestBuildMetricsResourcesDoesNotGrantNodeAgentExternalNodeExporterAccess(t *testing.T) {
 	metricsCmpt := &MetricsComponent{
 		cluster: &v1.Cluster{
@@ -1169,6 +1278,16 @@ func envValue(env []corev1.EnvVar, name string) string {
 	}
 
 	return ""
+}
+
+func hasEnv(env []corev1.EnvVar, name string) bool {
+	for _, item := range env {
+		if item.Name == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func findMetricsDaemonSet(t *testing.T, objs *unstructured.UnstructuredList, name string) *appsv1.DaemonSet {

--- a/internal/cluster/component/metrics/metrics_status.go
+++ b/internal/cluster/component/metrics/metrics_status.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/cluster/component"
 	"github.com/neutree-ai/neutree/internal/util"
 )
@@ -120,29 +121,31 @@ func (m *MetricsComponent) CheckResourcesStatus(ctx context.Context) (*MetricsSt
 		}
 	}
 
-	acceleratorExporters, err := m.planAcceleratorExporters(ctx)
-	if err != nil {
-		status.Errors = append(status.Errors, fmt.Sprintf("accelerator-exporter plan failed: %v", err))
-	} else if len(acceleratorExporters) > 0 {
-		status.AcceleratorExporterRequired = true
-		status.AcceleratorExporterDaemonSetsReady = true
+	if m.acceleratorExporterMode() == v1.ClusterAcceleratorExporterModeManaged {
+		acceleratorExporters, err := m.planAcceleratorExporters(ctx)
+		if err != nil {
+			status.Errors = append(status.Errors, fmt.Sprintf("accelerator-exporter plan failed: %v", err))
+		} else if len(acceleratorExporters) > 0 {
+			status.AcceleratorExporterRequired = true
+			status.AcceleratorExporterDaemonSetsReady = true
 
-		for _, exporter := range acceleratorExporters {
-			exporterReady, exporterPodsReady, exporterTotalPods, checkErr := m.checkDaemonSetStatus(ctx, exporter.Name)
-			if checkErr != nil {
-				status.AcceleratorExporterDaemonSetsReady = false
-				status.Errors = append(status.Errors,
-					fmt.Sprintf("accelerator-exporter daemonset %s check failed: %v", exporter.Name, checkErr))
+			for _, exporter := range acceleratorExporters {
+				exporterReady, exporterPodsReady, exporterTotalPods, checkErr := m.checkDaemonSetStatus(ctx, exporter.Name)
+				if checkErr != nil {
+					status.AcceleratorExporterDaemonSetsReady = false
+					status.Errors = append(status.Errors,
+						fmt.Sprintf("accelerator-exporter daemonset %s check failed: %v", exporter.Name, checkErr))
 
-				continue
+					continue
+				}
+
+				if !exporterReady {
+					status.AcceleratorExporterDaemonSetsReady = false
+				}
+
+				status.AcceleratorExporterPodsReady += exporterPodsReady
+				status.AcceleratorExporterTotalPods += exporterTotalPods
 			}
-
-			if !exporterReady {
-				status.AcceleratorExporterDaemonSetsReady = false
-			}
-
-			status.AcceleratorExporterPodsReady += exporterPodsReady
-			status.AcceleratorExporterTotalPods += exporterTotalPods
 		}
 	}
 

--- a/internal/cluster/component/metrics/metrics_status_test.go
+++ b/internal/cluster/component/metrics/metrics_status_test.go
@@ -275,6 +275,51 @@ func TestCheckResourcesStatusIncludesAcceleratorExporterDaemonSet(t *testing.T) 
 	assert.True(t, status.AcceleratorExporterDaemonSetsReady)
 }
 
+func TestCheckResourcesStatusDoesNotRequireManagedAcceleratorExporterInExternalMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(
+			readyMetricsDeployment("vmagent"),
+			readyMetricsDeployment("neutree-kube-state-metrics"),
+			readyMetricsDaemonSet("neutree-node-exporter", 1),
+			readyMetricsDaemonSet("neutree-node-agent", 1),
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu-node",
+					Labels: map[string]string{
+						"nvidia.com/gpu.present": "true",
+					},
+				},
+			},
+		).
+		Build()
+
+	metricsCmpt := &MetricsComponent{
+		ctrlClient:     fakeClient,
+		namespace:      "default",
+		acceleratorMgr: accelerator.NewManager(gin.New()),
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
+			Spec: &v1.ClusterSpec{
+				Version: "v1.1.0",
+				Config: &v1.ClusterConfig{Metrics: &v1.ClusterMetricsConfig{
+					AcceleratorExporter: &v1.ClusterAcceleratorExporterConfig{
+						Mode: v1.ClusterAcceleratorExporterModeExternal,
+					},
+				}},
+			},
+		},
+	}
+
+	status, err := metricsCmpt.CheckResourcesStatus(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, status.Ready())
+	assert.False(t, status.AcceleratorExporterRequired)
+	assert.False(t, status.AcceleratorExporterDaemonSetsReady)
+	assert.Empty(t, status.Errors)
+}
+
 func TestSupportsClusterVersionAtLeast(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/tests/e2e/cluster_k8s_config_test.go
+++ b/tests/e2e/cluster_k8s_config_test.go
@@ -242,7 +242,7 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			ClusterH.EnsureDeleted(clusterName)
 		})
 
-		It("should scrape external accelerator exporter without installing managed DCGM", Label("C2623077"), func() {
+		It("should scrape external accelerator exporter without installing managed DCGM", Label("C2732256"), func() {
 			assertK8sExternalAcceleratorExporterResources(
 				context.Background(),
 				k8sH,

--- a/tests/e2e/cluster_metrics_helper.go
+++ b/tests/e2e/cluster_metrics_helper.go
@@ -153,12 +153,14 @@ func assertK8sExternalAcceleratorExporterResources(
 		))
 
 		visibleDevices := ""
+
 		for _, env := range nodeAgentContainer.Env {
 			if env.Name == "NVIDIA_VISIBLE_DEVICES" {
 				visibleDevices = env.Value
 				break
 			}
 		}
+
 		ExpectWithOffset(1, visibleDevices).To(Equal("all"))
 	} else {
 		_, err = k8sH.GetDaemonSet(ctx, namespace, "neutree-node-exporter")

--- a/tests/e2e/cluster_metrics_helper.go
+++ b/tests/e2e/cluster_metrics_helper.go
@@ -146,10 +146,20 @@ func assertK8sExternalAcceleratorExporterResources(
 
 		nodeAgent := eventuallyDaemonSetReady(ctx, k8sH, namespace, "neutree-node-agent")
 		ExpectWithOffset(1, nodeAgent.Spec.Template.Spec.Containers).NotTo(BeEmpty())
-		ExpectWithOffset(1, nodeAgent.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--metrics-mode=external"))
-		ExpectWithOffset(1, nodeAgent.Spec.Template.Spec.Containers[0].Args).NotTo(ContainElement(
+		nodeAgentContainer := nodeAgent.Spec.Template.Spec.Containers[0]
+		ExpectWithOffset(1, nodeAgentContainer.Args).To(ContainElement("--metrics-mode=external"))
+		ExpectWithOffset(1, nodeAgentContainer.Args).NotTo(ContainElement(
 			ContainSubstring("--accelerator-exporter-url="),
 		))
+
+		visibleDevices := ""
+		for _, env := range nodeAgentContainer.Env {
+			if env.Name == "NVIDIA_VISIBLE_DEVICES" {
+				visibleDevices = env.Value
+				break
+			}
+		}
+		ExpectWithOffset(1, visibleDevices).To(Equal("all"))
 	} else {
 		_, err = k8sH.GetDaemonSet(ctx, namespace, "neutree-node-exporter")
 		ExpectWithOffset(1, apierrors.IsNotFound(err)).To(BeTrue(), "node-exporter should not exist before cluster version v1.1.0")

--- a/tests/e2e/cluster_metrics_helper.go
+++ b/tests/e2e/cluster_metrics_helper.go
@@ -152,16 +152,10 @@ func assertK8sExternalAcceleratorExporterResources(
 			ContainSubstring("--accelerator-exporter-url="),
 		))
 
-		visibleDevices := ""
-
-		for _, env := range nodeAgentContainer.Env {
-			if env.Name == "NVIDIA_VISIBLE_DEVICES" {
-				visibleDevices = env.Value
-				break
-			}
-		}
-
-		ExpectWithOffset(1, visibleDevices).To(Equal("all"))
+		ExpectWithOffset(1, nodeAgentContainer.Env).To(ContainElement(And(
+			HaveField("Name", "NVIDIA_VISIBLE_DEVICES"),
+			HaveField("Value", "all"),
+		)))
 	} else {
 		_, err = k8sH.GetDaemonSet(ctx, namespace, "neutree-node-exporter")
 		ExpectWithOffset(1, apierrors.IsNotFound(err)).To(BeTrue(), "node-exporter should not exist before cluster version v1.1.0")

--- a/tests/e2e/cluster_metrics_helper.go
+++ b/tests/e2e/cluster_metrics_helper.go
@@ -151,11 +151,6 @@ func assertK8sExternalAcceleratorExporterResources(
 		ExpectWithOffset(1, nodeAgentContainer.Args).NotTo(ContainElement(
 			ContainSubstring("--accelerator-exporter-url="),
 		))
-
-		ExpectWithOffset(1, nodeAgentContainer.Env).To(ContainElement(And(
-			HaveField("Name", "NVIDIA_VISIBLE_DEVICES"),
-			HaveField("Value", "all"),
-		)))
 	} else {
 		_, err = k8sH.GetDaemonSet(ctx, namespace, "neutree-node-exporter")
 		ExpectWithOffset(1, apierrors.IsNotFound(err)).To(BeTrue(), "node-exporter should not exist before cluster version v1.1.0")


### PR DESCRIPTION
## Issue

NEU-548

## Summary

Project environment variables from matched accelerator exporter profiles to node-agent in both Managed and External modes.

## Changes

- Reuse matched exporter profiles when rendering node-agent environment variables.
- Keep managed exporter resources and readiness checks exclusive to Managed mode.
- Cover selector matching, allowed environment-variable projection, and External-mode status behavior.
- Keep Kubernetes External-mode resource assertions accelerator agnostic.

## Test Plan

### Unit test

- `go test ./internal/cluster/component/metrics ./tests/e2e`
- `go vet ./internal/cluster/component/metrics ./tests/e2e`
- Repository-pinned `golangci-lint` v1.64.6

### DB test

Not required: no DB schema or persistence changes.

### E2E test

- Local E2E package compilation passed.
- The scoped live code E2E batch was not completed; manual validation was used for this PR runtime.
- Manual validation on the deployed PR runtime confirmed that `neutree-node-agent` has `NVIDIA_VISIBLE_DEVICES`.
- Manual validation confirmed that the Cluster and Endpoint Overview dashboards display GPU architecture, CUDA Capability, Driver, and CUDA Driver correctly. Dashboard rendering is not covered by the scoped code E2E case.

## Risk & Rollback

The change is limited to metrics resource rendering and readiness checks. Revert the NEU-548 commits on this branch to restore prior behavior.