### PR TITLE
fix: reload Kong plugins after chart upgrades

### DIFF
--- a/deploy/chart/neutree/templates/kong-install.yaml
+++ b/deploy/chart/neutree/templates/kong-install.yaml
@@ -344,6 +344,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: {{ include "neutree.fullname" . }}-kong
+      annotations:
+        checksum/neutree-ai-gateway-plugin: {{ (.Files.Glob "gateway/kong/plugins/neutree-ai-gateway/*").AsConfig | sha256sum | quote }}
+        checksum/neutree-ai-statistics-plugin: {{ (.Files.Glob "gateway/kong/plugins/neutree-ai-statistics/*").AsConfig | sha256sum | quote }}
+        checksum/neutree-ai-access-plugin: {{ (.Files.Glob "gateway/kong/plugins/neutree-ai-access/*").AsConfig | sha256sum | quote }}
+        checksum/neutree-ai-quota-plugin: {{ (.Files.Glob "gateway/kong/plugins/neutree-ai-quota/*").AsConfig | sha256sum | quote }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Issue

NEU-572

## Summary

Ensure Helm upgrades roll Kong when mounted custom plugin content changes, so Kong reloads the schema used by current Core gateway synchronization.

## Changes

- Add deterministic checksum annotations for all four plugin ConfigMaps mounted by `neutree-kong`.
- Preserve ConfigMap names, volumes, plugin behavior, and existing rolling-update behavior for unchanged content.

## Test Plan

### Unit test

- Deferred by owner decision until shared Helm unit test infrastructure exists.

### DB test

- Not applicable: no database changes.

### E2E test

- Local manual Helm render validation passed: baseline plugin configuration and each temporary single-plugin modification produced different checksum values; unchanged plugin checksums remained stable.
- These checksums are part of the Kong Deployment Pod template, so Helm upgrade changes the template and Kubernetes performs a rolling update of Kong.
- Enterprise Helm upgrade validation was explicitly waived by the owner to advance this workflow. The missing two-version enterprise chart artifact/profile and Helm upgrade helper remain residual risk.

## Risk & Rollback

- The first deployment of this chart change rolls Kong once; later upgrades roll Kong only when plugin content changes.
- Roll back with `helm rollback` to restore the prior chart revision; do not modify a live ConfigMap or restart Kong manually.