### PR TITLE
ci: derive release baseline versions

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -25,3 +25,17 @@ jobs:
           git tag "${NIGHTLY_TAG}" -m "${NIGHTLY_TAG}"
           git push origin "${NIGHTLY_TAG}"
           echo "tag=${NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
+      - name: Trigger Release Workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const nightlyTag = '${{ steps.create_nightly_tag.outputs.tag }}';
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yaml',
+              ref: 'main',
+              inputs: {
+                tag: nightlyTag
+              },
+            })

--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -25,21 +25,3 @@ jobs:
           git tag "${NIGHTLY_TAG}" -m "${NIGHTLY_TAG}"
           git push origin "${NIGHTLY_TAG}"
           echo "tag=${NIGHTLY_TAG}" >> "${GITHUB_OUTPUT}"
-      - name: Trigger Workflow
-        uses: actions/github-script@v7
-        env:
-          NIGHTLY_CLUSTER_VERSION: ${{ secrets.NIGHTLY_CLUSTER_VERSION }}
-        with:
-          script: |
-            const nightlyTag = '${{ steps.create_nightly_tag.outputs.tag }}';
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'release.yaml',
-              ref: 'main',
-              inputs: {
-                tag: nightlyTag,
-                ui_version: nightlyTag,
-                cluster_version: process.env.NIGHTLY_CLUSTER_VERSION
-              },
-            })

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,6 @@ jobs:
       baseline_version: ${{ steps.versions.outputs.baseline_version }}
       ui_version: ${{ steps.versions.outputs.ui_version }}
       cluster_version: ${{ steps.versions.outputs.cluster_version }}
-      community_version: ${{ steps.versions.outputs.community_version }}
     steps:
       - name: Resolve release versions
         id: versions
@@ -45,29 +44,21 @@ jobs:
             exit 1
           fi
 
-          baseline_version="${release_version%-enterprise}"
-          baseline_version="${baseline_version%%-nightly-*}"
+          baseline_version="${release_version%%-nightly-*}"
+          ui_version="$release_version"
           cluster_version="$baseline_version"
-          community_version="$baseline_version"
-          if [[ "$release_version" == *-enterprise ]]; then
-            ui_version="$baseline_version"
-          else
-            ui_version="$release_version"
-          fi
 
           {
             echo "release_version=${release_version}"
             echo "baseline_version=${baseline_version}"
             echo "ui_version=${ui_version}"
             echo "cluster_version=${cluster_version}"
-            echo "community_version=${community_version}"
           } >> "$GITHUB_OUTPUT"
 
           echo "Release version: ${release_version}"
           echo "Baseline version: ${baseline_version}"
           echo "UI version: ${ui_version}"
           echo "Cluster version: ${cluster_version}"
-          echo "Community version: ${community_version}"
       - name: Validate release tag
         env:
           RELEASE_VERSION: ${{ steps.versions.outputs.release_version }}
@@ -90,7 +81,6 @@ jobs:
       VERSION: ${{ needs.prepare.outputs.release_version }}
       UI_VERSION: ${{ needs.prepare.outputs.ui_version }}
       CLUSTER_VERSION: ${{ needs.prepare.outputs.cluster_version }}
-      COMMUNITY_VERSION: ${{ needs.prepare.outputs.community_version }}
     runs-on: ubuntu-22.04
     name: build amd64 image
     steps:
@@ -118,7 +108,6 @@ jobs:
       VERSION: ${{ needs.prepare.outputs.release_version }}
       UI_VERSION: ${{ needs.prepare.outputs.ui_version }}
       CLUSTER_VERSION: ${{ needs.prepare.outputs.cluster_version }}
-      COMMUNITY_VERSION: ${{ needs.prepare.outputs.community_version }}
     runs-on: ubuntu-22.04-arm
     name: build arm64 image
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,58 +18,85 @@ jobs:
     outputs:
       release_version: ${{ steps.versions.outputs.release_version }}
       baseline_version: ${{ steps.versions.outputs.baseline_version }}
