### PR TITLE
fix: support explicit HTTP registries

### DIFF
--- a/controllers/image_registry_controller.go
+++ b/controllers/image_registry_controller.go
@@ -136,7 +136,11 @@ func (c *ImageRegistryController) connectImageRegistry(imageRegistry *v1.ImageRe
 		authenticator = authn.FromConfig(authConfig)
 	}
 
-	hasPermission, err := c.imageService.CheckPullPermission(testImage, authenticator)
+	hasPermission, err := c.imageService.CheckPullPermission(
+		testImage,
+		authenticator,
+		util.IsHTTPRegistryURL(imageRegistry.Spec.URL),
+	)
 	if err != nil {
 		return errors.Wrapf(err, "failed to connect %s at URL %s",
 			imageRegistry.Metadata.WorkspaceName(), imageRegistry.Spec.URL)

--- a/controllers/image_registry_controller_test.go
+++ b/controllers/image_registry_controller_test.go
@@ -20,6 +20,36 @@ func newTestImageRegistryController(storage *storagemocks.MockStorage, svc *regi
 	}
 }
 
+func TestImageRegistryControllerConnectImageRegistryPassesHTTPRegistryScheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		useHTTP bool
+	}{
+		{name: "explicit HTTP", url: "http://registry.example.com:5000", useHTTP: true},
+		{name: "explicit HTTPS", url: "https://registry.example.com:5000"},
+		{name: "URL without scheme", url: "registry.example.com:5000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			imageService := registrymocks.NewMockImageService(t)
+			imageService.
+				On("CheckPullPermission", "registry.example.com:5000/neutree/neutree-serve", mock.Anything, tt.useHTTP).
+				Return(true, nil)
+
+			controller := newTestImageRegistryController(storagemocks.NewMockStorage(t), imageService)
+			err := controller.connectImageRegistry(&v1.ImageRegistry{
+				Metadata: &v1.Metadata{Name: "test"},
+				Spec:     &v1.ImageRegistrySpec{URL: tt.url},
+			})
+
+			assert.NoError(t, err)
+			imageService.AssertExpectations(t)
+		})
+	}
+}
+
 func TestImageRegistryController_Sync_Delete(t *testing.T) {
 	now := time.Now().Format(time.RFC3339Nano)
 
@@ -125,7 +155,7 @@ func TestImageRegistryController_Sync_PendingOrNoStatus(t *testing.T) {
 			name:  "Pending/NoStatus -> Connected (check pull permission success)",
 			input: testImageRegistry(),
 			mockSetup: func(input *v1.ImageRegistry, s *storagemocks.MockStorage, imageSvc *registrymocks.MockImageService) {
-				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything, true).Run(func(args mock.Arguments) {
 					image := args.Get(0).(string)
 					assert.Equal(t, "test/neutree/neutree-serve", image)
 					arg := args.Get(1).(authn.Authenticator)
@@ -144,7 +174,7 @@ func TestImageRegistryController_Sync_PendingOrNoStatus(t *testing.T) {
 			name:  "Pending/NoStatus -> Failed (check pull permission failed)",
 			input: testImageRegistry(),
 			mockSetup: func(input *v1.ImageRegistry, s *storagemocks.MockStorage, imageSvc *registrymocks.MockImageService) {
-				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything, true).Run(func(args mock.Arguments) {
 					image := args.Get(0).(string)
 					assert.Equal(t, "test/neutree/neutree-serve", image)
 					arg := args.Get(1).(authn.Authenticator)
@@ -239,7 +269,7 @@ func TestImageRegistryController_Sync_Conneted(t *testing.T) {
 			name:  "Connected -> Connected (check pull permission success)",
 			input: testImageRegistry(),
 			mockSetup: func(input *v1.ImageRegistry, s *storagemocks.MockStorage, imageSvc *registrymocks.MockImageService) {
-				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything, true).Run(func(args mock.Arguments) {
 					image := args.Get(0).(string)
 					assert.Equal(t, "test/neutree/neutree-serve", image)
 					arg := args.Get(1).(authn.Authenticator)
@@ -254,7 +284,7 @@ func TestImageRegistryController_Sync_Conneted(t *testing.T) {
 			name:  "Connected -> Failed (check pull permission failed)",
 			input: testImageRegistry(),
 			mockSetup: func(input *v1.ImageRegistry, s *storagemocks.MockStorage, imageSvc *registrymocks.MockImageService) {
-				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything, true).Run(func(args mock.Arguments) {
 					image := args.Get(0).(string)
 					assert.Equal(t, "test/neutree/neutree-serve", image)
 					arg := args.Get(1).(authn.Authenticator)
@@ -351,7 +381,7 @@ func TestImageRegistryController_Sync_Failed(t *testing.T) {
 			name:  "Failed -> Connected (check pull permission success)",
 			input: testImageRegistry(),
 			mockSetup: func(input *v1.ImageRegistry, s *storagemocks.MockStorage, imageSvc *registrymocks.MockImageService) {
-				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything, true).Run(func(args mock.Arguments) {
 					image := args.Get(0).(string)
 					assert.Equal(t, "test/neutree/neutree-serve", image)
 					arg := args.Get(1).(authn.Authenticator)
@@ -370,7 +400,7 @@ func TestImageRegistryController_Sync_Failed(t *testing.T) {
 			name:  "Failed -> Failed (check pull permission failed)",
 			input: testImageRegistry(),
 			mockSetup: func(input *v1.ImageRegistry, s *storagemocks.MockStorage, imageSvc *registrymocks.MockImageService) {
-				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				imageSvc.On("CheckPullPermission", mock.Anything, mock.Anything, true).Run(func(args mock.Arguments) {
 					image := args.Get(0).(string)
 					assert.Equal(t, "test/neutree/neutree-serve", image)
 					arg := args.Get(1).(authn.Authenticator)

--- a/internal/registry/image.go
+++ b/internal/registry/image.go
@@ -14,10 +14,10 @@ import (
 type ImageService interface {
 	CheckImageExists(image string, auth authn.Authenticator) (bool, error)
 	// CheckPullPermission checks if the provided auth has pull permission for the image
-	CheckPullPermission(image string, auth authn.Authenticator) (bool, error)
-	ListImageTags(imageRepo string, auth authn.Authenticator) ([]string, error)
+	CheckPullPermission(image string, auth authn.Authenticator, useHTTP bool) (bool, error)
+	ListImageTags(imageRepo string, auth authn.Authenticator, useHTTP bool) ([]string, error)
 	// GetImageLabels returns the labels from an image's config.
-	GetImageLabels(image string, auth authn.Authenticator) (map[string]string, error)
+	GetImageLabels(image string, auth authn.Authenticator, useHTTP bool) (map[string]string, error)
 }
 
 type imageService struct {
@@ -52,13 +52,13 @@ func (svc *imageService) CheckImageExists(image string, auth authn.Authenticator
 	return true, nil
 }
 
-func (svc *imageService) CheckPullPermission(image string, auth authn.Authenticator) (bool, error) {
-	ref, err := name.ParseReference(image)
+func (svc *imageService) CheckPullPermission(image string, auth authn.Authenticator, useHTTP bool) (bool, error) {
+	ref, err := name.ParseReference(image, registryNameOptions(useHTTP)...)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to parse image "+image)
 	}
 
-	_, err = remote.Head(ref, remote.WithAuth(auth), remote.WithTransport(svc.transport))
+	_, err = remote.Head(ref, remote.WithAuth(auth), remote.WithTransport(svc.registryTransport(ref.Context().Registry.RegistryStr(), useHTTP)))
 	if err != nil {
 		if transportErr, ok := err.(*transport.Error); ok {
 			if transportErr.StatusCode == http.StatusUnauthorized || transportErr.StatusCode == http.StatusForbidden {
@@ -77,13 +77,13 @@ func (svc *imageService) CheckPullPermission(image string, auth authn.Authentica
 	return true, nil
 }
 
-func (svc *imageService) GetImageLabels(image string, auth authn.Authenticator) (map[string]string, error) {
-	ref, err := name.ParseReference(image)
+func (svc *imageService) GetImageLabels(image string, auth authn.Authenticator, useHTTP bool) (map[string]string, error) {
+	ref, err := name.ParseReference(image, registryNameOptions(useHTTP)...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse image "+image)
 	}
 
-	img, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(svc.transport))
+	img, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(svc.registryTransport(ref.Context().Registry.RegistryStr(), useHTTP)))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch image "+image)
 	}
@@ -100,13 +100,13 @@ func (svc *imageService) GetImageLabels(image string, auth authn.Authenticator) 
 	return cfg.Config.Labels, nil
 }
 
-func (svc *imageService) ListImageTags(imageRepo string, auth authn.Authenticator) ([]string, error) {
-	repo, err := name.NewRepository(imageRepo)
+func (svc *imageService) ListImageTags(imageRepo string, auth authn.Authenticator, useHTTP bool) ([]string, error) {
+	repo, err := name.NewRepository(imageRepo, registryNameOptions(useHTTP)...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse image repo "+imageRepo)
 	}
 
-	tags, err := remote.List(repo, remote.WithAuth(auth), remote.WithTransport(svc.transport))
+	tags, err := remote.List(repo, remote.WithAuth(auth), remote.WithTransport(svc.registryTransport(repo.Registry.RegistryStr(), useHTTP)))
 	if err != nil {
 		if transportErr, ok := err.(*transport.Error); ok {
 			if transportErr.StatusCode == http.StatusNotFound {
@@ -118,4 +118,36 @@ func (svc *imageService) ListImageTags(imageRepo string, auth authn.Authenticato
 	}
 
 	return tags, nil
+}
+
+func registryNameOptions(useHTTP bool) []name.Option {
+	if useHTTP {
+		return []name.Option{name.Insecure}
+	}
+
+	return nil
+}
+
+func (svc *imageService) registryTransport(registry string, useHTTP bool) http.RoundTripper {
+	if useHTTP {
+		return svc.transport
+	}
+
+	return &forceHTTPSRegistryTransport{inner: svc.transport, registry: registry}
+}
+
+type forceHTTPSRegistryTransport struct {
+	inner    http.RoundTripper
+	registry string
+}
+
+func (t *forceHTTPSRegistryTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if request.URL.Scheme != "http" || request.URL.Host != t.registry {
+		return t.inner.RoundTrip(request)
+	}
+
+	request = request.Clone(request.Context())
+	request.URL.Scheme = "https"
+
+	return t.inner.RoundTrip(request)
 }

--- a/internal/registry/image_test.go
+++ b/internal/registry/image_test.go
@@ -1,0 +1,136 @@
+package registry
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/stretchr/testify/require"
+)
+
+const testImageConfig = `{"architecture":"amd64","os":"linux","config":{"Labels":{"neutree.ai/cluster-version":"v1.2.0"}},"rootfs":{"type":"layers","diff_ids":[]}}`
+
+func TestImageService_CheckPullPermissionUsesConfiguredScheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		newServer func(http.Handler) *httptest.Server
+		useHTTP   bool
+		scheme    string
+	}{
+		{name: "explicit HTTP", newServer: httptest.NewServer, useHTTP: true, scheme: "http"},
+		{name: "HTTPS by default", newServer: httptest.NewTLSServer, scheme: "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.newServer(testRegistryHandler())
+			t.Cleanup(server.Close)
+
+			image := strings.TrimPrefix(server.URL, tt.scheme+"://") + "/neutree/router:v1.2.0"
+			allowed, err := NewImageService().CheckPullPermission(image, authn.Anonymous, tt.useHTTP)
+
+			require.NoError(t, err)
+			require.True(t, allowed)
+		})
+	}
+}
+
+func TestImageService_ListImageTagsUsesConfiguredScheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		newServer func(http.Handler) *httptest.Server
+		useHTTP   bool
+		scheme    string
+	}{
+		{name: "explicit HTTP", newServer: httptest.NewServer, useHTTP: true, scheme: "http"},
+		{name: "HTTPS by default", newServer: httptest.NewTLSServer, scheme: "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.newServer(testRegistryHandler())
+			t.Cleanup(server.Close)
+
+			repository := strings.TrimPrefix(server.URL, tt.scheme+"://") + "/neutree/router"
+			tags, err := NewImageService().ListImageTags(repository, authn.Anonymous, tt.useHTTP)
+
+			require.NoError(t, err)
+			require.Equal(t, []string{"v1.2.0"}, tags)
+		})
+	}
+}
+
+func TestImageService_GetImageLabelsUsesConfiguredScheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		newServer func(http.Handler) *httptest.Server
+		useHTTP   bool
+		scheme    string
+	}{
+		{name: "explicit HTTP", newServer: httptest.NewServer, useHTTP: true, scheme: "http"},
+		{name: "HTTPS by default", newServer: httptest.NewTLSServer, scheme: "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.newServer(testRegistryHandler())
+			t.Cleanup(server.Close)
+
+			image := strings.TrimPrefix(server.URL, tt.scheme+"://") + "/neutree/router:v1.2.0"
+			labels, err := NewImageService().GetImageLabels(image, authn.Anonymous, tt.useHTTP)
+
+			require.NoError(t, err)
+			require.Equal(t, "v1.2.0", labels["neutree.ai/cluster-version"])
+		})
+	}
+}
+
+func TestImageService_DefaultHTTPSDoesNotDowngradeToHTTP(t *testing.T) {
+	server := httptest.NewServer(testRegistryHandler())
+	t.Cleanup(server.Close)
+
+	registryHost := strings.TrimPrefix(server.URL, "http://")
+	service := NewImageService()
+
+	allowed, err := service.CheckPullPermission(registryHost+"/neutree/router:v1.2.0", authn.Anonymous, false)
+	require.Error(t, err)
+	require.False(t, allowed)
+
+	_, err = service.ListImageTags(registryHost+"/neutree/router", authn.Anonymous, false)
+	require.Error(t, err)
+
+	_, err = service.GetImageLabels(registryHost+"/neutree/router:v1.2.0", authn.Anonymous, false)
+	require.Error(t, err)
+}
+
+func testRegistryHandler() http.Handler {
+	configDigest := fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(testImageConfig)))
+	manifest := fmt.Sprintf(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","size":%d,"digest":"%s"},"layers":[]}`,
+		len(testImageConfig), configDigest)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case "/v2/neutree/router/tags/list":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"name":"neutree/router","tags":["v1.2.0"]}`))
+		case "/v2/neutree/router/manifests/v1.2.0":
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(manifest)))
+			w.Header().Set("Docker-Content-Digest", fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(manifest))))
+			if r.Method != http.MethodHead {
+				_, _ = w.Write([]byte(manifest))
+			}
+		case "/v2/neutree/router/blobs/" + configDigest:
+			w.Header().Set("Content-Type", "application/vnd.oci.image.config.v1+json")
+			_, _ = w.Write([]byte(testImageConfig))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}

--- a/internal/registry/mocks/mock_image_service.go
+++ b/internal/registry/mocks/mock_image_service.go
@@ -77,9 +77,9 @@ func (_c *MockImageService_CheckImageExists_Call) RunAndReturn(run func(string, 
 	return _c
 }
 
-// CheckPullPermission provides a mock function with given fields: image, auth
-func (_m *MockImageService) CheckPullPermission(image string, auth authn.Authenticator) (bool, error) {
-	ret := _m.Called(image, auth)
+// CheckPullPermission provides a mock function with given fields: image, auth, useHTTP
+func (_m *MockImageService) CheckPullPermission(image string, auth authn.Authenticator, useHTTP bool) (bool, error) {
+	ret := _m.Called(image, auth, useHTTP)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckPullPermission")
@@ -87,17 +87,17 @@ func (_m *MockImageService) CheckPullPermission(image string, auth authn.Authent
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, authn.Authenticator) (bool, error)); ok {
-		return rf(image, auth)
+	if rf, ok := ret.Get(0).(func(string, authn.Authenticator, bool) (bool, error)); ok {
+		return rf(image, auth, useHTTP)
 	}
-	if rf, ok := ret.Get(0).(func(string, authn.Authenticator) bool); ok {
-		r0 = rf(image, auth)
+	if rf, ok := ret.Get(0).(func(string, authn.Authenticator, bool) bool); ok {
+		r0 = rf(image, auth, useHTTP)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, authn.Authenticator) error); ok {
-		r1 = rf(image, auth)
+	if rf, ok := ret.Get(1).(func(string, authn.Authenticator, bool) error); ok {
+		r1 = rf(image, auth, useHTTP)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -113,13 +113,14 @@ type MockImageService_CheckPullPermission_Call struct {
 // CheckPullPermission is a helper method to define mock.On call
 //   - image string
 //   - auth authn.Authenticator
-func (_e *MockImageService_Expecter) CheckPullPermission(image interface{}, auth interface{}) *MockImageService_CheckPullPermission_Call {
-	return &MockImageService_CheckPullPermission_Call{Call: _e.mock.On("CheckPullPermission", image, auth)}
+//   - useHTTP bool
+func (_e *MockImageService_Expecter) CheckPullPermission(image interface{}, auth interface{}, useHTTP interface{}) *MockImageService_CheckPullPermission_Call {
+	return &MockImageService_CheckPullPermission_Call{Call: _e.mock.On("CheckPullPermission", image, auth, useHTTP)}
 }
 
-func (_c *MockImageService_CheckPullPermission_Call) Run(run func(image string, auth authn.Authenticator)) *MockImageService_CheckPullPermission_Call {
+func (_c *MockImageService_CheckPullPermission_Call) Run(run func(image string, auth authn.Authenticator, useHTTP bool)) *MockImageService_CheckPullPermission_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(authn.Authenticator))
+		run(args[0].(string), args[1].(authn.Authenticator), args[2].(bool))
 	})
 	return _c
 }
@@ -129,14 +130,14 @@ func (_c *MockImageService_CheckPullPermission_Call) Return(_a0 bool, _a1 error)
 	return _c
 }
 
-func (_c *MockImageService_CheckPullPermission_Call) RunAndReturn(run func(string, authn.Authenticator) (bool, error)) *MockImageService_CheckPullPermission_Call {
+func (_c *MockImageService_CheckPullPermission_Call) RunAndReturn(run func(string, authn.Authenticator, bool) (bool, error)) *MockImageService_CheckPullPermission_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetImageLabels provides a mock function with given fields: image, auth
-func (_m *MockImageService) GetImageLabels(image string, auth authn.Authenticator) (map[string]string, error) {
-	ret := _m.Called(image, auth)
+// GetImageLabels provides a mock function with given fields: image, auth, useHTTP
+func (_m *MockImageService) GetImageLabels(image string, auth authn.Authenticator, useHTTP bool) (map[string]string, error) {
+	ret := _m.Called(image, auth, useHTTP)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetImageLabels")
@@ -144,19 +145,19 @@ func (_m *MockImageService) GetImageLabels(image string, auth authn.Authenticato
 
 	var r0 map[string]string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, authn.Authenticator) (map[string]string, error)); ok {
-		return rf(image, auth)
+	if rf, ok := ret.Get(0).(func(string, authn.Authenticator, bool) (map[string]string, error)); ok {
+		return rf(image, auth, useHTTP)
 	}
-	if rf, ok := ret.Get(0).(func(string, authn.Authenticator) map[string]string); ok {
-		r0 = rf(image, auth)
+	if rf, ok := ret.Get(0).(func(string, authn.Authenticator, bool) map[string]string); ok {
+		r0 = rf(image, auth, useHTTP)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, authn.Authenticator) error); ok {
-		r1 = rf(image, auth)
+	if rf, ok := ret.Get(1).(func(string, authn.Authenticator, bool) error); ok {
+		r1 = rf(image, auth, useHTTP)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -172,13 +173,14 @@ type MockImageService_GetImageLabels_Call struct {
 // GetImageLabels is a helper method to define mock.On call
 //   - image string
 //   - auth authn.Authenticator
-func (_e *MockImageService_Expecter) GetImageLabels(image interface{}, auth interface{}) *MockImageService_GetImageLabels_Call {
-	return &MockImageService_GetImageLabels_Call{Call: _e.mock.On("GetImageLabels", image, auth)}
+//   - useHTTP bool
+func (_e *MockImageService_Expecter) GetImageLabels(image interface{}, auth interface{}, useHTTP interface{}) *MockImageService_GetImageLabels_Call {
+	return &MockImageService_GetImageLabels_Call{Call: _e.mock.On("GetImageLabels", image, auth, useHTTP)}
 }
 
-func (_c *MockImageService_GetImageLabels_Call) Run(run func(image string, auth authn.Authenticator)) *MockImageService_GetImageLabels_Call {
+func (_c *MockImageService_GetImageLabels_Call) Run(run func(image string, auth authn.Authenticator, useHTTP bool)) *MockImageService_GetImageLabels_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(authn.Authenticator))
+		run(args[0].(string), args[1].(authn.Authenticator), args[2].(bool))
 	})
 	return _c
 }
@@ -188,14 +190,14 @@ func (_c *MockImageService_GetImageLabels_Call) Return(_a0 map[string]string, _a
 	return _c
 }
 
-func (_c *MockImageService_GetImageLabels_Call) RunAndReturn(run func(string, authn.Authenticator) (map[string]string, error)) *MockImageService_GetImageLabels_Call {
+func (_c *MockImageService_GetImageLabels_Call) RunAndReturn(run func(string, authn.Authenticator, bool) (map[string]string, error)) *MockImageService_GetImageLabels_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// ListImageTags provides a mock function with given fields: imageRepo, auth
-func (_m *MockImageService) ListImageTags(imageRepo string, auth authn.Authenticator) ([]string, error) {
-	ret := _m.Called(imageRepo, auth)
+// ListImageTags provides a mock function with given fields: imageRepo, auth, useHTTP
+func (_m *MockImageService) ListImageTags(imageRepo string, auth authn.Authenticator, useHTTP bool) ([]string, error) {
+	ret := _m.Called(imageRepo, auth, useHTTP)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListImageTags")
@@ -203,19 +205,19 @@ func (_m *MockImageService) ListImageTags(imageRepo string, auth authn.Authentic
 
 	var r0 []string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, authn.Authenticator) ([]string, error)); ok {
-		return rf(imageRepo, auth)
+	if rf, ok := ret.Get(0).(func(string, authn.Authenticator, bool) ([]string, error)); ok {
+		return rf(imageRepo, auth, useHTTP)
 	}
-	if rf, ok := ret.Get(0).(func(string, authn.Authenticator) []string); ok {
-		r0 = rf(imageRepo, auth)
+	if rf, ok := ret.Get(0).(func(string, authn.Authenticator, bool) []string); ok {
+		r0 = rf(imageRepo, auth, useHTTP)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, authn.Authenticator) error); ok {
-		r1 = rf(imageRepo, auth)
+	if rf, ok := ret.Get(1).(func(string, authn.Authenticator, bool) error); ok {
+		r1 = rf(imageRepo, auth, useHTTP)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -231,13 +233,14 @@ type MockImageService_ListImageTags_Call struct {
 // ListImageTags is a helper method to define mock.On call
 //   - imageRepo string
 //   - auth authn.Authenticator
-func (_e *MockImageService_Expecter) ListImageTags(imageRepo interface{}, auth interface{}) *MockImageService_ListImageTags_Call {
-	return &MockImageService_ListImageTags_Call{Call: _e.mock.On("ListImageTags", imageRepo, auth)}
+//   - useHTTP bool
+func (_e *MockImageService_Expecter) ListImageTags(imageRepo interface{}, auth interface{}, useHTTP interface{}) *MockImageService_ListImageTags_Call {
+	return &MockImageService_ListImageTags_Call{Call: _e.mock.On("ListImageTags", imageRepo, auth, useHTTP)}
 }
 
-func (_c *MockImageService_ListImageTags_Call) Run(run func(imageRepo string, auth authn.Authenticator)) *MockImageService_ListImageTags_Call {
+func (_c *MockImageService_ListImageTags_Call) Run(run func(imageRepo string, auth authn.Authenticator, useHTTP bool)) *MockImageService_ListImageTags_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(authn.Authenticator))
+		run(args[0].(string), args[1].(authn.Authenticator), args[2].(bool))
 	})
 	return _c
 }
@@ -247,7 +250,7 @@ func (_c *MockImageService_ListImageTags_Call) Return(_a0 []string, _a1 error) *
 	return _c
 }
 
-func (_c *MockImageService_ListImageTags_Call) RunAndReturn(run func(string, authn.Authenticator) ([]string, error)) *MockImageService_ListImageTags_Call {
+func (_c *MockImageService_ListImageTags_Call) RunAndReturn(run func(string, authn.Authenticator, bool) ([]string, error)) *MockImageService_ListImageTags_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/routes/clusters/cluster_versions.go
+++ b/internal/routes/clusters/cluster_versions.go
@@ -62,6 +62,7 @@ func getAvailableClusterVersions(deps *Dependencies) gin.HandlerFunc {
 		}
 
 		imageRegistry := &imageRegistries[0]
+		useHTTP := util.IsHTTPRegistryURL(imageRegistry.Spec.URL)
 
 		imagePrefix, err := util.GetImagePrefix(imageRegistry)
 		if err != nil {
@@ -106,7 +107,7 @@ func getAvailableClusterVersions(deps *Dependencies) gin.HandlerFunc {
 		// Labeled images are deduplicated by version and filtered by accelerator type.
 		imageSvc := deps.ImageService
 
-		tags, err := imageSvc.ListImageTags(imageRepo, auth)
+		tags, err := imageSvc.ListImageTags(imageRepo, auth, useHTTP)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list image tags: %v", err)})
 			return
@@ -135,7 +136,7 @@ func getAvailableClusterVersions(deps *Dependencies) gin.HandlerFunc {
 
 				imageRef := imageRepo + ":" + t
 
-				labels, labelErr := imageSvc.GetImageLabels(imageRef, auth)
+				labels, labelErr := imageSvc.GetImageLabels(imageRef, auth, useHTTP)
 				if labelErr != nil {
 					klog.V(4).Infof("skipping tag %s: failed to get labels: %v", t, labelErr)
 					return

--- a/internal/routes/clusters/cluster_versions_test.go
+++ b/internal/routes/clusters/cluster_versions_test.go
@@ -32,6 +32,44 @@ func createTestContextWithQuery(queryParams map[string]string) (*gin.Context, *h
 	return c, w
 }
 
+func TestGetAvailableClusterVersionsPassesHTTPRegistryScheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		useHTTP bool
+	}{
+		{name: "explicit HTTP", url: "http://registry.example.com:5000", useHTTP: true},
+		{name: "explicit HTTPS", url: "https://registry.example.com:5000"},
+		{name: "URL without scheme", url: "registry.example.com:5000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := storageMocks.NewMockStorage(t)
+			imageService := registryMocks.NewMockImageService(t)
+			storage.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{{
+				Spec: &v1.ImageRegistrySpec{URL: tt.url},
+			}}, nil)
+			imageService.
+				On("ListImageTags", "registry.example.com:5000/"+v1.NeutreeRouterImageName, mock.Anything, tt.useHTTP).
+				Return([]string{"v1.2.0"}, nil)
+			imageService.
+				On("GetImageLabels", "registry.example.com:5000/neutree/router:v1.2.0", mock.Anything, tt.useHTTP).
+				Return(map[string]string{v1.ImageLabelVersion: "v1.2.0"}, nil)
+
+			context, recorder := createTestContextWithQuery(map[string]string{
+				"workspace":      "default",
+				"image_registry": "registry",
+				"cluster_type":   "kubernetes",
+			})
+			getAvailableClusterVersions(&Dependencies{Storage: storage, ImageService: imageService})(context)
+
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			imageService.AssertExpectations(t)
+		})
+	}
+}
+
 func TestGetAvailableClusterVersions(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -53,26 +91,26 @@ func TestGetAvailableClusterVersions(t *testing.T) {
 				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{
 					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
 				}, nil)
-				imgSvc.On("ListImageTags", mock.Anything, mock.Anything).Return([]string{
+				imgSvc.On("ListImageTags", mock.Anything, mock.Anything, false).Return([]string{
 					"v1.0.0", "v1.0.0-rocm", "v1.0.1", "v1.0.1-rc.1", "v1.0.2", "v1.1.0",
 					"v1.0.1-nightly-20260313", "latest",
 				}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0-rocm" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0-rocm" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1-rc.1" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1-rc.1" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1-rc.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.1.0" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.1.0" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.1.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 				// Unlabeled tags — skipped
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1-nightly-20260313" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1-nightly-20260313" }), mock.Anything, false).
 					Return(map[string]string{}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:latest" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:latest" }), mock.Anything, false).
 					Return(map[string]string{}, nil)
 			},
 			expectedStatusCode: http.StatusOK,
@@ -91,16 +129,16 @@ func TestGetAvailableClusterVersions(t *testing.T) {
 				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{
 					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
 				}, nil)
-				imgSvc.On("ListImageTags", mock.Anything, mock.Anything).Return([]string{
+				imgSvc.On("ListImageTags", mock.Anything, mock.Anything, false).Return([]string{
 					"v1.0.0", "v1.0.0-rocm", "v1.0.2", "v1.0.2-rocm",
 				}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0-rocm" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0-rocm" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2-rocm" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2-rocm" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
 			},
 			expectedStatusCode: http.StatusOK,
@@ -120,14 +158,14 @@ func TestGetAvailableClusterVersions(t *testing.T) {
 				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{
 					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
 				}, nil)
-				imgSvc.On("ListImageTags", "registry.example.com/"+v1.NeutreeRouterImageName, mock.Anything).Return([]string{
+				imgSvc.On("ListImageTags", "registry.example.com/"+v1.NeutreeRouterImageName, mock.Anything, false).Return([]string{
 					"v1.0.0", "v1.0.1", "v1.1.0",
 				}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.0.0" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.0.0" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.0.1" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.0.1" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.1.0" }), mock.Anything).
+				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.1.0" }), mock.Anything, false).
 					Return(map[string]string{v1.ImageLabelVersion: "v1.1.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
 			},
 			expectedStatusCode: http.StatusOK,
@@ -176,7 +214,7 @@ func TestGetAvailableClusterVersions(t *testing.T) {
 				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{
 					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
 				}, nil)
-				imgSvc.On("ListImageTags", mock.Anything, mock.Anything).Return(nil, errors.New("registry unreachable"))
+				imgSvc.On("ListImageTags", mock.Anything, mock.Anything, false).Return(nil, errors.New("registry unreachable"))
 			},
 			expectedStatusCode: http.StatusInternalServerError,
 			expectedError:      "failed to list image tags",

--- a/internal/util/image_registry.go
+++ b/internal/util/image_registry.go
@@ -101,6 +101,11 @@ func StripRegistryScheme(rawURL string) string {
 	return stripped
 }
 
+// IsHTTPRegistryURL reports whether a registry URL explicitly opts into HTTP.
+func IsHTTPRegistryURL(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "http://")
+}
+
 func GetImageRegistryHost(r *v1.ImageRegistry) (string, error) {
 	return parseRegistryHost(r.Spec.URL)
 }

--- a/internal/util/image_registry_test.go
+++ b/internal/util/image_registry_test.go
@@ -6,6 +6,27 @@ import (
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
+func TestIsHTTPRegistryURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "explicit HTTP", url: "http://registry.example.com:5000", want: true},
+		{name: "explicit HTTPS", url: "https://registry.example.com:5000"},
+		{name: "URL without scheme", url: "registry.example.com:5000"},
+		{name: "uppercase HTTP is not an explicit opt in", url: "HTTP://registry.example.com:5000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsHTTPRegistryURL(tt.url); got != tt.want {
+				t.Errorf("IsHTTPRegistryURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetImagePrefix(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Issue

NEU-606

## Summary

Allow image registry operations to use HTTP only when ImageRegistry URL explicitly starts with `http://`, while HTTPS and scheme-less URLs remain HTTPS-only.

## Changes

- Propagate explicit registry protocol selection through ImageRegistry connection validation and cluster version discovery.
- Configure registry pull-permission, tag-list, and image-label requests consistently.
- Add HTTP/TLS Registry v2 coverage and regenerate the ImageService mock.

## Test Plan

### Unit test

- Passed `go vet ./...`.
- Passed affected package tests: `internal/registry`, `internal/util`, `controllers`, and `internal/routes/clusters`.
- Passed grouped non-DB, non-E2E Go regression packages.
- Ran `make mockgen`; retained only the ImageService generated mock change.

### DB test

- Not affected: no DB, migration, RLS, or storage changes.
- `db/dbtest` requires the local Docker daemon; it was unavailable during verification.

### E2E test

- Passed scoped HTTP Registry V2 runtime verification with a temporary plain-HTTP registry. An ImageRegistry using explicit `http://` reached `Connected`; Kubernetes `available_versions` returned the two labeled router versions.
- Confirmed no protocol downgrade: the same plain-HTTP registry with no scheme or explicit `https://` reached `Failed`, with core logs showing HTTPS requests rejected by the HTTP server.
- Manual runtime coverage was used because the current E2E suite has no temporary HTTP Registry fixture. Node image pulling and inference workloads are intentionally outside this change.

## Risk & Rollback

The change only affects URLs explicitly prefixed with lowercase `http://`. Roll back by reverting this commit; existing HTTPS and scheme-less registry behavior remains HTTPS-only.