### PR TITLE
feat: CLI model usage export (NEU-546)

### DIFF
--- a/cmd/neutree-cli/app/cmd/export/export.go
+++ b/cmd/neutree-cli/app/cmd/export/export.go
@@ -29,6 +29,7 @@ func NewExportCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newAccessLogCmd())
+	cmd.AddCommand(newModelUsageCmd())
 
 	return cmd
 }

--- a/cmd/neutree-cli/app/cmd/export/model_usage.go
+++ b/cmd/neutree-cli/app/cmd/export/model_usage.go
@@ -163,11 +163,6 @@ func runUsageExport(req usageExportRequest) (int, error) {
 		return 0, err
 	}
 
-	writer, err := newUsageWriter(req.opts.format, req.dataOut)
-	if err != nil {
-		return 0, err
-	}
-
 	rows, err := req.lister.GetUsageByDimension(client.UsageFilters{
 		StartDate:    start,
 		EndDate:      end,
@@ -175,6 +170,15 @@ func runUsageExport(req usageExportRequest) (int, error) {
 		EndpointName: req.opts.endpoint,
 		Workspace:    resolveUsageWorkspace(req.opts.workspace, req.opts.allWorkspaces),
 	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Build the writer only after the RPC succeeds. This RPC is non-paginated —
+	// the fetch above already holds every row — so opening the writer first buys
+	// no streaming benefit and would emit a CSV header (buffered on construction)
+	// even when the RPC then fails, leaving misleading partial output.
+	writer, err := newUsageWriter(req.opts.format, req.dataOut)
 	if err != nil {
 		return 0, err
 	}
@@ -202,35 +206,44 @@ func runUsageExport(req usageExportRequest) (int, error) {
 	return total, nil
 }
 
-// resolveWindow fills in the default window (last defaultWindowDays through
-// today, UTC) for any unset bound and validates explicit ones. Both bounds are
-// inclusive dates, matching the RPC's BETWEEN semantics.
+// resolveWindow resolves the inclusive [start, end] date window. An unset
+// --until defaults to today (UTC); an unset --since defaults to
+// defaultWindowDays before the *resolved end* (not before "now"), so an
+// explicit past --until still yields a full trailing window rather than a
+// start that runs ahead of the end. Explicit bounds are validated, and a window
+// with start after end is rejected. Both bounds are inclusive, matching the
+// RPC's BETWEEN semantics.
 func resolveWindow(since, until string, now time.Time) (string, string, error) {
-	end := until
-	if end == "" {
-		end = now.UTC().Format(dateLayout)
-	} else if err := validateDate(end); err != nil {
-		return "", "", fmt.Errorf("invalid --until: %w", err)
+	end := now.UTC()
+
+	if until != "" {
+		t, err := time.Parse(dateLayout, until)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid --until: %q is not a valid date (want YYYY-MM-DD)", until)
+		}
+
+		end = t
 	}
 
-	start := since
-	if start == "" {
-		start = now.UTC().AddDate(0, 0, -defaultWindowDays).Format(dateLayout)
-	} else if err := validateDate(start); err != nil {
-		return "", "", fmt.Errorf("invalid --since: %w", err)
+	start := end.AddDate(0, 0, -defaultWindowDays)
+
+	if since != "" {
+		t, err := time.Parse(dateLayout, since)
+		if err != nil {
+			return "", "", fmt.Errorf("invalid --since: %q is not a valid date (want YYYY-MM-DD)", since)
+		}
+
+		start = t
 	}
 
-	return start, end, nil
-}
-
-// validateDate rejects anything that is not a bare YYYY-MM-DD date, so a
-// malformed flag fails locally with a clear message instead of as a server error.
-func validateDate(v string) error {
-	if _, err := time.Parse(dateLayout, v); err != nil {
-		return fmt.Errorf("%q is not a valid date (want YYYY-MM-DD)", v)
+	// Compare on the date, not the clock: a defaulted end carries now's
+	// time-of-day, which must not make an equal-date start look "after" it.
+	if start.Format(dateLayout) > end.Format(dateLayout) {
+		return "", "", fmt.Errorf("invalid window: --since %s is after --until %s",
+			start.Format(dateLayout), end.Format(dateLayout))
 	}
 
-	return nil
+	return start.Format(dateLayout), end.Format(dateLayout), nil
 }
 
 // resolveUsageWorkspace maps the workspace flags to the p_workspace value.

--- a/cmd/neutree-cli/app/cmd/export/model_usage.go
+++ b/cmd/neutree-cli/app/cmd/export/model_usage.go
@@ -1,0 +1,261 @@
+package export
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+// usageLister fetches model-usage aggregates. *client.UsageService satisfies
+// it; injecting the interface (rather than a concrete client) lets the export
+// logic be unit tested with an in-memory fake — no HTTP server, no filesystem.
+type usageLister interface {
+	GetUsageByDimension(filters client.UsageFilters) ([]client.UsageRow, error)
+}
+
+// dateLayout is the YYYY-MM-DD form used by the RPC's DATE parameters and by the
+// --since/--until flags.
+const dateLayout = "2006-01-02"
+
+// defaultWindowDays is how far back --since defaults when unset. It mirrors the
+// UI's default usage window so the CLI and UI show the same range out of the box.
+const defaultWindowDays = 30
+
+// modelUsageOptions holds the flags for `export model-usage`.
+type modelUsageOptions struct {
+	workspace     string
+	allWorkspaces bool
+	format        string
+	file          string
+
+	since string
+	until string
+
+	apiKeyID     string
+	endpoint     string
+	model        string // client-side filter (RPC has no model param)
+	endpointType string // client-side filter (RPC has no endpoint_type param)
+}
+
+func newModelUsageCmd() *cobra.Command {
+	opts := &modelUsageOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "model-usage",
+		Short: "Export model usage statistics",
+		Long: `Export model usage statistics (per day, API key, endpoint, and model).
+
+Usage is already day-aggregated server-side, so the whole result set comes back
+in a single request — there is no pagination. Data is written to stdout by
+default (redirect with --file); all progress and diagnostics go to stderr, so
+the data stream stays clean for pipes and redirection.
+
+The default output is CSV (the common case is a spreadsheet); pass --format json
+or jsonl for machine consumption. The default window is the last 30 days; bound
+it with --since/--until (YYYY-MM-DD, both inclusive).
+
+Pass --all-workspaces (-A) to aggregate across every workspace you may read.
+--model and --endpoint-type filter client-side (the RPC does not take them),
+matching the UI's behavior.
+
+Examples:
+  # Last 30 days for the default workspace, as CSV to stdout
+  neutree-cli export model-usage -w default
+
+  # A bounded window, all workspaces, to a file
+  neutree-cli export model-usage -A --since 2026-07-01 --until 2026-07-15 -f usage.csv
+
+  # One API key, JSON Lines piped to jq
+  neutree-cli export model-usage --api-key-id <uuid> --format jsonl | jq -c .`,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runModelUsageExport(opts)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&opts.workspace, "workspace", "w", "default", "Workspace name")
+	f.BoolVarP(&opts.allWorkspaces, "all-workspaces", "A", false, "Aggregate across every workspace you may read (mutually exclusive with --workspace)")
+	f.StringVar(&opts.format, "format", "csv", "Output format: csv, json, jsonl")
+	f.StringVarP(&opts.file, "file", "f", "", "Output file path (default: stdout)")
+	f.StringVar(&opts.since, "since", "", "Start date, inclusive (YYYY-MM-DD; default: 30 days ago)")
+	f.StringVar(&opts.until, "until", "", "End date, inclusive (YYYY-MM-DD; default: today)")
+	f.StringVar(&opts.apiKeyID, "api-key-id", "", "Filter by API key ID (UUID)")
+	f.StringVar(&opts.endpoint, "endpoint", "", "Filter by endpoint name")
+	f.StringVar(&opts.model, "model", "", "Filter by model name (client-side)")
+	f.StringVar(&opts.endpointType, "endpoint-type", "", "Filter by endpoint type (client-side)")
+
+	cmd.MarkFlagsMutuallyExclusive("workspace", "all-workspaces")
+
+	return cmd
+}
+
+func runModelUsageExport(opts *modelUsageOptions) error {
+	c, err := global.NewClient()
+	if err != nil {
+		return err
+	}
+
+	// Resolve output. A file is buffered; stdout is written directly. Progress
+	// always goes to stderr so it never corrupts the data stream.
+	var out *os.File
+
+	if opts.file != "" {
+		out, err = os.Create(opts.file)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer out.Close()
+	} else {
+		out = os.Stdout
+	}
+
+	bw := bufio.NewWriter(out)
+	defer bw.Flush() //nolint:errcheck
+
+	total, err := runUsageExport(usageExportRequest{
+		lister:   c.Usage,
+		dataOut:  bw,
+		progress: os.Stderr,
+		now:      time.Now(),
+		opts:     opts,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := bw.Flush(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "done: exported %d model usage record(s)\n", total)
+
+	return nil
+}
+
+// usageExportRequest carries the fully-resolved inputs for a single export run.
+// It depends only on the usageLister interface and io.Writers (plus an injected
+// clock), so runUsageExport is unit testable with an in-memory lister and byte
+// buffers.
+type usageExportRequest struct {
+	lister   usageLister
+	dataOut  io.Writer // record stream (stdout or a file)
+	progress io.Writer // diagnostics (stderr)
+	now      time.Time // clock for the default window
+	opts     *modelUsageOptions
+}
+
+// runUsageExport resolves the window, fetches the aggregates in one RPC, applies
+// client-side filters, and writes each row in the chosen format. It returns the
+// number of records written.
+func runUsageExport(req usageExportRequest) (int, error) {
+	start, end, err := resolveWindow(req.opts.since, req.opts.until, req.now)
+	if err != nil {
+		return 0, err
+	}
+
+	writer, err := newUsageWriter(req.opts.format, req.dataOut)
+	if err != nil {
+		return 0, err
+	}
+
+	rows, err := req.lister.GetUsageByDimension(client.UsageFilters{
+		StartDate:    start,
+		EndDate:      end,
+		APIKeyID:     req.opts.apiKeyID,
+		EndpointName: req.opts.endpoint,
+		Workspace:    resolveUsageWorkspace(req.opts.workspace, req.opts.allWorkspaces),
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	total := 0
+
+	for i := range rows {
+		if !matchesClientFilters(rows[i], req.opts.model, req.opts.endpointType) {
+			continue
+		}
+
+		if err := writer.Write(rows[i]); err != nil {
+			return total, err
+		}
+
+		total++
+	}
+
+	if err := writer.Close(); err != nil {
+		return total, err
+	}
+
+	fmt.Fprintf(req.progress, "exported %d model usage record(s)...\n", total)
+
+	return total, nil
+}
+
+// resolveWindow fills in the default window (last defaultWindowDays through
+// today, UTC) for any unset bound and validates explicit ones. Both bounds are
+// inclusive dates, matching the RPC's BETWEEN semantics.
+func resolveWindow(since, until string, now time.Time) (string, string, error) {
+	end := until
+	if end == "" {
+		end = now.UTC().Format(dateLayout)
+	} else if err := validateDate(end); err != nil {
+		return "", "", fmt.Errorf("invalid --until: %w", err)
+	}
+
+	start := since
+	if start == "" {
+		start = now.UTC().AddDate(0, 0, -defaultWindowDays).Format(dateLayout)
+	} else if err := validateDate(start); err != nil {
+		return "", "", fmt.Errorf("invalid --since: %w", err)
+	}
+
+	return start, end, nil
+}
+
+// validateDate rejects anything that is not a bare YYYY-MM-DD date, so a
+// malformed flag fails locally with a clear message instead of as a server error.
+func validateDate(v string) error {
+	if _, err := time.Parse(dateLayout, v); err != nil {
+		return fmt.Errorf("%q is not a valid date (want YYYY-MM-DD)", v)
+	}
+
+	return nil
+}
+
+// resolveUsageWorkspace maps the workspace flags to the p_workspace value.
+// --all-workspaces resolves to the empty string, which the client omits so the
+// RPC sees SQL NULL (union across every workspace the caller may read) — no
+// sentinel value, unlike the trace endpoint.
+func resolveUsageWorkspace(workspace string, allWorkspaces bool) string {
+	if allWorkspaces {
+		return ""
+	}
+
+	return workspace
+}
+
+// matchesClientFilters applies the --model and --endpoint-type filters that the
+// RPC does not support, mirroring the UI's client-side filtering. An empty
+// filter matches everything.
+func matchesClientFilters(row client.UsageRow, model, endpointType string) bool {
+	if model != "" && row.ModelName != model {
+		return false
+	}
+
+	if endpointType != "" && row.EndpointType != endpointType {
+		return false
+	}
+
+	return true
+}

--- a/cmd/neutree-cli/app/cmd/export/model_usage_test.go
+++ b/cmd/neutree-cli/app/cmd/export/model_usage_test.go
@@ -185,6 +185,17 @@ func TestResolveWindow(t *testing.T) {
 	require.Equal(t, "2026-01-01", start)
 	require.Equal(t, "2026-01-31", end)
 
+	// An explicit past --until still yields a full trailing window: --since
+	// defaults relative to the resolved end, not to "now".
+	start, end, err = resolveWindow("", "2026-01-31", fixedNow)
+	require.NoError(t, err)
+	require.Equal(t, "2026-01-01", start)
+	require.Equal(t, "2026-01-31", end)
+
+	// A start after the end is rejected rather than sent to the server.
+	_, _, err = resolveWindow("2026-07-10", "2026-07-01", fixedNow)
+	require.ErrorContains(t, err, "after")
+
 	// Malformed bounds are rejected.
 	_, _, err = resolveWindow("nope", "", fixedNow)
 	require.ErrorContains(t, err, "invalid --since")

--- a/cmd/neutree-cli/app/cmd/export/model_usage_test.go
+++ b/cmd/neutree-cli/app/cmd/export/model_usage_test.go
@@ -1,0 +1,209 @@
+package export
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+// fakeUsageLister is an in-memory usageLister. It records the filters it was
+// called with (so tests can assert window/workspace resolution) and returns a
+// canned set of rows.
+type fakeUsageLister struct {
+	rows    []client.UsageRow
+	lastArg client.UsageFilters
+	calls   int
+	err     error
+}
+
+func (f *fakeUsageLister) GetUsageByDimension(filters client.UsageFilters) ([]client.UsageRow, error) {
+	f.calls++
+	f.lastArg = filters
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.rows, nil
+}
+
+func i64(n int64) *int64 { return &n }
+
+func usageRow(model, endpointType string) client.UsageRow {
+	return client.UsageRow{
+		Date:             "2026-07-15",
+		APIKeyID:         "key-1",
+		APIKeyName:       "my-key",
+		EndpointType:     endpointType,
+		EndpointName:     "ep-1",
+		ModelName:        model,
+		Workspace:        "default",
+		Usage:            i64(3),
+		PromptTokens:     i64(10),
+		CompletionTokens: i64(20),
+	}
+}
+
+// fixedNow is a stable clock so default-window assertions are deterministic.
+var fixedNow = time.Date(2026, 7, 16, 8, 30, 0, 0, time.UTC)
+
+func runUsage(t *testing.T, lister usageLister, opts *modelUsageOptions) (int, string) {
+	t.Helper()
+
+	var data bytes.Buffer
+
+	total, err := runUsageExport(usageExportRequest{
+		lister:   lister,
+		dataOut:  &data,
+		progress: io.Discard,
+		now:      fixedNow,
+		opts:     opts,
+	})
+	require.NoError(t, err)
+
+	return total, data.String()
+}
+
+func TestRunUsageExportDefaultWindowAndCSV(t *testing.T) {
+	lister := &fakeUsageLister{rows: []client.UsageRow{usageRow("m1", "endpoint")}}
+
+	total, out := runUsage(t, lister, &modelUsageOptions{format: "csv", workspace: "default"})
+
+	require.Equal(t, 1, total)
+
+	// Default window: today and today-30d, both inclusive.
+	require.Equal(t, "2026-07-16", lister.lastArg.EndDate)
+	require.Equal(t, "2026-06-16", lister.lastArg.StartDate)
+	require.Equal(t, "default", lister.lastArg.Workspace)
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	require.Len(t, lines, 2) // header + 1 row
+	require.Equal(t, strings.Join(usageCSVHeader, ","), lines[0])
+	require.Contains(t, lines[1], "my-key")
+}
+
+func TestRunUsageExportExplicitWindow(t *testing.T) {
+	lister := &fakeUsageLister{rows: []client.UsageRow{usageRow("m1", "endpoint")}}
+
+	_, _ = runUsage(t, lister, &modelUsageOptions{
+		format: "csv", workspace: "default",
+		since: "2026-07-01", until: "2026-07-10",
+	})
+
+	require.Equal(t, "2026-07-01", lister.lastArg.StartDate)
+	require.Equal(t, "2026-07-10", lister.lastArg.EndDate)
+}
+
+func TestRunUsageExportAllWorkspacesOmitsWorkspace(t *testing.T) {
+	lister := &fakeUsageLister{rows: []client.UsageRow{usageRow("m1", "endpoint")}}
+
+	_, _ = runUsage(t, lister, &modelUsageOptions{
+		format: "csv", workspace: "default", allWorkspaces: true,
+	})
+
+	// All-workspaces resolves to empty so the client sends no p_workspace (NULL).
+	require.Equal(t, "", lister.lastArg.Workspace)
+}
+
+func TestRunUsageExportClientSideFilters(t *testing.T) {
+	lister := &fakeUsageLister{rows: []client.UsageRow{
+		usageRow("gpt", "endpoint"),
+		usageRow("llama", "external-endpoint"),
+		usageRow("gpt", "external-endpoint"),
+	}}
+
+	// Filter to model=gpt AND endpoint-type=endpoint -> only the first row.
+	total, out := runUsage(t, lister, &modelUsageOptions{
+		format: "jsonl", workspace: "default",
+		model: "gpt", endpointType: "endpoint",
+	})
+
+	require.Equal(t, 1, total)
+
+	var rec client.UsageRow
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &rec))
+	require.Equal(t, "gpt", rec.ModelName)
+	require.Equal(t, "endpoint", rec.EndpointType)
+}
+
+func TestRunUsageExportRejectsBadDate(t *testing.T) {
+	lister := &fakeUsageLister{}
+
+	_, err := runUsageExport(usageExportRequest{
+		lister:   lister,
+		dataOut:  io.Discard,
+		progress: io.Discard,
+		now:      fixedNow,
+		opts:     &modelUsageOptions{format: "csv", since: "07-01-2026"},
+	})
+	require.ErrorContains(t, err, "invalid --since")
+	require.Equal(t, 0, lister.calls) // never reached the RPC
+}
+
+func TestRunUsageExportPropagatesListError(t *testing.T) {
+	lister := &fakeUsageLister{err: fmt.Errorf("boom")}
+
+	_, err := runUsageExport(usageExportRequest{
+		lister:   lister,
+		dataOut:  io.Discard,
+		progress: io.Discard,
+		now:      fixedNow,
+		opts:     &modelUsageOptions{format: "csv"},
+	})
+	require.ErrorContains(t, err, "boom")
+}
+
+func TestRunUsageExportUnsupportedFormat(t *testing.T) {
+	_, err := runUsageExport(usageExportRequest{
+		lister:   &fakeUsageLister{},
+		dataOut:  io.Discard,
+		progress: io.Discard,
+		now:      fixedNow,
+		opts:     &modelUsageOptions{format: "xml"},
+	})
+	require.Error(t, err)
+}
+
+func TestResolveWindow(t *testing.T) {
+	// Both defaulted.
+	start, end, err := resolveWindow("", "", fixedNow)
+	require.NoError(t, err)
+	require.Equal(t, "2026-06-16", start)
+	require.Equal(t, "2026-07-16", end)
+
+	// Explicit values pass through.
+	start, end, err = resolveWindow("2026-01-01", "2026-01-31", fixedNow)
+	require.NoError(t, err)
+	require.Equal(t, "2026-01-01", start)
+	require.Equal(t, "2026-01-31", end)
+
+	// Malformed bounds are rejected.
+	_, _, err = resolveWindow("nope", "", fixedNow)
+	require.ErrorContains(t, err, "invalid --since")
+
+	_, _, err = resolveWindow("", "nope", fixedNow)
+	require.ErrorContains(t, err, "invalid --until")
+}
+
+func TestResolveUsageWorkspace(t *testing.T) {
+	require.Equal(t, "prod", resolveUsageWorkspace("prod", false))
+	require.Equal(t, "", resolveUsageWorkspace("prod", true)) // -A wins, omits filter
+	require.Equal(t, "default", resolveUsageWorkspace("default", false))
+}
+
+func TestMatchesClientFilters(t *testing.T) {
+	row := usageRow("gpt", "endpoint")
+
+	require.True(t, matchesClientFilters(row, "", ""))                   // no filter
+	require.True(t, matchesClientFilters(row, "gpt", "endpoint"))        // both match
+	require.False(t, matchesClientFilters(row, "llama", ""))             // model mismatch
+	require.False(t, matchesClientFilters(row, "", "external-endpoint")) // type mismatch
+}

--- a/cmd/neutree-cli/app/cmd/export/writer.go
+++ b/cmd/neutree-cli/app/cmd/export/writer.go
@@ -10,25 +10,26 @@ import (
 	"github.com/neutree-ai/neutree/pkg/client"
 )
 
-// traceWriter streams AI trace records to an output in a specific format.
-// Records are written one at a time so exports never buffer the full result
-// set in memory. Close finalizes the stream (e.g. the closing JSON bracket).
-type traceWriter interface {
-	Write(t client.AITrace) error
+// recordWriter streams records of type T to an output in a specific format.
+// Records are written one at a time so exports never buffer the full result set
+// in memory. Close finalizes the stream (e.g. the closing JSON bracket).
+type recordWriter[T any] interface {
+	Write(t T) error
 	Close() error
 }
 
-// newTraceWriter builds a writer for the given format. Supported formats:
-// "jsonl" (default), "json", "csv".
-func newTraceWriter(format string, w io.Writer) (traceWriter, error) {
+// newRecordWriter builds a writer for the given format. Supported formats:
+// "jsonl" (default), "json", "csv". header and csvRow describe how a record
+// maps to CSV columns; JSON/JSONL formats marshal the record directly.
+func newRecordWriter[T any](format string, w io.Writer, header []string, csvRow func(T) []string) (recordWriter[T], error) {
 	switch format {
 	case "jsonl", "":
-		return &jsonlWriter{enc: json.NewEncoder(w)}, nil
+		return &jsonlWriter[T]{enc: json.NewEncoder(w)}, nil
 	case "json":
-		return &jsonArrayWriter{w: w}, nil
+		return &jsonArrayWriter[T]{w: w}, nil
 	case "csv":
-		cw := &csvWriter{cw: csv.NewWriter(w)}
-		if err := cw.cw.Write(csvHeader); err != nil {
+		cw := &csvWriter[T]{cw: csv.NewWriter(w), row: csvRow}
+		if err := cw.cw.Write(header); err != nil {
 			return nil, err
 		}
 
@@ -39,22 +40,22 @@ func newTraceWriter(format string, w io.Writer) (traceWriter, error) {
 }
 
 // jsonlWriter emits one JSON object per line (newline-delimited JSON).
-type jsonlWriter struct {
+type jsonlWriter[T any] struct {
 	enc *json.Encoder
 }
 
-func (jw *jsonlWriter) Write(t client.AITrace) error { return jw.enc.Encode(t) }
-func (jw *jsonlWriter) Close() error                 { return nil }
+func (jw *jsonlWriter[T]) Write(t T) error { return jw.enc.Encode(t) }
+func (jw *jsonlWriter[T]) Close() error    { return nil }
 
 // jsonArrayWriter emits a single well-formed JSON array, streamed element by
 // element so the whole slice never lives in memory at once.
-type jsonArrayWriter struct {
+type jsonArrayWriter[T any] struct {
 	w       io.Writer
 	started bool
 	failed  bool
 }
 
-func (aw *jsonArrayWriter) Write(t client.AITrace) error {
+func (aw *jsonArrayWriter[T]) Write(t T) error {
 	sep := "[\n  "
 	if aw.started {
 		sep = ",\n  "
@@ -81,7 +82,7 @@ func (aw *jsonArrayWriter) Write(t client.AITrace) error {
 	return nil
 }
 
-func (aw *jsonArrayWriter) Close() error {
+func (aw *jsonArrayWriter[T]) Close() error {
 	if aw.failed {
 		return nil
 	}
@@ -96,7 +97,26 @@ func (aw *jsonArrayWriter) Close() error {
 	return err
 }
 
-// csvHeader lists the columns in the order csvWriter emits them.
+// csvWriter emits one CSV row per record, mapping a record to its columns with
+// the row function supplied at construction.
+type csvWriter[T any] struct {
+	cw  *csv.Writer
+	row func(T) []string
+}
+
+func (cw *csvWriter[T]) Write(t T) error { return cw.cw.Write(cw.row(t)) }
+
+func (cw *csvWriter[T]) Close() error {
+	cw.cw.Flush()
+	return cw.cw.Error()
+}
+
+// --- access-log (AI trace) writer ---
+
+// traceWriter is the access-log record writer.
+type traceWriter = recordWriter[client.AITrace]
+
+// csvHeader lists the trace columns in the order traceCSVRow emits them.
 var csvHeader = []string{
 	"request_id", "time", "workspace", "endpoint_type", "endpoint_name",
 	"api_key_id", "request_uri", "request_model", "response_model",
@@ -105,26 +125,22 @@ var csvHeader = []string{
 	"request_body", "response_body",
 }
 
-// csvWriter emits one CSV row per trace. Body columns are empty unless the
+// traceCSVRow renders a trace as a CSV row. Body columns are empty unless the
 // export was run with --with-body.
-type csvWriter struct {
-	cw *csv.Writer
-}
-
-func (cw *csvWriter) Write(t client.AITrace) error {
-	return cw.cw.Write([]string{
+func traceCSVRow(t client.AITrace) []string {
+	return []string{
 		t.RequestID, t.Time, t.Workspace, t.EndpointType, t.EndpointName,
 		t.APIKeyID, t.RequestURI, t.RequestModel, t.ResponseModel,
 		strconv.Itoa(t.ResponseStatus),
 		intPtrStr(t.PromptTokens), intPtrStr(t.CompletionTokens), intPtrStr(t.TotalTokens),
 		t.FinishReason, strconv.FormatBool(t.Stream), t.UserAgent, intPtrStr(t.DurationMs),
 		t.RequestBody, t.ResponseBody,
-	})
+	}
 }
 
-func (cw *csvWriter) Close() error {
-	cw.cw.Flush()
-	return cw.cw.Error()
+// newTraceWriter builds an access-log writer for the given format.
+func newTraceWriter(format string, w io.Writer) (traceWriter, error) {
+	return newRecordWriter(format, w, csvHeader, traceCSVRow)
 }
 
 // intPtrStr renders a *int as its decimal string, or "" when nil.
@@ -134,4 +150,40 @@ func intPtrStr(p *int) string {
 	}
 
 	return strconv.Itoa(*p)
+}
+
+// --- model-usage writer ---
+
+// usageWriter is the model-usage record writer.
+type usageWriter = recordWriter[client.UsageRow]
+
+// usageCSVHeader lists the model-usage columns in the order usageCSVRow emits
+// them; it matches the get_usage_by_dimension RPC return shape.
+var usageCSVHeader = []string{
+	"date", "api_key_id", "api_key_name", "endpoint_type", "endpoint_name",
+	"model_name", "workspace", "usage", "prompt_tokens", "completion_tokens",
+}
+
+// usageCSVRow renders one usage aggregate bucket as a CSV row. Token columns are
+// empty for pre-dimensional records the server returns with NULL counts.
+func usageCSVRow(u client.UsageRow) []string {
+	return []string{
+		u.Date, u.APIKeyID, u.APIKeyName, u.EndpointType, u.EndpointName,
+		u.ModelName, u.Workspace,
+		int64PtrStr(u.Usage), int64PtrStr(u.PromptTokens), int64PtrStr(u.CompletionTokens),
+	}
+}
+
+// newUsageWriter builds a model-usage writer for the given format.
+func newUsageWriter(format string, w io.Writer) (usageWriter, error) {
+	return newRecordWriter(format, w, usageCSVHeader, usageCSVRow)
+}
+
+// int64PtrStr renders a *int64 as its decimal string, or "" when nil.
+func int64PtrStr(p *int64) string {
+	if p == nil {
+		return ""
+	}
+
+	return strconv.FormatInt(*p, 10)
 }

--- a/cmd/neutree-cli/app/cmd/export/writer_test.go
+++ b/cmd/neutree-cli/app/cmd/export/writer_test.go
@@ -80,3 +80,44 @@ func TestUnsupportedFormat(t *testing.T) {
 	_, err := newTraceWriter("xml", &bytes.Buffer{})
 	require.Error(t, err)
 }
+
+func i64Ptr(n int64) *int64 { return &n }
+
+func TestUsageCSVWriterHeaderAndNullColumns(t *testing.T) {
+	var buf bytes.Buffer
+
+	w, err := newUsageWriter("csv", &buf)
+	require.NoError(t, err)
+	require.NoError(t, w.Write(client.UsageRow{
+		Date:       "2026-07-15",
+		APIKeyName: "my-key",
+		Usage:      i64Ptr(42),
+		// PromptTokens/CompletionTokens left nil -> empty columns
+	}))
+	require.NoError(t, w.Close())
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	require.Equal(t, strings.Join(usageCSVHeader, ","), lines[0])
+	require.Contains(t, lines[1], "my-key")
+	require.True(t, strings.HasSuffix(lines[1], ",42,,")) // usage=42, prompt/completion empty
+}
+
+func TestUsageJSONWriterEmitsValidArray(t *testing.T) {
+	var buf bytes.Buffer
+
+	w, err := newUsageWriter("json", &buf)
+	require.NoError(t, err)
+	require.NoError(t, w.Write(client.UsageRow{APIKeyID: "a"}))
+	require.NoError(t, w.Write(client.UsageRow{APIKeyID: "b"}))
+	require.NoError(t, w.Close())
+
+	var recs []client.UsageRow
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &recs))
+	require.Len(t, recs, 2)
+}
+
+func TestUsageUnsupportedFormat(t *testing.T) {
+	_, err := newUsageWriter("xml", &bytes.Buffer{})
+	require.Error(t, err)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -20,6 +20,7 @@ type Client struct {
 	ModelRegistries *ModelRegistriesService
 	Generic         *GenericService
 	Traces          *TracesService
+	Usage           *UsageService
 }
 
 // ClientOption is a function that configures a Client
@@ -103,6 +104,7 @@ func NewClient(baseURL string, options ...ClientOption) *Client {
 	client.ImageRegistries = NewImageRegistriesService(client)
 	client.ModelRegistries = NewModelRegistriesService(client)
 	client.Traces = NewTracesService(client)
+	client.Usage = NewUsageService(client)
 
 	s, err := BuildScheme()
 	if err == nil {

--- a/pkg/client/usage.go
+++ b/pkg/client/usage.go
@@ -1,0 +1,121 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// UsageService handles model-usage statistics via the get_usage_by_dimension
+// PostgREST RPC.
+//
+// Usage is stored day-aggregated in the api_daily_usage table and exposed
+// through the api.get_usage_by_dimension function (a SECURITY DEFINER RPC that
+// scopes rows to the caller via auth.uid() plus workspace:usage-read). The RPC
+// returns the whole result set in one response — there is no pagination.
+type UsageService struct {
+	client *Client
+}
+
+// NewUsageService creates a new usage service.
+func NewUsageService(client *Client) *UsageService {
+	return &UsageService{client: client}
+}
+
+// UsageRow is one (day × api_key × endpoint_type × endpoint_name × model)
+// aggregate bucket returned by get_usage_by_dimension. Token counts (and, for
+// pre-dimensional records, endpoint_type/model_name) can be null on the wire —
+// modeled as pointers/omittable so an absent value is distinct from zero.
+type UsageRow struct {
+	Date             string `json:"date"`
+	APIKeyID         string `json:"api_key_id"`
+	APIKeyName       string `json:"api_key_name"`
+	EndpointType     string `json:"endpoint_type"`
+	EndpointName     string `json:"endpoint_name"`
+	ModelName        string `json:"model_name"`
+	Workspace        string `json:"workspace"`
+	Usage            *int64 `json:"usage"`
+	PromptTokens     *int64 `json:"prompt_tokens"`
+	CompletionTokens *int64 `json:"completion_tokens"`
+}
+
+// UsageFilters are the RPC parameters. StartDate/EndDate are required
+// (YYYY-MM-DD, inclusive). Empty optional fields are omitted from the request
+// body so the server applies its NULL default: all API keys, all endpoints, or
+// all workspaces the caller may read.
+type UsageFilters struct {
+	StartDate    string // p_start_date (required)
+	EndDate      string // p_end_date (required)
+	APIKeyID     string // p_api_key_id (optional UUID)
+	EndpointName string // p_endpoint_name (optional)
+	Workspace    string // p_workspace (optional; empty = all workspaces)
+}
+
+// GetUsageByDimension POSTs the RPC and returns every aggregate bucket in the
+// window. Unlike the trace list endpoint there is no cursor: a single request
+// returns the full array.
+func (s *UsageService) GetUsageByDimension(filters UsageFilters) ([]UsageRow, error) {
+	if filters.StartDate == "" || filters.EndDate == "" {
+		return nil, fmt.Errorf("start and end date are required")
+	}
+
+	// Only send the optional params that are set; PostgREST reads a missing
+	// argument as SQL NULL, which the RPC treats as "no filter" — so an empty
+	// workspace means all workspaces without any sentinel value.
+	body := map[string]any{
+		"p_start_date": filters.StartDate,
+		"p_end_date":   filters.EndDate,
+	}
+
+	if filters.APIKeyID != "" {
+		body["p_api_key_id"] = filters.APIKeyID
+	}
+
+	if filters.EndpointName != "" {
+		body["p_endpoint_name"] = filters.EndpointName
+	}
+
+	if filters.Workspace != "" {
+		body["p_workspace"] = filters.Workspace
+	}
+
+	jsonData, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	reqURL := fmt.Sprintf("%s/api/v1/rpc/get_usage_by_dimension", s.client.baseURL)
+
+	req, err := http.NewRequest("POST", reqURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+
+		switch resp.StatusCode {
+		case http.StatusForbidden:
+			return nil, fmt.Errorf("permission denied: viewing another user's usage needs workspace:usage-read")
+		default:
+			return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		}
+	}
+
+	var rows []UsageRow
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}

--- a/pkg/client/usage.go
+++ b/pkg/client/usage.go
@@ -3,9 +3,11 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // UsageService handles model-usage statistics via the get_usage_by_dimension
@@ -106,7 +108,12 @@ func (s *UsageService) GetUsageByDimension(filters UsageFilters) ([]UsageRow, er
 
 		switch resp.StatusCode {
 		case http.StatusForbidden:
-			return nil, fmt.Errorf("permission denied: viewing another user's usage needs workspace:usage-read")
+			base := "permission denied: viewing another user's usage needs workspace:usage-read"
+			if body := strings.TrimSpace(string(bodyBytes)); body != "" {
+				return nil, fmt.Errorf("%s (server: %s)", base, body)
+			}
+
+			return nil, errors.New(base)
 		default:
 			return nil, fmt.Errorf("server returned status %d: %s", resp.StatusCode, string(bodyBytes))
 		}

--- a/pkg/client/usage_test.go
+++ b/pkg/client/usage_test.go
@@ -89,6 +89,7 @@ func TestGetUsageByDimensionErrorStatusMapping(t *testing.T) {
 
 	_, err := c.Usage.GetUsageByDimension(UsageFilters{StartDate: "2026-07-01", EndDate: "2026-07-15"})
 	require.ErrorContains(t, err, "workspace:usage-read")
+	require.ErrorContains(t, err, "nope") // server body preserved for diagnosis
 }
 
 func ptrInt64(n int64) *int64 { return &n }

--- a/pkg/client/usage_test.go
+++ b/pkg/client/usage_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUsageByDimensionBuildsBodyAndParsesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/rpc/get_usage_by_dimension", r.URL.Path)
+		require.Equal(t, "api-key", r.Header.Get("Authorization"))
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "2026-07-01", body["p_start_date"])
+		require.Equal(t, "2026-07-15", body["p_end_date"])
+		require.Equal(t, "key-1", body["p_api_key_id"])
+		require.Equal(t, "ep-1", body["p_endpoint_name"])
+		require.Equal(t, "default", body["p_workspace"])
+
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]UsageRow{
+			{Date: "2026-07-15", APIKeyID: "key-1", Usage: ptrInt64(3)},
+		})
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+
+	rows, err := c.Usage.GetUsageByDimension(UsageFilters{
+		StartDate:    "2026-07-01",
+		EndDate:      "2026-07-15",
+		APIKeyID:     "key-1",
+		EndpointName: "ep-1",
+		Workspace:    "default",
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "key-1", rows[0].APIKeyID)
+	require.Equal(t, int64(3), *rows[0].Usage)
+}
+
+func TestGetUsageByDimensionOmitsEmptyOptionalParams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		// Only the two required dates are present; empty optionals are omitted so
+		// PostgREST reads them as SQL NULL (no filter / all workspaces).
+		_, hasKey := body["p_api_key_id"]
+		_, hasEndpoint := body["p_endpoint_name"]
+		_, hasWorkspace := body["p_workspace"]
+		require.False(t, hasKey)
+		require.False(t, hasEndpoint)
+		require.False(t, hasWorkspace)
+
+		_ = json.NewEncoder(w).Encode([]UsageRow{})
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("k"))
+
+	_, err := c.Usage.GetUsageByDimension(UsageFilters{StartDate: "2026-07-01", EndDate: "2026-07-15"})
+	require.NoError(t, err)
+}
+
+func TestGetUsageByDimensionRequiresDates(t *testing.T) {
+	c := NewClient("http://example.com", WithAPIKey("k"))
+
+	_, err := c.Usage.GetUsageByDimension(UsageFilters{StartDate: "2026-07-01"})
+	require.ErrorContains(t, err, "required")
+}
+
+func TestGetUsageByDimensionErrorStatusMapping(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "nope")
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("k"))
+
+	_, err := c.Usage.GetUsageByDimension(UsageFilters{StartDate: "2026-07-01", EndDate: "2026-07-15"})
+	require.ErrorContains(t, err, "workspace:usage-read")
+}
+
+func ptrInt64(n int64) *int64 { return &n }


### PR DESCRIPTION
## What

Adds `neutree-cli export model-usage`, giving the model-usage statistics a CLI export path for archival, offline reconciliation, and billing. Until now usage was only viewable in the UI with no batch export.

This mirrors the access-log export (NEU-544, #489) but is simpler: usage is already day-aggregated server-side behind the `get_usage_by_dimension` RPC, so a single request returns the whole result set — no cursor, no dedup, no stall detection, no body handling.

Resolves NEU-546.

## Changes

- **`pkg/client/usage.go`** — new `UsageService.GetUsageByDimension(filters)` that POSTs the RPC and returns every aggregate bucket in one request. Empty optional params are omitted from the body so PostgREST reads them as SQL `NULL` (e.g. an empty workspace unions across every workspace the caller may read — no sentinel value).
- **`export/writer.go`** — generalized the format writer to a generic `recordWriter[T]` (csv/json/jsonl). `newTraceWriter` becomes a thin wrapper (the `traceWriter` alias keeps the access-log code and tests unchanged); adds `newUsageWriter`.
- **`export/model_usage.go`** — `newModelUsageCmd` plus a DI-friendly `runUsageExport` (injected lister interface + `io.Writer` + clock, so the logic is unit-tested with no HTTP server or filesystem). Defaults to CSV (usage is commonly dropped into a spreadsheet); default window is the last 30 days, aligned with the UI. `--model` / `--endpoint-type` filter client-side (the RPC has no such params), matching the UI.
- **`export/export.go`, `pkg/client/client.go`** — wiring.

## Flags

```
neutree-cli export model-usage [flags]
  --since / --until    YYYY-MM-DD (inclusive; default: last 30 days)
  -w, --workspace      default "default"
  -A, --all-workspaces omit workspace filter (all workspaces you may read)
  --api-key-id         server-side filter (UUID)
  --endpoint           server-side filter
  --model              client-side filter
  --endpoint-type      client-side filter
  --format             csv (default) | json | jsonl
  -f, --file           output file (default: stdout)
```

Progress and diagnostics go to stderr so the data stream on stdout stays clean for pipes and redirection.

## Permissions

The RPC scopes rows via `auth.uid()`: own keys are always visible, plus every key in any workspace where the caller holds `workspace:usage-read` (migrations 064/066). No backend changes.

## Testing

- Unit tests for the client (RPC body construction, optional-param omission, permission-error mapping) and the command (default window, explicit window, `-A` workspace omission, client-side filtering, bad-date local rejection, error propagation) plus writer tests for the usage CSV/JSON paths.
- `go vet` clean; golangci-lint reports 0 issues.
- Verified end-to-end against a live deployment: default/explicit windows, CSV/JSON output, server-side and client-side filters, file output, empty-result handling, and stdout/stderr separation all behave as designed, including permission scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
