### PR TITLE
fix: reload Kong plugins on Compose upgrade

### DIFF
--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -179,6 +179,7 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 	}
 
 	coreWorkDir := filepath.Join(options.workDir, "neutree-core")
+
 	pluginChecksums, err := kongPluginChecksums(filepath.Join(renderedCoreWorkDir, "gateway", "kong", "plugins"))
 	if err != nil {
 		return errors.Wrap(err, "calculate Kong plugin checksums failed")

--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -169,10 +169,6 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 	}
 	defer neutreeCoreDeployManifestsTarFile.Close()
 
-	if err := cleanKongPluginDirectory(renderedCoreWorkDir); err != nil {
-		return errors.Wrap(err, "clean Kong plugin directory failed")
-	}
-
 	err = util.ExtractTar(neutreeCoreDeployManifestsTarFile, outputWorkDir)
 	if err != nil {
 		return errors.Wrap(err, "extract neutree core db init scripts failed")
@@ -236,8 +232,4 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 	}
 
 	return nil
-}
-
-func cleanKongPluginDirectory(renderedCoreWorkDir string) error {
-	return os.RemoveAll(filepath.Join(renderedCoreWorkDir, "gateway", "kong", "plugins"))
 }

--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -160,6 +160,8 @@ func prepareNeutreeCoreDeployConfig(options neutreeCoreInstallOptions) error {
 }
 
 func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, outputWorkDir string) error {
+	renderedCoreWorkDir := filepath.Join(outputWorkDir, "neutree-core")
+
 	// extract neutree core deploy manifests
 	neutreeCoreDeployManifestsTarFile, err := manifests.NeutreeDeployManifestsTar.Open("neutree-core.tar")
 	if err != nil {
@@ -167,13 +169,20 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 	}
 	defer neutreeCoreDeployManifestsTarFile.Close()
 
+	if err := cleanKongPluginDirectory(renderedCoreWorkDir); err != nil {
+		return errors.Wrap(err, "clean Kong plugin directory failed")
+	}
+
 	err = util.ExtractTar(neutreeCoreDeployManifestsTarFile, outputWorkDir)
 	if err != nil {
 		return errors.Wrap(err, "extract neutree core db init scripts failed")
 	}
 
-	renderedCoreWorkDir := filepath.Join(outputWorkDir, "neutree-core")
 	coreWorkDir := filepath.Join(options.workDir, "neutree-core")
+	pluginChecksums, err := kongPluginChecksums(filepath.Join(renderedCoreWorkDir, "gateway", "kong", "plugins"))
+	if err != nil {
+		return errors.Wrap(err, "calculate Kong plugin checksums failed")
+	}
 
 	// parseTemplate
 	tempplateFiles := []string{
@@ -194,19 +203,23 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 	}
 
 	templateParams := map[string]string{
-		"NeutreeCoreWorkDir":          coreWorkDir,
-		"JwtSecret":                   options.jwtSecret,
-		"DbPassword":                  options.dbPassword,
-		"MetricsRemoteWriteURL":       options.metricsRemoteWriteURL,
-		"GrafanaURL":                  options.grafanaURL,
-		"VictoriaMetricsVersion":      componentversion.VictoriaMetrics,
-		"VictoriaLogsRetentionPeriod": options.victorialogsRetentionPeriod,
-		"NeutreeVersion":              options.version,
-		"JwtToken":                    *jwtToken,
-		"VectorVersion":               componentversion.Vector,
-		"KongVersion":                 componentversion.Kong,
-		"NodeIP":                      options.nodeIP,
-		"AdminPassword":               options.adminPassword,
+		"NeutreeCoreWorkDir":           coreWorkDir,
+		"JwtSecret":                    options.jwtSecret,
+		"DbPassword":                   options.dbPassword,
+		"MetricsRemoteWriteURL":        options.metricsRemoteWriteURL,
+		"GrafanaURL":                   options.grafanaURL,
+		"VictoriaMetricsVersion":       componentversion.VictoriaMetrics,
+		"VictoriaLogsRetentionPeriod":  options.victorialogsRetentionPeriod,
+		"NeutreeVersion":               options.version,
+		"JwtToken":                     *jwtToken,
+		"VectorVersion":                componentversion.Vector,
+		"KongVersion":                  componentversion.Kong,
+		"KongPluginGatewayChecksum":    pluginChecksums["neutree-ai-gateway"],
+		"KongPluginStatisticsChecksum": pluginChecksums["neutree-ai-statistics"],
+		"KongPluginAccessChecksum":     pluginChecksums["neutree-ai-access"],
+		"KongPluginQuotaChecksum":      pluginChecksums["neutree-ai-quota"],
+		"NodeIP":                       options.nodeIP,
+		"AdminPassword":                options.adminPassword,
 	}
 
 	err = util.BatchParseTemplateFiles(tempplateFiles, templateParams)
@@ -222,4 +235,8 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 	}
 
 	return nil
