### PR TITLE
feat: chunk oversized AI-trace bodies past VictoriaLogs' 2MiB cap (NEU-539)

### DIFF
--- a/cmd/neutree-cli/app/cmd/export/writer.go
+++ b/cmd/neutree-cli/app/cmd/export/writer.go
@@ -122,7 +122,7 @@ var csvHeader = []string{
 	"api_key_id", "request_uri", "request_model", "response_model",
 	"response_status", "prompt_tokens", "completion_tokens", "total_tokens",
 	"finish_reason", "stream", "user_agent", "duration_ms",
-	"request_body", "response_body",
+	"request_body", "response_body", "body_truncated", "body_incomplete",
 }
 
 // traceCSVRow renders a trace as a CSV row. Body columns are empty unless the
@@ -135,6 +135,7 @@ func traceCSVRow(t client.AITrace) []string {
 		intPtrStr(t.PromptTokens), intPtrStr(t.CompletionTokens), intPtrStr(t.TotalTokens),
 		t.FinishReason, strconv.FormatBool(t.Stream), t.UserAgent, intPtrStr(t.DurationMs),
 		t.RequestBody, t.ResponseBody,
+		strconv.FormatBool(t.BodyTruncated), strconv.FormatBool(t.BodyIncomplete),
 	}
 }
 

--- a/deploy/chart/neutree/templates/vector-install.yaml
+++ b/deploy/chart/neutree/templates/vector-install.yaml
@@ -147,6 +147,10 @@ data:
           # into companion chunk records (~1MiB each) that neutree-api's trace
           # store reassembles on read. Chunks share the parent's timestamp and
           # stream fields so they live in the same stream and expire together.
+          # Chunking additionally requires a non-empty string request id: it is the
+          # grouping key that ties chunks back to their parent, so a missing or
+          # non-string id falls back to the single-record path (as before this
+          # change) rather than risk cross-trace chunk mixing.
           #
           # chunk_data is base64: chunks() splits on raw byte offsets, which can
           # cut a multi-byte UTF-8 character in half — the halves would be
@@ -154,7 +158,7 @@ data:
           # never be reassembled byte-exact. Base64 text is ASCII, so any byte
           # split survives; 1MiB is a multiple of 4, so every chunk (and any
           # truncated prefix of chunks) stays independently valid base64.
