### PR TITLE
fix: retain target worker specs during upgrade

### DIFF
--- a/internal/cluster/staticcluster/planner.go
+++ b/internal/cluster/staticcluster/planner.go
@@ -137,8 +137,8 @@ func (r *Planner) buildDesiredNodePlans(
 	attachMetricsConfigFiles(cluster, plans)
 
 	// Snapshot the normalized target before upgrade staging can replace plan
-	// components with the observed StaticNode Spec. Use indexed plans so updates
-	// to DesiredNodePlan fields are applied to the slice, not a value copy.
+	// components with the observed StaticNode Spec. Use the indexed plan because
+	// TargetComponents is a DesiredNodePlan field, not an object behind Node.
 	for i := range plans {
 		plan := &plans[i]
 		if plan.Node == nil || plan.Node.Spec == nil {
@@ -153,8 +153,7 @@ func (r *Planner) buildDesiredNodePlans(
 
 	// Upgrade staging may adopt observed components; normalize the final Spec
 	// that will be written to the StaticNode.
-	for i := range plans {
-		plan := &plans[i]
+	for _, plan := range plans {
 		plan.Node.Spec.Components = withComponentConfigHashes(plan.Node.Spec.Components)
 	}
 

--- a/internal/cluster/staticcluster/planner.go
+++ b/internal/cluster/staticcluster/planner.go
@@ -153,6 +153,8 @@ func (r *Planner) buildDesiredNodePlans(
 
 	// Upgrade staging may adopt observed components; normalize the final Spec
 	// that will be written to the StaticNode.
+	// TODO: Standardize plan traversal style when this path is refactored. Keep
+	// this range form for now because it only updates the StaticNode behind Node.
 	for _, plan := range plans {
 		plan.Node.Spec.Components = withComponentConfigHashes(plan.Node.Spec.Components)
 	}

--- a/internal/cluster/staticcluster/planner.go
+++ b/internal/cluster/staticcluster/planner.go
@@ -121,9 +121,8 @@ func (r *Planner) buildDesiredNodePlans(
 		desiredNode.Spec.Warm = buildNodeWarmSpec(components)
 		desiredNode.Spec.Components = components
 		plans = append(plans, DesiredNodePlan{
-			Accelerator:      acceleratorStatus,
-			Node:             desiredNode,
-			TargetComponents: copyNodeComponents(components),
+			Accelerator: acceleratorStatus,
+			Node:        desiredNode,
 		})
 	}
 
@@ -136,6 +135,17 @@ func (r *Planner) buildDesiredNodePlans(
 	})
 
 	attachMetricsConfigFiles(cluster, plans)
+
+	for i := range plans {
+		plan := &plans[i]
+		if plan.Node == nil || plan.Node.Spec == nil {
+			continue
+		}
+
+		plan.Node.Spec.Components = withComponentConfigHashes(plan.Node.Spec.Components)
+		plan.TargetComponents = copyNodeComponents(plan.Node.Spec.Components)
+	}
+
 	applyRayRecreateUpgradePlan(cluster, currentByName, plans)
 
 	for _, plan := range plans {

--- a/internal/cluster/staticcluster/planner.go
+++ b/internal/cluster/staticcluster/planner.go
@@ -137,7 +137,8 @@ func (r *Planner) buildDesiredNodePlans(
 	attachMetricsConfigFiles(cluster, plans)
 
 	// Snapshot the normalized target before upgrade staging can replace plan
-	// components with the observed StaticNode Spec.
+	// components with the observed StaticNode Spec. Use indexed plans so updates
+	// to DesiredNodePlan fields are applied to the slice, not a value copy.
 	for i := range plans {
 		plan := &plans[i]
 		if plan.Node == nil || plan.Node.Spec == nil {
@@ -152,7 +153,8 @@ func (r *Planner) buildDesiredNodePlans(
 
 	// Upgrade staging may adopt observed components; normalize the final Spec
 	// that will be written to the StaticNode.
-	for _, plan := range plans {
+	for i := range plans {
+		plan := &plans[i]
 		plan.Node.Spec.Components = withComponentConfigHashes(plan.Node.Spec.Components)
 	}
 

--- a/internal/cluster/staticcluster/planner.go
+++ b/internal/cluster/staticcluster/planner.go
@@ -136,6 +136,8 @@ func (r *Planner) buildDesiredNodePlans(
 
 	attachMetricsConfigFiles(cluster, plans)
 
+	// Snapshot the normalized target before upgrade staging can replace plan
+	// components with the observed StaticNode Spec.
 	for i := range plans {
 		plan := &plans[i]
 		if plan.Node == nil || plan.Node.Spec == nil {
@@ -148,6 +150,8 @@ func (r *Planner) buildDesiredNodePlans(
 
 	applyRayRecreateUpgradePlan(cluster, currentByName, plans)
 
+	// Upgrade staging may adopt observed components; normalize the final Spec
+	// that will be written to the StaticNode.
 	for _, plan := range plans {
 		plan.Node.Spec.Components = withComponentConfigHashes(plan.Node.Spec.Components)
 	}

--- a/internal/cluster/staticcluster/planner_test.go
+++ b/internal/cluster/staticcluster/planner_test.go
@@ -869,6 +869,218 @@ func TestPlannerPlansRayRecreateUpgradeOrder(t *testing.T) {
 	}
 }
 
+func TestPlannerKeepsTargetWorkerSpecDuringRayRecreateUpgrade(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     v1.NodeComponentPhase
+		nodePhase v1.StaticNodePhase
+	}{
+		{
+			name:      "worker starting",
+			phase:     v1.NodeComponentPhaseStarting,
+			nodePhase: v1.StaticNodePhaseReconciling,
+		},
+		{
+			name:      "worker pending",
+			phase:     v1.NodeComponentPhasePending,
+			nodePhase: v1.StaticNodePhaseReconciling,
+		},
+		{
+			name:      "worker failed",
+			phase:     v1.NodeComponentPhaseFailed,
+			nodePhase: v1.StaticNodePhaseFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := testStaticNodeCluster()
+			cluster.Spec.Version = "v1.2.1"
+			cluster.Status = &v1.StaticNodeClusterStatus{
+				Phase:   v1.StaticNodeClusterPhaseUpgrading,
+				Version: "v1.2.0",
+			}
+			currentNodes := staticNodeUpgradeCurrentNodes()
+			markUpgradeHeadTargetRunning(currentNodes)
+
+			targetPlans, err := (&Planner{}).Plan(context.Background(), cluster, currentNodes)
+			require.NoError(t, err)
+			targetWorker := findStaticNode(staticNodesFromPlans(targetPlans), "worker-0")
+			require.NotNil(t, targetWorker)
+
+			worker := findStaticNode(currentNodes, "worker-0")
+			require.NotNil(t, worker)
+			worker.Spec = targetWorker.Spec
+			worker.Status.Phase = tt.nodePhase
+			worker.Status.Components = []v1.NodeComponentStatus{{
+				Name:   rayWorkerComponentName,
+				Phase:  tt.phase,
+				Reason: "transitional state",
+			}}
+
+			desiredNodePlans, err := (&Planner{}).Plan(context.Background(), cluster, currentNodes)
+
+			require.NoError(t, err)
+			status := (StatusAggregator{}).Aggregate(cluster, currentNodes, desiredNodePlans)
+			assert.Contains(t, status.ErrorMessage, staticNodeClusterUpgradeStepStartingWorkers)
+
+			desiredWorker := findStaticNode(staticNodesFromPlans(desiredNodePlans), "worker-0")
+			require.NotNil(t, desiredWorker)
+			assert.Equal(t, findComponent(targetWorker.Spec.Components, rayWorkerComponentName),
+				findComponent(desiredWorker.Spec.Components, rayWorkerComponentName))
+		})
+	}
+}
+
+func TestPlannerKeepsTargetWorkerSpecWhenHeadTemporarilyLeavesTarget(t *testing.T) {
+	cluster := testStaticNodeCluster()
+	cluster.Spec.Version = "v1.2.1"
+	cluster.Status = &v1.StaticNodeClusterStatus{
+		Phase:   v1.StaticNodeClusterPhaseUpgrading,
+		Version: "v1.2.0",
+	}
+	currentNodes := staticNodeUpgradeCurrentNodes()
+	markUpgradeHeadTargetRunning(currentNodes)
+
+	targetPlans, err := (&Planner{}).Plan(context.Background(), cluster, currentNodes)
+	require.NoError(t, err)
+	targetWorker := findStaticNode(staticNodesFromPlans(targetPlans), "worker-0")
+	require.NotNil(t, targetWorker)
+
+	worker := findStaticNode(currentNodes, "worker-0")
+	require.NotNil(t, worker)
+	worker.Spec = &v1.StaticNodeSpec{
+		Role:       targetWorker.Spec.Role,
+		Components: copyNodeComponents(targetWorker.Spec.Components),
+	}
+	worker.Status.Phase = v1.StaticNodePhaseReconciling
+	worker.Status.Components = []v1.NodeComponentStatus{{
+		Name:  rayWorkerComponentName,
+		Phase: v1.NodeComponentPhaseStarting,
+	}}
+
+	head := findStaticNode(currentNodes, "head-0")
+	require.NotNil(t, head)
+	head.Status.Components = []v1.NodeComponentStatus{{
+		Name:          rayHeadComponentName,
+		Ready:         true,
+		Phase:         v1.NodeComponentPhaseRunning,
+		ObservedImage: "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+	}}
+
+	desiredNodePlans, err := (&Planner{}).Plan(context.Background(), cluster, currentNodes)
+
+	require.NoError(t, err)
+	status := (StatusAggregator{}).Aggregate(cluster, currentNodes, desiredNodePlans)
+	assert.Contains(t, status.ErrorMessage, staticNodeClusterUpgradeStepStartingWorkers)
+	desiredWorker := findStaticNode(staticNodesFromPlans(desiredNodePlans), "worker-0")
+	require.NotNil(t, desiredWorker)
+	assert.Equal(t, findComponent(targetWorker.Spec.Components, rayWorkerComponentName),
+		findComponent(desiredWorker.Spec.Components, rayWorkerComponentName))
+}
+
+func TestPlannerContinuesStartingWorkersForPartiallyIssuedWorkerSpecs(t *testing.T) {
+	cluster := testStaticNodeCluster()
+	cluster.Spec.Version = "v1.2.1"
+	cluster.Spec.Nodes = append(cluster.Spec.Nodes, v1.StaticNodeClusterNodeSpec{
+		Name: "worker-1",
+		IP:   "10.0.0.12",
+		Role: v1.StaticNodeRoleWorker,
+	})
+	cluster.Status = &v1.StaticNodeClusterStatus{
+		Phase:   v1.StaticNodeClusterPhaseUpgrading,
+		Version: "v1.2.0",
+	}
+	currentNodes := staticNodeUpgradeCurrentNodes()
+	workerZero := findStaticNode(currentNodes, "worker-0")
+	require.NotNil(t, workerZero)
+	currentNodes = append(currentNodes, &v1.StaticNode{
+		Metadata: &v1.Metadata{Name: "worker-1"},
+		Spec: &v1.StaticNodeSpec{
+			Role:       v1.StaticNodeRoleWorker,
+			Components: copyNodeComponents(workerZero.Spec.Components),
+		},
+		Status: &v1.StaticNodeStatus{
+			Phase:       v1.StaticNodePhaseReady,
+			Accelerator: workerZero.Status.Accelerator,
+			Warm:        &v1.WarmStatus{Ready: true},
+			Components:  append([]v1.NodeComponentStatus{}, workerZero.Status.Components...),
+		},
+	})
+	markUpgradeHeadTargetRunning(currentNodes)
+	workerOne := findStaticNode(currentNodes, "worker-1")
+	require.NotNil(t, workerOne)
+	workerOne.Status.Components = []v1.NodeComponentStatus{{
+		Name:  rayWorkerComponentName,
+		Phase: v1.NodeComponentPhaseStopped,
+	}}
+
+	targetPlans, err := (&Planner{}).Plan(context.Background(), cluster, currentNodes)
+	require.NoError(t, err)
+	targetWorkerZero := findStaticNode(staticNodesFromPlans(targetPlans), "worker-0")
+	require.NotNil(t, targetWorkerZero)
+	workerZero.Spec = targetWorkerZero.Spec
+	workerZero.Status.Phase = v1.StaticNodePhaseReconciling
+	workerZero.Status.Components = []v1.NodeComponentStatus{{
+		Name:  rayWorkerComponentName,
+		Phase: v1.NodeComponentPhaseStarting,
+	}}
+
+	desiredNodePlans, err := (&Planner{}).Plan(context.Background(), cluster, currentNodes)
+
+	require.NoError(t, err)
+	status := (StatusAggregator{}).Aggregate(cluster, currentNodes, desiredNodePlans)
+	assert.Contains(t, status.ErrorMessage, staticNodeClusterUpgradeStepStartingWorkers)
+	for _, name := range []string{"worker-0", "worker-1"} {
+		targetWorker := findStaticNode(staticNodesFromPlans(targetPlans), name)
+		desiredWorker := findStaticNode(staticNodesFromPlans(desiredNodePlans), name)
+		require.NotNil(t, targetWorker)
+		require.NotNil(t, desiredWorker)
+		assert.Equal(t, findComponent(targetWorker.Spec.Components, rayWorkerComponentName),
+			findComponent(desiredWorker.Spec.Components, rayWorkerComponentName))
+	}
+}
+
+func TestPlannerDoesNotTreatDifferentWorkerSpecAsTarget(t *testing.T) {
+	cluster := testStaticNodeCluster()
+	cluster.Spec.Version = "v1.2.1"
+	cluster.Status = &v1.StaticNodeClusterStatus{
+		Phase:   v1.StaticNodeClusterPhaseUpgrading,
+		Version: "v1.2.0",
+	}
+	currentNodes := staticNodeUpgradeCurrentNodes()
+	markUpgradeHeadTargetRunning(currentNodes)
+
+	targetPlans, err := (&Planner{}).Plan(context.Background(), cluster, currentNodes)
+	require.NoError(t, err)
+	targetWorker := findStaticNode(staticNodesFromPlans(targetPlans), "worker-0")
+	require.NotNil(t, targetWorker)
+
+	worker := findStaticNode(currentNodes, "worker-0")
+	require.NotNil(t, worker)
+	worker.Spec = &v1.StaticNodeSpec{
+		Role:       targetWorker.Spec.Role,
+		Components: copyNodeComponents(targetWorker.Spec.Components),
+	}
+	workerRay := findComponent(worker.Spec.Components, rayWorkerComponentName)
+	require.NotNil(t, workerRay)
+	workerRay.ConfigHash = "different-config-hash"
+	worker.Status.Phase = v1.StaticNodePhaseReconciling
+	worker.Status.Components = []v1.NodeComponentStatus{{
+		Name:  rayWorkerComponentName,
+		Phase: v1.NodeComponentPhaseStarting,
+	}}
+
+	desiredNodePlans, err := (&Planner{}).Plan(context.Background(), cluster, currentNodes)
+
+	require.NoError(t, err)
+	status := (StatusAggregator{}).Aggregate(cluster, currentNodes, desiredNodePlans)
+	assert.Contains(t, status.ErrorMessage, staticNodeClusterUpgradeStepStoppingWorkers)
+	desiredWorker := findStaticNode(staticNodesFromPlans(desiredNodePlans), "worker-0")
+	require.NotNil(t, desiredWorker)
+	assert.Nil(t, findComponent(desiredWorker.Spec.Components, rayWorkerComponentName))
+}
+
 func TestPlannerAdvancesRayRecreateUpgradeStep(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cluster/staticcluster/upgrade.go
+++ b/internal/cluster/staticcluster/upgrade.go
@@ -1,6 +1,10 @@
 package staticcluster
 
-import v1 "github.com/neutree-ai/neutree/api/v1"
+import (
+	"reflect"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
 
 type staticNodeClusterUpgradeStep string
 
@@ -89,6 +93,8 @@ func staticNodeClusterUpgradeStepFromObservedState(
 	switch {
 	case staticNodeClusterRayRuntimeRunningTarget(cluster, currentNodes, plans):
 		return staticNodeClusterUpgradeStepVerifying
+	case staticNodeClusterWorkerTargetSpecIssued(cluster, currentNodes, plans):
+		return staticNodeClusterUpgradeStepStartingWorkers
 	case staticNodeClusterWorkersStopped(cluster, currentNodes) &&
 		staticNodeClusterHeadRayRunningTarget(cluster, currentNodes, plans):
 		return staticNodeClusterUpgradeStepStartingWorkers
@@ -187,6 +193,39 @@ func staticNodeClusterWorkersStopped(cluster *v1.StaticNodeCluster, nodes []*v1.
 	return true
 }
 
+func staticNodeClusterWorkerTargetSpecIssued(
+	cluster *v1.StaticNodeCluster,
+	nodes []*v1.StaticNode,
+	plans []DesiredNodePlan,
+) bool {
+	workerNames := staticNodeClusterWorkerNames(cluster)
+	nodesByName := staticNodeByName(nodes)
+
+	for name := range workerNames {
+		node := nodesByName[name]
+		if staticNodeRayWorkerSpecTarget(node, desiredRayComponent(plans, name, rayWorkerComponentName)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func staticNodeRayWorkerSpecTarget(node *v1.StaticNode, target *v1.NodeComponentSpec) bool {
+	if node == nil || node.Spec == nil || target == nil {
+		return false
+	}
+
+	for i := range node.Spec.Components {
+		component := &node.Spec.Components[i]
+		if component.Name == rayWorkerComponentName {
+			return reflect.DeepEqual(*component, *target)
+		}
+	}
+
+	return false
+}
+
 func staticNodeClusterRayRuntimeRunningTarget(
 	cluster *v1.StaticNodeCluster,
 	nodes []*v1.StaticNode,
@@ -252,6 +291,19 @@ func desiredRayComponentImage(
 	nodeName string,
 	componentName string,
 ) string {
+	component := desiredRayComponent(plans, nodeName, componentName)
+	if component == nil {
+		return ""
+	}
+
+	return component.Image
+}
+
+func desiredRayComponent(
+	plans []DesiredNodePlan,
+	nodeName string,
+	componentName string,
+) *v1.NodeComponentSpec {
 	for _, plan := range plans {
 		if plan.Node == nil || plan.Node.Spec == nil {
 			continue
@@ -266,14 +318,14 @@ func desiredRayComponentImage(
 			components = plan.Node.Spec.Components
 		}
 
-		for _, component := range components {
-			if component.Name == componentName {
-				return component.Image
+		for i := range components {
+			if components[i].Name == componentName {
+				return &components[i]
 			}
 		}
 	}
 
-	return ""
+	return nil
 }
 
 func staticNodeClusterWorkerNames(cluster *v1.StaticNodeCluster) map[string]struct{} {


### PR DESCRIPTION
## Issue

NEU-596

## Summary

Preserve the intended worker ray component specification throughout a static-cluster recreate upgrade. This prevents the cluster planner from removing a worker target Spec while the worker controller is reporting a transitional status.

## Changes

- Finalize the target component snapshot after metrics configuration and config hashes are attached.
- Keep the recreate upgrade in `StartingWorkers` once an exact target worker Spec has been issued.
- Preserve `Verifying` priority and the existing initial worker-stop/head-start ordering.
- Add coverage for transitional worker states, temporary head status regression, partial multi-worker issuance, and target Spec mismatch.

## Test Plan

### Unit test

- Passed: `go test ./internal/cluster/staticcluster -count=1`
- Passed: `go vet ./api/... ./controllers/... ./internal/... ./pkg/... ./cmd/neutree-core/...`
- Passed: `bin/golangci-lint run ./internal/cluster/staticcluster/...`
- Not run: full `go test ./...` / `go vet ./...` cannot start because the repository checkout lacks `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`.

### DB test

- Not applicable: no database schema, migration, or storage-layer change.

### E2E test

- Passed manual lifecycle validation on Enterprise CP `10.255.1.54` using a fresh SSH static cluster with CPU head `10.255.1.136` and GPU worker `192.168.19.218`; no code E2E was added by request.
- Creation: `default/sshgpu` reached Cluster `Running 2/2` and StaticNodeCluster `Ready 2/2` at `v1.1.0`; both Ray components were `Running`.
- Upgrade: changed the same cluster to `v1.1.1-alpha.3`. After head replacement, the worker target `ray-worker` Spec was issued while the worker was `Starting`, with the target image and ConfigHash `d77747e...4072106e`.
- Assertion: from target worker Spec issuance through convergence, no `StoppingWorkers` recurrence was observed and the worker target Spec remained present.
- Final: Cluster `Running 2/2` and StaticNodeCluster `Ready 2/2`, with spec/status versions `v1.1.1-alpha.3`; head and worker Ray components were `Running` / `ready=true`.
- Cleanup: soft-deleted the test cluster; Cluster, StaticNodeCluster, and StaticNode counts reached zero, and CP health remained `200`.

## Risk & Rollback

No schema or public API change. The change only affects static-cluster recreate-upgrade stage selection and retains an already-issued desired worker Spec until the cluster reaches verification. Rollback validation is intentionally out of scope for this task.