### PR TITLE
fix: route top-level CLI errors to stderr

### DIFF
--- a/cmd/neutree-cli/app/cmd/cmd.go
+++ b/cmd/neutree-cli/app/cmd/cmd.go
@@ -68,7 +68,7 @@ Examples:
 func Execute() {
 	err := NewNeutreeCliCommand().Execute()
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

QA hit this while verifying NEU-544 ([Slack thread](https://smartx1.slack.com/archives/C09LB8TV90S/p1784385392825109)): `neutree-cli export access-log --random x` prints `unknown flag: --random` to **stdout** with empty stderr.

The top-level `Execute()` in `cmd/neutree-cli/app/cmd/cmd.go` printed errors with `fmt.Println`, i.e. to stdout. The `export` subcommands document that data goes to stdout and all progress/diagnostics go to stderr, so a parse error could pollute redirected JSONL/JSON/CSV output. Because the export commands set `SilenceUsage`/`SilenceErrors`, this stdout print was the only place the error surfaced.

## Change

One line: print top-level errors with `fmt.Fprintln(os.Stderr, ...)`. This applies to every subcommand's top-level error, matching Unix convention.

## Verification

```
$ neutree-cli export access-log --random x > out.txt 2> err.txt
exit=1
stdout: (empty)
stderr: unknown flag: --random
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015z6W8qNmv1QQQ3MYLAq1zm