### PR TITLE
feat: support pushing arbitrary container images to a managed image registry (NEU-604)

### DIFF
--- a/cmd/neutree-cli/app/cmd/cmd.go
+++ b/cmd/neutree-cli/app/cmd/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/export"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/get"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
+	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/image"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/launch"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/model"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/packageimport"
@@ -28,6 +29,7 @@ func NewNeutreeCliCommand() *cobra.Command {
 Available Commands:
   • launch: Deploy Neutree components and services
   • model: Manage Neutree models
+  • image: Push container images to a Neutree-managed image registry
   • engine: Manage Neutree engines
 
 Examples:
@@ -56,6 +58,7 @@ Examples:
 	neutreeCliCmd.AddCommand(engine.NewEngineCmd())
 	neutreeCliCmd.AddCommand(export.NewExportCmd())
 	neutreeCliCmd.AddCommand(get.NewGetCmd())
+	neutreeCliCmd.AddCommand(image.NewImageCmd())
 	neutreeCliCmd.AddCommand(launch.NewLaunchCmd())
 	neutreeCliCmd.AddCommand(model.NewModelCmd())
 	neutreeCliCmd.AddCommand(packageimport.NewImportCmd())

--- a/cmd/neutree-cli/app/cmd/image/image.go
+++ b/cmd/neutree-cli/app/cmd/image/image.go
@@ -1,0 +1,26 @@
+package image
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// image-specific flag variables
+var (
+	workspace string
+	registry  string
+)
+
+func NewImageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Management commands for container images",
+		Long:  `These commands help you manage container images in a Neutree-managed image registry`,
+	}
+
+	cmd.PersistentFlags().StringVarP(&workspace, "workspace", "w", "default", "Workspace to use")
+	cmd.PersistentFlags().StringVarP(&registry, "image-registry", "r", "default", "Image registry to use")
+
+	cmd.AddCommand(NewPushCmd())
+
+	return cmd
+}

