### PR TITLE
fix: require a workspace when creating an API key (NEU-579)

### DIFF
--- a/contributing/database.md
+++ b/contributing/database.md
@@ -12,8 +12,9 @@
 
 - Location: `db/migrations/`.
 - Naming: `NNN_<description>.up.sql` + `NNN_<description>.down.sql`.
-- Current highest number: **059** — start new migrations at 060.
+- Current highest number: **079** — start new migrations at 080.
 - Any migration that touches RLS or permissions must ship with an integration test under `db/dbtest/`.
+- **Redefining an existing function**: `CREATE OR REPLACE` replaces the whole body, so base it on the *latest* migration that defines the function, not the first one you find. `grep -l 'FUNCTION api.<name>' db/migrations/*.up.sql` lists them all — copying an older body silently reverts every change made in between.
 
 > ⚠️ **Pair rule (new migrations)**: every new migration must ship `.up.sql` and `.down.sql` together; a missing `.down.sql` breaks rollback. The pre-commit hook (P0-2) enforces this.
 >
@@ -61,8 +62,17 @@ COMMIT;
 ## Testing
 
 - Unit tests: no real DB; use the mocks generated under `pkg/storage/mocks`.
-- Integration tests: `db/dbtest/` spins up a real PostgreSQL + PostgREST + GoTrue.
+- Integration tests: `db/dbtest/` spins up a real PostgreSQL + GoTrue.
 - Command: `make db-test`.
+
+> ⚠️ **JWT claims in tests**: the helpers in `db/dbtest/helper.go` set the legacy
+> per-claim GUCs (`request.jwt.claim.sub`). PostgREST 10 dropped those and only
+> sets `request.jwt.claims` (a single JSON value); we run PostgREST 14. `auth.uid()`
+> reads both, so tests using `sub` pass either way — but SQL that reads any *other*
+> claim from a legacy GUC is dead code in production while still passing here. That
+> is how NEU-579 went unnoticed. When a migration reads a claim, read it as
+> `NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> '<claim>'`
+> and assert it with a test that sets the JSON form.
 
 ## Row-Level Security
 

--- a/db/dbtest/api_key_workspace_required_test.go
+++ b/db/dbtest/api_key_workspace_required_test.go
@@ -1,0 +1,78 @@
+package dbtest
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+// TestCreateApiKeyRequiresWorkspace covers 079_api_key_workspace_required.
+//
+// An API key is always scoped to one workspace, but p_workspace used to accept
+// null: nothing rejected it and the resulting key had a null metadata.workspace.
+// The enterprise api.has_permission treats such a key as invalid and fails
+// closed, so the key silently loses access to everything. Reject it up front.
+func TestCreateApiKeyRequiresWorkspace(t *testing.T) {
+	db := GetTestDB(t)
+	ctx := context.Background()
+
+	user := CreateTestUser(t, "wsrequired", "wsrequired@example.com", "testpassword")
+
+	rejected := []struct {
+		name      string
+		workspace *string
+	}{
+		{name: "null workspace", workspace: nil},
+		{name: "empty workspace", workspace: strPtr("")},
+	}
+
+	for _, tt := range rejected {
+		t.Run(tt.name, func(t *testing.T) {
+			var id string
+
+			err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+				return tx.QueryRowContext(ctx, `
+					SELECT id FROM api.create_api_key(
+						p_workspace := $1,
+						p_name := 'ws-required-key',
+						p_quota := 0
+					)`, tt.workspace).Scan(&id)
+			})
+			if err == nil {
+				_, _ = db.ExecContext(ctx, "DELETE FROM api.api_keys WHERE id = $1", id)
+				t.Fatal("create_api_key accepted a key without a workspace, want rejection")
+			}
+
+			if !strings.Contains(err.Error(), "workspace is required") {
+				t.Fatalf("create_api_key failed for the wrong reason: %v", err)
+			}
+		})
+	}
+
+	t.Run("workspace is still accepted", func(t *testing.T) {
+		var id, workspace string
+
+		err := execWithContext(t, db, []SetContextFunc{setUserContext(user.ID), setJwtSecretContext()}, func(tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx, `
+				SELECT id, (metadata).workspace FROM api.create_api_key(
+					p_workspace := 'default',
+					p_name := 'ws-required-ok',
+					p_quota := 0
+				)`).Scan(&id, &workspace)
+		})
+		if err != nil {
+			t.Fatalf("create_api_key with a workspace: %v", err)
+		}
+
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(ctx, "DELETE FROM api.api_keys WHERE id = $1", id)
+		})
+
+		if workspace != "default" {
+			t.Errorf("metadata.workspace = %q, want %q", workspace, "default")
+		}
+	})
+}
+
+func strPtr(s string) *string { return &s }

