### PR TITLE
ci: bump nightly base version to v1.2.0

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -21,7 +21,7 @@ jobs:
         id: create_nightly_tag
         run: |
           DATE=$(date +'%Y%m%d')
-          NIGHTLY_TAG="v1.1.1-nightly-${DATE}"
+          NIGHTLY_TAG="v1.2.0-nightly-${DATE}"
           git tag "${NIGHTLY_TAG}" -m "${NIGHTLY_TAG}"
           git push origin "${NIGHTLY_TAG}"
           echo "tag=${NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Issue

n/a

## Summary

Bump the Neutree nightly tag base version from v1.1.1 to v1.2.0.

## Changes

- Generate nightly tags as v1.2.0-nightly-YYYYMMDD.

## Test Plan

### Unit test

- N/A: CI workflow configuration only.
- `git diff --check` and Ruby YAML parsing passed.

### DB test

- N/A: no database changes.

### E2E test

- N/A: no runtime behavior changed; manual testing is not required.

## Risk & Rollback

Low code risk. Merge the UI, Neutree, and enterprise PRs before the next 00:00 UTC UI nightly window so all same-day dependency tags use v1.2.0. If the coordinated cutover is missed, avoid the enterprise nightly until the matching UI and community tags exist, or manually dispatch the upstream workflows first. Revert the workflow base version before the next nightly run to restore v1.1.1 tags.

_Trivial CI configuration change; docs MR and TestRail are not applicable._