-          if length(req_body) + length(resp_body) <= 1572864 {
+          if length(req_body) + length(resp_body) <= 1572864 || !is_string(.request.id) || .request.id == "" {
               . = rec
           } else {
               chunk_size = 1048576 # 1MiB of base64 text (~768KiB of body) per chunk record

--- a/deploy/chart/neutree/templates/vector-install.yaml
+++ b/deploy/chart/neutree/templates/vector-install.yaml
@@ -100,11 +100,19 @@ data:
         inputs:
           - filter_trace_logs
         source: |
-          . = {
+          # Field names and limits below form a contract with the query side:
+          # internal/routes/logs/trace_store.go reassembles chunked bodies and
+          # filters record_type="chunk" out of every trace query. Keep in sync.
+          rid = .request.id || "ai-trace"
+          rid = to_string(rid) ?? "ai-trace"
+          req_body = to_string(.ai."trace".request_body) ?? ""
+          resp_body = to_string(.ai."trace".response_body) ?? ""
+
+          rec = {
               # VictoriaLogs rejects records without a non-empty `_msg`. Failed
               # requests often carry no response body, so `_msg` must be a field
               # that is always populated — never the (optional) response body.
-              "_msg":           .request.id || "ai-trace",
+              "_msg":           rid,
               "request_id":     .request.id,
               "timestamp":      .started_at,
               "workspace":      .extracted_data.workspace || "",
@@ -128,8 +136,80 @@ data:
               "stream":         .ai."trace".stream || false,
               "user_agent":     .request.headers."user-agent" || "",
               "duration_ms":    .latencies.request,
-              "request_body":   .ai."trace".request_body || "",
-              "response_body":  .ai."trace".response_body || "",
+              "request_body":   req_body,
+              "response_body":  resp_body,
+          }
+
+          # VictoriaLogs hard-drops any record whose estimated JSON size exceeds
+          # 2MiB (maxUncompressedBlockSize — hardcoded upstream, cannot be raised;
+          # https://docs.victoriametrics.com/victorialogs/faq/). Bodies that fit
+          # comfortably below that ship as a single record; larger bodies are split
+          # into companion chunk records (~1MiB each) that neutree-api's trace
+          # store reassembles on read. Chunks share the parent's timestamp and
+          # stream fields so they live in the same stream and expire together.
+          #
+          # chunk_data is base64: chunks() splits on raw byte offsets, which can
+          # cut a multi-byte UTF-8 character in half — the halves would be
+          # lossily replaced (U+FFFD) during JSON encoding and the body could
+          # never be reassembled byte-exact. Base64 text is ASCII, so any byte
+          # split survives; 1MiB is a multiple of 4, so every chunk (and any
+          # truncated prefix of chunks) stays independently valid base64.
+          if length(req_body) + length(resp_body) <= 1572864 {
+              . = rec
+          } else {
+              chunk_size = 1048576 # 1MiB of base64 text (~768KiB of body) per chunk record
+              max_chunks = 16      # per body (~12MiB of body); anything longer is truncated
+
+              req_chunks = chunks(encode_base64(req_body), chunk_size)
+              resp_chunks = chunks(encode_base64(resp_body), chunk_size)
+
+              truncated = false
+              if length(req_chunks) > max_chunks {
+                  req_chunks = slice(req_chunks, 0, max_chunks) ?? req_chunks
+                  truncated = true
+              }
+              if length(resp_chunks) > max_chunks {
+                  resp_chunks = slice(resp_chunks, 0, max_chunks) ?? resp_chunks
+                  truncated = true
+              }
+
+              rec.request_body = ""
+              rec.response_body = ""
+              rec.body_chunked = true
+              rec.body_truncated = truncated
+              rec.request_chunks = length(req_chunks)
+              rec.response_chunks = length(resp_chunks)
+
+              events = [rec]
+              for_each(array!(req_chunks)) -> |i, chunk| {
+                  events = push(events, {
+                      "_msg":          rid + "#request." + to_string(i),
+                      "record_type":   "chunk",
+                      "request_id":    rec.request_id,
+                      "timestamp":     rec.timestamp,
+                      "workspace":     rec.workspace,
+                      "endpoint_type": rec.endpoint_type,
+                      "endpoint_name": rec.endpoint_name,
+                      "chunk_kind":    "request",
+                      "chunk_seq":     i,
+                      "chunk_data":    chunk,
+                  })
+              }
+              for_each(array!(resp_chunks)) -> |i, chunk| {
+                  events = push(events, {
+                      "_msg":          rid + "#response." + to_string(i),
+                      "record_type":   "chunk",
+                      "request_id":    rec.request_id,
+                      "timestamp":     rec.timestamp,
+                      "workspace":     rec.workspace,
+                      "endpoint_type": rec.endpoint_type,
+                      "endpoint_name": rec.endpoint_name,
+                      "chunk_kind":    "response",
+                      "chunk_seq":     i,
+                      "chunk_data":    chunk,
+                  })
+              }
+              . = events
           }
       {{- end }}
     sinks:

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -270,8 +270,10 @@ victorialogs:
   # Log retention period. Override at deploy time with
   # `--set victorialogs.retentionPeriod=<period>` (e.g. 30d, 90d, 1y).
   retentionPeriod: 30d
-  # AI-trace request/response bodies can be large; raise the per-line ingest
-  # limit (bytes) so VictoriaLogs does not drop them. Matches docker-compose.
+  # Raise the HTTP line-reader limit (bytes) so large AI-trace lines are not
+  # rejected at ingestion. This does NOT lift VictoriaLogs' separate hard-coded
+  # 2MiB per-record storage cap; oversized request/response bodies are split
+  # into ~1MiB chunk records by Vector instead. Matches docker-compose.
   maxLineSizeBytes: 16777216
   resources:
     requests:

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -322,8 +322,12 @@ services:
       # Log retention period. Defaults to 30d; override at deploy time with
       # `neutree-cli launch neutree-core --victorialogs-retention-period <period>`.
       - -retentionPeriod={{ .VictoriaLogsRetentionPeriod }}
-      # AI-trace request/response bodies can be large; raise the per-line
-      # ingest limit to 16MiB so VictoriaLogs does not drop them.
+      # Raise the HTTP line-reader limit so large AI-trace lines are not
+      # rejected at ingestion. Note this does NOT lift VictoriaLogs' separate
+      # hard-coded 2MiB per-record storage cap — records between 2MiB and this
+      # limit would still be silently dropped by the storage layer. Oversized
+      # request/response bodies are therefore split into ~1MiB chunk records
+      # by Vector (see vector/vector.yml, prepare_trace_payload).
       - -insert.maxLineSizeBytes=16777216
     volumes:
       - vl_data:/victoria-logs-data

--- a/deploy/docker/neutree-core/vector/vector.yml
+++ b/deploy/docker/neutree-core/vector/vector.yml
@@ -132,6 +132,10 @@ transforms:
       # into companion chunk records (~1MiB each) that neutree-api's trace
       # store reassembles on read. Chunks share the parent's timestamp and
       # stream fields so they live in the same stream and expire together.
+      # Chunking additionally requires a non-empty string request id: it is the
+      # grouping key that ties chunks back to their parent, so a missing or
+      # non-string id falls back to the single-record path (as before this
+      # change) rather than risk cross-trace chunk mixing.
       #
       # chunk_data is base64: chunks() splits on raw byte offsets, which can
       # cut a multi-byte UTF-8 character in half — the halves would be
@@ -139,7 +143,7 @@ transforms:
       # never be reassembled byte-exact. Base64 text is ASCII, so any byte
       # split survives; 1MiB is a multiple of 4, so every chunk (and any
       # truncated prefix of chunks) stays independently valid base64.
-      if length(req_body) + length(resp_body) <= 1572864 {
+      if length(req_body) + length(resp_body) <= 1572864 || !is_string(.request.id) || .request.id == "" {
           . = rec
       } else {
           chunk_size = 1048576 # 1MiB of base64 text (~768KiB of body) per chunk record

--- a/deploy/docker/neutree-core/vector/vector.yml
+++ b/deploy/docker/neutree-core/vector/vector.yml
@@ -85,11 +85,19 @@ transforms:
     inputs:
       - filter_trace_logs
     source: |
-      . = {
+      # Field names and limits below form a contract with the query side:
+      # internal/routes/logs/trace_store.go reassembles chunked bodies and
+      # filters record_type="chunk" out of every trace query. Keep in sync.
+      rid = .request.id || "ai-trace"
+      rid = to_string(rid) ?? "ai-trace"
+      req_body = to_string(.ai."trace".request_body) ?? ""
+      resp_body = to_string(.ai."trace".response_body) ?? ""
+
+      rec = {
           # VictoriaLogs rejects records without a non-empty `_msg`. Failed
           # requests often carry no response body, so `_msg` must be a field
           # that is always populated — never the (optional) response body.
-          "_msg":           .request.id || "ai-trace",
+          "_msg":           rid,
           "request_id":     .request.id,
           "timestamp":      .started_at,
           "workspace":      .extracted_data.workspace || "",
@@ -113,8 +121,80 @@ transforms:
           "stream":         .ai."trace".stream || false,
           "user_agent":     .request.headers."user-agent" || "",
           "duration_ms":    .latencies.request,
-          "request_body":   .ai."trace".request_body || "",
-          "response_body":  .ai."trace".response_body || "",
+          "request_body":   req_body,
+          "response_body":  resp_body,
+      }
+
+      # VictoriaLogs hard-drops any record whose estimated JSON size exceeds
+      # 2MiB (maxUncompressedBlockSize — hardcoded upstream, cannot be raised;
+      # https://docs.victoriametrics.com/victorialogs/faq/). Bodies that fit
+      # comfortably below that ship as a single record; larger bodies are split
+      # into companion chunk records (~1MiB each) that neutree-api's trace
+      # store reassembles on read. Chunks share the parent's timestamp and
+      # stream fields so they live in the same stream and expire together.
+      #
+      # chunk_data is base64: chunks() splits on raw byte offsets, which can
+      # cut a multi-byte UTF-8 character in half — the halves would be
+      # lossily replaced (U+FFFD) during JSON encoding and the body could
+      # never be reassembled byte-exact. Base64 text is ASCII, so any byte
+      # split survives; 1MiB is a multiple of 4, so every chunk (and any
+      # truncated prefix of chunks) stays independently valid base64.
+      if length(req_body) + length(resp_body) <= 1572864 {
+          . = rec
+      } else {
+          chunk_size = 1048576 # 1MiB of base64 text (~768KiB of body) per chunk record
+          max_chunks = 16      # per body (~12MiB of body); anything longer is truncated
+
+          req_chunks = chunks(encode_base64(req_body), chunk_size)
+          resp_chunks = chunks(encode_base64(resp_body), chunk_size)
+
+          truncated = false
+          if length(req_chunks) > max_chunks {
+              req_chunks = slice(req_chunks, 0, max_chunks) ?? req_chunks
+              truncated = true
+          }
+          if length(resp_chunks) > max_chunks {
+              resp_chunks = slice(resp_chunks, 0, max_chunks) ?? resp_chunks
+              truncated = true
+          }
+
+          rec.request_body = ""
+          rec.response_body = ""
+          rec.body_chunked = true
+          rec.body_truncated = truncated
+          rec.request_chunks = length(req_chunks)
+          rec.response_chunks = length(resp_chunks)
+
+          events = [rec]
+          for_each(array!(req_chunks)) -> |i, chunk| {
+              events = push(events, {
+                  "_msg":          rid + "#request." + to_string(i),
+                  "record_type":   "chunk",
+                  "request_id":    rec.request_id,
+                  "timestamp":     rec.timestamp,
+                  "workspace":     rec.workspace,
+                  "endpoint_type": rec.endpoint_type,
+                  "endpoint_name": rec.endpoint_name,
+                  "chunk_kind":    "request",
+                  "chunk_seq":     i,
+                  "chunk_data":    chunk,
+              })
+          }
+          for_each(array!(resp_chunks)) -> |i, chunk| {
+              events = push(events, {
+                  "_msg":          rid + "#response." + to_string(i),
+                  "record_type":   "chunk",
+                  "request_id":    rec.request_id,
+                  "timestamp":     rec.timestamp,
+                  "workspace":     rec.workspace,
+                  "endpoint_type": rec.endpoint_type,
+                  "endpoint_name": rec.endpoint_name,
+                  "chunk_kind":    "response",
+                  "chunk_seq":     i,
+                  "chunk_data":    chunk,
+              })
+          }
+          . = events
       }
 sinks:
   postgrest_rpc:

--- a/internal/routes/logs/ai_trace.go
+++ b/internal/routes/logs/ai_trace.go
@@ -40,11 +40,30 @@ type AITrace struct {
 	DurationMs       *int   `json:"duration_ms,omitempty"`
 	RequestBody      string `json:"request_body,omitempty"`
 	ResponseBody     string `json:"response_body,omitempty"`
+
+	// BodyTruncated marks a record whose bodies exceeded the ingestion cap and
+	// were cut off by Vector; the stored bodies are a prefix of the originals.
+	BodyTruncated bool `json:"body_truncated,omitempty"`
+	// BodyIncomplete marks a chunked record for which some body chunks could
+	// not be read back (partial ingestion loss); the returned bodies hold the
+	// longest decodable prefix.
+	BodyIncomplete bool `json:"body_incomplete,omitempty"`
+
+	// Chunked-body storage metadata, private to the trace store: whether this
+	// record's bodies live in companion chunk records, and how many each body
+	// was split into. Never serialized; the API always returns whole bodies.
+	bodyChunked    bool
+	requestChunks  int
+	responseChunks int
 }
 
 // stringTrue is the literal a boolean-valued string (a query flag, or a
 // stringified VictoriaLogs field) must equal to be considered on.
 const stringTrue = "true"
+
+// includeBodyMaxLimit caps the page size of body-carrying list queries
+// (?include_body=true); metadata-only pages may go up to 500.
+const includeBodyMaxLimit = 50
 
 // AITraceListResponse is the wire format for GET /api/v1/ai-traces/:workspace.
 //
@@ -386,6 +405,15 @@ func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
 		// ?include_body=true so bodies come back inline, avoiding a per-record
 		// detail lookup.
 		includeBody := c.Query("include_body") == stringTrue
+
+		// Body-carrying pages are bounded tighter: with bodies of up to tens
+		// of MiB per record, a 500-record page could produce a GiB-scale
+		// response. Clamping here is transparent to pagers — nextBefore is
+		// derived from the effective limit, so cursoring still walks the full
+		// result set in smaller pages.
+		if includeBody && limit > includeBodyMaxLimit {
+			limit = includeBodyMaxLimit
+		}
 
 		window := timeWindow{Start: strings.TrimSpace(c.Query("start"))}
 		// `before` is the inclusive upper bound from the previous page's last

--- a/internal/routes/logs/ai_trace.go
+++ b/internal/routes/logs/ai_trace.go
@@ -1,11 +1,8 @@
 package logs
 
 import (
-	"bufio"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -45,23 +42,9 @@ type AITrace struct {
 	ResponseBody     string `json:"response_body,omitempty"`
 }
 
-// listProjection is the LogsQL `fields` projection for the list query: every
-// metadata column the list view renders, deliberately excluding the large
-// request_body / response_body fields so list responses stay small.
-const listProjection = "_time, request_id, workspace, endpoint_type, " +
-	"endpoint_name, api_key_id, request_uri, request_model, response_model, " +
-	"response_status, prompt_tokens, completion_tokens, total_tokens, " +
-	"finish_reason, stream, user_agent, duration_ms"
-
 // stringTrue is the literal a boolean-valued string (a query flag, or a
 // stringified VictoriaLogs field) must equal to be considered on.
 const stringTrue = "true"
-
-// fullProjection extends listProjection with the large request/response body
-// columns. The list endpoint uses it only when the caller passes
-// ?include_body=true — chiefly the CLI export, which fetches bodies inline to
-// avoid an N+1 per-record detail lookup.
-const fullProjection = listProjection + ", request_body, response_body"
 
 // AITraceListResponse is the wire format for GET /api/v1/ai-traces/:workspace.
 //
@@ -83,6 +66,25 @@ type AITraceDayCount struct {
 // the activity bar chart at the top of the SPA's trace list.
 type AITraceStatsResponse struct {
 	Days []AITraceDayCount `json:"days"`
+}
+
+// AITraceKeyStat is one API key's aggregated traffic over the requested window.
+// Powers the API-key list ranking overview and the detail "request performance"
+// card. SuccessRate is derived client-side as Success/Requests.
+type AITraceKeyStat struct {
+	APIKeyID      string  `json:"api_key_id"`
+	Requests      int64   `json:"requests"`
+	Tokens        int64   `json:"tokens"`
+	Success       int64   `json:"success"`
+	AvgDurationMs float64 `json:"avg_duration_ms"`
+}
+
+// AITraceKeyStatsResponse is the wire format for
+// GET /api/v1/ai-traces/:workspace/key-stats — per-API-key request count, token
+// total, success count and average latency over a trailing window (default 24h).
+type AITraceKeyStatsResponse struct {
+	WindowHours int              `json:"window_hours"`
+	Keys        []AITraceKeyStat `json:"keys"`
 }
 
 // RegisterAITraceRoutes mounts the AI inference trace endpoints.
@@ -342,13 +344,23 @@ func traceEndpointTypeFilter(c *gin.Context) string {
 	return fmt.Sprintf("endpoint_type:=%s", logsQLQuoteValue(et))
 }
 
+// requireTraceStore resolves the trace store, or answers 503 and returns nil
+// when no --ai-trace-store-url is configured.
+func requireTraceStore(c *gin.Context, deps *Dependencies) *traceStore {
+	store := newTraceStore(deps)
+	if store == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "ai trace store is not configured",
+		})
+	}
+
+	return store
+}
+
 func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if deps.AITraceStoreURL == "" {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"error": "ai trace store is not configured",
-			})
-
+		store := requireTraceStore(c, deps)
+		if store == nil {
 			return
 		}
 
@@ -360,65 +372,31 @@ func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
 			}
 		}
 
-		// Leading clause scopes the query to the workspace(s) the caller may read
-		// (a concrete workspace, or the cross-workspace "_all_" aggregate).
-		queryParts := []string{traceScopeClause(c)}
-
-		if endpoint := strings.TrimSpace(c.Query("endpoint_name")); endpoint != "" {
-			queryParts = append(queryParts, fmt.Sprintf("endpoint_name:=%s", logsQLQuoteValue(endpoint)))
+		filters := traceFilters{
+			EndpointName: strings.TrimSpace(c.Query("endpoint_name")),
+			EndpointType: strings.TrimSpace(c.Query("endpoint_type")),
+			Status:       strings.TrimSpace(c.Query("status")),
+			APIKeyID:     strings.TrimSpace(c.Query("api_key_id")),
+			FinishReason: strings.TrimSpace(c.Query("finish_reason")),
+			Model:        strings.TrimSpace(c.Query("model")),
 		}
 
-		if endpointType := strings.TrimSpace(c.Query("endpoint_type")); endpointType != "" {
-			queryParts = append(queryParts, fmt.Sprintf("endpoint_type:=%s", logsQLQuoteValue(endpointType)))
-		}
+		// The list view never renders request/response bodies, so they are
+		// omitted by default. Callers exporting the full record opt in via
+		// ?include_body=true so bodies come back inline, avoiding a per-record
+		// detail lookup.
+		includeBody := c.Query("include_body") == stringTrue
 
-		if status := strings.TrimSpace(c.Query("status")); status != "" {
-			queryParts = append(queryParts, fmt.Sprintf("response_status:=%s", logsQLQuoteValue(status)))
-		}
-
-		if apiKeyID := strings.TrimSpace(c.Query("api_key_id")); apiKeyID != "" {
-			queryParts = append(queryParts, fmt.Sprintf("api_key_id:=%s", logsQLQuoteValue(apiKeyID)))
-		}
-
-		if fr := strings.TrimSpace(c.Query("finish_reason")); fr != "" {
-			queryParts = append(queryParts, fmt.Sprintf("finish_reason:=%s", logsQLQuoteValue(fr)))
-		}
-
-		if model := strings.TrimSpace(c.Query("model")); model != "" {
-			// model can match either request or response model
-			queryParts = append(queryParts, fmt.Sprintf(
-				"(request_model:=%s OR response_model:=%s)",
-				logsQLQuoteValue(model), logsQLQuoteValue(model),
-			))
-		}
-
-		// The list view never renders request/response bodies — project them
-		// out so VictoriaLogs returns only the small metadata columns. Callers
-		// exporting the full record (?include_body=true) opt into the larger
-		// projection so bodies come back inline, avoiding a per-record lookup.
-		projection := listProjection
-		if c.Query("include_body") == stringTrue {
-			projection = fullProjection
-		}
-
-		query := strings.Join(queryParts, " ") +
-			" | sort by (_time) desc | limit " + strconv.Itoa(limit) +
-			" | fields " + projection
-
-		params := url.Values{}
-
-		if start := strings.TrimSpace(c.Query("start")); start != "" {
-			params.Set("start", start)
-		}
+		window := timeWindow{Start: strings.TrimSpace(c.Query("start"))}
 		// `before` is the inclusive upper bound from the previous page's last
 		// record's timestamp. To page strictly older we pass it as end.
 		if before := strings.TrimSpace(c.Query("before")); before != "" {
-			params.Set("end", before)
-		} else if end := strings.TrimSpace(c.Query("end")); end != "" {
-			params.Set("end", end)
+			window.End = before
+		} else {
+			window.End = strings.TrimSpace(c.Query("end"))
 		}
 
-		items, err := queryAITraces(deps, query, params)
+		items, err := store.List(traceScopeClause(c), filters, limit, includeBody, window)
 		if err != nil {
 			klog.Errorf("ai-trace: list: %v", err)
 			c.JSON(http.StatusBadGateway, gin.H{
@@ -445,11 +423,8 @@ func handleListAITraces(deps *Dependencies) gin.HandlerFunc {
 // so the SPA's detail drawer fetches them lazily through this route.
 func handleGetAITrace(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if deps.AITraceStoreURL == "" {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"error": "ai trace store is not configured",
-			})
-
+		store := requireTraceStore(c, deps)
+		if store == nil {
 			return
 		}
 
@@ -465,12 +440,7 @@ func handleGetAITrace(deps *Dependencies) gin.HandlerFunc {
 		// The scope clause confines the lookup to workspaces/endpoint types the
 		// caller may read, so an "_all_" detail fetch cannot read a trace the
 		// caller has no permission for.
-		query := fmt.Sprintf(
-			"%s request_id:=%s | sort by (_time) desc | limit 1",
-			traceScopeClause(c), logsQLQuoteValue(requestID),
-		)
-
-		items, err := queryAITraces(deps, query, url.Values{})
+		item, err := store.Get(traceScopeClause(c), requestID)
 		if err != nil {
 			klog.Errorf("ai-trace: detail: %v", err)
 			c.JSON(http.StatusBadGateway, gin.H{
@@ -480,7 +450,7 @@ func handleGetAITrace(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		if len(items) == 0 {
+		if item == nil {
 			c.JSON(http.StatusNotFound, gin.H{
 				"error": "trace not found",
 			})
@@ -488,7 +458,7 @@ func handleGetAITrace(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, items[0])
+		c.JSON(http.StatusOK, item)
 	}
 }
 
@@ -500,11 +470,8 @@ const maxStatsDays = 90
 // powering the activity bar chart at the top of the SPA's trace list.
 func handleAITraceStats(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if deps.AITraceStoreURL == "" {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"error": "ai trace store is not configured",
-			})
-
+		store := requireTraceStore(c, deps)
+		if store == nil {
 			return
 		}
 
@@ -517,19 +484,10 @@ func handleAITraceStats(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		query := fmt.Sprintf(
-			"%s | stats by (_time:1d) count() total",
-			traceScopeClause(c),
-		)
-
-		params := url.Values{}
-		params.Set("start", startDay.Format(time.RFC3339))
 		// `end` is pushed to the start of the day after endDay so the final
 		// (possibly partial) day is always fully covered, regardless of whether
 		// VictoriaLogs treats the bound as inclusive or exclusive.
-		params.Set("end", endDay.AddDate(0, 0, 1).Format(time.RFC3339))
-
-		counts, err := queryAITraceDayCounts(deps, query, params)
+		counts, err := store.DayCounts(traceScopeClause(c), startDay, endDay.AddDate(0, 0, 1))
 		if err != nil {
 			klog.Errorf("ai-trace: stats: %v", err)
 			c.JSON(http.StatusBadGateway, gin.H{
@@ -619,77 +577,6 @@ func statsWindow(c *gin.Context) (startDay, endDay time.Time, ok bool) {
 	return startDay, endDay, true
 }
 
-// queryAITraceDayCounts runs a `stats by (_time:1d)` LogsQL query and returns
-// a map of UTC date (YYYY-MM-DD) to request count.
-func queryAITraceDayCounts(deps *Dependencies, query string, params url.Values) (map[string]int, error) {
-	params.Set("query", query)
-	reqURL := strings.TrimRight(deps.AITraceStoreURL, "/") + "/select/logsql/query?" + params.Encode()
-
-	resp, err := deps.HTTPClient.Get(reqURL)
-	if err != nil {
-		return nil, fmt.Errorf("query victorialogs: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("victorialogs returned status %d", resp.StatusCode)
-	}
-
-	counts := make(map[string]int)
-	scanner := bufio.NewScanner(resp.Body)
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-
-		var r struct {
-			Time  string `json:"_time"`
-			Total string `json:"total"`
-		}
-
-		if err := json.Unmarshal(line, &r); err != nil {
-			continue
-		}
-
-		// `_time` is an RFC3339 day bucket; key by the date component.
-		date := r.Time
-		if len(date) >= 10 {
-			date = date[:10]
-		}
-
-		if n, err := strconv.Atoi(r.Total); err == nil {
-			counts[date] = n
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan victorialogs response: %w", err)
-	}
-
-	return counts, nil
-}
-
-// AITraceKeyStat is one API key's aggregated traffic over the requested window.
-// Powers the API-key list ranking overview and the detail "request performance"
-// card. SuccessRate is derived client-side as Success/Requests.
-type AITraceKeyStat struct {
-	APIKeyID      string  `json:"api_key_id"`
-	Requests      int64   `json:"requests"`
-	Tokens        int64   `json:"tokens"`
-	Success       int64   `json:"success"`
-	AvgDurationMs float64 `json:"avg_duration_ms"`
-}
-
-// AITraceKeyStatsResponse is the wire format for
-// GET /api/v1/ai-traces/:workspace/key-stats — per-API-key request count, token
-// total, success count and average latency over a trailing window (default 24h).
-type AITraceKeyStatsResponse struct {
-	WindowHours int              `json:"window_hours"`
-	Keys        []AITraceKeyStat `json:"keys"`
-}
-
 // maxKeyStatsWindowHours bounds the trailing window the key-stats endpoint will
 // aggregate over (30 days), keeping a single LogsQL scan bounded.
 const maxKeyStatsWindowHours = 720
@@ -701,11 +588,8 @@ const maxKeyStatsWindowHours = 720
 // one call (the detail view picks its key out of the result).
 func handleAITraceKeyStats(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if deps.AITraceStoreURL == "" {
-			c.JSON(http.StatusServiceUnavailable, gin.H{
-				"error": "ai trace store is not configured",
-			})
-
+		store := requireTraceStore(c, deps)
+		if store == nil {
 			return
 		}
 
@@ -717,21 +601,9 @@ func handleAITraceKeyStats(deps *Dependencies) gin.HandlerFunc {
 			}
 		}
 
-		// Success = 2xx/3xx response_status (regex match, robust to the field being
-		// stored as a string); tokens sums total_tokens (missing => 0); avg latency
-		// over duration_ms. Empty api_key_id rows (untagged traffic) are dropped by
-		// the parser.
-		query := fmt.Sprintf(
-			"%s | stats by (api_key_id) count() requests, "+
-				"sum(total_tokens) tokens, avg(duration_ms) avg_duration_ms, "+
-				"count() if (response_status:~\"^[23]\") success",
-			traceScopeClause(c),
-		)
+		since := time.Now().UTC().Add(-time.Duration(windowHours) * time.Hour)
 
-		params := url.Values{}
-		params.Set("start", time.Now().UTC().Add(-time.Duration(windowHours)*time.Hour).Format(time.RFC3339))
-
-		keys, err := queryAITraceKeyStats(deps, query, params)
+		keys, err := store.KeyStats(traceScopeClause(c), since)
 		if err != nil {
 			klog.Errorf("ai-trace: key-stats: %v", err)
 			c.JSON(http.StatusBadGateway, gin.H{
@@ -746,245 +618,4 @@ func handleAITraceKeyStats(deps *Dependencies) gin.HandlerFunc {
 			Keys:        keys,
 		})
 	}
-}
-
-// queryAITraceKeyStats runs the per-key `stats by (api_key_id)` aggregation and
-// decodes the NDJSON result rows (all values arrive as strings from VL).
-func queryAITraceKeyStats(deps *Dependencies, query string, params url.Values) ([]AITraceKeyStat, error) {
-	params.Set("query", query)
-	reqURL := strings.TrimRight(deps.AITraceStoreURL, "/") + "/select/logsql/query?" + params.Encode()
-
-	resp, err := deps.HTTPClient.Get(reqURL)
-	if err != nil {
-		return nil, fmt.Errorf("query victorialogs: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("victorialogs returned status %d", resp.StatusCode)
-	}
-
-	out := make([]AITraceKeyStat, 0, 16)
-	scanner := bufio.NewScanner(resp.Body)
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-
-		var r struct {
-			APIKeyID      string `json:"api_key_id"`
-			Requests      string `json:"requests"`
-			Tokens        string `json:"tokens"`
-			AvgDurationMs string `json:"avg_duration_ms"`
-			Success       string `json:"success"`
-		}
-
-		if err := json.Unmarshal(line, &r); err != nil {
-			continue
-		}
-
-		// Drop the untagged bucket (requests with no api_key_id): it cannot be
-		// attributed to any key in the ranking.
-		if strings.TrimSpace(r.APIKeyID) == "" {
-			continue
-		}
-
-		// VL may format count()/sum() results as plain ints or floats
-		// ("1240000" or "1.24e6"); parse as float and truncate for robustness.
-		stat := AITraceKeyStat{
-			APIKeyID:      r.APIKeyID,
-			Requests:      parseIntLoose(r.Requests),
-			Tokens:        parseIntLoose(r.Tokens),
-			Success:       parseIntLoose(r.Success),
-			AvgDurationMs: parseFloatLoose(r.AvgDurationMs),
-		}
-
-		out = append(out, stat)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan victorialogs response: %w", err)
-	}
-
-	return out, nil
-}
-
-// parseIntLoose parses a VL numeric result (which may be int- or float-
-// formatted) into an int64, truncating any fractional part. Returns 0 on error.
-// Integer-formatted values parse as base-10 int64 first so large counts
-// (>= 2^53) keep full precision; only float/scientific forms fall back to float.
-func parseIntLoose(s string) int64 {
-	s = strings.TrimSpace(s)
-	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
-		return n
-	}
-
-	if f, err := strconv.ParseFloat(s, 64); err == nil {
-		return int64(f)
-	}
-
-	return 0
-}
-
-// parseFloatLoose parses a VL numeric result into a float64, returning 0 on error.
-func parseFloatLoose(s string) float64 {
-	if f, err := strconv.ParseFloat(strings.TrimSpace(s), 64); err == nil {
-		return f
-	}
-
-	return 0
-}
-
-// queryAITraces runs a LogsQL query against VictoriaLogs and decodes the
-// NDJSON response into AITrace records.
-func queryAITraces(deps *Dependencies, query string, params url.Values) ([]AITrace, error) {
-	params.Set("query", query)
-	reqURL := strings.TrimRight(deps.AITraceStoreURL, "/") + "/select/logsql/query?" + params.Encode()
-
-	resp, err := deps.HTTPClient.Get(reqURL)
-	if err != nil {
-		return nil, fmt.Errorf("query victorialogs: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("victorialogs returned status %d", resp.StatusCode)
-	}
-
-	items := make([]AITrace, 0, 64)
-	scanner := bufio.NewScanner(resp.Body)
-	// A detail record can be large because it embeds the full request and
-	// response bodies.
-	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-
-		item, ok := decodeVLRecord(line)
-		if !ok {
-			continue
-		}
-
-		items = append(items, item)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan victorialogs response: %w", err)
-	}
-
-	return items, nil
-}
-
-// vlRecord matches the shape Vector writes to VictoriaLogs.
-// All values come back as strings; we coerce types we care about.
-type vlRecord struct {
-	Time             string `json:"_time"`
-	Stream           string `json:"_stream,omitempty"`
-	RequestID        string `json:"request_id"`
-	Workspace        string `json:"workspace"`
-	EndpointType     string `json:"endpoint_type"`
-	EndpointName     string `json:"endpoint_name"`
-	APIKeyID         string `json:"api_key_id"`
-	RequestURI       string `json:"request_uri"`
-	RequestModel     string `json:"request_model"`
-	ResponseModel    string `json:"response_model"`
-	ResponseStatus   string `json:"response_status"`
-	PromptTokens     string `json:"prompt_tokens"`
-	CompletionTokens string `json:"completion_tokens"`
-	TotalTokens      string `json:"total_tokens"`
-	FinishReason     string `json:"finish_reason"`
-	IsStream         string `json:"stream"`
-	UserAgent        string `json:"user_agent"`
-	DurationMs       string `json:"duration_ms"`
-	RequestBody      string `json:"request_body"`
-	ResponseBody     string `json:"response_body"`
-}
-
-func decodeVLRecord(line []byte) (AITrace, bool) {
-	var r vlRecord
-	if err := json.Unmarshal(line, &r); err != nil {
-		return AITrace{}, false
-	}
-
-	t := AITrace{
-		RequestID:     r.RequestID,
-		Time:          r.Time,
-		Workspace:     r.Workspace,
-		EndpointType:  r.EndpointType,
-		EndpointName:  r.EndpointName,
-		APIKeyID:      r.APIKeyID,
-		RequestURI:    r.RequestURI,
-		RequestModel:  r.RequestModel,
-		ResponseModel: r.ResponseModel,
-		FinishReason:  r.FinishReason,
-		Stream:        r.IsStream == stringTrue,
-		UserAgent:     r.UserAgent,
-		RequestBody:   r.RequestBody,
-		ResponseBody:  r.ResponseBody,
-	}
-	if r.Time == "" {
-		t.Time = time.Now().UTC().Format(time.RFC3339Nano)
-	}
-
-	if n, err := strconv.Atoi(r.ResponseStatus); err == nil {
-		t.ResponseStatus = n
-	}
-
-	if r.PromptTokens != "" {
-		if n, err := strconv.Atoi(r.PromptTokens); err == nil {
-			t.PromptTokens = &n
-		}
-	}
-
-	if r.CompletionTokens != "" {
-		if n, err := strconv.Atoi(r.CompletionTokens); err == nil {
-			t.CompletionTokens = &n
-		}
-	}
-
-	if r.TotalTokens != "" {
-		if n, err := strconv.Atoi(r.TotalTokens); err == nil {
-			t.TotalTokens = &n
-		}
-	}
-
-	if r.DurationMs != "" {
-		// `latencies.request` arrives as a float-formatted string from Vector.
-		if f, err := strconv.ParseFloat(r.DurationMs, 64); err == nil {
-			n := int(f)
-			t.DurationMs = &n
-		}
-	}
-
-	return t, true
-}
-
-// logsQLQuoteValue wraps a string literal for an exact-match LogsQL filter
-// (`field:=value`). VL accepts double-quoted strings; inner quotes/backslashes
-// are escaped. Empty input is permitted by the caller and produces `""`.
-func logsQLQuoteValue(v string) string {
-	var b strings.Builder
-	b.Grow(len(v) + 2)
-	b.WriteByte('"')
-
-	for _, r := range v {
-		switch r {
-		case '\\', '"':
-			b.WriteByte('\\')
-			b.WriteRune(r)
-		case '\n':
-			b.WriteString("\\n")
-		default:
-			b.WriteRune(r)
-		}
-	}
-
-	b.WriteByte('"')
-
-	return b.String()
 }

--- a/internal/routes/logs/ai_trace_test.go
+++ b/internal/routes/logs/ai_trace_test.go
@@ -577,3 +577,39 @@ func TestHandleAITraceKeyStats_DecodesNDJSON(t *testing.T) {
 	assert.Equal(t, "k2", resp.Keys[1].APIKeyID)
 	assert.Equal(t, int64(52), resp.Keys[1].Requests)
 }
+
+func TestHandleListAITraces_IncludeBodyClampsLimit(t *testing.T) {
+	// Body-carrying pages are clamped to includeBodyMaxLimit; metadata-only
+	// pages keep the requested size.
+	cases := []struct {
+		name      string
+		rawQuery  string
+		wantLimit string
+	}{
+		{"metadata keeps 500", "limit=500", "| limit 500"},
+		{"body clamps to 50", "limit=500&include_body=true", "| limit 50"},
+		{"body below cap untouched", "limit=10&include_body=true", "| limit 10"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotQuery string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotQuery = r.URL.Query().Get("query")
+				w.Header().Set("Content-Type", "application/x-ndjson")
+			}))
+			defer server.Close()
+
+			deps := &Dependencies{AITraceStoreURL: server.URL, HTTPClient: &util.DefaultHTTPClient{}}
+
+			c, w := traceCtx("user-1", "ws1")
+			c.Request = httptest.NewRequest("GET", "/?"+tc.rawQuery, nil)
+
+			handleListAITraces(deps)(c)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, gotQuery, tc.wantLimit, "query: %s", gotQuery)
+		})
+	}
+}

--- a/internal/routes/logs/trace_store.go
+++ b/internal/routes/logs/trace_store.go
@@ -2,10 +2,12 @@ package logs
 
 import (
 	"bufio"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -49,10 +51,31 @@ const listProjection = "_time, request_id, workspace, endpoint_type, " +
 	"finish_reason, stream, user_agent, duration_ms"
 
 // fullProjection extends listProjection with the large request/response body
-// columns. Used only when the caller opts in via ?include_body=true — chiefly
+// columns plus the chunked-body metadata needed to reassemble oversized
+// bodies. Used only when the caller opts in via ?include_body=true — chiefly
 // the CLI export, which fetches bodies inline to avoid an N+1 per-record
 // detail lookup.
-const fullProjection = listProjection + ", request_body, response_body"
+const fullProjection = listProjection + ", request_body, response_body, " +
+	"body_chunked, body_truncated, request_chunks, response_chunks"
+
+// Chunked-body storage schema. Oversized request/response bodies would exceed
+// VictoriaLogs' hard-coded 2MiB per-record cap, so Vector splits them into
+// companion "chunk" records that this store reassembles on read. The field
+// names and limits below form a contract with Vector's prepare_trace_payload
+// transform (deploy/docker/neutree-core/vector/vector.yml and the chart copy
+// in vector-install.yaml). Keep both sides in sync.
+const (
+	// chunkRecordType is the record_type value marking a chunk record. Trace
+	// records (including all pre-chunking data) carry no record_type at all,
+	// which is why every trace query filters with a negative match.
+	chunkRecordType = "chunk"
+	// chunkKindRequest / chunkKindResponse say which body a chunk belongs to.
+	chunkKindRequest  = "request"
+	chunkKindResponse = "response"
+	// maxChunksPerBody mirrors Vector's max_chunks: the most chunk records a
+	// single body can produce (longer bodies are truncated at ingestion).
+	maxChunksPerBody = 16
+)
 
 // traceFilters are the caller-facing list filters. The store translates them
 // to LogsQL; handlers never build query fragments themselves.
@@ -121,11 +144,13 @@ func (w timeWindow) params() url.Values {
 	return params
 }
 
-// baseQuery prepends the permission scope to every query the store issues.
-// Storage-level record filtering (e.g. excluding non-trace record types)
-// belongs here so no query path can forget it.
+// baseQuery prepends the permission scope to every query the store issues and
+// excludes chunk records — an internal storage detail that must never surface
+// as a trace (it would inflate list pages, stats counts, and per-key
+// aggregates). The negative match keeps pre-chunking records visible: they
+// carry no record_type field, so `NOT record_type:="chunk"` passes them.
 func (s *traceStore) baseQuery(scope string) string {
-	return scope
+	return scope + " NOT record_type:=" + logsQLQuoteValue(chunkRecordType)
 }
 
 // List returns up to limit traces, newest first. Bodies are included only
@@ -143,7 +168,29 @@ func (s *traceStore) List(scope string, f traceFilters, limit int, includeBody b
 		" | sort by (_time) desc | limit " + strconv.Itoa(limit) +
 		" | fields " + projection
 
-	return s.queryTraces(query, w.params())
+	items, err := s.queryTraces(query, w.params())
+	if err != nil {
+		return nil, err
+	}
+
+	// A body-carrying page must hand back whole bodies: reassemble any
+	// chunked records in one batched chunk fetch. Without includeBody the
+	// projection omits the chunk metadata, so nothing is flagged here.
+	if includeBody {
+		chunked := make([]*AITrace, 0)
+
+		for i := range items {
+			if items[i].bodyChunked {
+				chunked = append(chunked, &items[i])
+			}
+		}
+
+		if err := s.reassembleBodies(scope, chunked); err != nil {
+			return nil, err
+		}
+	}
+
+	return items, nil
 }
 
 // Get returns the single trace with the given request id — including the full
@@ -164,7 +211,164 @@ func (s *traceStore) Get(scope, requestID string) (*AITrace, error) {
 		return nil, nil
 	}
 
+	if err := s.reassembleBodies(scope, []*AITrace{&items[0]}); err != nil {
+		return nil, err
+	}
+
 	return &items[0], nil
+}
+
+// traceChunk is one decoded chunk record.
+type traceChunk struct {
+	kind string
+	seq  int
+	data string // base64 slice of the body
+}
+
+// reassembleBodies fetches the chunk records for every chunked trace in the
+// slice (one batched query) and reconstructs their request/response bodies in
+// place. Traces not flagged as chunked are left untouched. Chunk records have
+// no transactional tie to their parent, so a partially ingested trace is
+// degraded — bodies hold the longest decodable prefix and BodyIncomplete is
+// set — rather than failing the whole read.
+func (s *traceStore) reassembleBodies(scope string, traces []*AITrace) error {
+	chunked := make([]*AITrace, 0, len(traces))
+
+	for _, t := range traces {
+		if t.bodyChunked {
+			chunked = append(chunked, t)
+		}
+	}
+
+	if len(chunked) == 0 {
+		return nil
+	}
+
+	ids := make([]string, 0, len(chunked))
+	for _, t := range chunked {
+		ids = append(ids, t.RequestID)
+	}
+
+	byID, err := s.fetchChunks(scope, ids)
+	if err != nil {
+		return err
+	}
+
+	for _, t := range chunked {
+		chunks := byID[t.RequestID]
+
+		reqParts := make([]traceChunk, 0, t.requestChunks)
+		respParts := make([]traceChunk, 0, t.responseChunks)
+
+		for _, ch := range chunks {
+			switch ch.kind {
+			case chunkKindRequest:
+				reqParts = append(reqParts, ch)
+			case chunkKindResponse:
+				respParts = append(respParts, ch)
+			}
+		}
+
+		var reqOK, respOK bool
+		t.RequestBody, reqOK = assembleBody(reqParts, t.requestChunks)
+		t.ResponseBody, respOK = assembleBody(respParts, t.responseChunks)
+		t.BodyIncomplete = !reqOK || !respOK
+	}
+
+	return nil
+}
+
+// fetchChunks returns the chunk records for the given request ids, grouped by
+// request id. The query is scoped like any trace query — a caller who may not
+// read a trace can never read its chunks — but deliberately bypasses
+// baseQuery, which exists to exclude exactly these records.
+func (s *traceStore) fetchChunks(scope string, requestIDs []string) (map[string][]traceChunk, error) {
+	quoted := make([]string, 0, len(requestIDs))
+	for _, id := range requestIDs {
+		quoted = append(quoted, logsQLQuoteValue(id))
+	}
+
+	query := fmt.Sprintf(
+		"%s record_type:=%s request_id:in(%s) | fields request_id, chunk_kind, chunk_seq, chunk_data | limit %d",
+		scope, logsQLQuoteValue(chunkRecordType), strings.Join(quoted, ","),
+		len(requestIDs)*2*maxChunksPerBody,
+	)
+
+	resp, err := s.selectQuery(query, url.Values{})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	out := make(map[string][]traceChunk, len(requestIDs))
+	scanner := bufio.NewScanner(resp.Body)
+	// Each line carries up to ~1MiB of base64 body data plus JSON escaping.
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var r struct {
+			RequestID string `json:"request_id"`
+			ChunkKind string `json:"chunk_kind"`
+			ChunkSeq  string `json:"chunk_seq"`
+			ChunkData string `json:"chunk_data"`
+		}
+
+		if err := json.Unmarshal(line, &r); err != nil {
+			continue
+		}
+
+		seq, err := strconv.Atoi(r.ChunkSeq)
+		if err != nil {
+			continue
+		}
+
+		out[r.RequestID] = append(out[r.RequestID], traceChunk{
+			kind: r.ChunkKind,
+			seq:  seq,
+			data: r.ChunkData,
+		})
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan victorialogs response: %w", err)
+	}
+
+	return out, nil
+}
+
+// assembleBody reconstructs one body from its chunks. Only the contiguous
+// prefix (seq 0, 1, 2, ...) is used so the concatenated base64 always decodes
+// to an exact prefix of the original body — a gap must not splice unrelated
+// ranges together. ok is false when any chunk of the recorded count is
+// missing, duplicated, or undecodable.
+func assembleBody(parts []traceChunk, want int) (string, bool) {
+	sort.Slice(parts, func(i, j int) bool { return parts[i].seq < parts[j].seq })
+
+	var b strings.Builder
+
+	got := 0
+
+	for _, p := range parts {
+		if p.seq != got {
+			break
+		}
+
+		b.WriteString(p.data)
+
+		got++
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(b.String())
+	if err != nil {
+		return "", false
+	}
+
+	return string(decoded), got == want && len(parts) == want
 }
 
 // DayCounts returns per-UTC-day trace counts for [start, end), keyed by
@@ -405,6 +609,10 @@ type vlRecord struct {
 	DurationMs       string `json:"duration_ms"`
 	RequestBody      string `json:"request_body"`
 	ResponseBody     string `json:"response_body"`
+	BodyChunked      string `json:"body_chunked"`
+	BodyTruncated    string `json:"body_truncated"`
+	RequestChunks    string `json:"request_chunks"`
+	ResponseChunks   string `json:"response_chunks"`
 }
 
 func decodeVLRecord(line []byte) (AITrace, bool) {
@@ -428,7 +636,18 @@ func decodeVLRecord(line []byte) (AITrace, bool) {
 		UserAgent:     r.UserAgent,
 		RequestBody:   r.RequestBody,
 		ResponseBody:  r.ResponseBody,
+		BodyTruncated: r.BodyTruncated == stringTrue,
+		bodyChunked:   r.BodyChunked == stringTrue,
 	}
+
+	if n, err := strconv.Atoi(r.RequestChunks); err == nil {
+		t.requestChunks = n
+	}
+
+	if n, err := strconv.Atoi(r.ResponseChunks); err == nil {
+		t.responseChunks = n
+	}
+
 	if r.Time == "" {
 		t.Time = time.Now().UTC().Format(time.RFC3339Nano)
 	}

--- a/internal/routes/logs/trace_store.go
+++ b/internal/routes/logs/trace_store.go
@@ -61,9 +61,11 @@ const fullProjection = listProjection + ", request_body, response_body, " +
 // Chunked-body storage schema. Oversized request/response bodies would exceed
 // VictoriaLogs' hard-coded 2MiB per-record cap, so Vector splits them into
 // companion "chunk" records that this store reassembles on read. The field
-// names and limits below form a contract with Vector's prepare_trace_payload
-// transform (deploy/docker/neutree-core/vector/vector.yml and the chart copy
-// in vector-install.yaml). Keep both sides in sync.
+// names below form a contract with Vector's prepare_trace_payload transform
+// (deploy/docker/neutree-core/vector/vector.yml and the chart copy in
+// vector-install.yaml) — keep both sides in sync. Sizing (chunk_size,
+// max_chunks) is Vector's alone: the store learns per-trace chunk counts from
+// the parent record itself.
 const (
 	// chunkRecordType is the record_type value marking a chunk record. Trace
 	// records (including all pre-chunking data) carry no record_type at all,
@@ -72,9 +74,6 @@ const (
 	// chunkKindRequest / chunkKindResponse say which body a chunk belongs to.
 	chunkKindRequest  = "request"
 	chunkKindResponse = "response"
-	// maxChunksPerBody mirrors Vector's max_chunks: the most chunk records a
-	// single body can produce (longer bodies are truncated at ingestion).
-	maxChunksPerBody = 16
 )
 
 // traceFilters are the caller-facing list filters. The store translates them
@@ -244,14 +243,29 @@ func (s *traceStore) reassembleBodies(scope string, traces []*AITrace) error {
 		return nil
 	}
 
+	// The parents' own chunk counts say exactly how many chunk rows to expect
+	// — they live in the same record as the body_chunked flag, so they are
+	// exactly as trustworthy, and the store needs no mirror of Vector's
+	// max_chunks limit.
 	ids := make([]string, 0, len(chunked))
+	expected := 0
+
 	for _, t := range chunked {
 		ids = append(ids, t.RequestID)
+		expected += t.requestChunks + t.responseChunks
 	}
 
-	byID, err := s.fetchChunks(scope, ids)
-	if err != nil {
-		return err
+	// expected == 0 means every parent recorded zero chunks; there is nothing
+	// to fetch (and LogsQL would read `limit 0` as unlimited).
+	var byID map[string][]traceChunk
+
+	if expected > 0 {
+		var err error
+
+		byID, err = s.fetchChunks(scope, ids, expected)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, t := range chunked {
@@ -279,10 +293,13 @@ func (s *traceStore) reassembleBodies(scope string, traces []*AITrace) error {
 }
 
 // fetchChunks returns the chunk records for the given request ids, grouped by
-// request id. The query is scoped like any trace query — a caller who may not
-// read a trace can never read its chunks — but deliberately bypasses
+// request id. `expected` is the exact row count the parents recorded; stray
+// extra rows (e.g. a re-ingested duplicate) push a real chunk past the limit,
+// which assembleBody then reports as body_incomplete — the designed
+// degradation. The query is scoped like any trace query — a caller who may
+// not read a trace can never read its chunks — but deliberately bypasses
 // baseQuery, which exists to exclude exactly these records.
-func (s *traceStore) fetchChunks(scope string, requestIDs []string) (map[string][]traceChunk, error) {
+func (s *traceStore) fetchChunks(scope string, requestIDs []string, expected int) (map[string][]traceChunk, error) {
 	quoted := make([]string, 0, len(requestIDs))
 	for _, id := range requestIDs {
 		quoted = append(quoted, logsQLQuoteValue(id))
@@ -291,7 +308,7 @@ func (s *traceStore) fetchChunks(scope string, requestIDs []string) (map[string]
 	query := fmt.Sprintf(
 		"%s record_type:=%s request_id:in(%s) | fields request_id, chunk_kind, chunk_seq, chunk_data | limit %d",
 		scope, logsQLQuoteValue(chunkRecordType), strings.Join(quoted, ","),
-		len(requestIDs)*2*maxChunksPerBody,
+		expected,
 	)
 
 	resp, err := s.selectQuery(query, url.Values{})

--- a/internal/routes/logs/trace_store.go
+++ b/internal/routes/logs/trace_store.go
@@ -366,6 +366,13 @@ func (s *traceStore) fetchChunks(scope string, requestIDs []string, expected int
 // ranges together. ok is false when any chunk of the recorded count is
 // missing, duplicated, or undecodable.
 func assembleBody(parts []traceChunk, want int) (string, bool) {
+	// A parent that recorded zero chunks has an empty body by definition;
+	// stray rows (e.g. re-ingested duplicates sharing the request id) must
+	// not resurrect content the parent says does not exist.
+	if want == 0 {
+		return "", len(parts) == 0
+	}
+
 	sort.Slice(parts, func(i, j int) bool { return parts[i].seq < parts[j].seq })
 
 	var b strings.Builder
@@ -384,7 +391,10 @@ func assembleBody(parts []traceChunk, want int) (string, bool) {
 
 	decoded, err := base64.StdEncoding.DecodeString(b.String())
 	if err != nil {
-		return "", false
+		// DecodeString hands back the bytes it decoded before the error, so a
+		// corrupt chunk degrades to the longest decodable prefix instead of
+		// wiping out the valid chunks before it.
+		return string(decoded), false
 	}
 
 	return string(decoded), got == want && len(parts) == want

--- a/internal/routes/logs/trace_store.go
+++ b/internal/routes/logs/trace_store.go
@@ -43,12 +43,14 @@ func newTraceStore(deps *Dependencies) *traceStore {
 }
 
 // listProjection is the LogsQL `fields` projection for the list query: every
-// metadata column the list view renders, deliberately excluding the large
-// request_body / response_body fields so list responses stay small.
+// metadata column the list view renders — including the body_truncated flag,
+// so truncated traces are recognizable without fetching bodies — while
+// deliberately excluding the large request_body / response_body fields so
+// list responses stay small.
 const listProjection = "_time, request_id, workspace, endpoint_type, " +
 	"endpoint_name, api_key_id, request_uri, request_model, response_model, " +
 	"response_status, prompt_tokens, completion_tokens, total_tokens, " +
-	"finish_reason, stream, user_agent, duration_ms"
+	"finish_reason, stream, user_agent, duration_ms, body_truncated"
 
 // fullProjection extends listProjection with the large request/response body
 // columns plus the chunked-body metadata needed to reassemble oversized
@@ -56,7 +58,7 @@ const listProjection = "_time, request_id, workspace, endpoint_type, " +
 // the CLI export, which fetches bodies inline to avoid an N+1 per-record
 // detail lookup.
 const fullProjection = listProjection + ", request_body, response_body, " +
-	"body_chunked, body_truncated, request_chunks, response_chunks"
+	"body_chunked, request_chunks, response_chunks"
 
 // Chunked-body storage schema. Oversized request/response bodies would exceed
 // VictoriaLogs' hard-coded 2MiB per-record cap, so Vector splits them into

--- a/internal/routes/logs/trace_store.go
+++ b/internal/routes/logs/trace_store.go
@@ -1,0 +1,492 @@
+package logs
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/neutree-ai/neutree/internal/util"
+)
+
+// traceStore is the only layer that knows how AI inference traces are
+// physically stored in VictoriaLogs — the LogsQL dialect, the NDJSON wire
+// shapes, and (in the future) the chunked representation of oversized bodies.
+// Handlers deal in whole AITrace values and HTTP-level concerns only.
+//
+// The `scope` string accepted by every method is the LogsQL expression the
+// permission layer produced (see traceScopeClause); it is "who may see what",
+// not a storage detail, so it crosses the boundary as an opaque clause.
+type traceStore struct {
+	baseURL string
+	client  util.HTTPClient
+}
+
+// newTraceStore returns the trace store backed by the configured
+// VictoriaLogs URL, or nil when the AI trace store is not configured
+// (handlers turn nil into a 503 before any query is attempted).
+func newTraceStore(deps *Dependencies) *traceStore {
+	if deps.AITraceStoreURL == "" {
+		return nil
+	}
+
+	return &traceStore{
+		baseURL: strings.TrimRight(deps.AITraceStoreURL, "/"),
+		client:  deps.HTTPClient,
+	}
+}
+
+// listProjection is the LogsQL `fields` projection for the list query: every
+// metadata column the list view renders, deliberately excluding the large
+// request_body / response_body fields so list responses stay small.
+const listProjection = "_time, request_id, workspace, endpoint_type, " +
+	"endpoint_name, api_key_id, request_uri, request_model, response_model, " +
+	"response_status, prompt_tokens, completion_tokens, total_tokens, " +
+	"finish_reason, stream, user_agent, duration_ms"
+
+// fullProjection extends listProjection with the large request/response body
+// columns. Used only when the caller opts in via ?include_body=true — chiefly
+// the CLI export, which fetches bodies inline to avoid an N+1 per-record
+// detail lookup.
+const fullProjection = listProjection + ", request_body, response_body"
+
+// traceFilters are the caller-facing list filters. The store translates them
+// to LogsQL; handlers never build query fragments themselves.
+type traceFilters struct {
+	EndpointName string
+	EndpointType string
+	Status       string
+	APIKeyID     string
+	FinishReason string
+	Model        string
+}
+
+// clauses renders the filters as LogsQL AND-clauses, in a fixed order.
+func (f traceFilters) clauses() []string {
+	out := make([]string, 0, 6)
+
+	if f.EndpointName != "" {
+		out = append(out, fmt.Sprintf("endpoint_name:=%s", logsQLQuoteValue(f.EndpointName)))
+	}
+
+	if f.EndpointType != "" {
+		out = append(out, fmt.Sprintf("endpoint_type:=%s", logsQLQuoteValue(f.EndpointType)))
+	}
+
+	if f.Status != "" {
+		out = append(out, fmt.Sprintf("response_status:=%s", logsQLQuoteValue(f.Status)))
+	}
+
+	if f.APIKeyID != "" {
+		out = append(out, fmt.Sprintf("api_key_id:=%s", logsQLQuoteValue(f.APIKeyID)))
+	}
+
+	if f.FinishReason != "" {
+		out = append(out, fmt.Sprintf("finish_reason:=%s", logsQLQuoteValue(f.FinishReason)))
+	}
+
+	if f.Model != "" {
+		// model can match either request or response model
+		out = append(out, fmt.Sprintf(
+			"(request_model:=%s OR response_model:=%s)",
+			logsQLQuoteValue(f.Model), logsQLQuoteValue(f.Model),
+		))
+	}
+
+	return out
+}
+
+// timeWindow carries the optional RFC3339 start/end bounds of a query straight
+// through to the VictoriaLogs HTTP API. Zero values mean "unbounded".
+type timeWindow struct {
+	Start string
+	End   string
+}
+
+func (w timeWindow) params() url.Values {
+	params := url.Values{}
+
+	if w.Start != "" {
+		params.Set("start", w.Start)
+	}
+
+	if w.End != "" {
+		params.Set("end", w.End)
+	}
+
+	return params
+}
+
+// baseQuery prepends the permission scope to every query the store issues.
+// Storage-level record filtering (e.g. excluding non-trace record types)
+// belongs here so no query path can forget it.
+func (s *traceStore) baseQuery(scope string) string {
+	return scope
+}
+
+// List returns up to limit traces, newest first. Bodies are included only
+// when includeBody is set; otherwise the projection omits them so responses
+// stay small.
+func (s *traceStore) List(scope string, f traceFilters, limit int, includeBody bool, w timeWindow) ([]AITrace, error) {
+	queryParts := append([]string{s.baseQuery(scope)}, f.clauses()...)
+
+	projection := listProjection
+	if includeBody {
+		projection = fullProjection
+	}
+
+	query := strings.Join(queryParts, " ") +
+		" | sort by (_time) desc | limit " + strconv.Itoa(limit) +
+		" | fields " + projection
+
+	return s.queryTraces(query, w.params())
+}
+
+// Get returns the single trace with the given request id — including the full
+// request/response bodies — or nil when no matching record exists within the
+// caller's scope.
+func (s *traceStore) Get(scope, requestID string) (*AITrace, error) {
+	query := fmt.Sprintf(
+		"%s request_id:=%s | sort by (_time) desc | limit 1",
+		s.baseQuery(scope), logsQLQuoteValue(requestID),
+	)
+
+	items, err := s.queryTraces(query, url.Values{})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	return &items[0], nil
+}
+
+// DayCounts returns per-UTC-day trace counts for [start, end), keyed by
+// YYYY-MM-DD.
+func (s *traceStore) DayCounts(scope string, start, end time.Time) (map[string]int, error) {
+	query := fmt.Sprintf("%s | stats by (_time:1d) count() total", s.baseQuery(scope))
+
+	params := url.Values{}
+	params.Set("start", start.Format(time.RFC3339))
+	params.Set("end", end.Format(time.RFC3339))
+
+	return s.queryDayCounts(query, params)
+}
+
+// KeyStats returns per-API-key aggregates (request count, tokens, success
+// count, average latency) since the given instant.
+func (s *traceStore) KeyStats(scope string, since time.Time) ([]AITraceKeyStat, error) {
+	// Success = 2xx/3xx response_status (regex match, robust to the field being
+	// stored as a string); tokens sums total_tokens (missing => 0); avg latency
+	// over duration_ms. Empty api_key_id rows (untagged traffic) are dropped by
+	// the parser.
+	query := fmt.Sprintf(
+		"%s | stats by (api_key_id) count() requests, "+
+			"sum(total_tokens) tokens, avg(duration_ms) avg_duration_ms, "+
+			"count() if (response_status:~\"^[23]\") success",
+		s.baseQuery(scope),
+	)
+
+	params := url.Values{}
+	params.Set("start", since.Format(time.RFC3339))
+
+	return s.queryKeyStats(query, params)
+}
+
+// select runs a LogsQL query against VictoriaLogs and returns the raw NDJSON
+// response body; the caller must Close it.
+func (s *traceStore) selectQuery(query string, params url.Values) (*http.Response, error) {
+	params.Set("query", query)
+	reqURL := s.baseURL + "/select/logsql/query?" + params.Encode()
+
+	resp, err := s.client.Get(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("query victorialogs: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+
+		return nil, fmt.Errorf("victorialogs returned status %d", resp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+// queryTraces runs a LogsQL query and decodes the NDJSON response into
+// AITrace records.
+func (s *traceStore) queryTraces(query string, params url.Values) ([]AITrace, error) {
+	resp, err := s.selectQuery(query, params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	items := make([]AITrace, 0, 64)
+	scanner := bufio.NewScanner(resp.Body)
+	// A detail record can be large because it embeds the full request and
+	// response bodies.
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		item, ok := decodeVLRecord(line)
+		if !ok {
+			continue
+		}
+
+		items = append(items, item)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan victorialogs response: %w", err)
+	}
+
+	return items, nil
+}
+
+// queryDayCounts runs a `stats by (_time:1d)` LogsQL query and returns a map
+// of UTC date (YYYY-MM-DD) to request count.
+func (s *traceStore) queryDayCounts(query string, params url.Values) (map[string]int, error) {
+	resp, err := s.selectQuery(query, params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	counts := make(map[string]int)
+	scanner := bufio.NewScanner(resp.Body)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var r struct {
+			Time  string `json:"_time"`
+			Total string `json:"total"`
+		}
+
+		if err := json.Unmarshal(line, &r); err != nil {
+			continue
+		}
+
+		// `_time` is an RFC3339 day bucket; key by the date component.
+		date := r.Time
+		if len(date) >= 10 {
+			date = date[:10]
+		}
+
+		if n, err := strconv.Atoi(r.Total); err == nil {
+			counts[date] = n
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan victorialogs response: %w", err)
+	}
+
+	return counts, nil
+}
+
+// queryKeyStats runs the per-key `stats by (api_key_id)` aggregation and
+// decodes the NDJSON result rows (all values arrive as strings from VL).
+func (s *traceStore) queryKeyStats(query string, params url.Values) ([]AITraceKeyStat, error) {
+	resp, err := s.selectQuery(query, params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	out := make([]AITraceKeyStat, 0, 16)
+	scanner := bufio.NewScanner(resp.Body)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var r struct {
+			APIKeyID      string `json:"api_key_id"`
+			Requests      string `json:"requests"`
+			Tokens        string `json:"tokens"`
+			AvgDurationMs string `json:"avg_duration_ms"`
+			Success       string `json:"success"`
+		}
+
+		if err := json.Unmarshal(line, &r); err != nil {
+			continue
+		}
+
+		// Drop the untagged bucket (requests with no api_key_id): it cannot be
+		// attributed to any key in the ranking.
+		if strings.TrimSpace(r.APIKeyID) == "" {
+			continue
+		}
+
+		// VL may format count()/sum() results as plain ints or floats
+		// ("1240000" or "1.24e6"); parse as float and truncate for robustness.
+		stat := AITraceKeyStat{
+			APIKeyID:      r.APIKeyID,
+			Requests:      parseIntLoose(r.Requests),
+			Tokens:        parseIntLoose(r.Tokens),
+			Success:       parseIntLoose(r.Success),
+			AvgDurationMs: parseFloatLoose(r.AvgDurationMs),
+		}
+
+		out = append(out, stat)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan victorialogs response: %w", err)
+	}
+
+	return out, nil
+}
+
+// parseIntLoose parses a VL numeric result (which may be int- or float-
+// formatted) into an int64, truncating any fractional part. Returns 0 on error.
+// Integer-formatted values parse as base-10 int64 first so large counts
+// (>= 2^53) keep full precision; only float/scientific forms fall back to float.
+func parseIntLoose(s string) int64 {
+	s = strings.TrimSpace(s)
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n
+	}
+
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return int64(f)
+	}
+
+	return 0
+}
+
+// parseFloatLoose parses a VL numeric result into a float64, returning 0 on error.
+func parseFloatLoose(s string) float64 {
+	if f, err := strconv.ParseFloat(strings.TrimSpace(s), 64); err == nil {
+		return f
+	}
+
+	return 0
+}
+
+// vlRecord matches the shape Vector writes to VictoriaLogs.
+// All values come back as strings; we coerce types we care about.
+type vlRecord struct {
+	Time             string `json:"_time"`
+	Stream           string `json:"_stream,omitempty"`
+	RequestID        string `json:"request_id"`
+	Workspace        string `json:"workspace"`
+	EndpointType     string `json:"endpoint_type"`
+	EndpointName     string `json:"endpoint_name"`
+	APIKeyID         string `json:"api_key_id"`
+	RequestURI       string `json:"request_uri"`
+	RequestModel     string `json:"request_model"`
+	ResponseModel    string `json:"response_model"`
+	ResponseStatus   string `json:"response_status"`
+	PromptTokens     string `json:"prompt_tokens"`
+	CompletionTokens string `json:"completion_tokens"`
+	TotalTokens      string `json:"total_tokens"`
+	FinishReason     string `json:"finish_reason"`
+	IsStream         string `json:"stream"`
+	UserAgent        string `json:"user_agent"`
+	DurationMs       string `json:"duration_ms"`
+	RequestBody      string `json:"request_body"`
+	ResponseBody     string `json:"response_body"`
+}
+
+func decodeVLRecord(line []byte) (AITrace, bool) {
+	var r vlRecord
+	if err := json.Unmarshal(line, &r); err != nil {
+		return AITrace{}, false
+	}
+
+	t := AITrace{
+		RequestID:     r.RequestID,
+		Time:          r.Time,
+		Workspace:     r.Workspace,
+		EndpointType:  r.EndpointType,
+		EndpointName:  r.EndpointName,
+		APIKeyID:      r.APIKeyID,
+		RequestURI:    r.RequestURI,
+		RequestModel:  r.RequestModel,
+		ResponseModel: r.ResponseModel,
+		FinishReason:  r.FinishReason,
+		Stream:        r.IsStream == stringTrue,
+		UserAgent:     r.UserAgent,
+		RequestBody:   r.RequestBody,
+		ResponseBody:  r.ResponseBody,
+	}
+	if r.Time == "" {
+		t.Time = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	if n, err := strconv.Atoi(r.ResponseStatus); err == nil {
+		t.ResponseStatus = n
+	}
+
+	if r.PromptTokens != "" {
+		if n, err := strconv.Atoi(r.PromptTokens); err == nil {
+			t.PromptTokens = &n
+		}
+	}
+
+	if r.CompletionTokens != "" {
+		if n, err := strconv.Atoi(r.CompletionTokens); err == nil {
+			t.CompletionTokens = &n
+		}
+	}
+
+	if r.TotalTokens != "" {
+		if n, err := strconv.Atoi(r.TotalTokens); err == nil {
+			t.TotalTokens = &n
+		}
+	}
+
+	if r.DurationMs != "" {
+		// `latencies.request` arrives as a float-formatted string from Vector.
+		if f, err := strconv.ParseFloat(r.DurationMs, 64); err == nil {
+			n := int(f)
+			t.DurationMs = &n
+		}
+	}
+
+	return t, true
+}
+
+// logsQLQuoteValue wraps a string literal for an exact-match LogsQL filter
+// (`field:=value`). VL accepts double-quoted strings; inner quotes/backslashes
+// are escaped. Empty input is permitted by the caller and produces `""`.
+func logsQLQuoteValue(v string) string {
+	var b strings.Builder
+	b.Grow(len(v) + 2)
+	b.WriteByte('"')
+
+	for _, r := range v {
+		switch r {
+		case '\\', '"':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		case '\n':
+			b.WriteString("\\n")
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	b.WriteByte('"')
+
+	return b.String()
+}

--- a/internal/routes/logs/trace_store_test.go
+++ b/internal/routes/logs/trace_store_test.go
@@ -212,8 +212,10 @@ func TestList_IncludeBodyReassemblesInOneBatch(t *testing.T) {
 
 func TestList_WithoutBodySkipsChunkFetch(t *testing.T) {
 	// Metadata-only pages never trigger chunk fetches, even when the page
-	// contains chunked records (their metadata is not even projected).
-	page := `{"request_id":"req-a","workspace":"ws1","response_status":"200"}` + "\n"
+	// contains chunked records (their chunk metadata is not even projected) —
+	// but the body_truncated flag IS projected, so truncated traces stay
+	// recognizable in the list view.
+	page := `{"request_id":"req-a","workspace":"ws1","response_status":"200","body_truncated":"true"}` + "\n"
 
 	fake := &fakeVL{responses: []string{page}}
 	server := fake.server(t)
@@ -225,8 +227,10 @@ func TestList_WithoutBodySkipsChunkFetch(t *testing.T) {
 	items, err := store.List(`workspace:="ws1"`, traceFilters{}, 50, false, timeWindow{})
 	require.NoError(t, err)
 	require.Len(t, items, 1)
+	assert.True(t, items[0].BodyTruncated)
 	require.Len(t, fake.queries, 1)
 	assert.NotContains(t, fake.queries[0], "body_chunked")
+	assert.Contains(t, fake.queries[0], "body_truncated")
 }
 
 func TestAssembleBody(t *testing.T) {

--- a/internal/routes/logs/trace_store_test.go
+++ b/internal/routes/logs/trace_store_test.go
@@ -203,6 +203,9 @@ func TestList_IncludeBodyReassemblesInOneBatch(t *testing.T) {
 
 	require.Len(t, fake.queries, 2, "all chunked records share one chunk fetch")
 	assert.Contains(t, fake.queries[1], `request_id:in("req-a","req-c")`)
+	// The fetch limit is inferred from the parents' chunk counts (1+1 and
+	// 1+0), not from any constant mirroring Vector's max_chunks.
+	assert.Contains(t, fake.queries[1], "| limit 3")
 	// Body-mode list queries must project the chunk metadata columns.
 	assert.Contains(t, fake.queries[0], "body_chunked")
 }

--- a/internal/routes/logs/trace_store_test.go
+++ b/internal/routes/logs/trace_store_test.go
@@ -250,6 +250,11 @@ func TestAssembleBody(t *testing.T) {
 		{"missing middle keeps prefix", []traceChunk{{seq: 0, data: b64("abc")}, {seq: 2, data: b64("ghi")}}, 3, "abc", false},
 		{"duplicate seq", []traceChunk{{seq: 0, data: b64("abc")}, {seq: 0, data: b64("abc")}}, 2, "abc", false},
 		{"undecodable", []traceChunk{{seq: 0, data: "!!!not-base64!!!"}}, 1, "", false},
+		// A corrupt later chunk degrades to the longest decodable prefix
+		// rather than wiping out the valid chunks before it.
+		{"corrupt tail keeps prefix", []traceChunk{{seq: 0, data: b64("abc")}, {seq: 1, data: "###"}}, 2, "abc", false},
+		// Stray rows must not resurrect a body the parent recorded as empty.
+		{"stray parts with want zero", []traceChunk{{seq: 0, data: b64("ghost")}}, 0, "", false},
 	}
 
 	for _, tc := range cases {

--- a/internal/routes/logs/trace_store_test.go
+++ b/internal/routes/logs/trace_store_test.go
@@ -1,0 +1,293 @@
+package logs
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neutree-ai/neutree/internal/util"
+)
+
+// fakeVL is a minimal VictoriaLogs stand-in: it records every LogsQL query it
+// receives and answers each with the next canned NDJSON response.
+type fakeVL struct {
+	queries   []string
+	responses []string
+}
+
+func (f *fakeVL) server(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.queries = append(f.queries, r.URL.Query().Get("query"))
+		w.Header().Set("Content-Type", "application/x-ndjson")
+
+		if len(f.responses) > 0 {
+			_, _ = w.Write([]byte(f.responses[0]))
+			f.responses = f.responses[1:]
+		}
+	}))
+}
+
+func newTestStore(serverURL string) *traceStore {
+	return newTraceStore(&Dependencies{
+		AITraceStoreURL: serverURL,
+		HTTPClient:      &util.DefaultHTTPClient{},
+	})
+}
+
+// chunkLine renders one chunk record the way VictoriaLogs returns it (all
+// values as strings); data is base64-encoded here for test readability.
+func chunkLine(requestID, kind string, seq int, rawData string) string {
+	rec := map[string]string{
+		"request_id": requestID,
+		"chunk_kind": kind,
+		"chunk_seq":  fmt.Sprintf("%d", seq),
+		"chunk_data": base64.StdEncoding.EncodeToString([]byte(rawData)),
+	}
+	b, _ := json.Marshal(rec)
+
+	return string(b) + "\n"
+}
+
+func TestBaseQuery_ExcludesChunkRecords(t *testing.T) {
+	// Every query the store issues must filter out chunk records; forgetting
+	// this on any path would leak storage internals into lists and stats.
+	fake := &fakeVL{responses: []string{"", "", "", ""}}
+	server := fake.server(t)
+
+	defer server.Close()
+
+	store := newTestStore(server.URL)
+
+	_, err := store.List(`workspace:="ws1"`, traceFilters{}, 10, false, timeWindow{})
+	require.NoError(t, err)
+
+	_, err = store.Get(`workspace:="ws1"`, "req-1")
+	require.NoError(t, err)
+
+	_, err = store.DayCounts(`workspace:="ws1"`, timeMustParse(t, "2026-07-01T00:00:00Z"), timeMustParse(t, "2026-07-02T00:00:00Z"))
+	require.NoError(t, err)
+
+	_, err = store.KeyStats(`workspace:="ws1"`, timeMustParse(t, "2026-07-01T00:00:00Z"))
+	require.NoError(t, err)
+
+	require.Len(t, fake.queries, 4)
+
+	for i, q := range fake.queries {
+		assert.Containsf(t, q, `NOT record_type:="chunk"`, "query %d: %s", i, q)
+	}
+}
+
+func TestGet_ReassemblesChunkedBodies(t *testing.T) {
+	// A chunked trace is returned with whole bodies, reassembled from its
+	// chunk records — out-of-order chunk rows must not corrupt the result.
+	parent := `{"request_id":"req-1","workspace":"ws1","body_chunked":"true",` +
+		`"request_chunks":"2","response_chunks":"1","response_status":"200"}` + "\n"
+	chunks := chunkLine("req-1", "response", 0, `{"answer":42}`) +
+		chunkLine("req-1", "request", 1, `world`) + // out of order on purpose
+		chunkLine("req-1", "request", 0, `hello `)
+
+	fake := &fakeVL{responses: []string{parent, chunks}}
+	server := fake.server(t)
+
+	defer server.Close()
+
+	store := newTestStore(server.URL)
+
+	item, err := store.Get(`workspace:="ws1"`, "req-1")
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	assert.Equal(t, "hello world", item.RequestBody)
+	assert.Equal(t, `{"answer":42}`, item.ResponseBody)
+	assert.False(t, item.BodyIncomplete)
+	assert.False(t, item.BodyTruncated)
+
+	// The chunk fetch is scoped like any trace query but must NOT carry the
+	// chunk exclusion — it selects exactly the excluded records.
+	require.Len(t, fake.queries, 2)
+	assert.Contains(t, fake.queries[1], `record_type:="chunk"`)
+	assert.Contains(t, fake.queries[1], `request_id:in("req-1")`)
+	assert.NotContains(t, fake.queries[1], "NOT record_type")
+	assert.Contains(t, fake.queries[1], `workspace:="ws1"`, "chunk fetch must stay permission-scoped")
+}
+
+func TestGet_MissingChunkMarksIncomplete(t *testing.T) {
+	// Chunk records have no transactional tie to the parent: a lost chunk
+	// degrades the body to its longest decodable prefix instead of failing.
+	parent := `{"request_id":"req-1","workspace":"ws1","body_chunked":"true",` +
+		`"request_chunks":"3","response_chunks":"0","response_status":"200"}` + "\n"
+	chunks := chunkLine("req-1", "request", 0, "part0.") +
+		chunkLine("req-1", "request", 2, "part2.") // seq 1 lost
+
+	fake := &fakeVL{responses: []string{parent, chunks}}
+	server := fake.server(t)
+
+	defer server.Close()
+
+	store := newTestStore(server.URL)
+
+	item, err := store.Get(`workspace:="ws1"`, "req-1")
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	// Only the contiguous prefix survives; splicing part0+part2 would forge a
+	// body that never existed.
+	assert.Equal(t, "part0.", item.RequestBody)
+	assert.True(t, item.BodyIncomplete)
+}
+
+func TestGet_LegacyRecordUnchanged(t *testing.T) {
+	// Pre-chunking records carry no chunk metadata: no second query is made
+	// and the inline bodies pass through untouched.
+	parent := `{"request_id":"req-1","workspace":"ws1","response_status":"200",` +
+		`"request_body":"{\"q\":1}","response_body":"{\"a\":2}"}` + "\n"
+
+	fake := &fakeVL{responses: []string{parent}}
+	server := fake.server(t)
+
+	defer server.Close()
+
+	store := newTestStore(server.URL)
+
+	item, err := store.Get(`workspace:="ws1"`, "req-1")
+	require.NoError(t, err)
+	require.NotNil(t, item)
+
+	assert.Equal(t, `{"q":1}`, item.RequestBody)
+	assert.Equal(t, `{"a":2}`, item.ResponseBody)
+	assert.False(t, item.BodyIncomplete)
+	require.Len(t, fake.queries, 1, "no chunk fetch for a legacy record")
+}
+
+func TestList_IncludeBodyReassemblesInOneBatch(t *testing.T) {
+	// A body-carrying page reassembles every chunked record on it with a
+	// single batched chunk query; plain records are untouched.
+	page := `{"request_id":"req-a","workspace":"ws1","body_chunked":"true",` +
+		`"request_chunks":"1","response_chunks":"1","response_status":"200"}` + "\n" +
+		`{"request_id":"req-b","workspace":"ws1","response_status":"200",` +
+		`"request_body":"inline-req","response_body":"inline-resp"}` + "\n" +
+		`{"request_id":"req-c","workspace":"ws1","body_chunked":"true",` +
+		`"request_chunks":"1","response_chunks":"0","response_status":"500","body_truncated":"true"}` + "\n"
+	chunks := chunkLine("req-a", "request", 0, "a-req") +
+		chunkLine("req-a", "response", 0, "a-resp") +
+		chunkLine("req-c", "request", 0, "c-req")
+
+	fake := &fakeVL{responses: []string{page, chunks}}
+	server := fake.server(t)
+
+	defer server.Close()
+
+	store := newTestStore(server.URL)
+
+	items, err := store.List(`workspace:="ws1"`, traceFilters{}, 50, true, timeWindow{})
+	require.NoError(t, err)
+	require.Len(t, items, 3)
+
+	assert.Equal(t, "a-req", items[0].RequestBody)
+	assert.Equal(t, "a-resp", items[0].ResponseBody)
+	assert.Equal(t, "inline-req", items[1].RequestBody)
+	assert.Equal(t, "c-req", items[2].RequestBody)
+	assert.Empty(t, items[2].ResponseBody)
+	assert.True(t, items[2].BodyTruncated)
+	assert.False(t, items[2].BodyIncomplete)
+
+	require.Len(t, fake.queries, 2, "all chunked records share one chunk fetch")
+	assert.Contains(t, fake.queries[1], `request_id:in("req-a","req-c")`)
+	// Body-mode list queries must project the chunk metadata columns.
+	assert.Contains(t, fake.queries[0], "body_chunked")
+}
+
+func TestList_WithoutBodySkipsChunkFetch(t *testing.T) {
+	// Metadata-only pages never trigger chunk fetches, even when the page
+	// contains chunked records (their metadata is not even projected).
+	page := `{"request_id":"req-a","workspace":"ws1","response_status":"200"}` + "\n"
+
+	fake := &fakeVL{responses: []string{page}}
+	server := fake.server(t)
+
+	defer server.Close()
+
+	store := newTestStore(server.URL)
+
+	items, err := store.List(`workspace:="ws1"`, traceFilters{}, 50, false, timeWindow{})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Len(t, fake.queries, 1)
+	assert.NotContains(t, fake.queries[0], "body_chunked")
+}
+
+func TestAssembleBody(t *testing.T) {
+	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+
+	cases := []struct {
+		name   string
+		parts  []traceChunk
+		want   int
+		body   string
+		ok     bool
+	}{
+		{"empty complete", nil, 0, "", true},
+		{"single", []traceChunk{{seq: 0, data: b64("abc")}}, 1, "abc", true},
+		{"out of order", []traceChunk{{seq: 1, data: b64("def")}, {seq: 0, data: b64("abc")}}, 2, "abcdef", true},
+		{"missing head", []traceChunk{{seq: 1, data: b64("def")}}, 2, "", false},
+		{"missing middle keeps prefix", []traceChunk{{seq: 0, data: b64("abc")}, {seq: 2, data: b64("ghi")}}, 3, "abc", false},
+		{"duplicate seq", []traceChunk{{seq: 0, data: b64("abc")}, {seq: 0, data: b64("abc")}}, 2, "abc", false},
+		{"undecodable", []traceChunk{{seq: 0, data: "!!!not-base64!!!"}}, 1, "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, ok := assembleBody(tc.parts, tc.want)
+			assert.Equal(t, tc.body, body)
+			assert.Equal(t, tc.ok, ok)
+		})
+	}
+}
+
+func TestVectorContract_ChunkedRoundTrip(t *testing.T) {
+	// End-to-end shape check against the exact record layout Vector's
+	// prepare_trace_payload emits for an oversized CJK body (verified against
+	// vector 0.47.0): base64 chunk_data, integer-string chunk_seq, parent
+	// counts. Byte-exactness across a chunk boundary is the property that
+	// motivated base64 (raw chunks() splits multi-byte characters).
+	body := strings.Repeat("访问日志超大请求体测试", 3) // multi-byte content
+	encoded := base64.StdEncoding.EncodeToString([]byte(body))
+	half := (len(encoded) / 2 / 4) * 4 // split on a 4-char base64 boundary mid-character
+
+	parent := `{"request_id":"req-1","workspace":"ws1","body_chunked":"true",` +
+		`"request_chunks":"2","response_chunks":"0","response_status":"200"}` + "\n"
+	chunks := `{"request_id":"req-1","chunk_kind":"request","chunk_seq":"0","chunk_data":"` + encoded[:half] + `"}` + "\n" +
+		`{"request_id":"req-1","chunk_kind":"request","chunk_seq":"1","chunk_data":"` + encoded[half:] + `"}` + "\n"
+
+	fake := &fakeVL{responses: []string{parent, chunks}}
+	server := fake.server(t)
+
+	defer server.Close()
+
+	store := newTestStore(server.URL)
+
+	item, err := store.Get(`workspace:="ws1"`, "req-1")
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	assert.Equal(t, body, item.RequestBody)
+	assert.False(t, item.BodyIncomplete)
+}
+
+func timeMustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+
+	return parsed
+}

--- a/pkg/client/ai_trace.go
+++ b/pkg/client/ai_trace.go
@@ -53,6 +53,13 @@ type AITrace struct {
 	DurationMs       *int   `json:"duration_ms,omitempty"`
 	RequestBody      string `json:"request_body,omitempty"`
 	ResponseBody     string `json:"response_body,omitempty"`
+
+	// BodyTruncated marks a record whose bodies exceeded the server's storage
+	// cap and were cut off at ingestion; BodyIncomplete marks one for which
+	// part of the stored body could not be read back. In both cases the bodies
+	// hold a prefix of the originals.
+	BodyTruncated  bool `json:"body_truncated,omitempty"`
+	BodyIncomplete bool `json:"body_incomplete,omitempty"`
 }
 
 // TraceListFilters are the optional server-side filters for a list query. Empty


### PR DESCRIPTION
## Problem

VictoriaLogs hard-drops any record whose estimated JSON size exceeds **2MiB** (`maxUncompressedBlockSize` — hardcoded upstream, cannot be raised; [VL FAQ](https://docs.victoriametrics.com/victorialogs/faq/#what-length-a-log-record-is-expected-to-have)). Access logs with large request/response bodies (multimodal requests with base64 images, long-context agent payloads, long SSE streams) were silently lost — the raised `-insert.maxLineSizeBytes=16MiB` only moved the drop from the HTTP line reader to the storage layer.

Design discussion: [NEU-539](http://jira.smartx.com/browse/NEU-539) (layered plan in comments).

## Approach

Chunk awareness is confined to exactly two places; Kong, the SPA, and the CLI are structurally unable to observe chunks.

**Ingest — Vector `prepare_trace_payload`** (compose + chart copies kept in sync):
- Bodies totalling ≤1.5MiB: single record, byte-identical to today (zero overhead for normal traffic).
- Larger: parent record (metadata + `body_chunked` + chunk counts) plus companion chunk records (`record_type=chunk`, `chunk_kind`/`chunk_seq`/`chunk_data`) of **1MiB base64** each, sharing the parent's timestamp and stream fields.
- base64 because VRL `chunks()` splits raw bytes and lossily breaks multi-byte UTF-8 at chunk boundaries (verified — CJK bodies could never reassemble byte-exact); 1MiB is 4-aligned so any prefix of chunks stays valid base64.
- Bodies past 16 chunks (**~12MiB raw per side**) are truncated at a clean boundary and flagged `body_truncated`.

**Read — `traceStore`** (`internal/routes/logs/trace_store.go`, extracted in the first commit as a pure refactor):
- Every trace query grows from `baseQuery()`, which appends `NOT record_type:="chunk"` — list/detail/stats/key-stats can't forget the filter, and legacy records (no `record_type` field) pass it unchanged: **no migration, no backfill**.
- Detail and body-carrying list pages (`?include_body=true`) reassemble bodies — one batched chunk fetch per page, Go-side integer sort on `chunk_seq`.
- Partial ingestion loss degrades to the longest decodable prefix + `body_incomplete` instead of failing or splicing non-adjacent ranges.
- `include_body` pages clamped to 50 records (single traces can now reach tens of MiB); cursor pagination is unaffected.

**Clients**: `request_body`/`response_body` remain whole bodies on the wire. `body_truncated`/`body_incomplete` are additive `omitempty` fields, passed through by `pkg/client` and the CLI export writers (two trailing CSV columns).

## Compatibility & rollout

- **New reads old**: guaranteed by the opt-in fields (negative filter + absent-field defaults). Old and new records coexist in the same stream forever.
- **Old reads new**: not compatible — deploy **neutree-api before the Vector config**. Rolling back Vector alone is always safe (returns to today's >2MiB drop behavior).

## Testing

- Unit: chunk-exclusion asserted on all four query paths; reassembly (out-of-order, missing/duplicate seq, truncation, undecodable); legacy-format regression; CJK round-trip; `include_body` clamp.
- VRL verified against real `timberio/vector:0.47.0`: CJK bodies reassemble byte-exact across chunk boundaries; 13MB body truncates to a cleanly decodable prefix.
- **Full-stack on the 24.140 dev box** (real Vector→VL→API→CLI):
  - control group on the old config reproduced the silent drop (`ignoring too long log entry … 2097152`);
  - 3.1MB+6.2MB CJK trace → 4+8 chunks, detail/API/CLI-export bodies match the originals by sha256;
  - 14.4MB trace → 16 chunks, `body_truncated=true`, clean 12MiB prefix;
  - pre-upgrade records read back unchanged; stats/key-stats counts unpolluted by 29 chunk rows;
  - `neutree-cli export access-log` end-to-end: 4 records, no chunk rows, flags present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzEMtdRDbedu7qeuSwNKd7