+      ui_version: ${{ steps.versions.outputs.ui_version }}
+      cluster_version: ${{ steps.versions.outputs.cluster_version }}
       community_version: ${{ steps.versions.outputs.community_version }}
     steps:
       - name: Resolve release versions
         id: versions
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            release_version="${{ github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            release_version="$DISPATCH_TAG"
           else
-            release_version="${{ github.ref_name }}"
+            if [ "$REF_TYPE" != "tag" ]; then
+              echo "Release workflow must run from a tag ref, got: $REF_TYPE" >&2
+              exit 1
+            fi
+            release_version="$REF_NAME"
           fi
 
-          case "$release_version" in
-            v*) ;;
-            *)
-              echo "Release tag must start with v: $release_version" >&2
-              exit 1
-              ;;
-          esac
+          if ! [[ "$release_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a v-prefixed semver tag: $release_version" >&2
+            exit 1
+          fi
 
           baseline_version="${release_version%-enterprise}"
+          baseline_version="${baseline_version%%-nightly-*}"
+          cluster_version="$baseline_version"
+          community_version="$baseline_version"
+          if [[ "$release_version" == *-enterprise ]]; then
+            ui_version="$baseline_version"
+          else
+            ui_version="$release_version"
+          fi
 
           {
             echo "release_version=${release_version}"
             echo "baseline_version=${baseline_version}"
-            echo "community_version=${baseline_version}"
+            echo "ui_version=${ui_version}"
+            echo "cluster_version=${cluster_version}"
+            echo "community_version=${community_version}"
           } >> "$GITHUB_OUTPUT"
 
           echo "Release version: ${release_version}"
           echo "Baseline version: ${baseline_version}"
-          echo "UI version: ${baseline_version}"
-          echo "Cluster version: ${baseline_version}"
-          echo "Community version: ${baseline_version}"
+          echo "UI version: ${ui_version}"
+          echo "Cluster version: ${cluster_version}"
+          echo "Community version: ${community_version}"
+      - name: Validate release tag
+        env:
+          RELEASE_VERSION: ${{ steps.versions.outputs.release_version }}
+        run: |
+          git ls-remote --exit-code --tags \
+            https://github.com/${{ github.repository }}.git \
+            "refs/tags/${RELEASE_VERSION}"
       - name: Validate UI release tag
+        env:
+          UI_VERSION: ${{ steps.versions.outputs.ui_version }}
         run: |
           git ls-remote --exit-code --tags \
             https://github.com/neutree-ai/ui.git \
-            "refs/tags/${{ steps.versions.outputs.baseline_version }}"
+            "refs/tags/${UI_VERSION}"
 
   build-amd64-image:
     needs:
       - prepare
     env:
       VERSION: ${{ needs.prepare.outputs.release_version }}
-      UI_VERSION: ${{ needs.prepare.outputs.baseline_version }}
-      CLUSTER_VERSION: ${{ needs.prepare.outputs.baseline_version }}
+      UI_VERSION: ${{ needs.prepare.outputs.ui_version }}
+      CLUSTER_VERSION: ${{ needs.prepare.outputs.cluster_version }}
       COMMUNITY_VERSION: ${{ needs.prepare.outputs.community_version }}
     runs-on: ubuntu-22.04
     name: build amd64 image
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release_version }}
+          ref: refs/tags/${{ needs.prepare.outputs.release_version }}
       - name: Login docker
         uses: docker/login-action@v3
         with:
@@ -89,15 +116,15 @@ jobs:
       - prepare
     env:
       VERSION: ${{ needs.prepare.outputs.release_version }}
-      UI_VERSION: ${{ needs.prepare.outputs.baseline_version }}
-      CLUSTER_VERSION: ${{ needs.prepare.outputs.baseline_version }}
+      UI_VERSION: ${{ needs.prepare.outputs.ui_version }}
+      CLUSTER_VERSION: ${{ needs.prepare.outputs.cluster_version }}
       COMMUNITY_VERSION: ${{ needs.prepare.outputs.community_version }}
     runs-on: ubuntu-22.04-arm
     name: build arm64 image
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release_version }}
+          ref: refs/tags/${{ needs.prepare.outputs.release_version }}
       - name: Login docker
         uses: docker/login-action@v3
         with:
