### PR TITLE
fix: render deploy templates with text/template, not html/template (NEU-583)

### DIFF
--- a/cmd/neutree-cli/app/cmd/launch/core_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/core_test.go
@@ -154,6 +154,43 @@ func TestPrepareNeutreeCoreDeployConfig(t *testing.T) {
 	}
 }
 
+// NEU-583 regression: rendering the embedded manifests must not HTML-escape
+// the Vector VRL program — html/template turned `<=` into `&lt;=`, which
+// Vector rejects (exit 78 restart loop), silently disabling the NEU-539
+// chunking topology on Docker CP deployments.
+func TestPrepareNeutreeCoreDeployConfig_PreservesVRLOperators(t *testing.T) {
+	tempDir := t.TempDir()
+
+	options := neutreeCoreInstallOptions{
+		commonOptions: &commonOptions{
+			workDir:    tempDir,
+			nodeIP:     "192.168.1.1",
+			deployType: constants.DeployTypeLocal,
+			deployMode: constants.DeployModeSingle,
+		},
+		jwtSecret: "test-secret",
+		version:   "v1.0.0",
+	}
+
+	require.NoError(t, prepareNeutreeCoreDeployConfig(options))
+
+	for _, f := range []string{
+		filepath.Join(tempDir, "neutree-core", "vector", "vector.yml"),
+		filepath.Join(tempDir, "neutree-core", "docker-compose.yml"),
+	} {
+		content, err := os.ReadFile(f)
+		require.NoError(t, err)
+		assert.NotContainsf(t, string(content), "&lt;", "HTML-escaped operator in %s", f)
+		assert.NotContainsf(t, string(content), "&amp;", "HTML-escaped ampersand in %s", f)
+		assert.NotContainsf(t, string(content), "&#", "HTML entity in %s", f)
+	}
+
+	vector, err := os.ReadFile(filepath.Join(tempDir, "neutree-core", "vector", "vector.yml"))
+	require.NoError(t, err)
+	// The NEU-539 chunking threshold must survive rendering verbatim.
+	assert.Contains(t, string(vector), "<= 1572864")
+}
+
 func TestValidateNeutreeCoreVersionCompatibility(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/cmd/neutree-cli/app/util/template.go
+++ b/cmd/neutree-cli/app/util/template.go
@@ -2,9 +2,13 @@ package util
 
 import (
 	"bytes"
-	"html/template"
 	"os"
 	"strings"
+	// These helpers render deployment artifacts (compose YAML, Vector
+	// VRL, prometheus config) — never HTML. html/template would entity-escape
+	// content and parameter values (`<=` becomes `&lt;=`), corrupting VRL
+	// programs and any credential containing <, >, &, ' or ".
+	"text/template"
 
 	"github.com/pkg/errors"
 )

--- a/cmd/neutree-cli/app/util/template.go
+++ b/cmd/neutree-cli/app/util/template.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"os"
 	"strings"
-	// These helpers render deployment artifacts (compose YAML, Vector
-	// VRL, prometheus config) — never HTML. html/template would entity-escape
-	// content and parameter values (`<=` becomes `&lt;=`), corrupting VRL
-	// programs and any credential containing <, >, &, ' or ".
 	"text/template"
 
 	"github.com/pkg/errors"
 )
 
-// ParseTemplate validates and parses passed as argument template
+// ParseTemplate validates and parses passed as argument template.
+//
+// It renders deployment artifacts (compose YAML, Vector VRL, prometheus
+// config) — never HTML — so it must stay on text/template: html/template
+// entity-escapes content and parameter values (`<=` becomes `&lt;=`),
+// corrupting VRL programs and any credential containing <, >, &, ' or "
+// (NEU-583).
 func ParseTemplate(strtmpl string, obj interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 

--- a/cmd/neutree-cli/app/util/template_test.go
+++ b/cmd/neutree-cli/app/util/template_test.go
@@ -192,3 +192,19 @@ func TestBatchParseTemplateFilesErrorCases(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+// NEU-583 regression: the helpers render YAML/VRL deployment files, so they
+// must use text/template — html/template entity-escapes VRL operators
+// (`<=` → `&lt;=`) and special characters in parameter values, producing
+// configs Vector rejects (exit 78 restart loop).
+func TestParseTemplate_NoHTMLEscaping(t *testing.T) {
+	out, err := ParseTemplate(
+		`if length(req_body) + length(resp_body) <= 1572864 { pw = "{{.AdminPassword}}" }`,
+		map[string]string{"AdminPassword": `p<&'">w`},
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, string(out), "<= 1572864")
+	assert.Contains(t, string(out), `p<&'">w`)
+	assert.NotContains(t, string(out), "&lt;")
+	assert.NotContains(t, string(out), "&amp;")
+}


### PR DESCRIPTION
## Problem

[NEU-583](http://jira.smartx.com/browse/NEU-583): `neutree-cli launch neutree-core` renders the extracted deploy manifests through `html/template`, which entity-escapes template content and parameter values. The NEU-539 chunking VRL introduced the first `<` into a templated file, so the rendered `vector/vector.yml` carries `&lt;= 1572864` — Vector rejects it (hot reload restores the old topology; a restart enters an exit-78 loop) and the chunking capability silently never activates on Docker CP deployments. The same escaping corrupts any parameter value containing `<`, `>`, `&`, `'` or `"` (e.g. an admin password).

Root cause was fully identified by QE (Ruiyang Zhang) in the ticket — this PR implements the suggested fix.

## Change

- `cmd/neutree-cli/app/util/template.go`: `html/template` → `text/template` (one-line swap; the helpers only ever render YAML/VRL/compose artifacts, with an import comment explaining why text/template is load-bearing).
- Regression tests at both layers:
  - util: raw `<=` and special characters in values survive rendering, no `&lt;`/`&amp;`.
  - launch: renders the real embedded `neutree-core.tar` manifests and asserts `vector.yml` keeps `<= 1572864` with no HTML entities in any rendered file.

## Not in this PR

The ticket also suggests deploy-time Vector config validation / post-deploy health checks — that's a separate hardening feature; tracked in the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzEMtdRDbedu7qeuSwNKd7
