### PR TITLE
fix: backfill masked array fields by element identity, not index (NEU-592)

### DIFF
--- a/api/v1/external_endpoint_types.go
+++ b/api/v1/external_endpoint_types.go
@@ -60,8 +60,12 @@ const (
 )
 
 type ExternalEndpointSpec struct {
-	// Upstreams is the list of upstream entries
-	Upstreams []ExternalEndpointUpstreamEntry `json:"upstreams"`
+	// Upstreams is the list of upstream entries.
+	// The mergekey tag lets the API proxy backfill each entry's masked
+	// auth.credential from the stored entry with the same identity (upstream.url
+	// or endpoint_ref) instead of by array index, so deleting or reordering
+	// entries cannot leak one upstream's credential into another.
+	Upstreams []ExternalEndpointUpstreamEntry `json:"upstreams" mergekey:"upstream.url,endpoint_ref"`
 
 	// Timeout is the request timeout in milliseconds, default 60000
 	Timeout *int `json:"timeout,omitempty"`

--- a/api/v1/static_node_cluster_types.go
+++ b/api/v1/static_node_cluster_types.go
@@ -28,7 +28,9 @@ type StaticNodeClusterSpec struct {
 	// Metrics configures static-node observability collectors.
 	Metrics *ClusterMetricsConfig `json:"metrics,omitempty" yaml:"metrics,omitempty"`
 	// Nodes declares the desired static machines that make up the cluster.
-	Nodes []StaticNodeClusterNodeSpec `json:"nodes,omitempty"`
+	// mergekey makes the API proxy backfill each node's masked ssh_auth from the
+	// stored node with the same ip, not the same array index (see NEU-592).
+	Nodes []StaticNodeClusterNodeSpec `json:"nodes,omitempty" mergekey:"ip"`
 	// UpgradeStrategy controls how the static cluster rolls from the observed version to Version.
 	UpgradeStrategy *ClusterUpgradeStrategy `json:"upgrade_strategy,omitempty"`
 }

--- a/internal/routes/proxies/resource_proxy.go
+++ b/internal/routes/proxies/resource_proxy.go
@@ -258,14 +258,79 @@ func extractFieldsRecursive(t reflect.Type, prefix string, excludeFields map[str
 	}
 }
 
-// mergeExcludedFields merges excluded fields from source into target
-// Only merges fields that are in excludeFields and missing in target
-func mergeExcludedFields(target, source map[string]interface{}, excludeFields map[string]struct{}) {
-	mergeExcludedFieldsRecursive(target, source, excludeFields, "")
+// extractArrayMergeKeysFromTag extracts mergekey tags from slice-of-struct
+// fields. Returns a map from the array's JSON path (e.g. "spec.upstreams") to
+// the candidate identity paths of its elements (e.g. ["upstream.url", "endpoint_ref"]).
+func extractArrayMergeKeysFromTag(t reflect.Type) map[string][]string {
+	mergeKeys := make(map[string][]string)
+	extractArrayMergeKeysRecursive(t, "", mergeKeys)
+
+	return mergeKeys
+}
+
+func extractArrayMergeKeysRecursive(t reflect.Type, prefix string, mergeKeys map[string][]string) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if !field.IsExported() {
+			continue
+		}
+
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" || jsonTag == "-" {
+			continue
+		}
+
+		jsonName := strings.Split(jsonTag, ",")[0]
+
+		fieldPath := jsonName
+		if prefix != "" {
+			fieldPath = prefix + "." + jsonName
+		}
+
+		fieldType := field.Type
+		if fieldType.Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+
+		if fieldType.Kind() == reflect.Slice {
+			if mergeKeyTag := field.Tag.Get("mergekey"); mergeKeyTag != "" {
+				mergeKeys[fieldPath] = strings.Split(mergeKeyTag, ",")
+			}
+
+			fieldType = fieldType.Elem()
+			if fieldType.Kind() == reflect.Ptr {
+				fieldType = fieldType.Elem()
+			}
+		}
+
+		if fieldType.Kind() == reflect.Struct {
+			extractArrayMergeKeysRecursive(fieldType, fieldPath, mergeKeys)
+		}
+	}
+}
+
+// mergeExcludedFields merges excluded fields from source into target.
+// Only merges fields that are in excludeFields and missing in target.
+// arrayMergeKeys maps an array field path (e.g. "spec.upstreams") to the
+// candidate identity paths of its elements (from the mergekey struct tag);
+// arrays listed there are merged by element identity instead of by index.
+func mergeExcludedFields(target, source map[string]interface{}, excludeFields map[string]struct{}, arrayMergeKeys map[string][]string) {
+	mergeExcludedFieldsRecursive(target, source, excludeFields, arrayMergeKeys, "")
 }
 
 // mergeExcludedFieldsRecursive recursively merges excluded fields