@@ -122,7 +149,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release_version }}
+          ref: refs/tags/${{ needs.prepare.outputs.release_version }}
       - name: Login docker
         uses: docker/login-action@v3
         with:
@@ -143,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare.outputs.release_version }}
+          ref: refs/tags/${{ needs.prepare.outputs.release_version }}
       - name: Set up go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,31 +11,67 @@ on:
         description: "the release tag (e.g : v0.1.0-nightly-20250405)"
         required: true
         type: string
-      ui_version:
-        description: "the ui release version (e.g : v0.1.0)"
-        required: true
-        type: string
-      cluster_version:
-        description: "the default cluster version (e.g : v1)"
-        required: true
-        type: string
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    name: resolve release versions
+    outputs:
+      release_version: ${{ steps.versions.outputs.release_version }}
+      baseline_version: ${{ steps.versions.outputs.baseline_version }}
+      community_version: ${{ steps.versions.outputs.community_version }}
+    steps:
+      - name: Resolve release versions
+        id: versions
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_version="${{ github.event.inputs.tag }}"
+          else
+            release_version="${{ github.ref_name }}"
+          fi
+
+          case "$release_version" in
+            v*) ;;
+            *)
+              echo "Release tag must start with v: $release_version" >&2
+              exit 1
+              ;;
+          esac
+
+          baseline_version="${release_version%-enterprise}"
+
+          {
+            echo "release_version=${release_version}"
+            echo "baseline_version=${baseline_version}"
+            echo "community_version=${baseline_version}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Release version: ${release_version}"
+          echo "Baseline version: ${baseline_version}"
+          echo "UI version: ${baseline_version}"
+          echo "Cluster version: ${baseline_version}"
+          echo "Community version: ${baseline_version}"
+      - name: Validate UI release tag
+        run: |
+          git ls-remote --exit-code --tags \
+            https://github.com/neutree-ai/ui.git \
+            "refs/tags/${{ steps.versions.outputs.baseline_version }}"
+
   build-amd64-image:
+    needs:
+      - prepare
     env:
-      UI_VERSION: ${{ secrets.RELEASE_UI_VERSION }}
-      CLUSTER_VERSION: ${{ secrets.RELEASE_CLUSTER_VERSION }}
+      VERSION: ${{ needs.prepare.outputs.release_version }}
+      UI_VERSION: ${{ needs.prepare.outputs.baseline_version }}
+      CLUSTER_VERSION: ${{ needs.prepare.outputs.baseline_version }}
+      COMMUNITY_VERSION: ${{ needs.prepare.outputs.community_version }}
     runs-on: ubuntu-22.04
     name: build amd64 image
     steps:
-      - uses: actions/checkout@v2
-      - name: Check out specific tag when manually triggered
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          git fetch --all && git checkout ${{ github.event.inputs.tag }}
-          echo "UI_VERSION=${{ github.event.inputs.ui_version }}" >> $GITHUB_ENV
-          echo "CLUSTER_VERSION=${{ github.event.inputs.cluster_version }}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release_version }}
       - name: Login docker
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.IMAGE_PUSH_USERNAME }}
           password: ${{ secrets.IMAGE_PUSH_TOKEN }}
@@ -49,21 +85,21 @@ jobs:
           IMAGE_PROJECT: ${{ secrets.RELEASE_IMAGE_PROJECT }}
           IMAGE_REPO: ${{ secrets.IMAGE_REPO }}
   build-arm64-image:
+    needs:
+      - prepare
     env:
-      UI_VERSION: ${{ secrets.RELEASE_UI_VERSION }}
-      CLUSTER_VERSION: ${{ secrets.RELEASE_CLUSTER_VERSION }}
+      VERSION: ${{ needs.prepare.outputs.release_version }}
+      UI_VERSION: ${{ needs.prepare.outputs.baseline_version }}
+      CLUSTER_VERSION: ${{ needs.prepare.outputs.baseline_version }}
+      COMMUNITY_VERSION: ${{ needs.prepare.outputs.community_version }}
     runs-on: ubuntu-22.04-arm
     name: build arm64 image
     steps:
-      - uses: actions/checkout@v2
-      - name: Check out specific tag when manually triggered
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          git fetch --all && git checkout ${{ github.event.inputs.tag }}
-          echo "UI_VERSION=${{ github.event.inputs.ui_version }}" >> $GITHUB_ENV
-          echo "CLUSTER_VERSION=${{ github.event.inputs.cluster_version }}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release_version }}
       - name: Login docker
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.IMAGE_PUSH_USERNAME }}
           password: ${{ secrets.IMAGE_PUSH_TOKEN }}
@@ -80,53 +116,49 @@ jobs:
     runs-on: ubuntu-latest
     name: merge and push manifests
     needs:
+      - prepare
       - build-amd64-image
       - build-arm64-image
     steps:
-      - uses: actions/checkout@v2
-      - name: Check out specific tag when manually triggered
-        if: github.event_name == 'workflow_dispatch'
-        run: git fetch --all && git checkout ${{ github.event.inputs.tag }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release_version }}
       - name: Login docker
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.IMAGE_PUSH_USERNAME }}
           password: ${{ secrets.IMAGE_PUSH_TOKEN }}
       - name: push manifests
         run: make docker-push-manifest
         env:
+          VERSION: ${{ needs.prepare.outputs.release_version }}
           IMAGE_PROJECT: ${{ secrets.RELEASE_IMAGE_PROJECT }}
           IMAGE_REPO: ${{ secrets.IMAGE_REPO }}
   release:
     runs-on: ubuntu-latest
     name: release
     needs:
+      - prepare
       - push-manifests
     steps:
-      - uses: actions/checkout@v2
-      - name: Check out specific tag when manually triggered
-        if: github.event_name == 'workflow_dispatch'
-        run: git fetch --all && git checkout ${{ github.event.inputs.tag }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.release_version }}
       - name: Set up go
         uses: actions/setup-go@v5
         with:
           go-version: "1.23"
       - name: generate release artifacts
         run: make release
-      - name: Set release tag
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "RELEASE_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-          else
-            echo "RELEASE_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
+        env:
+          VERSION: ${{ needs.prepare.outputs.release_version }}
 
       - name: Generate draft release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
-          tag_name: ${{ env.RELEASE_TAG }}
-          name: Release ${{ env.RELEASE_TAG }}
+          tag_name: ${{ needs.prepare.outputs.release_version }}
+          name: Release ${{ needs.prepare.outputs.release_version }}
           files: out/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue

n/a

## Summary

Simplify the open-source release workflow so release jobs derive UI and cluster versions from the release tag. Normal releases use the tag directly; nightly releases keep the nightly UI tag while using the base version as the default cluster baseline.

## Changes

- Add a release `prepare` job that derives `release_version`, `baseline_version`, `ui_version`, and `cluster_version` from either the pushed tag or manual dispatch tag.
- Use the derived `ui_version` and `cluster_version` during API image builds, while keeping `VERSION` as the actual release tag for image and release artifacts.
- Validate that the release tag exists in the current repository and the derived UI tag exists in `neutree-ai/ui` before building release images.
- Remove manual `ui_version` / `cluster_version` dispatch inputs and old release secrets plumbing.
- Keep nightly build automation by dispatching `release.yaml` with only the generated nightly tag input after pushing the tag.
- Checkout release jobs via `refs/tags/<release_version>` and update release workflow actions to supported major versions.

## Test Plan

Unit test:
- YAML parse for `.github/workflows/release.yaml` and `.github/workflows/daily-build.yaml` passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yaml .github/workflows/daily-build.yaml` passed.
- Shell derivation check passed for:
  - `v1.1.1 -> ui=v1.1.1 cluster=v1.1.1`
  - `v1.2.0-nightly-20260728 -> ui=v1.2.0-nightly-20260728 cluster=v1.2.0`

DB test:
- Not affected. This change only updates GitHub Actions release workflows.

E2E test:
- Not required. This is a Trivial build/release workflow change with no deployed runtime behavior change.

## Risk & Rollback

Risk is limited to open-source release automation. If a release tag is misconfigured or the matching UI tag is missing, the workflow now fails early in the `prepare` job before image builds. Rollback is to revert this PR and restore explicit workflow inputs/secrets for UI and cluster versions.