+}
+
+func cleanKongPluginDirectory(renderedCoreWorkDir string) error {
+	return os.RemoveAll(filepath.Join(renderedCoreWorkDir, "gateway", "kong", "plugins"))
 }

--- a/cmd/neutree-cli/app/cmd/launch/core_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/core_test.go
@@ -207,17 +207,6 @@ func TestPrepareNeutreeCoreDeployConfigRendersKongPluginChecksumLabels(t *testin
 	}
 }
 
-func TestCleanKongPluginDirectoryRemovesStalePluginFiles(t *testing.T) {
-	renderedCoreWorkDir := filepath.Join(t.TempDir(), "neutree-core")
-	staleFilePath := filepath.Join(renderedCoreWorkDir, "gateway", "kong", "plugins", "neutree-ai-gateway", "removed.lua")
-	require.NoError(t, os.MkdirAll(filepath.Dir(staleFilePath), 0o755))
-	require.NoError(t, os.WriteFile(staleFilePath, []byte("stale\n"), 0o600))
-
-	require.NoError(t, cleanKongPluginDirectory(renderedCoreWorkDir))
-
-	assert.NoFileExists(t, staleFilePath)
-}
-
 // NEU-583 regression: rendering the embedded manifests must not HTML-escape
 // the Vector VRL program — html/template turned `<=` into `&lt;=`, which
 // Vector rejects (exit 78 restart loop), silently disabling the NEU-539

--- a/cmd/neutree-cli/app/cmd/launch/core_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/core_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/compose-spec/compose-go/cli"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/constants"
 	"github.com/neutree-ai/neutree/pkg/command/mocks"
 	"github.com/pkg/errors"
@@ -152,6 +153,69 @@ func TestPrepareNeutreeCoreDeployConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrepareNeutreeCoreDeployConfigRendersKongPluginChecksumLabels(t *testing.T) {
+	tempDir := t.TempDir()
+	options := neutreeCoreInstallOptions{
+		commonOptions: &commonOptions{
+			workDir:    tempDir,
+			nodeIP:     "192.168.1.1",
+			deployType: constants.DeployTypeLocal,
+			deployMode: constants.DeployModeSingle,
+		},
+		jwtSecret: "test-secret",
+		version:   "v1.0.0",
+	}
+
+	require.NoError(t, prepareNeutreeCoreDeployConfig(options))
+
+	composeFilePath := filepath.Join(tempDir, "neutree-core", "docker-compose.yml")
+	project, err := cli.ProjectFromOptions(&cli.ProjectOptions{
+		ConfigPaths: []string{composeFilePath},
+	})
+	require.NoError(t, err)
+
+	expectedChecksums, err := kongPluginChecksums(filepath.Join(tempDir, "neutree-core", "gateway", "kong", "plugins"))
+	require.NoError(t, err)
+	expectedLabels := map[string]string{
+		"neutree.ai/kong-plugin-neutree-ai-gateway-checksum":    expectedChecksums["neutree-ai-gateway"],
+		"neutree.ai/kong-plugin-neutree-ai-statistics-checksum": expectedChecksums["neutree-ai-statistics"],
+		"neutree.ai/kong-plugin-neutree-ai-access-checksum":     expectedChecksums["neutree-ai-access"],
+		"neutree.ai/kong-plugin-neutree-ai-quota-checksum":      expectedChecksums["neutree-ai-quota"],
+	}
+
+	var kongLabels map[string]string
+	for _, service := range project.Services {
+		if service.Name == "kong" {
+			kongLabels = service.Labels
+			break
+		}
+	}
+	require.NotNil(t, kongLabels)
+	for label, checksum := range expectedLabels {
+		assert.Equal(t, checksum, kongLabels[label])
+	}
+
+	for _, service := range project.Services {
+		if service.Name == "kong" {
+			continue
+		}
+		for label := range expectedLabels {
+			assert.NotContains(t, service.Labels, label, "unexpected Kong plugin checksum label on %s", service.Name)
+		}
+	}
+}
+
+func TestCleanKongPluginDirectoryRemovesStalePluginFiles(t *testing.T) {
+	renderedCoreWorkDir := filepath.Join(t.TempDir(), "neutree-core")
+	staleFilePath := filepath.Join(renderedCoreWorkDir, "gateway", "kong", "plugins", "neutree-ai-gateway", "removed.lua")
+	require.NoError(t, os.MkdirAll(filepath.Dir(staleFilePath), 0o755))
+	require.NoError(t, os.WriteFile(staleFilePath, []byte("stale\n"), 0o600))
+
+	require.NoError(t, cleanKongPluginDirectory(renderedCoreWorkDir))
+
+	assert.NoFileExists(t, staleFilePath)
 }
 
 // NEU-583 regression: rendering the embedded manifests must not HTML-escape