--- a/cmd/neutree-cli/app/cmd/image/push.go
+++ b/cmd/neutree-cli/app/cmd/image/push.go
@@ -1,0 +1,74 @@
+package image
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
+	cliImage "github.com/neutree-ai/neutree/internal/cli/image"
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+func NewPushCmd() *cobra.Command {
+	var target string
+	var archivePath string
+	var registryUsername string
+	var registryPassword string
+
+	cmd := &cobra.Command{
+		Use:   "push [image]",
+		Short: "Push a container image to a Neutree-managed image registry",
+		Long: `Push a local container image to the image registry managed by Neutree.
+
+The image is tagged into the registry the same way Neutree renders image
+references, so the printed target reference can be used directly as an engine
+image override (e.g. the flex engine's engine_args.image).
+
+The image must exist in the local Docker daemon; use --archive to load it from
+a "docker save" tar first. Registry credentials are read from the Neutree image
+registry resource, and can be overridden with --registry-username/--registry-password.`,
+		Example: `  # Push a locally built image to the default image registry
+  neutree-cli image push my-workload:v1
+
+  # Load from an offline archive and push under a different repository
+  neutree-cli image push my-workload:v1 --archive my-workload.tar --target team-a/my-workload:v1`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := global.NewClient(client.WithTimeout(0))
+			if err != nil {
+				return err
+			}
+
+			pusher, err := cliImage.NewPusher(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+
+			target, err := cliImage.Push(cmd.Context(), c.ImageRegistries, pusher, cliImage.PushOptions{
+				Workspace:   workspace,
+				Registry:    registry,
+				SourceImage: args[0],
+				Target:      target,
+				ArchivePath: archivePath,
+				Username:    registryUsername,
+				Password:    registryPassword,
+			})
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Image pushed successfully: %s\n", target)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&target, "target", "", "Repository[:tag] inside the target registry (default: derived from the source image)")
+	cmd.Flags().StringVar(&archivePath, "archive", "", `Load the image from a "docker save" tar archive before pushing`)
+	cmd.Flags().StringVar(&registryUsername, "registry-username", "", "Username for the image registry (default: the registry's stored credentials)")
+	cmd.Flags().StringVar(&registryPassword, "registry-password", "", "Password for the image registry (default: the registry's stored credentials)")
+
+	return cmd
+}

--- a/contributing/architecture-neutree-cli.md
+++ b/contributing/architecture-neutree-cli.md
@@ -28,6 +28,7 @@ Subcommands live under `cmd/neutree-cli/app/cmd/`. Each top-level directory is a
 | `cleanup` | Tear down a compose stack deployed by `launch` (`cleanup neutree-core` or `cleanup obs-stack`); `--remove-data` also drops volumes. |
 | `launch` | Two subcommands: `launch neutree-core` (operational stack — neutree-api + neutree-core + Postgres/GoTrue/PostgREST + Kong + vmagent + vector) and `launch obs-stack` (VictoriaMetrics + Grafana). Both via Docker Compose. |
 | `engine` | Engine-specific operations (import a package, list versions, ...). |
+| `image` | Push an arbitrary container image into a Neutree-managed image registry (`image push`). |
 | `model` | Model registry / catalog operations. |
 | `packageimport` | Import engine packages and similar bundles. |
 | `resource` | Generic resource operations not tied to a single verb. |
@@ -56,6 +57,24 @@ The CLI sends the API key on `Authorization`; `neutree-api`'s `auth` middleware 
 There is currently no Kubernetes-native install path in `neutree-cli`; the Helm chart at `deploy/chart/` is applied with `helm install` directly by operators outside this tool.
 
 Note: this is independent from the runtime cluster mode (K8s vs SSH) — the runtime mode controls how user `Endpoint` resources are scheduled (`Cluster.spec.config`), not how the CP itself is installed.
+
+## Arbitrary Image Push
+
+`neutree-cli image push <image>` tags a local Docker image into the `ImageRegistry` resource
+named by `--image-registry` / `--workspace` and pushes it. The printed reference is what the
+platform will pull, which makes it usable verbatim as an engine `image` override (the flex
+engine's `engine_args.image`). Credentials come from the registry's stored auth via the
+`credentials/image_registries` endpoint (`image_registry:read-credentials`), with
+`--registry-username` / `--registry-password` as the fallback for keys that lack the permission.
+
+The target reference uses `util.RelocateImageRef`, **not** the `util.RewriteImageRef` the
+orchestrators render pull specs with. The two agree except on Docker Hub prefixes: `RewriteImageRef`
+deliberately leaves a reference alone when the registry is Docker Hub (already pullable, no prefix
+needed), which on the push side would send the image to whatever registry the *source* reference
+names — a different host than the one whose credentials are in play. `RelocateImageRef` always
+applies the prefix; `RewriteImageRef` is now the Docker-Hub short-circuit in front of it.
+
+Implementation: `internal/cli/image/` (`push.go` workflow, `pusher.go` Docker primitives).
 
 ## Engine Package Import
 

--- a/contributing/architecture-neutree-cli.md
+++ b/contributing/architecture-neutree-cli.md
@@ -67,6 +67,13 @@ engine's `engine_args.image`). Credentials come from the registry's stored auth 
 `credentials/image_registries` endpoint (`image_registry:read-credentials`), with
 `--registry-username` / `--registry-password` as the fallback for keys that lack the permission.
 
+Neutree only requires a registry's stored credentials to grant **pull** — the account behind them
+may well be unable to push. That failure comes back from the registry as an opaque string, so
+`explainPushFailure` classifies it by which credentials were actually used (stored / flags /
+anonymous / unreadable) and names the thing to change: update the `ImageRegistry` resource, or pass
+`--registry-username` / `--registry-password`. Failures that are not authentication failures are
+returned untouched, so a missing local image is never misreported as a permission problem.
+
 The target reference uses `util.RelocateImageRef`, **not** the `util.RewriteImageRef` the
 orchestrators render pull specs with. The two agree except on Docker Hub prefixes: `RewriteImageRef`
 deliberately leaves a reference alone when the registry is Docker Hub (already pullable, no prefix

--- a/internal/cli/image/push.go
+++ b/internal/cli/image/push.go
@@ -72,9 +72,13 @@ func Push(ctx context.Context, lister RegistryLister, pusher ImagePusher, opts P
 		return "", errors.Wrapf(err, "failed to resolve image prefix for image registry %s", opts.Registry)
 	}
 
-	registryAuth, err := buildRegistryAuth(imageRegistry, host, opts)
+	registryAuth, credSource, err := buildRegistryAuth(imageRegistry, host, opts)
 	if err != nil {
 		return "", err
+	}
+
+	if credentialsDenied {
+		credSource = credentialsUnreadable
 	}
 
 	source := normalizeReference(opts.SourceImage)
@@ -98,14 +102,7 @@ func Push(ctx context.Context, lister RegistryLister, pusher ImagePusher, opts P
 	}
 
 	if err := pusher.TagAndPush(ctx, source, target, registryAuth); err != nil {
-		if credentialsDenied {
-			return "", errors.Wrapf(err,
-				"pushed anonymously because the credentials of image registry %s could not be read: the API key "+
-					"may lack the image_registry:read-credentials permission, pass --registry-username/--registry-password",
-				opts.Registry)
-		}
-
-		return "", err
+		return "", explainPushFailure(err, credSource, opts.Registry)
 	}
 
 	return target, nil
@@ -183,22 +180,104 @@ func getRegistry(lister RegistryLister, opts PushOptions, withCreds bool) (*v1.I
 	return &registries[0], nil
 }
 
+// credentialSource records where the push credentials came from, so that an
+// authentication failure can name the thing the user has to change.
+type credentialSource int
+
+const (
+	// credentialsFromRegistry: the registry resource's stored credentials.
+	credentialsFromRegistry credentialSource = iota
+	// credentialsFromFlags: --registry-username / --registry-password.
+	credentialsFromFlags
+	// credentialsAnonymous: the registry stores no credentials.
+	credentialsAnonymous
+	// credentialsUnreadable: the registry may store credentials, but this API
+	// key may not read them, so the push went out anonymously.
+	credentialsUnreadable
+)
+
 // buildRegistryAuth prefers explicit credentials over the stored ones. A
 // registry with neither is pushed to anonymously — the platform itself skips
 // docker login for those (see controllers/static_node_controller.go).
-func buildRegistryAuth(imageRegistry *v1.ImageRegistry, host string, opts PushOptions) (string, error) {
+func buildRegistryAuth(imageRegistry *v1.ImageRegistry, host string, opts PushOptions) (string, credentialSource, error) {
 	username, password := opts.Username, opts.Password
+	source := credentialsFromFlags
 
 	if username == "" {
 		var err error
 
 		username, password, err = util.GetImageRegistryAuthInfo(imageRegistry)
 		if err != nil {
-			return "", errors.Wrap(err, "failed to read image registry credentials")
+			return "", source, errors.Wrap(err, "failed to read image registry credentials")
+		}
+
+		source = credentialsFromRegistry
+		if username == "" {
+			source = credentialsAnonymous
 		}
 	}
 
-	return util.EncodeRegistryAuth(username, password, host)
+	auth, err := util.EncodeRegistryAuth(username, password, host)
+
+	return auth, source, err
+}
+
+// explainPushFailure attaches a hint to an authentication failure, naming what
+// the user has to change. Registry credentials in Neutree are only required to
+// grant pull, so a valid credential that cannot push is the expected failure,
+// not a corner case. Non-authentication failures (a missing local image, a
+// broken daemon) are returned untouched — a credential hint would misdirect.
+func explainPushFailure(err error, source credentialSource, registry string) error {
+	if !isAuthFailure(err) {
+		return err
+	}
+
+	switch source {
+	case credentialsUnreadable:
+		return errors.Wrapf(err,
+			"pushed anonymously because the credentials of image registry %s could not be read: the API key "+
+				"may lack the image_registry:read-credentials permission, pass --registry-username/--registry-password",
+			registry)
+	case credentialsFromRegistry:
+		return errors.Wrapf(err,
+			"the stored credentials of image registry %s were rejected: Neutree only requires them to grant pull, "+
+				"so update the registry with an account that may push, or pass --registry-username/--registry-password",
+			registry)
+	case credentialsAnonymous:
+		return errors.Wrapf(err,
+			"pushed anonymously because image registry %s stores no credentials: add credentials that may push to "+
+				"the registry, or pass --registry-username/--registry-password",
+			registry)
+	case credentialsFromFlags:
+		return errors.Wrapf(err,
+			"the credentials passed with --registry-username/--registry-password were rejected by image registry %s",
+			registry)
+	}
+
+	return err
+}
+
+// isAuthFailure reports whether err looks like a registry rejecting the
+// credentials. The Docker daemon surfaces these as opaque strings from the
+// registry's own response, so matching on text is the only option; the phrases
+// below are what Docker Registry v2 implementations (including Harbor) return.
+func isAuthFailure(err error) bool {
+	message := strings.ToLower(err.Error())
+
+	for _, phrase := range []string{
+		"denied",
+		"unauthorized",
+		"authentication required",
+		"no basic auth credentials",
+		"insufficient_scope",
+		"forbidden",
+	} {
+		if strings.Contains(message, phrase) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // normalizeReference appends the implicit :latest tag so the reported target is

--- a/internal/cli/image/push.go
+++ b/internal/cli/image/push.go
@@ -1,0 +1,217 @@
+package image
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/util"
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+// RegistryLister is the subset of client.ImageRegistriesService used here.
+type RegistryLister interface {
+	List(opts client.ImageRegistryListOptions) ([]v1.ImageRegistry, error)
+}
+
+// ImagePusher loads, tags and pushes images; implemented by Pusher.
+type ImagePusher interface {
+	LoadArchive(ctx context.Context, archivePath string) error
+	TagAndPush(ctx context.Context, source, target, registryAuth string) error
+}
+
+// PushOptions describes one `neutree-cli image push` invocation.
+type PushOptions struct {
+	// Workspace holds the image registry resource.
+	Workspace string
+
+	// Registry is the name of the Neutree image registry resource to push to.
+	Registry string
+
+	// SourceImage is the local image reference to push.
+	SourceImage string
+
+	// Target optionally overrides the repository[:tag] inside the target
+	// registry. It is resolved against the registry prefix just like
+	// SourceImage, so "myorg/app:v1" is enough.
+	Target string
+
+	// ArchivePath optionally points at a `docker save` tar to load before pushing.
+	ArchivePath string
+
+	// Username and Password override the credentials stored on the image
+	// registry resource. Both must be set together.
+	Username string
+	Password string
+}
+
+// Push loads (optionally), tags and pushes SourceImage into the Neutree-managed
+// image registry named by the options. The returned reference is the one the
+// platform can pull, i.e. the value to use in an engine `image` override.
+func Push(ctx context.Context, lister RegistryLister, pusher ImagePusher, opts PushOptions) (string, error) {
+	if err := opts.normalizeAndValidate(); err != nil {
+		return "", err
+	}
+
+	imageRegistry, credentialsDenied, err := resolveRegistry(lister, opts)
+	if err != nil {
+		return "", err
+	}
+
+	host, err := util.GetImageRegistryHost(imageRegistry)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to resolve host of image registry %s", opts.Registry)
+	}
+
+	prefix, err := util.BuildImagePrefix(host, imageRegistry.Spec.Repository)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to resolve image prefix for image registry %s", opts.Registry)
+	}
+
+	registryAuth, err := buildRegistryAuth(imageRegistry, host, opts)
+	if err != nil {
+		return "", err
+	}
+
+	source := normalizeReference(opts.SourceImage)
+
+	desired := source
+	if opts.Target != "" {
+		desired = normalizeReference(opts.Target)
+	}
+
+	// Validate before loading, so a bad --target fails in milliseconds rather
+	// than after a multi-gigabyte archive import.
+	target := util.RelocateImageRef(prefix, desired)
+	if _, err := name.ParseReference(target); err != nil {
+		return "", errors.Wrapf(err, "resolved target image reference %q is not valid", target)
+	}
+
+	if opts.ArchivePath != "" {
+		if err := pusher.LoadArchive(ctx, opts.ArchivePath); err != nil {
+			return "", err
+		}
+	}
+
+	if err := pusher.TagAndPush(ctx, source, target, registryAuth); err != nil {
+		if credentialsDenied {
+			return "", errors.Wrapf(err,
+				"pushed anonymously because the credentials of image registry %s could not be read: the API key "+
+					"may lack the image_registry:read-credentials permission, pass --registry-username/--registry-password",
+				opts.Registry)
+		}
+
+		return "", err
+	}
+
+	return target, nil
+}
+
+// normalizeAndValidate trims the identifier-like fields so validation and
+// execution agree on the values — `--image-registry "default "` resolves rather
+// than 404s. Credentials and paths are left alone: whitespace can be meaningful
+// in a password or a filename.
+func (o *PushOptions) normalizeAndValidate() error {
+	o.Workspace = strings.TrimSpace(o.Workspace)
+	o.Registry = strings.TrimSpace(o.Registry)
+	o.SourceImage = strings.TrimSpace(o.SourceImage)
+	o.Target = strings.TrimSpace(o.Target)
+
+	if o.SourceImage == "" {
+		return errors.New("image reference is required")
+	}
+
+	if o.Registry == "" {
+		return errors.New("image registry name is required")
+	}
+
+	if (o.Username == "") != (o.Password == "") {
+		return errors.New("--registry-username and --registry-password must be set together")
+	}
+
+	return nil
+}
+
+// resolveRegistry reads the image registry, preferring the credentialed view.
+// It reports whether the credentials were denied, so the caller can explain a
+// later authentication failure. Errors other than "this key may not read
+// credentials" are returned as is, so a real outage is never silently
+// downgraded to an anonymous push.
+func resolveRegistry(lister RegistryLister, opts PushOptions) (*v1.ImageRegistry, bool, error) {
+	// Explicit credentials win over the stored ones, so do not fetch a secret
+	// that would only be discarded.
+	if opts.Username != "" {
+		imageRegistry, err := getRegistry(lister, opts, false)
+		return imageRegistry, false, err
+	}
+
+	imageRegistry, err := getRegistry(lister, opts, true)
+	if err == nil {
+		return imageRegistry, false, nil
+	}
+
+	// 401/403: the key may not read credentials. 404: this control plane has no
+	// credentials endpoint. Both are recoverable through the masked read.
+	if !client.HasStatus(err, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound) {
+		return nil, false, err
+	}
+
+	imageRegistry, err = getRegistry(lister, opts, false)
+
+	return imageRegistry, err == nil, err
+}
+
+func getRegistry(lister RegistryLister, opts PushOptions, withCreds bool) (*v1.ImageRegistry, error) {
+	// The server filters by name and workspace, so this returns 0 or 1 element.
+	registries, err := lister.List(client.ImageRegistryListOptions{
+		Workspace: opts.Workspace,
+		Name:      opts.Registry,
+		WithCreds: withCreds,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get image registry %s", opts.Registry)
+	}
+
+	if len(registries) == 0 {
+		return nil, errors.Errorf("image registry %s not found in workspace %s", opts.Registry, opts.Workspace)
+	}
+
+	return &registries[0], nil
+}
+
+// buildRegistryAuth prefers explicit credentials over the stored ones. A
+// registry with neither is pushed to anonymously — the platform itself skips
+// docker login for those (see controllers/static_node_controller.go).
+func buildRegistryAuth(imageRegistry *v1.ImageRegistry, host string, opts PushOptions) (string, error) {
+	username, password := opts.Username, opts.Password
+
+	if username == "" {
+		var err error
+
+		username, password, err = util.GetImageRegistryAuthInfo(imageRegistry)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to read image registry credentials")
+		}
+	}
+
+	return util.EncodeRegistryAuth(username, password, host)
+}
+
+// normalizeReference appends the implicit :latest tag so the reported target is
+// unambiguous. Digest references and already-tagged references are untouched.
+func normalizeReference(ref string) string {
+	if strings.Contains(ref, "@") {
+		return ref
+	}
+
+	lastSlash := strings.LastIndex(ref, "/")
+	if strings.Contains(ref[lastSlash+1:], ":") {
+		return ref
+	}
+
+	return ref + ":latest"
+}

--- a/internal/cli/image/push_test.go
+++ b/internal/cli/image/push_test.go
@@ -325,6 +325,68 @@ func TestPushAnonymousFailureHintsAtCredentialsOnlyAfterFallback(t *testing.T) {
 	assert.Contains(t, err.Error(), "unauthorized")
 }
 
+// The credentials Neutree stores are only required to grant pull, so a
+// pull-only account failing to push is the expected failure and has to name the
+// registry resource the user must update.
+func TestPushHintsAtPullOnlyStoredCredentials(t *testing.T) {
+	for _, denial := range []string{
+		"denied: requested access to the resource is denied",
+		"unauthorized: authentication required",
+		"insufficient_scope: authorization failed",
+	} {
+		t.Run(denial, func(t *testing.T) {
+			lister := &fakeLister{withCreds: []v1.ImageRegistry{credentialedRegistry()}}
+			pusher := &fakePusher{pushErr: errors.New(denial)}
+
+			_, err := Push(context.Background(), lister, pusher, baseOptions())
+			require.Error(t, err)
+
+			require.Len(t, pusher.pushed, 1)
+			assert.Equal(t, expectedAuth(t), pusher.pushed[0].auth, "the stored credentials were used")
+			assert.Contains(t, err.Error(), "stored credentials of image registry default were rejected")
+			assert.Contains(t, err.Error(), "--registry-username/--registry-password")
+			assert.Contains(t, err.Error(), denial, "the registry's own message stays visible")
+			assert.NotContains(t, err.Error(), "image_registry:read-credentials",
+				"credentials that were read fine must not be blamed on API key permissions")
+		})
+	}
+}
+
+// A hint pointing at credentials would misdirect when the failure has nothing
+// to do with them.
+func TestPushDoesNotHintAtCredentialsForOtherFailures(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{credentialedRegistry()}}
+	pusher := &fakePusher{pushErr: errors.New("failed to tag my-workload:v1 (is the image present in the local Docker daemon?)")}
+
+	_, err := Push(context.Background(), lister, pusher, baseOptions())
+	require.Error(t, err)
+	assert.Equal(t, pusher.pushErr.Error(), err.Error(), "the error is returned untouched")
+}
+
+func TestPushHintsAtMissingCredentialsWhenAnonymous(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{maskedRegistry()}}
+	pusher := &fakePusher{pushErr: errors.New("no basic auth credentials")}
+
+	_, err := Push(context.Background(), lister, pusher, baseOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image registry default stores no credentials")
+}
+
+func TestPushHintsAtRejectedFlagCredentials(t *testing.T) {
+	lister := &fakeLister{masked: []v1.ImageRegistry{maskedRegistry()}}
+	pusher := &fakePusher{pushErr: errors.New("denied: requested access to the resource is denied")}
+
+	opts := baseOptions()
+	opts.Username = "user"
+	opts.Password = "pass"
+
+	_, err := Push(context.Background(), lister, pusher, opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--registry-username/--registry-password were rejected")
+	assert.NotContains(t, err.Error(), "stored credentials",
+		"explicit flags win over the stored credentials, so the stored ones cannot be at fault")
+}
+
 func TestPushLoadsArchiveBeforePushing(t *testing.T) {
 	lister := &fakeLister{withCreds: []v1.ImageRegistry{credentialedRegistry()}}
 	pusher := &fakePusher{}

--- a/internal/cli/image/push_test.go
+++ b/internal/cli/image/push_test.go
@@ -1,0 +1,430 @@
+package image
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/util"
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+const testRegistryHost = "registry.example.com"
+
+type fakeLister struct {
+	withCreds    []v1.ImageRegistry
+	withCredsErr error
+	masked       []v1.ImageRegistry
+	maskedErr    error
+
+	calls []client.ImageRegistryListOptions
+}
+
+func (f *fakeLister) List(opts client.ImageRegistryListOptions) ([]v1.ImageRegistry, error) {
+	f.calls = append(f.calls, opts)
+
+	if opts.WithCreds {
+		return f.withCreds, f.withCredsErr
+	}
+
+	return f.masked, f.maskedErr
+}
+
+type pushCall struct {
+	source string
+	target string
+	auth   string
+}
+
+type fakePusher struct {
+	loaded  []string
+	pushed  []pushCall
+	loadErr error
+	pushErr error
+}
+
+func (f *fakePusher) LoadArchive(_ context.Context, archivePath string) error {
+	f.loaded = append(f.loaded, archivePath)
+	return f.loadErr
+}
+
+func (f *fakePusher) TagAndPush(_ context.Context, source, target, registryAuth string) error {
+	f.pushed = append(f.pushed, pushCall{source: source, target: target, auth: registryAuth})
+	return f.pushErr
+}
+
+func testRegistry(url, repository string, auth v1.ImageRegistryAuthConfig) v1.ImageRegistry {
+	return v1.ImageRegistry{
+		Metadata: &v1.Metadata{Name: "default", Workspace: "default"},
+		Spec: &v1.ImageRegistrySpec{
+			URL:        url,
+			Repository: repository,
+			AuthConfig: auth,
+		},
+	}
+}
+
+func credentialedRegistry() v1.ImageRegistry {
+	return testRegistry(testRegistryHost, "neutree", v1.ImageRegistryAuthConfig{
+		Username: "user",
+		Password: "pass",
+	})
+}
+
+func maskedRegistry() v1.ImageRegistry {
+	return testRegistry(testRegistryHost, "neutree", v1.ImageRegistryAuthConfig{})
+}
+
+func apiError(status int) error {
+	return &client.APIError{Expected: []int{http.StatusOK}, StatusCode: status, Body: "denied"}
+}
+
+// expectedAuth is the blob the production code builds for the shared test credentials.
+func expectedAuth(t *testing.T) string {
+	t.Helper()
+
+	auth, err := util.EncodeRegistryAuth("user", "pass", testRegistryHost)
+	require.NoError(t, err)
+
+	return auth
+}
+
+func baseOptions() PushOptions {
+	return PushOptions{Workspace: "default", Registry: "default", SourceImage: "my-workload:v1"}
+}
+
+const digest = "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestPushTargetReference(t *testing.T) {
+	tests := []struct {
+		name           string
+		url            string
+		repository     string
+		source         string
+		target         string
+		expectedSource string
+		expectedTarget string
+	}{
+		{
+			name:           "bare image gets registry and project prefix",
+			url:            "https://" + testRegistryHost,
+			repository:     "neutree",
+			source:         "my-workload:v1",
+			expectedSource: "my-workload:v1",
+			expectedTarget: testRegistryHost + "/neutree/my-workload:v1",
+		},
+		{
+			name:           "untagged image is normalized to latest",
+			url:            testRegistryHost,
+			repository:     "neutree",
+			source:         "my-workload",
+			expectedSource: "my-workload:latest",
+			expectedTarget: testRegistryHost + "/neutree/my-workload:latest",
+		},
+		{
+			name:           "source registry host is replaced",
+			url:            testRegistryHost,
+			repository:     "neutree",
+			source:         "ghcr.io/acme/my-workload:v1",
+			expectedSource: "ghcr.io/acme/my-workload:v1",
+			expectedTarget: testRegistryHost + "/neutree/acme/my-workload:v1",
+		},
+		{
+			name:           "registry without project",
+			url:            testRegistryHost + ":5000",
+			source:         "my-workload:v1",
+			expectedSource: "my-workload:v1",
+			expectedTarget: testRegistryHost + ":5000/my-workload:v1",
+		},
+		{
+			name:           "target overrides the repository path",
+			url:            testRegistryHost,
+			repository:     "neutree",
+			source:         "my-workload:v1",
+			target:         "team-a/renamed:v2",
+			expectedSource: "my-workload:v1",
+			expectedTarget: testRegistryHost + "/neutree/team-a/renamed:v2",
+		},
+		{
+			name:           "image already in the target registry is pushed as is",
+			url:            testRegistryHost,
+			repository:     "neutree",
+			source:         testRegistryHost + "/neutree/my-workload:v1",
+			expectedSource: testRegistryHost + "/neutree/my-workload:v1",
+			expectedTarget: testRegistryHost + "/neutree/my-workload:v1",
+		},
+		{
+			// The pull-side rewrite skips Docker Hub prefixes; a push must not,
+			// or the image lands on the source registry with another registry's
+			// credentials in hand.
+			name:           "docker hub registry still receives the prefix",
+			url:            "docker.io",
+			repository:     "myorg",
+			source:         "ghcr.io/acme/tiny:v1",
+			expectedSource: "ghcr.io/acme/tiny:v1",
+			expectedTarget: "docker.io/myorg/acme/tiny:v1",
+		},
+		{
+			name:           "digest reference is preserved",
+			url:            testRegistryHost,
+			repository:     "neutree",
+			source:         "my-workload" + digest,
+			expectedSource: "my-workload" + digest,
+			expectedTarget: testRegistryHost + "/neutree/my-workload" + digest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := testRegistry(tt.url, tt.repository, v1.ImageRegistryAuthConfig{Username: "user", Password: "pass"})
+			lister := &fakeLister{withCreds: []v1.ImageRegistry{reg}}
+			pusher := &fakePusher{}
+
+			opts := baseOptions()
+			opts.SourceImage = tt.source
+			opts.Target = tt.target
+
+			target, err := Push(context.Background(), lister, pusher, opts)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedTarget, target)
+			require.Len(t, pusher.pushed, 1)
+			assert.Equal(t, tt.expectedSource, pusher.pushed[0].source)
+			assert.Equal(t, tt.expectedTarget, pusher.pushed[0].target)
+		})
+	}
+}
+
+func TestPushUsesRegistryCredentials(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{credentialedRegistry()}}
+	pusher := &fakePusher{}
+
+	_, err := Push(context.Background(), lister, pusher, baseOptions())
+	require.NoError(t, err)
+
+	require.Len(t, pusher.pushed, 1)
+	assert.Equal(t, expectedAuth(t), pusher.pushed[0].auth)
+	require.Len(t, lister.calls, 1)
+	assert.True(t, lister.calls[0].WithCreds)
+}
+
+func TestPushDecodesAuthField(t *testing.T) {
+	reg := testRegistry(testRegistryHost, "neutree", v1.ImageRegistryAuthConfig{
+		Auth: base64.StdEncoding.EncodeToString([]byte("user:pass")),
+	})
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{reg}}
+	pusher := &fakePusher{}
+
+	_, err := Push(context.Background(), lister, pusher, baseOptions())
+	require.NoError(t, err)
+
+	require.Len(t, pusher.pushed, 1)
+	assert.Equal(t, expectedAuth(t), pusher.pushed[0].auth)
+}
+
+func TestPushSkipsCredentialsFetchWhenFlagsGiven(t *testing.T) {
+	lister := &fakeLister{masked: []v1.ImageRegistry{maskedRegistry()}}
+	pusher := &fakePusher{}
+
+	opts := baseOptions()
+	opts.Username = "user"
+	opts.Password = "pass"
+
+	_, err := Push(context.Background(), lister, pusher, opts)
+	require.NoError(t, err)
+
+	require.Len(t, lister.calls, 1, "explicit credentials must not fetch the stored secret")
+	assert.False(t, lister.calls[0].WithCreds)
+	require.Len(t, pusher.pushed, 1)
+	assert.Equal(t, expectedAuth(t), pusher.pushed[0].auth)
+}
+
+func TestPushTrimsIdentifierOptions(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{credentialedRegistry()}}
+	pusher := &fakePusher{}
+
+	target, err := Push(context.Background(), lister, pusher, PushOptions{
+		Workspace:   " default ",
+		Registry:    " default ",
+		SourceImage: " my-workload:v1 ",
+		Target:      "   ",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, testRegistryHost+"/neutree/my-workload:v1", target)
+	require.Len(t, lister.calls, 1)
+	assert.Equal(t, "default", lister.calls[0].Workspace)
+	assert.Equal(t, "default", lister.calls[0].Name)
+}
+
+func TestPushDoesNotFallBackOnServerError(t *testing.T) {
+	lister := &fakeLister{
+		withCredsErr: apiError(http.StatusInternalServerError),
+		masked:       []v1.ImageRegistry{maskedRegistry()},
+	}
+	pusher := &fakePusher{}
+
+	_, err := Push(context.Background(), lister, pusher, baseOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Len(t, lister.calls, 1, "must not retry against the masked endpoint")
+	assert.Empty(t, pusher.pushed)
+}
+
+func TestPushFallsBackOnCredentialPermissionErrors(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			lister := &fakeLister{
+				withCredsErr: apiError(status),
+				masked:       []v1.ImageRegistry{maskedRegistry()},
+			}
+			pusher := &fakePusher{}
+
+			target, err := Push(context.Background(), lister, pusher, baseOptions())
+			require.NoError(t, err)
+
+			assert.Equal(t, testRegistryHost+"/neutree/my-workload:v1", target)
+			require.Len(t, lister.calls, 2)
+			assert.True(t, lister.calls[0].WithCreds)
+			assert.False(t, lister.calls[1].WithCreds)
+			require.Len(t, pusher.pushed, 1)
+			assert.Empty(t, pusher.pushed[0].auth, "masked read exposes no credentials")
+		})
+	}
+}
+
+func TestPushAnonymouslyWhenRegistryHasNoCredentials(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{maskedRegistry()}}
+	pusher := &fakePusher{pushErr: errors.New("no basic auth credentials")}
+
+	_, err := Push(context.Background(), lister, pusher, baseOptions())
+	require.Error(t, err)
+
+	require.Len(t, pusher.pushed, 1)
+	assert.Empty(t, pusher.pushed[0].auth)
+	assert.NotContains(t, err.Error(), "read-credentials",
+		"a registry that simply stores no credentials must not be blamed on API key permissions")
+}
+
+func TestPushAnonymousFailureHintsAtCredentialsOnlyAfterFallback(t *testing.T) {
+	lister := &fakeLister{
+		withCredsErr: apiError(http.StatusForbidden),
+		masked:       []v1.ImageRegistry{maskedRegistry()},
+	}
+	pusher := &fakePusher{pushErr: errors.New("unauthorized")}
+
+	_, err := Push(context.Background(), lister, pusher, baseOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image_registry:read-credentials")
+	assert.Contains(t, err.Error(), "unauthorized")
+}
+
+func TestPushLoadsArchiveBeforePushing(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{credentialedRegistry()}}
+	pusher := &fakePusher{}
+
+	opts := baseOptions()
+	opts.ArchivePath = "/tmp/my-workload.tar"
+
+	_, err := Push(context.Background(), lister, pusher, opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"/tmp/my-workload.tar"}, pusher.loaded)
+	assert.Len(t, pusher.pushed, 1)
+}
+
+func TestPushArchiveLoadFailureSkipsPush(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{credentialedRegistry()}}
+	pusher := &fakePusher{loadErr: errors.New("bad archive")}
+
+	opts := baseOptions()
+	opts.ArchivePath = "/tmp/broken.tar"
+
+	_, err := Push(context.Background(), lister, pusher, opts)
+	require.Error(t, err)
+	assert.Empty(t, pusher.pushed)
+}
+
+func TestPushInvalidTargetFailsBeforeLoadingArchive(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{credentialedRegistry()}}
+	pusher := &fakePusher{}
+
+	opts := baseOptions()
+	opts.Target = "NOT A REFERENCE"
+	opts.ArchivePath = "/tmp/my-workload.tar"
+
+	_, err := Push(context.Background(), lister, pusher, opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not valid")
+	assert.Empty(t, pusher.loaded, "a bad reference must not cost a multi-gigabyte archive load")
+	assert.Empty(t, pusher.pushed)
+}
+
+func TestPushRegistryNotFound(t *testing.T) {
+	lister := &fakeLister{withCreds: []v1.ImageRegistry{}, masked: []v1.ImageRegistry{}}
+	pusher := &fakePusher{}
+
+	_, err := Push(context.Background(), lister, pusher, baseOptions())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in workspace default")
+}
+
+func TestPushValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*PushOptions)
+		wantErr string
+	}{
+		{
+			name:    "missing image",
+			mutate:  func(o *PushOptions) { o.SourceImage = "  " },
+			wantErr: "image reference is required",
+		},
+		{
+			name:    "missing registry",
+			mutate:  func(o *PushOptions) { o.Registry = "" },
+			wantErr: "image registry name is required",
+		},
+		{
+			name:    "username without password",
+			mutate:  func(o *PushOptions) { o.Username = "user" },
+			wantErr: "must be set together",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := baseOptions()
+			tt.mutate(&opts)
+
+			_, err := Push(context.Background(), &fakeLister{}, &fakePusher{}, opts)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestNormalizeReference(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected string
+	}{
+		{"my-workload", "my-workload:latest"},
+		{"my-workload:v1", "my-workload:v1"},
+		{"ghcr.io/acme/my-workload", "ghcr.io/acme/my-workload:latest"},
+		{"registry:5000/acme/my-workload", "registry:5000/acme/my-workload:latest"},
+		{"registry:5000/acme/my-workload:v1", "registry:5000/acme/my-workload:v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeReference(tt.in))
+		})
+	}
+}