-func mergeExcludedFieldsRecursive(target, source map[string]interface{}, excludeFields map[string]struct{}, currentPath string) {
+func mergeExcludedFieldsRecursive(
+	target, source map[string]interface{}, excludeFields map[string]struct{}, arrayMergeKeys map[string][]string, currentPath string,
+) {
 	for key, sourceValue := range source {
 		fieldPath := key
 		if currentPath != "" {
@@ -285,12 +350,12 @@ func mergeExcludedFieldsRecursive(target, source map[string]interface{}, exclude
 		// Recursively merge nested objects
 		if sourceMap, ok := sourceValue.(map[string]interface{}); ok {
 			if targetMap, ok := target[key].(map[string]interface{}); ok {
-				mergeExcludedFieldsRecursive(targetMap, sourceMap, excludeFields, fieldPath)
+				mergeExcludedFieldsRecursive(targetMap, sourceMap, excludeFields, arrayMergeKeys, fieldPath)
 			} else if !ok && target[key] == nil {
 				// Target has this key but it's nil, create a new map and merge
 				target[key] = make(map[string]interface{})
 				if targetMap, ok := target[key].(map[string]interface{}); ok {
-					mergeExcludedFieldsRecursive(targetMap, sourceMap, excludeFields, fieldPath)
+					mergeExcludedFieldsRecursive(targetMap, sourceMap, excludeFields, arrayMergeKeys, fieldPath)
 				}
 			}
 		}
@@ -298,17 +363,93 @@ func mergeExcludedFieldsRecursive(target, source map[string]interface{}, exclude
 		// Recursively merge array elements
 		if sourceArr, ok := sourceValue.([]interface{}); ok {
 			if targetArr, ok := target[key].([]interface{}); ok {
-				for i := 0; i < len(sourceArr) && i < len(targetArr); i++ {
-					sourceElem, sourceOk := sourceArr[i].(map[string]interface{})
-					targetElem, targetOk := targetArr[i].(map[string]interface{})
+				if identityPaths, hasIdentity := arrayMergeKeys[fieldPath]; hasIdentity {
+					// Merge by element identity: pairing by index would leak one
+					// element's masked fields into another after a delete/reorder
+					// (NEU-592). Elements whose identity is missing from source are
+					// left untouched.
+					mergeArrayByIdentity(targetArr, sourceArr, identityPaths, excludeFields, arrayMergeKeys, fieldPath)
+				} else {
+					for i := 0; i < len(sourceArr) && i < len(targetArr); i++ {
+						sourceElem, sourceOk := sourceArr[i].(map[string]interface{})
+						targetElem, targetOk := targetArr[i].(map[string]interface{})
 
-					if sourceOk && targetOk {
-						mergeExcludedFieldsRecursive(targetElem, sourceElem, excludeFields, fieldPath)
+						if sourceOk && targetOk {
+							mergeExcludedFieldsRecursive(targetElem, sourceElem, excludeFields, arrayMergeKeys, fieldPath)
+						}
 					}
 				}
 			}
 		}
 	}
+}
+
+// mergeArrayByIdentity merges excluded fields between array elements paired by
+// identity value rather than position. Duplicate identities are paired in
+// order of occurrence; target elements without an identity or without a
+// matching source element are skipped.
+func mergeArrayByIdentity(
+	targetArr, sourceArr []interface{}, identityPaths []string,
+	excludeFields map[string]struct{}, arrayMergeKeys map[string][]string, fieldPath string,
+) {
+	sourceByIdentity := make(map[string][]map[string]interface{})
+
+	for _, item := range sourceArr {
+		sourceElem, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if identity := elementIdentity(sourceElem, identityPaths); identity != "" {
+			sourceByIdentity[identity] = append(sourceByIdentity[identity], sourceElem)
+		}
+	}
+
+	for _, item := range targetArr {
+		targetElem, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		identity := elementIdentity(targetElem, identityPaths)
+		if identity == "" {
+			continue
+		}
+
+		candidates := sourceByIdentity[identity]
+		if len(candidates) == 0 {
+			continue
+		}
+
+		sourceByIdentity[identity] = candidates[1:]
+		mergeExcludedFieldsRecursive(targetElem, candidates[0], excludeFields, arrayMergeKeys, fieldPath)
+	}
+}
+
+// elementIdentity resolves the first non-empty identity value of an array
+// element. Each candidate path is a dot-separated route into nested objects
+// (e.g. "upstream.url"). The matched path is included in the returned key so
+// that different identity fields never collide with each other.
+func elementIdentity(elem map[string]interface{}, identityPaths []string) string {
+	for _, path := range identityPaths {
+		var current interface{} = elem
+
+		for _, part := range strings.Split(path, ".") {
+			currentMap, ok := current.(map[string]interface{})
+			if !ok {
+				current = nil
+				break
+			}
+
+			current = currentMap[part]
+		}
+
+		if s, ok := current.(string); ok && s != "" {
+			return path + "=" + s
+		}
+	}
+
+	return ""
 }
 
 // isEmptyValue checks if a value is considered empty
@@ -492,6 +633,7 @@ func CreateStructProxyHandler[T any](deps *Dependencies, tableName string) gin.H
 	var zero T
 	structType := reflect.TypeOf(zero)
 	excludeFields := extractExcludeFieldsFromTag(structType)
+	arrayMergeKeys := extractArrayMergeKeysFromTag(structType)
 	topLevelFields := extractTopLevelJSONFields(structType)
 
 	return func(c *gin.Context) {
@@ -507,7 +649,7 @@ func CreateStructProxyHandler[T any](deps *Dependencies, tableName string) gin.H
 
 		// Handle PATCH requests with excluded fields backfilling
 		if c.Request.Method == "PATCH" && len(excludeFields) > 0 {
-			handlePatchWithBackfill(c, deps, tableName, excludeFields)
+			handlePatchWithBackfill(c, deps, tableName, excludeFields, arrayMergeKeys)
 			return
 		}
 
@@ -557,7 +699,9 @@ func CreateStructProxyHandler[T any](deps *Dependencies, tableName string) gin.H
 }
 
 // handlePatchWithBackfill handles PATCH requests with excluded fields backfilling
-func handlePatchWithBackfill(c *gin.Context, deps *Dependencies, tableName string, excludeFields map[string]struct{}) {
+func handlePatchWithBackfill(
+	c *gin.Context, deps *Dependencies, tableName string, excludeFields map[string]struct{}, arrayMergeKeys map[string][]string,
+) {
 	// Read request body
 	bodyBytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -605,7 +749,7 @@ func handlePatchWithBackfill(c *gin.Context, deps *Dependencies, tableName strin
 		// Continue without backfill if fetch fails (resource might not exist yet)
 	} else if currentResource != nil {
 		// Merge excluded fields from current resource into request body
-		mergeExcludedFields(requestBody, currentResource, excludeFields)
+		mergeExcludedFields(requestBody, currentResource, excludeFields, arrayMergeKeys)
 		klog.V(4).Infof("Backfilled excluded fields for PATCH request")
 	}
 

--- a/internal/routes/proxies/resource_proxy.go
+++ b/internal/routes/proxies/resource_proxy.go
@@ -154,13 +154,54 @@ func (w *responseCapture) WriteString(s string) (int, error) {
 	return w.body.WriteString(s)
 }
 
-// extractExcludeFieldsFromTag extracts fields marked with api:"-" tag from a struct type
-// Returns a map of JSON paths to exclude
-func extractExcludeFieldsFromTag(t reflect.Type) map[string]struct{} {
-	excludeFields := make(map[string]struct{})
-	extractFieldsRecursive(t, "", excludeFields)
+// structTagConfig holds everything the resource proxy derives from a resource
+// struct's tags in a single reflection pass.
+type structTagConfig struct {
+	// excludeFields are JSON paths of fields tagged api:"-" (masked in responses).
+	excludeFields map[string]struct{}
+	// arrayMergeKeys maps an array field's JSON path (e.g. "spec.upstreams") to
+	// the candidate identity paths of its elements, from the mergekey tag.
+	arrayMergeKeys map[string][]string
+	// arrayPaths records every slice-of-struct field path, for validation.
+	arrayPaths map[string]struct{}
+}
 
-	return excludeFields
+// extractStructTagConfig walks a resource struct type once and collects the
+// masked-field paths and array identity keys. It panics if an array contains a
+// masked field but declares no mergekey tag: backfilling such an array by
+// index leaks one element's masked value into another after a delete/reorder
+// (NEU-592), so that configuration must fail at startup, not in production.
+func extractStructTagConfig(t reflect.Type) structTagConfig {
+	cfg := structTagConfig{
+		excludeFields:  make(map[string]struct{}),
+		arrayMergeKeys: make(map[string][]string),
+		arrayPaths:     make(map[string]struct{}),
+	}
+
+	extractStructTagsRecursive(t, "", &cfg)
+
+	for excludedPath := range cfg.excludeFields {
+		for arrayPath := range cfg.arrayPaths {
+			if !strings.HasPrefix(excludedPath, arrayPath+".") {
+				continue
+			}
+
+			// An array that is itself masked gets merged wholesale, so its
+			// elements never go through per-element pairing.
+			if _, wholeArrayMasked := cfg.excludeFields[arrayPath]; wholeArrayMasked {
+				continue
+			}
+
+			if _, ok := cfg.arrayMergeKeys[arrayPath]; !ok {
+				panic(fmt.Sprintf(
+					"resource type %s: array %q contains masked field %q but has no mergekey tag declaring its element identity",
+					t, arrayPath, excludedPath,
+				))
+			}
+		}
+	}
+
+	return cfg
 }
 
 func extractTopLevelJSONFields(t reflect.Type) []string {
@@ -196,8 +237,9 @@ func extractTopLevelJSONFields(t reflect.Type) []string {
 	return fields
 }
 
-// extractFieldsRecursive recursively extracts fields with api:"-" tag
-func extractFieldsRecursive(t reflect.Type, prefix string, excludeFields map[string]struct{}) {
+// extractStructTagsRecursive walks struct fields and records api:"-" masked
+// paths, slice-of-struct paths, and mergekey identity declarations.
+func extractStructTagsRecursive(t reflect.Type, prefix string, cfg *structTagConfig) {
 	// Handle pointer types
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -236,7 +278,7 @@ func extractFieldsRecursive(t reflect.Type, prefix string, excludeFields map[str
 		// Check if this field has api:"-" tag
 		apiTag := field.Tag.Get("api")
 		if apiTag == "-" {
-			excludeFields[fieldPath] = struct{}{}
+			cfg.excludeFields[fieldPath] = struct{}{}
 		}
 
 		// Recursively process nested structs and slices
@@ -246,74 +288,22 @@ func extractFieldsRecursive(t reflect.Type, prefix string, excludeFields map[str
 		}
 
 		if fieldType.Kind() == reflect.Slice {
-			fieldType = fieldType.Elem()
-			if fieldType.Kind() == reflect.Ptr {
-				fieldType = fieldType.Elem()
-			}
-		}
-
-		if fieldType.Kind() == reflect.Struct {
-			extractFieldsRecursive(fieldType, fieldPath, excludeFields)
-		}
-	}
-}
-
-// extractArrayMergeKeysFromTag extracts mergekey tags from slice-of-struct
-// fields. Returns a map from the array's JSON path (e.g. "spec.upstreams") to
-// the candidate identity paths of its elements (e.g. ["upstream.url", "endpoint_ref"]).
-func extractArrayMergeKeysFromTag(t reflect.Type) map[string][]string {
-	mergeKeys := make(map[string][]string)
-	extractArrayMergeKeysRecursive(t, "", mergeKeys)
-
-	return mergeKeys
-}
-
-func extractArrayMergeKeysRecursive(t reflect.Type, prefix string, mergeKeys map[string][]string) {
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
-
-	if t.Kind() != reflect.Struct {
-		return
-	}
-
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-
-		if !field.IsExported() {
-			continue
-		}
-
-		jsonTag := field.Tag.Get("json")
-		if jsonTag == "" || jsonTag == "-" {
-			continue
-		}
-
-		jsonName := strings.Split(jsonTag, ",")[0]
-
-		fieldPath := jsonName
-		if prefix != "" {
-			fieldPath = prefix + "." + jsonName
-		}
-
-		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
-			fieldType = fieldType.Elem()
-		}
-
-		if fieldType.Kind() == reflect.Slice {
 			if mergeKeyTag := field.Tag.Get("mergekey"); mergeKeyTag != "" {
-				mergeKeys[fieldPath] = strings.Split(mergeKeyTag, ",")
+				cfg.arrayMergeKeys[fieldPath] = strings.Split(mergeKeyTag, ",")
 			}
 
 			fieldType = fieldType.Elem()
 			if fieldType.Kind() == reflect.Ptr {
 				fieldType = fieldType.Elem()
 			}
+
+			if fieldType.Kind() == reflect.Struct {
+				cfg.arrayPaths[fieldPath] = struct{}{}
+			}
 		}
 
 		if fieldType.Kind() == reflect.Struct {
-			extractArrayMergeKeysRecursive(fieldType, fieldPath, mergeKeys)
+			extractStructTagsRecursive(fieldType, fieldPath, cfg)
 		}
 	}
 }
@@ -632,8 +622,9 @@ func CreateStructProxyHandler[T any](deps *Dependencies, tableName string) gin.H
 	// Extract exclude fields from struct type at initialization time (compile-time type safety)
 	var zero T
 	structType := reflect.TypeOf(zero)
-	excludeFields := extractExcludeFieldsFromTag(structType)
-	arrayMergeKeys := extractArrayMergeKeysFromTag(structType)
+	tagConfig := extractStructTagConfig(structType)
+	excludeFields := tagConfig.excludeFields
+	arrayMergeKeys := tagConfig.arrayMergeKeys
 	topLevelFields := extractTopLevelJSONFields(structType)
 
 	return func(c *gin.Context) {

--- a/internal/routes/proxies/resource_proxy_test.go
+++ b/internal/routes/proxies/resource_proxy_test.go
@@ -289,7 +289,7 @@ func Test_filterResponseBody(t *testing.T) {
 	})
 }
 
-func Test_extractExcludeFieldsFromTag(t *testing.T) {
+func Test_extractStructTagConfig_excludeFields(t *testing.T) {
 	t.Run("extract single field with api tag", func(t *testing.T) {
 		type TestStatus struct {
 			Phase   string `json:"phase"`
@@ -302,12 +302,12 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 			Status TestStatus `json:"status"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		expected := map[string]struct{}{
 			"status.secret": {},
 		}
-		assert.Equal(t, expected, result)
+		assert.Equal(t, expected, result.excludeFields)
 	})
 
 	t.Run("extract multiple fields with api tag", func(t *testing.T) {
@@ -327,13 +327,13 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 			Status   TestStatus   `json:"status"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		expected := map[string]struct{}{
 			"metadata.secret": {},
 			"status.sk_value": {},
 		}
-		assert.Equal(t, expected, result)
+		assert.Equal(t, expected, result.excludeFields)
 	})
 
 	t.Run("handle pointer types", func(t *testing.T) {
@@ -347,12 +347,12 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 			Status *TestStatus `json:"status"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		expected := map[string]struct{}{
 			"status.secret": {},
 		}
-		assert.Equal(t, expected, result)
+		assert.Equal(t, expected, result.excludeFields)
 	})
 
 	t.Run("no api tag returns empty map", func(t *testing.T) {
@@ -361,9 +361,9 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 			Name string `json:"name"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
-		assert.Empty(t, result)
+		assert.Empty(t, result.excludeFields)
 	})
 
 	t.Run("ignore fields with json:-", func(t *testing.T) {
@@ -373,12 +373,12 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 			Secret   string `json:"secret" api:"-"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		expected := map[string]struct{}{
 			"secret": {},
 		}
-		assert.Equal(t, expected, result)
+		assert.Equal(t, expected, result.excludeFields)
 	})
 
 	t.Run("ignore unexported fields", func(t *testing.T) {
@@ -388,10 +388,10 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 		}
 		obj := TestObject{secret: "hidden"}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		assert.Equal(t, "hidden", obj.secret)
-		assert.Empty(t, result)
+		assert.Empty(t, result.excludeFields)
 	})
 
 	t.Run("handle json tag with omitempty", func(t *testing.T) {
@@ -405,12 +405,12 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 			Status TestStatus `json:"status"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		expected := map[string]struct{}{
 			"status.secret": {},
 		}
-		assert.Equal(t, expected, result)
+		assert.Equal(t, expected, result.excludeFields)
 	})
 
 	t.Run("extract fields from slice element type", func(t *testing.T) {
@@ -426,32 +426,33 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 
 		type TestObject struct {
 			ID        string          `json:"id"`
-			Upstreams []UpstreamEntry `json:"upstreams"`
+			Upstreams []UpstreamEntry `json:"upstreams" mergekey:"url"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		expected := map[string]struct{}{
 			"upstreams.auth.credential": {},
 		}
-		assert.Equal(t, expected, result)
+		assert.Equal(t, expected, result.excludeFields)
 	})
 
 	t.Run("extract fields from pointer slice element type", func(t *testing.T) {
 		type Inner struct {
+			Name   string `json:"name"`
 			Secret string `json:"secret" api:"-"`
 		}
 
 		type TestObject struct {
-			Items []*Inner `json:"items"`
+			Items []*Inner `json:"items" mergekey:"name"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		expected := map[string]struct{}{
 			"items.secret": {},
 		}
-		assert.Equal(t, expected, result)
+		assert.Equal(t, expected, result.excludeFields)
 	})
 
 	t.Run("deeply nested structs", func(t *testing.T) {
@@ -472,12 +473,12 @@ func Test_extractExcludeFieldsFromTag(t *testing.T) {
 			L1 Level1 `json:"l1"`
 		}
 
-		result := extractExcludeFieldsFromTag(reflect.TypeOf(TestObject{}))
+		result := extractStructTagConfig(reflect.TypeOf(TestObject{}))
 
 		expected := map[string]struct{}{
 			"l1.l2.l3.deep_secret": {},
 		}
-		assert.Equal(t, expected, result)
+		assert.Equal(t, expected, result.excludeFields)
 	})
 }
 
@@ -1069,23 +1070,61 @@ func Test_mergeExcludedFields(t *testing.T) {
 	})
 }
 
-func Test_extractArrayMergeKeysFromTag(t *testing.T) {
+func Test_extractStructTagConfig_arrayMergeKeys(t *testing.T) {
 	t.Run("external endpoint upstreams declare identity keys", func(t *testing.T) {
-		mergeKeys := extractArrayMergeKeysFromTag(reflect.TypeOf(v1.ExternalEndpoint{}))
+		mergeKeys := extractStructTagConfig(reflect.TypeOf(v1.ExternalEndpoint{})).arrayMergeKeys
 
 		assert.Equal(t, []string{"upstream.url", "endpoint_ref"}, mergeKeys["spec.upstreams"])
 	})
 
 	t.Run("static node cluster nodes declare identity keys", func(t *testing.T) {
-		mergeKeys := extractArrayMergeKeysFromTag(reflect.TypeOf(v1.StaticNodeCluster{}))
+		mergeKeys := extractStructTagConfig(reflect.TypeOf(v1.StaticNodeCluster{})).arrayMergeKeys
 
 		assert.Equal(t, []string{"ip"}, mergeKeys["spec.nodes"])
 	})
 
 	t.Run("struct without mergekey tags yields no entries", func(t *testing.T) {
-		mergeKeys := extractArrayMergeKeysFromTag(reflect.TypeOf(v1.ApiKey{}))
+		mergeKeys := extractStructTagConfig(reflect.TypeOf(v1.ApiKey{})).arrayMergeKeys
 
 		assert.Empty(t, mergeKeys)
+	})
+
+	t.Run("panics when an array holds a masked field without a mergekey tag", func(t *testing.T) {
+		type entry struct {
+			Name   string `json:"name"`
+			Secret string `json:"secret" api:"-"`
+		}
+
+		type spec struct {
+			Entries []entry `json:"entries"`
+		}
+
+		type object struct {
+			Spec spec `json:"spec"`
+		}
+
+		assert.Panics(t, func() {
+			extractStructTagConfig(reflect.TypeOf(object{}))
+		})
+	})
+
+	t.Run("does not panic when the whole array is masked", func(t *testing.T) {
+		type entry struct {
+			Name   string `json:"name"`
+			Secret string `json:"secret" api:"-"`
+		}
+
+		type spec struct {
+			Entries []entry `json:"entries" api:"-"`
+		}
+
+		type object struct {
+			Spec spec `json:"spec"`
+		}
+
+		assert.NotPanics(t, func() {
+			extractStructTagConfig(reflect.TypeOf(object{}))
+		})
 	})
 }
 

--- a/internal/routes/proxies/resource_proxy_test.go
+++ b/internal/routes/proxies/resource_proxy_test.go
@@ -714,7 +714,7 @@ func Test_mergeExcludedFields(t *testing.T) {
 			"spec.credentials": {},
 		}
 
-		mergeExcludedFields(target, source, excludeFields)
+		mergeExcludedFields(target, source, excludeFields, nil)
 
 		expected := map[string]interface{}{
 			"id": "123",
@@ -748,7 +748,7 @@ func Test_mergeExcludedFields(t *testing.T) {
 			"spec.credentials": {},
 		}
 
-		mergeExcludedFields(target, source, excludeFields)
+		mergeExcludedFields(target, source, excludeFields, nil)
 
 		// Should keep the new_token, not override with old_token
 		assert.Equal(t, "new_token", target["spec"].(map[string]interface{})["credentials"])
@@ -780,7 +780,7 @@ func Test_mergeExcludedFields(t *testing.T) {
 			"status.sk_value":  {},
 		}
 
-		mergeExcludedFields(target, source, excludeFields)
+		mergeExcludedFields(target, source, excludeFields, nil)
 
 		assert.Equal(t, "hf_token", target["spec"].(map[string]interface{})["credentials"])
 		assert.Equal(t, "secret_key", target["status"].(map[string]interface{})["sk_value"])
@@ -802,7 +802,7 @@ func Test_mergeExcludedFields(t *testing.T) {
 			"spec.credentials": {},
 		}
 
-		mergeExcludedFields(target, source, excludeFields)
+		mergeExcludedFields(target, source, excludeFields, nil)
 
 		assert.Equal(t, "should_be_merged", target["spec"].(map[string]interface{})["credentials"])
 	})
@@ -838,7 +838,7 @@ func Test_mergeExcludedFields(t *testing.T) {
 			"spec.upstreams.auth.credential": {},
 		}
 
-		mergeExcludedFields(target, source, excludeFields)
+		mergeExcludedFields(target, source, excludeFields, nil)
 
 		upstreams := target["spec"].(map[string]interface{})["upstreams"].([]interface{})
 		auth := upstreams[0].(map[string]interface{})["auth"].(map[string]interface{})
@@ -890,13 +890,158 @@ func Test_mergeExcludedFields(t *testing.T) {
 			"spec.upstreams.auth.credential": {},
 		}
 
-		mergeExcludedFields(target, source, excludeFields)
+		mergeExcludedFields(target, source, excludeFields, nil)
 
 		upstreams := target["spec"].(map[string]interface{})["upstreams"].([]interface{})
 		auth0 := upstreams[0].(map[string]interface{})["auth"].(map[string]interface{})
 		auth1 := upstreams[1].(map[string]interface{})["auth"].(map[string]interface{})
 		assert.Equal(t, "token-1", auth0["credential"])
 		assert.Equal(t, "token-2", auth1["credential"])
+	})
+
+	// NEU-592: credential backfill must pair upstreams by identity, not index.
+	upstreamMergeKeys := map[string][]string{
+		"spec.upstreams": {"upstream.url", "endpoint_ref"},
+	}
+	upstreamExcludeFields := map[string]struct{}{
+		"spec.upstreams.auth.credential": {},
+	}
+	externalUpstream := func(url, credential string) map[string]interface{} {
+		return map[string]interface{}{
+			"upstream": map[string]interface{}{"url": url},
+			"auth": map[string]interface{}{
+				"type":       "bearer",
+				"credential": credential,
+			},
+		}
+	}
+	upstreamCredential := func(t *testing.T, target map[string]interface{}, index int) string {
+		t.Helper()
+
+		upstreams := target["spec"].(map[string]interface{})["upstreams"].([]interface{})
+		auth := upstreams[index].(map[string]interface{})["auth"].(map[string]interface{})
+
+		return auth["credential"].(string)
+	}
+
+	t.Run("identity merge survives deleting a leading upstream", func(t *testing.T) {
+		// Stored EE: [openrouter (no key), dogfood (key)]; the PATCH deletes the
+		// openrouter entry. Index pairing would hand dogfood the deleted entry's
+		// empty credential; identity pairing must keep dogfood's own key.
+		target := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://dogfood.example.com/v1", ""),
+				},
+			},
+		}
+		source := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://openrouter.ai/api/v1", ""),
+					externalUpstream("https://dogfood.example.com/v1", "sk_dogfood"),
+				},
+			},
+		}
+
+		mergeExcludedFields(target, source, upstreamExcludeFields, upstreamMergeKeys)
+
+		assert.Equal(t, "sk_dogfood", upstreamCredential(t, target, 0))
+	})
+
+	t.Run("identity merge survives reordering upstreams", func(t *testing.T) {
+		target := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://b.example.com/v1", ""),
+					externalUpstream("https://a.example.com/v1", ""),
+				},
+			},
+		}
+		source := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://a.example.com/v1", "key-a"),
+					externalUpstream("https://b.example.com/v1", "key-b"),
+				},
+			},
+		}
+
+		mergeExcludedFields(target, source, upstreamExcludeFields, upstreamMergeKeys)
+
+		assert.Equal(t, "key-b", upstreamCredential(t, target, 0))
+		assert.Equal(t, "key-a", upstreamCredential(t, target, 1))
+	})
+
+	t.Run("identity merge does not backfill a new upstream", func(t *testing.T) {
+		// A brand-new URL has no stored credential; it must stay empty instead of
+		// inheriting another entry's key.
+		target := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://new.example.com/v1", ""),
+				},
+			},
+		}
+		source := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://old.example.com/v1", "old-key"),
+				},
+			},
+		}
+
+		mergeExcludedFields(target, source, upstreamExcludeFields, upstreamMergeKeys)
+
+		assert.Equal(t, "", upstreamCredential(t, target, 0))
+	})
+
+	t.Run("identity merge matches endpoint_ref entries and keeps explicit credentials", func(t *testing.T) {
+		target := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					map[string]interface{}{"endpoint_ref": "qwen3-local"},
+					externalUpstream("https://a.example.com/v1", "user-typed-new-key"),
+				},
+			},
+		}
+		source := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://a.example.com/v1", "stored-key"),
+					map[string]interface{}{"endpoint_ref": "qwen3-local"},
+				},
+			},
+		}
+
+		mergeExcludedFields(target, source, upstreamExcludeFields, upstreamMergeKeys)
+
+		// The user-provided replacement key must win over the stored one.
+		assert.Equal(t, "user-typed-new-key", upstreamCredential(t, target, 1))
+	})
+
+	t.Run("identity merge pairs duplicate identities in order", func(t *testing.T) {
+		target := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://dup.example.com/v1", ""),
+					externalUpstream("https://dup.example.com/v1", ""),
+				},
+			},
+		}
+		source := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"upstreams": []interface{}{
+					externalUpstream("https://dup.example.com/v1", "first"),
+					externalUpstream("https://dup.example.com/v1", "second"),
+				},
+			},
+		}
+
+		mergeExcludedFields(target, source, upstreamExcludeFields, upstreamMergeKeys)
+
+		assert.Equal(t, "first", upstreamCredential(t, target, 0))
+		assert.Equal(t, "second", upstreamCredential(t, target, 1))
 	})
 
 	t.Run("do not merge non-excluded fields", func(t *testing.T) {
@@ -915,12 +1060,32 @@ func Test_mergeExcludedFields(t *testing.T) {
 			"spec.credentials": {},
 		}
 
-		mergeExcludedFields(target, source, excludeFields)
+		mergeExcludedFields(target, source, excludeFields, nil)
 
 		// type should not be overridden
 		assert.Equal(t, "new-type", target["spec"].(map[string]interface{})["type"])
 		// credentials should be merged
 		assert.Equal(t, "token", target["spec"].(map[string]interface{})["credentials"])
+	})
+}
+
+func Test_extractArrayMergeKeysFromTag(t *testing.T) {
+	t.Run("external endpoint upstreams declare identity keys", func(t *testing.T) {
+		mergeKeys := extractArrayMergeKeysFromTag(reflect.TypeOf(v1.ExternalEndpoint{}))
+
+		assert.Equal(t, []string{"upstream.url", "endpoint_ref"}, mergeKeys["spec.upstreams"])
+	})
+
+	t.Run("static node cluster nodes declare identity keys", func(t *testing.T) {
+		mergeKeys := extractArrayMergeKeysFromTag(reflect.TypeOf(v1.StaticNodeCluster{}))
+
+		assert.Equal(t, []string{"ip"}, mergeKeys["spec.nodes"])
+	})
+
+	t.Run("struct without mergekey tags yields no entries", func(t *testing.T) {
+		mergeKeys := extractArrayMergeKeysFromTag(reflect.TypeOf(v1.ApiKey{}))
+
+		assert.Empty(t, mergeKeys)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes [NEU-592](http://jira.smartx.com/browse/NEU-592): editing an External Endpoint in the UI and deleting an upstream silently corrupted the credentials of the remaining upstreams.

`spec.upstreams[].auth.credential` is masked in GET responses (`api:"-"`), so PATCH bodies arrive without credentials and the API proxy backfills them from the stored resource. The backfill paired array elements **by index**, so after a delete/reorder each remaining upstream inherited whatever credential used to sit at its position — either another upstream's key (cross-upstream secret leak) or an empty value (key silently wiped, unrecoverable from the DB).

QE repro (EE with `[openrouter (no key), dogfood (key)]`): delete the openrouter entry → the dogfood upstream inherits the deleted entry's empty credential → gateway forwards without Authorization → upstream rejects every request, which presents as "all API keys stopped working".

## Fix

- Array backfill now pairs elements by an identity declared with a `mergekey` struct tag on the slice field; elements with no stored match keep what the request sent instead of inheriting a neighbor's secret. Duplicate identities pair in order of occurrence. Arrays without the tag keep the index-based behavior.
- Tagged `ExternalEndpointSpec.Upstreams` (`upstream.url` / `endpoint_ref`) and `StaticNodeClusterSpec.Nodes` (`ip`) — the latter has the same bug shape for `nodes[].ssh_auth`.

## Testing

- New unit tests cover the QE repro (leading-entry deletion), reorder, new-entry no-inherit, endpoint_ref identity, explicit user-typed credential precedence, and duplicate identities; plus tag-extraction tests.
- `go test ./internal/routes/proxies/... ./api/...` passes; golangci-lint clean (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)