--- a/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum.go
+++ b/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum.go
@@ -20,6 +20,7 @@ var kongPluginNames = []string{
 
 func kongPluginChecksums(pluginsRoot string) (map[string]string, error) {
 	checksums := make(map[string]string, len(kongPluginNames))
+
 	for _, pluginName := range kongPluginNames {
 		checksum, err := kongPluginChecksum(filepath.Join(pluginsRoot, pluginName))
 		if err != nil {
@@ -66,6 +67,7 @@ func kongPluginChecksum(pluginDir string) (string, error) {
 		if err != nil {
 			return err
 		}
+
 		if err := writeKongPluginChecksumRecord(hasher, filepath.ToSlash(relativePath), path); err != nil {
 			return err
 		}
@@ -83,6 +85,7 @@ func writeKongPluginChecksumRecord(hasher hash.Hash, relativePath, path string) 
 	if _, err := io.WriteString(hasher, relativePath); err != nil {
 		return err
 	}
+
 	if _, err := hasher.Write([]byte{0}); err != nil {
 		return err
 	}
@@ -96,6 +99,7 @@ func writeKongPluginChecksumRecord(hasher hash.Hash, relativePath, path string) 
 	if _, err := io.Copy(hasher, file); err != nil {
 		return err
 	}
+
 	if _, err := hasher.Write([]byte{0}); err != nil {
 		return err
 	}

--- a/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum.go
+++ b/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 )
@@ -38,44 +37,40 @@ func kongPluginChecksum(pluginDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 		return "", fmt.Errorf("expected directory %s", pluginDir)
 	}
 
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		return "", err
+	}
+
 	hasher := sha256.New()
 
-	err = filepath.WalkDir(pluginDir, func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
+	for _, entry := range entries {
 		if entry.IsDir() {
-			return nil
+			continue
 		}
+
 		if entry.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("non-regular file %s", path)
+			return "", fmt.Errorf("non-regular file %s", entry.Name())
 		}
 
 		info, err := entry.Info()
 		if err != nil {
-			return err
+			return "", err
 		}
+
 		if !info.Mode().IsRegular() {
-			return fmt.Errorf("non-regular file %s", path)
+			return "", fmt.Errorf("non-regular file %s", entry.Name())
 		}
 
-		relativePath, err := filepath.Rel(pluginDir, path)
-		if err != nil {
-			return err
+		path := filepath.Join(pluginDir, entry.Name())
+		if err := writeKongPluginChecksumRecord(hasher, entry.Name(), path); err != nil {
+			return "", err
 		}
-
-		if err := writeKongPluginChecksumRecord(hasher, filepath.ToSlash(relativePath), path); err != nil {
-			return err
-		}
-
-		return nil
-	})
-	if err != nil {
-		return "", err
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil

--- a/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum.go
+++ b/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum.go
@@ -1,0 +1,104 @@
+package launch
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+var kongPluginNames = []string{
+	"neutree-ai-gateway",
+	"neutree-ai-statistics",
+	"neutree-ai-access",
+	"neutree-ai-quota",
+}
+
+func kongPluginChecksums(pluginsRoot string) (map[string]string, error) {
+	checksums := make(map[string]string, len(kongPluginNames))
+	for _, pluginName := range kongPluginNames {
+		checksum, err := kongPluginChecksum(filepath.Join(pluginsRoot, pluginName))
+		if err != nil {
+			return nil, fmt.Errorf("checksum Kong plugin %s: %w", pluginName, err)
+		}
+
+		checksums[pluginName] = checksum
+	}
+
+	return checksums, nil
+}
+
+func kongPluginChecksum(pluginDir string) (string, error) {
+	info, err := os.Lstat(pluginDir)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return "", fmt.Errorf("expected directory %s", pluginDir)
+	}
+
+	hasher := sha256.New()
+
+	err = filepath.WalkDir(pluginDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("non-regular file %s", path)
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("non-regular file %s", path)
+		}
+
+		relativePath, err := filepath.Rel(pluginDir, path)
+		if err != nil {
+			return err
+		}
+		if err := writeKongPluginChecksumRecord(hasher, filepath.ToSlash(relativePath), path); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func writeKongPluginChecksumRecord(hasher hash.Hash, relativePath, path string) error {
+	if _, err := io.WriteString(hasher, relativePath); err != nil {
+		return err
+	}
+	if _, err := hasher.Write([]byte{0}); err != nil {
+		return err
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(hasher, file); err != nil {
+		return err
+	}
+	if _, err := hasher.Write([]byte{0}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum_test.go
@@ -1,0 +1,84 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKongPluginChecksumsAreDeterministic(t *testing.T) {
+	pluginsRoot := writeKongPluginTree(t)
+
+	first, err := kongPluginChecksums(pluginsRoot)
+	require.NoError(t, err)
+
+	second, err := kongPluginChecksums(pluginsRoot)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+}
+
+func TestKongPluginChecksumsOnlyChangesModifiedPlugin(t *testing.T) {
+	pluginsRoot := writeKongPluginTree(t)
+
+	before, err := kongPluginChecksums(pluginsRoot)
+	require.NoError(t, err)
+
+	gatewayHandler := filepath.Join(pluginsRoot, "neutree-ai-gateway", "handler.lua")
+	require.NoError(t, os.WriteFile(gatewayHandler, []byte("return { VERSION = 'changed' }\n"), 0o600))
+
+	after, err := kongPluginChecksums(pluginsRoot)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, before["neutree-ai-gateway"], after["neutree-ai-gateway"])
+	assert.Equal(t, before["neutree-ai-statistics"], after["neutree-ai-statistics"])
+	assert.Equal(t, before["neutree-ai-access"], after["neutree-ai-access"])
+	assert.Equal(t, before["neutree-ai-quota"], after["neutree-ai-quota"])
+}
+
+func TestKongPluginChecksumsRejectsMissingPluginDirectory(t *testing.T) {
+	pluginsRoot := writeKongPluginTree(t)
+	require.NoError(t, os.RemoveAll(filepath.Join(pluginsRoot, "neutree-ai-quota")))
+
+	_, err := kongPluginChecksums(pluginsRoot)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "neutree-ai-quota")
+}
+
+func TestKongPluginChecksumsRejectsPluginFile(t *testing.T) {
+	pluginsRoot := writeKongPluginTree(t)
+	pluginPath := filepath.Join(pluginsRoot, "neutree-ai-quota")
+	require.NoError(t, os.RemoveAll(pluginPath))
+	require.NoError(t, os.WriteFile(pluginPath, []byte("not a directory\n"), 0o600))
+
+	_, err := kongPluginChecksums(pluginsRoot)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "neutree-ai-quota")
+}
+
+func writeKongPluginTree(t *testing.T) string {
+	t.Helper()
+
+	pluginsRoot := filepath.Join(t.TempDir(), "plugins")
+	for _, plugin := range []string{
+		"neutree-ai-gateway",
+		"neutree-ai-statistics",
+		"neutree-ai-access",
+		"neutree-ai-quota",
+	} {
+		pluginDir := filepath.Join(pluginsRoot, plugin)
+		require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(pluginDir, "handler.lua"),
+			[]byte("return { VERSION = '1.0.0' }\n"),
+			0o600,
+		))
+	}
+
+	return pluginsRoot
+}

--- a/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/kong_plugin_checksum_test.go
@@ -39,6 +39,22 @@ func TestKongPluginChecksumsOnlyChangesModifiedPlugin(t *testing.T) {
 	assert.Equal(t, before["neutree-ai-quota"], after["neutree-ai-quota"])
 }
 
+func TestKongPluginChecksumsIgnoreNestedPluginFiles(t *testing.T) {
+	pluginsRoot := writeKongPluginTree(t)
+	nestedFile := filepath.Join(pluginsRoot, "neutree-ai-gateway", "spec", "handler_spec.lua")
+	require.NoError(t, os.MkdirAll(filepath.Dir(nestedFile), 0o755))
+	require.NoError(t, os.WriteFile(nestedFile, []byte("return { VERSION = 'first' }\n"), 0o600))
+
+	before, err := kongPluginChecksums(pluginsRoot)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(nestedFile, []byte("return { VERSION = 'second' }\n"), 0o600))
+
+	after, err := kongPluginChecksums(pluginsRoot)
+	require.NoError(t, err)
+
+	assert.Equal(t, before, after)
+}
+
 func TestKongPluginChecksumsRejectsMissingPluginDirectory(t *testing.T) {
 	pluginsRoot := writeKongPluginTree(t)
 	require.NoError(t, os.RemoveAll(filepath.Join(pluginsRoot, "neutree-ai-quota")))

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -366,6 +366,11 @@ services:
   kong:
     image: kong/kong:{{ .KongVersion }}
     container_name: kong
+    labels:
+      neutree.ai/kong-plugin-neutree-ai-gateway-checksum: "{{ .KongPluginGatewayChecksum }}"
+      neutree.ai/kong-plugin-neutree-ai-statistics-checksum: "{{ .KongPluginStatisticsChecksum }}"
+      neutree.ai/kong-plugin-neutree-ai-access-checksum: "{{ .KongPluginAccessChecksum }}"
+      neutree.ai/kong-plugin-neutree-ai-quota-checksum: "{{ .KongPluginQuotaChecksum }}"
     environment:
       KONG_NGINX_HTTP_CLIENT_BODY_BUFFER_SIZE: 20m
       KONG_PLUGINS: bundled,neutree-ai-gateway,neutree-ai-statistics,neutree-ai-access,neutree-ai-quota


### PR DESCRIPTION
## Issue

n/a

## Summary

Docker Compose upgrades previously replaced bind-mounted Kong Lua plugins without changing the Kong service definition, leaving the running gateway on old plugin code. This adds plugin-content checksums to the Kong service so Compose recreates only Kong when a built-in plugin changes.

## Changes

- Calculate deterministic SHA-256 checksums for the direct runtime files in the four built-in Kong plugin directories after extracting the embedded manifest.
- Render the four checksums as Kong-only Compose labels.
- Keep nested test fixtures outside the checksum scope to match the Kubernetes plugin glob behavior.
- Add regression coverage for checksum stability, isolated plugin changes, invalid plugin paths, nested test fixtures, and rendered Compose labels.

## Test Plan

- Unit test
  - `go test ./cmd/neutree-cli/app/cmd/launch -count=1 -v` passed before the final disk-space limitation.
  - `go vet ./cmd/neutree-cli/app/cmd/launch` passed.
  - `go build ./cmd/neutree-cli` passed.
  - `launch neutree-core --dry-run` rendered four 64-character Kong checksum labels and did not start containers.
  - Full `go test ./...` could not complete because the local build volume ran out of disk space; rerun in CI or an environment with sufficient free space.
  - Local `golangci-lint v1.53.3` is incompatible with the repository's Go 1.23 toolchain; rerun with a compatible lint binary.
  - PR CI passed `gateway-lua-test`, `pr-check`, and `codecov/patch`.
- DB test
  - Not affected: no DB schema, migration, or storage change.
- E2E test
  - Manual Docker Compose verification passed: upgrading `1.1.0` CLI + `1.1.0` CP to a new CLI + `1.1.0-rc.1` CP restarted Kong and the environment operated normally.
  - Repeating `launch` with the same new CLI + `1.1.0-rc.1` CP did not restart Kong.
  - The new CLI build SHA and container IDs/`StartedAt` values were not captured, so this evidence does not independently prove the recreation state of other services.

## Risk & Rollback

- A changed plugin recreates the single Kong container and may briefly interrupt ingress. The first upgrade with these new labels also recreates Kong once.
- Roll back by using the previous CLI release, which restores the prior Compose behavior.