--- a/internal/cli/image/pusher.go
+++ b/internal/cli/image/pusher.go
@@ -1,0 +1,82 @@
+// Package image implements pushing arbitrary container images into a
+// Neutree-managed image registry, so that engine `image` overrides (e.g. the
+// flex engine) can reference workload images the platform can actually pull.
+package image
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/pkg/errors"
+)
+
+// dockerAPI is the subset of the Docker client used by Pusher.
+type dockerAPI interface {
+	ImageLoad(ctx context.Context, input io.Reader, opts ...client.ImageLoadOption) (image.LoadResponse, error)
+	ImageTag(ctx context.Context, source, target string) error
+	ImagePush(ctx context.Context, ref string, options image.PushOptions) (io.ReadCloser, error)
+}
+
+// Pusher tags and pushes images that are present in the local Docker daemon.
+type Pusher struct {
+	docker dockerAPI
+	out    io.Writer
+}
+
+// NewPusher creates a Pusher backed by the Docker daemon configured in the
+// environment (DOCKER_HOST and friends). Progress is streamed to out.
+func NewPusher(out io.Writer) (*Pusher, error) {
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Docker client")
+	}
+
+	if out == nil {
+		out = io.Discard
+	}
+
+	return &Pusher{docker: dockerClient, out: out}, nil
+}
+
+// LoadArchive loads a `docker save` tar archive into the local daemon.
+func (p *Pusher) LoadArchive(ctx context.Context, archivePath string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open image archive: %s", archivePath)
+	}
+	defer file.Close()
+
+	resp, err := p.docker.ImageLoad(ctx, file)
+	if err != nil {
+		return errors.Wrapf(err, "docker load failed for %s", archivePath)
+	}
+	defer resp.Body.Close()
+
+	return errors.Wrapf(p.display(resp.Body), "failed to display load progress for %s", archivePath)
+}
+
+// TagAndPush tags source as target and pushes target using registryAuth, the
+// base64-encoded Docker auth blob produced by EncodeRegistryAuth.
+func (p *Pusher) TagAndPush(ctx context.Context, source, target, registryAuth string) error {
+	if err := p.docker.ImageTag(ctx, source, target); err != nil {
+		return errors.Wrapf(err,
+			"failed to tag %s as %s (is the image present in the local Docker daemon? try `docker pull %s` or --archive)",
+			source, target, source)
+	}
+
+	resp, err := p.docker.ImagePush(ctx, target, image.PushOptions{RegistryAuth: registryAuth})
+	if err != nil {
+		return errors.Wrapf(err, "docker push failed for %s", target)
+	}
+	defer resp.Close()
+
+	return errors.Wrapf(p.display(resp), "failed to display push progress for %s", target)
+}
+
+func (p *Pusher) display(body io.Reader) error {
+	return jsonmessage.DisplayJSONMessagesStream(body, p.out, 0, false, nil)
+}