--- a/db/migrations/079_api_key_workspace_required.down.sql
+++ b/db/migrations/079_api_key_workspace_required.down.sql
@@ -1,0 +1,69 @@
+-- Rollback NEU-579 follow-up: restore the 071 version of create_api_key,
+-- which accepts a null or empty workspace.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION api.create_api_key(
+    p_workspace TEXT,
+    p_name TEXT,
+    p_quota INTEGER,
+    p_display_name TEXT DEFAULT NULL,
+    p_expires_in INTEGER DEFAULT NULL,
+    p_limits JSONB DEFAULT NULL
+) RETURNS api.api_keys
+SECURITY DEFINER
+AS $$
+DECLARE
+    p_user_id UUID;
+    v_key_id UUID;
+    v_key_value TEXT;
+    v_quota BIGINT;
+    v_result api.api_keys;
+BEGIN
+    p_user_id = auth.uid();
+
+    IF NOT EXISTS (SELECT 1 FROM api.user_profiles WHERE id = p_user_id) THEN
+        RAISE EXCEPTION 'User profile not found';
+    END IF;
+
+    IF p_display_name IS NULL THEN
+        p_display_name := p_name;
+    END IF;
+
+    -- Preserve legacy behavior: when only p_quota is given (no explicit limits),
+    -- derive a monthly token quota so the gateway still enforces it (mirrors the
+    -- spec.quota -> token_quota backfill above).
+    IF p_limits IS NULL AND p_quota IS NOT NULL AND p_quota > 0 THEN
+        p_limits := jsonb_build_object(
+            'token_quota', jsonb_build_object('limit', p_quota, 'period', 'monthly')
+        );
+    END IF;
+
+    -- Reject non-positive numeric limits (after the legacy derive above, which is
+    -- already guarded by p_quota > 0).
+    PERFORM api.validate_api_key_limits(p_limits);
+
+    -- Keep the legacy spec.quota field consistent with the enforced token quota
+    -- (spec.limits.token_quota.limit) so clients reading either see the same value.
+    v_quota := COALESCE((p_limits #>> '{token_quota,limit}')::bigint, 0);
+
+    v_key_id := gen_random_uuid();
+    v_key_value := api.generate_api_key(p_user_id, v_key_id, p_expires_in);
+
+    INSERT INTO api.api_keys (
+        id, api_version, kind, metadata, spec, status, user_id
+    ) VALUES (
+        v_key_id,
+        'v1',
+        'ApiKey',
+        ROW(p_name, p_display_name, p_workspace, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
+        ROW(v_quota, p_expires_in, p_limits)::api.api_key_spec,
+        ROW('Pending', CURRENT_TIMESTAMP, NULL, v_key_value, 0, CURRENT_TIMESTAMP, NULL)::api.api_key_status,
+        p_user_id
+    )
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/db/migrations/079_api_key_workspace_required.up.sql
+++ b/db/migrations/079_api_key_workspace_required.up.sql
@@ -1,0 +1,90 @@
+-- NEU-579 follow-up: require a workspace when creating an API key.
+--
+-- p_workspace has always been a mandatory positional parameter, and the UI and
+-- CLI always supply one, but nothing stopped a direct PostgREST RPC call from
+-- passing null -- there was no non-null check. A workspace-less key is not a
+-- product concept: the enterprise api.has_permission treats a key whose
+-- workspace is null as invalid and fails closed, so such a key silently loses
+-- access to everything, which is expensive to diagnose. Reject it up front.
+--
+-- Deliberately limited to a presence check. Also requiring the workspace to
+-- exist in api.workspaces would be stricter than any current caller assumes --
+-- every create_api_key call in db/dbtest passes a workspace that was never
+-- created -- so referential validation is left to a separate change.
+--
+-- Rebased on the 071 body (which added the validate_api_key_limits gate), not
+-- the 070 one; only the guard above IF p_display_name differs from 071.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION api.create_api_key(
+    p_workspace TEXT,
+    p_name TEXT,
+    p_quota INTEGER,
+    p_display_name TEXT DEFAULT NULL,
+    p_expires_in INTEGER DEFAULT NULL,
+    p_limits JSONB DEFAULT NULL
+) RETURNS api.api_keys
+SECURITY DEFINER
+AS $$
+DECLARE
+    p_user_id UUID;
+    v_key_id UUID;
+    v_key_value TEXT;
+    v_quota BIGINT;
+    v_result api.api_keys;
+BEGIN
+    p_user_id = auth.uid();
+
+    IF NOT EXISTS (SELECT 1 FROM api.user_profiles WHERE id = p_user_id) THEN
+        RAISE EXCEPTION 'User profile not found';
+    END IF;
+
+    -- An API key is always scoped to exactly one workspace.
+    IF p_workspace IS NULL OR p_workspace = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10044","message": "workspace is required to create an API key","hint": "Pass p_workspace with the name of an existing workspace"}',
+                  detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    IF p_display_name IS NULL THEN
+        p_display_name := p_name;
+    END IF;
+
+    -- Preserve legacy behavior: when only p_quota is given (no explicit limits),
+    -- derive a monthly token quota so the gateway still enforces it (mirrors the
+    -- spec.quota -> token_quota backfill above).
+    IF p_limits IS NULL AND p_quota IS NOT NULL AND p_quota > 0 THEN
+        p_limits := jsonb_build_object(
+            'token_quota', jsonb_build_object('limit', p_quota, 'period', 'monthly')
+        );
+    END IF;
+
+    -- Reject non-positive numeric limits (after the legacy derive above, which is
+    -- already guarded by p_quota > 0).
+    PERFORM api.validate_api_key_limits(p_limits);
+
+    -- Keep the legacy spec.quota field consistent with the enforced token quota
+    -- (spec.limits.token_quota.limit) so clients reading either see the same value.
+    v_quota := COALESCE((p_limits #>> '{token_quota,limit}')::bigint, 0);
+
+    v_key_id := gen_random_uuid();
+    v_key_value := api.generate_api_key(p_user_id, v_key_id, p_expires_in);
+
+    INSERT INTO api.api_keys (
+        id, api_version, kind, metadata, spec, status, user_id
+    ) VALUES (
+        v_key_id,
+        'v1',
+        'ApiKey',
+        ROW(p_name, p_display_name, p_workspace, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
+        ROW(v_quota, p_expires_in, p_limits)::api.api_key_spec,
+        ROW('Pending', CURRENT_TIMESTAMP, NULL, v_key_value, 0, CURRENT_TIMESTAMP, NULL)::api.api_key_status,
+        p_user_id
+    )
+    RETURNING * INTO v_result;
+
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
## Context

Follow-up to NEU-579. The main fix for that ticket lives in `neutree-enterprise` (the enterprise `api.has_permission` was reading the API key id from a GUC that PostgREST 14 no longer sets, so the API key workspace restriction never ran). This PR is the community-side hardening that pairs with it.

## Problem

`api.create_api_key` takes `p_workspace` as a mandatory positional parameter, and the UI and CLI always supply one — but nothing rejected a direct PostgREST RPC call that passed `null`. There is no non-null check.

A workspace-less key is not a product concept. The enterprise `api.has_permission` treats a key whose `metadata.workspace` is null as invalid and fails closed, so such a key silently loses access to every resource. That is a expensive failure mode to diagnose: the key exists, looks fine in the UI, and is denied everywhere.

## Change

`079_api_key_workspace_required` rejects a null or empty `p_workspace` with the standard `PGRST` error envelope (code `10044`, HTTP 400).

Two deliberate scope decisions:

- **Presence check only.** Also requiring the workspace to exist in `api.workspaces` would be stricter than any current caller assumes — every `create_api_key` call in `db/dbtest` passes a workspace that was never created, and all five would start failing. Referential validation is left to a separate change.
- **Rebased on the 071 body, not 070.** `071_apikey_limits_validation` redefines `create_api_key` after `070_apikey_limits` to add the `validate_api_key_limits` gate. Starting from the 070 body would have silently reverted it — `TestApiKeyLimits` caught this. The down migration restores 071 byte for byte.

## Docs

`contributing/database.md` picks up two rules earned here, plus a stale counter:

- Migration counter was stale at 059; the tree is at 079.
- When redefining a function, start from the *latest* migration that defines it — `CREATE OR REPLACE` replaces the whole body.
- Tests must set `request.jwt.claims` (JSON), not the legacy per-claim GUCs. The `db/dbtest` helpers set `request.jwt.claim.sub`, which PostgREST 10 dropped. `auth.uid()` reads both so `sub` works either way, but SQL reading any *other* claim from a legacy GUC is dead code in production while still passing locally. That is exactly how NEU-579 went unnoticed.

## Testing

`make db-test` — full suite green, including `TestApiKeyLimits` (which fails if the function body is rebased on 070 instead of 071).

New `TestCreateApiKeyRequiresWorkspace` covers null workspace rejected, empty workspace rejected, and a valid workspace still accepted with `metadata.workspace` round-tripping.

Migration rollback exercised for real: `migrate down 1` then `up` again, verifying the guard disappears and reappears alongside the 071 limits gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0131AYdQL5zfk42nWQjJkwUK