--- a/internal/cli/image/pusher_test.go
+++ b/internal/cli/image/pusher_test.go
@@ -1,0 +1,120 @@
+package image
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tagCall struct {
+	source string
+	target string
+}
+
+type fakeDocker struct {
+	loadBody    string
+	loadErr     error
+	loadedBytes []byte
+
+	tagCalls []tagCall
+	tagErr   error
+
+	pushRef     string
+	pushOptions image.PushOptions
+	pushBody    string
+	pushErr     error
+}
+
+func (f *fakeDocker) ImageLoad(_ context.Context, input io.Reader, _ ...client.ImageLoadOption) (image.LoadResponse, error) {
+	if f.loadErr != nil {
+		return image.LoadResponse{}, f.loadErr
+	}
+
+	loaded, err := io.ReadAll(input)
+	if err != nil {
+		return image.LoadResponse{}, err
+	}
+
+	f.loadedBytes = loaded
+
+	return image.LoadResponse{Body: io.NopCloser(bytes.NewBufferString(f.loadBody))}, nil
+}
+
+func (f *fakeDocker) ImageTag(_ context.Context, source, target string) error {
+	f.tagCalls = append(f.tagCalls, tagCall{source: source, target: target})
+	return f.tagErr
+}
+
+func (f *fakeDocker) ImagePush(_ context.Context, ref string, options image.PushOptions) (io.ReadCloser, error) {
+	f.pushRef = ref
+	f.pushOptions = options
+
+	if f.pushErr != nil {
+		return nil, f.pushErr
+	}
+
+	return io.NopCloser(bytes.NewBufferString(f.pushBody)), nil
+}
+
+func TestLoadArchive(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "image.tar")
+	require.NoError(t, os.WriteFile(archive, []byte("tarball"), 0o600))
+
+	out := &bytes.Buffer{}
+	docker := &fakeDocker{loadBody: `{"stream":"Loaded image: my-workload:v1\n"}`}
+	pusher := &Pusher{docker: docker, out: out}
+
+	require.NoError(t, pusher.LoadArchive(context.Background(), archive))
+	assert.Equal(t, []byte("tarball"), docker.loadedBytes, "the archive must reach the daemon")
+	assert.Contains(t, out.String(), "Loaded image: my-workload:v1")
+}
+
+func TestLoadArchiveMissingFile(t *testing.T) {
+	pusher := &Pusher{docker: &fakeDocker{}, out: io.Discard}
+
+	err := pusher.LoadArchive(context.Background(), filepath.Join(t.TempDir(), "missing.tar"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open image archive")
+}
+
+func TestTagAndPush(t *testing.T) {
+	out := &bytes.Buffer{}
+	docker := &fakeDocker{pushBody: `{"status":"Pushed"}`}
+	pusher := &Pusher{docker: docker, out: out}
+
+	err := pusher.TagAndPush(context.Background(), "my-workload:v1", "registry.example.com/neutree/my-workload:v1", "auth-blob")
+	require.NoError(t, err)
+
+	assert.Equal(t, []tagCall{{source: "my-workload:v1", target: "registry.example.com/neutree/my-workload:v1"}}, docker.tagCalls)
+	assert.Equal(t, "registry.example.com/neutree/my-workload:v1", docker.pushRef)
+	assert.Equal(t, "auth-blob", docker.pushOptions.RegistryAuth)
+	assert.Contains(t, out.String(), "Pushed")
+}
+
+func TestTagAndPushMissingLocalImage(t *testing.T) {
+	docker := &fakeDocker{tagErr: errors.New("No such image")}
+	pusher := &Pusher{docker: docker, out: io.Discard}
+
+	err := pusher.TagAndPush(context.Background(), "my-workload:v1", "registry.example.com/my-workload:v1", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is the image present in the local Docker daemon?")
+	assert.Empty(t, docker.pushRef)
+}
+
+func TestTagAndPushReportsRegistryError(t *testing.T) {
+	docker := &fakeDocker{pushBody: `{"errorDetail":{"message":"unauthorized"},"error":"unauthorized"}`}
+	pusher := &Pusher{docker: docker, out: io.Discard}
+
+	err := pusher.TagAndPush(context.Background(), "my-workload:v1", "registry.example.com/my-workload:v1", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthorized")
+}

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -2,15 +2,12 @@ package packageimport
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/api/types/registry"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 
@@ -231,20 +228,11 @@ func (i *Importer) pushImages(ctx context.Context, opts *ImportOptions, manifest
 		return []string{}, nil
 	}
 
-	user, token := opts.RegistryUser, opts.RegistryPassword
-
-	authConfig := registry.AuthConfig{
-		Username:      user,
-		Password:      token,
-		ServerAddress: util.StripRegistryScheme(opts.MirrorRegistry),
-	}
-
-	authConfigBytes, err := json.Marshal(authConfig)
+	registryAuth, err := util.EncodeRegistryAuth(opts.RegistryUser, opts.RegistryPassword,
+		util.StripRegistryScheme(opts.MirrorRegistry))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal auth config")
+		return nil, err
 	}
-
-	registryAuth := base64.URLEncoding.EncodeToString(authConfigBytes)
 
 	imagePrefix, err := util.BuildImagePrefix(opts.MirrorRegistry, opts.RegistryProject)
 	if err != nil {

--- a/internal/util/image.go
+++ b/internal/util/image.go
@@ -47,13 +47,31 @@ func BuildEngineImageRef(imagePrefix string, engineImage *v1.EngineImage) string
 // RewriteImageRef rewrites image into imagePrefix while preserving the image
 // repository path and removing any source registry host. Docker Hub prefixes
 // leave image references unchanged.
+//
+// This is the pull-side rule: a reference that is already pullable from Docker
+// Hub needs no prefix. Use RelocateImageRef when choosing a push destination.
 func RewriteImageRef(imagePrefix, image string) string {
+	if IsDockerHubImagePrefix(imagePrefix) {
+		return image
+	}
+
+	return RelocateImageRef(imagePrefix, image)
+}
+
+// RelocateImageRef rewrites image into imagePrefix for a push, preserving the
+// repository path and removing any source registry host.
+//
+// Unlike RewriteImageRef it applies the prefix even when the prefix is Docker
+// Hub: a push must land in the registry the caller named. Skipping the prefix
+// there would push the image back to whatever registry the source reference
+// points at — a different host than the one whose credentials are in play.
+func RelocateImageRef(imagePrefix, image string) string {
 	if image == "" {
 		return ""
 	}
 
 	imagePrefix = strings.TrimRight(strings.TrimSpace(imagePrefix), "/")
-	if imagePrefix == "" || IsDockerHubImagePrefix(imagePrefix) || strings.HasPrefix(image, imagePrefix+"/") {
+	if imagePrefix == "" || strings.HasPrefix(image, imagePrefix+"/") {
 		return image
 	}
 

--- a/internal/util/image_registry.go
+++ b/internal/util/image_registry.go
@@ -2,10 +2,12 @@ package util
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"net/url"
 	"regexp"
 	"strings"
 
+	"github.com/docker/docker/api/types/registry"
 	"github.com/pkg/errors"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
@@ -47,6 +49,26 @@ func GetImageRegistryAuthInfo(r *v1.ImageRegistry) (string, string, error) {
 	}
 
 	return "", "", nil
+}
+
+// EncodeRegistryAuth builds the base64-encoded Docker auth blob expected by the
+// Docker client's RegistryAuth push option. An empty username yields an empty
+// blob, i.e. an anonymous push.
+func EncodeRegistryAuth(username, password, serverAddress string) (string, error) {
+	if username == "" {
+		return "", nil
+	}
+
+	authConfigBytes, err := json.Marshal(registry.AuthConfig{
+		Username:      username,
+		Password:      password,
+		ServerAddress: serverAddress,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal registry auth config")
+	}
+
+	return base64.URLEncoding.EncodeToString(authConfigBytes), nil
 }
 
 // parseRegistryHost normalizes a registry URL by stripping any scheme and

--- a/internal/util/image_test.go
+++ b/internal/util/image_test.go
@@ -166,6 +166,66 @@ func TestRewriteImageRef(t *testing.T) {
 	}
 }
 
+func TestRelocateImageRef(t *testing.T) {
+	tests := []struct {
+		name        string
+		imagePrefix string
+		image       string
+		expected    string
+	}{
+		{
+			name:        "source registry is replaced by the target prefix",
+			imagePrefix: "registry.example.com/neutree-ai",
+			image:       "docker.io/neutree/neutree-node-agent:v1.2.0",
+			expected:    "registry.example.com/neutree-ai/neutree/neutree-node-agent:v1.2.0",
+		},
+		{
+			name:        "image without source registry keeps repository path",
+			imagePrefix: "registry.example.com/neutree-ai",
+			image:       "neutree/neutree-node-agent:v1.2.0",
+			expected:    "registry.example.com/neutree-ai/neutree/neutree-node-agent:v1.2.0",
+		},
+		{
+			name:        "already relocated image is unchanged",
+			imagePrefix: "registry.example.com/neutree-ai",
+			image:       "registry.example.com/neutree-ai/neutree/neutree-node-agent:v1.2.0",
+			expected:    "registry.example.com/neutree-ai/neutree/neutree-node-agent:v1.2.0",
+		},
+		{
+			// The pull-side RewriteImageRef leaves these alone; a push must not,
+			// or the image lands on the source registry instead of the target.
+			name:        "docker hub prefix still relocates an unqualified image",
+			imagePrefix: "docker.io/neutree-ai",
+			image:       "my-workload:v1",
+			expected:    "docker.io/neutree-ai/my-workload:v1",
+		},
+		{
+			name:        "docker hub prefix still replaces a foreign source registry",
+			imagePrefix: "docker.io/neutree-ai",
+			image:       "ghcr.io/acme/my-workload:v1",
+			expected:    "docker.io/neutree-ai/acme/my-workload:v1",
+		},
+		{
+			name:        "empty prefix leaves image unchanged",
+			imagePrefix: "",
+			image:       "docker.io/neutree/neutree-node-agent:v1.2.0",
+			expected:    "docker.io/neutree/neutree-node-agent:v1.2.0",
+		},
+		{
+			name:        "empty image stays empty",
+			imagePrefix: "registry.example.com/neutree-ai",
+			image:       "",
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, RelocateImageRef(tt.imagePrefix, tt.image))
+		})
+	}
+}
+
 func TestResolveEngineImage(t *testing.T) {
 	ev := &v1.EngineVersion{
 		Version: "v0.11.2",

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// APIError is returned when the API responds with an unexpected status code.
+// It preserves the status code so callers can branch on it — e.g. treat 403 on
+// the credentials endpoint as "credentials not available" rather than a hard
+// failure — via HasStatus, without matching on the message text.
+type APIError struct {
+	StatusCode int
+	Body       string
+
+	// Expected lists the status codes the caller accepted.
+	Expected []int
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("server returned non-%s status: %d, body: %s",
+		joinStatuses(e.Expected), e.StatusCode, e.Body)
+}
+
+// expectStatus returns an *APIError unless resp carries one of the allowed
+// status codes, draining the body into the error so callers can report it.
+func expectStatus(resp *http.Response, allowed ...int) error {
+	for _, code := range allowed {
+		if resp.StatusCode == code {
+			return nil
+		}
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+
+	return &APIError{StatusCode: resp.StatusCode, Body: string(body), Expected: allowed}
+}
+
+// HasStatus reports whether err is an *APIError carrying one of codes. It lets
+// callers act on the transport status without knowing how errors are formatted.
+func HasStatus(err error, codes ...int) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+
+	for _, code := range codes {
+		if apiErr.StatusCode == code {
+			return true
+		}
+	}
+
+	return false
+}
+
+func joinStatuses(codes []int) string {
+	parts := make([]string, 0, len(codes))
+	for _, code := range codes {
+		parts = append(parts, strconv.Itoa(code))
+	}
+
+	return strings.Join(parts, "/")
+}

--- a/pkg/client/resource.go
+++ b/pkg/client/resource.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 )
@@ -49,9 +48,8 @@ func (s *resourceService) list(params url.Values, result interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	if err := expectStatus(resp, http.StatusOK); err != nil {
+		return err
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
@@ -88,9 +86,8 @@ func (s *resourceService) get(workspace, name string, result interface{}) error 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	if err := expectStatus(resp, http.StatusOK); err != nil {
+		return err
 	}
 
 	// Decode into a slice first to check if resource exists
@@ -131,9 +128,8 @@ func (s *resourceService) create(data interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned non-200/201 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	if err := expectStatus(resp, http.StatusOK, http.StatusCreated); err != nil {
+		return err
 	}
 
 	return nil
@@ -168,9 +164,8 @@ func (s *resourceService) update(id string, data interface{}) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned non-200/204 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	if err := expectStatus(resp, http.StatusOK, http.StatusNoContent); err != nil {
+		return err
 	}
 
 	return nil
@@ -198,9 +193,8 @@ func (s *resourceService) delete(id string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned non-200/204 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	if err := expectStatus(resp, http.StatusOK, http.StatusNoContent); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Issue

NEU-604

## Summary

Adapting an arbitrary workload to Neutree (the flex engine plus a per-endpoint `image` override) requires the workload image to live somewhere the platform can pull from — i.e. the Neutree-managed image registry. Until now the only way to get an image in there was `neutree-cli import engine`, which is manifest-driven and meant for engine packages. This adds a direct `neutree-cli image push <image>`.

The important property is that the target reference is computed with `util.RelocateImageRef` — the helper both orchestrators render image references through — so the reference the command prints is exactly what the platform will pull, and can be pasted verbatim into an engine `image` override.

## Changes

- `neutree-cli image push <image>`: tags a local Docker image into the `ImageRegistry` resource selected by `--workspace` / `--image-registry` and pushes it, printing the resulting reference.
- Credentials resolve from the registry's stored auth via the `credentials/image_registries` endpoint (`image_registry:read-credentials`); API keys lacking that permission fall back to `--registry-username` / `--registry-password`. Registries with no stored credentials are pushed to anonymously, matching how `static_node_controller` treats them.
- A rejected push is explained by which credentials were actually used. Neutree only requires a registry's stored credentials to grant **pull**, so a pull-only account (the common Harbor setup) is an expected failure: instead of the registry's raw `denied: requested access to the resource is denied`, the command says the stored credentials of that registry were rejected and points at updating the `ImageRegistry` resource or passing `--registry-username` / `--registry-password`. The other three sources — explicit flags, anonymous, and credentials this API key may not read — each get their own message. Failures that are not authentication failures are returned untouched, so a missing local image is never misreported as a permission problem.
- `--archive` loads a `docker save` tar before pushing (offline flow); `--target` overrides the repository path inside the registry; untagged sources are normalized to `:latest` so the printed reference is unambiguous.
- Implementation under `internal/cli/image/` (`push.go` workflow, `pusher.go` Docker primitives) per the CLI boundary rule; `cmd/neutree-cli/app/cmd/image/` stays a thin Cobra shell.
- `contributing/architecture-neutree-cli.md` documents the new subcommand group.

## Test Plan

- [x] Unit: 26 cases in `internal/cli/image` covering reference derivation (bare name / untagged / foreign registry host / digest / already-in-target-registry / `--target`), all three credential paths, archive-before-push ordering, validation errors, and the four denial messages (including three real registry denial strings for the pull-only case, and a non-authentication failure that must stay untouched). `go test ./internal/cli/... ./cmd/neutree-cli/...` passes; `golangci-lint run` clean.
- [x] Manual E2E against a real v1.1.0-rc.1 control plane, pushing to a `registry:2` instance protected by htpasswd — anonymous access returns 401, so a successful push proves the stored credentials were fetched and used. 7 scenarios, every printed reference matched the blob's actual path in the registry catalog:

  | Scenario | Printed reference |
  |---|---|
  | bare name | `registry:2` → `127.0.0.1:15000/proj/registry:2` |
  | foreign registry host stripped | `ghcr.io/acme/tiny:v1` → `.../proj/acme/tiny:v1` |
  | `--target` override | → `.../proj/team-a/renamed:v9` |
  | untagged source | `my-workload` → `...:latest` |
  | image absent from daemon | fails with a `docker pull` / `--archive` hint |
  | `--archive` | pushed successfully |
  | no stored credentials + explicit flags | pushed successfully |

  The manual run predates the denial classification, which is covered by unit tests only — it was not re-run on hardware.

  Independent cross-check: the control plane's own connectivity probe for that registry rendered `127.0.0.1:15000/proj/neutree/neutree-serve` — the same prefix the CLI computed. All test artifacts were removed afterwards.
- [ ] E2E (if affected): not affected — no automated E2E suite covers `neutree-cli image`.
- [ ] DB integration (`make db-test`): not affected — no schema or migration changes.

## Risk & Rollback

Additive only: one new subcommand group and one new internal package. No DB schema change, no API change, no change to any existing code path (`cmd.go` only registers the new group). Nothing else calls `internal/cli/image`, so rollback is reverting the commit.

