### PR TITLE
fix: default Ray tensor parallel from requested GPUs

### DIFF
--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -946,7 +946,7 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 
 	setDefaultSGLangEnableMetricsForApplication(endpoint, &app)
 
-	setDefaultTensorParallelSize(endpoint, &app, rayResource.NumGPUs)
+	setDefaultTensorParallelSize(endpoint, &app, endpoint.Spec.Resources.GetGPUCount())
 
 	setEngineSpecialEnv(endpoint, deployedCluster, applicationEnv)
 

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -28,6 +28,20 @@ func intPtr(i int) *int { return &i }
 
 func stringPtr(v string) *string { return &v }
 
+// customRayResourceConverter models accelerators that schedule through Ray
+// custom resources instead of Ray's built-in num_gpus field.
+type customRayResourceConverter struct{}
+
+func (customRayResourceConverter) ConvertToRay(*v1.ResourceSpec) (*v1.RayResourceSpec, error) {
+	return &v1.RayResourceSpec{
+		Resources: map[string]float64{"NPU": 2},
+	}, nil
+}
+
+func (customRayResourceConverter) ConvertToKubernetes(*v1.ResourceSpec) (*v1.KubernetesResourceSpec, error) {
+	return &v1.KubernetesResourceSpec{}, nil
+}
+
 func endpointModelHashForTest(t *testing.T, endpoint *v1.Endpoint) string {
 	t.Helper()
 
@@ -2231,6 +2245,69 @@ func TestEndpointToApplication_TensorParallelSize(t *testing.T) {
 					assert.False(t, hasTensorParallel, "%s should not be set", tt.tpKey)
 				}
 			}
+		})
+	}
+}
+
+func TestEndpointToApplication_TensorParallelSizeUsesRequestedGPUCount(t *testing.T) {
+	const customAcceleratorType = "custom_accelerator"
+
+	modelRegistry := &v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
+	}
+	deployedCluster := &v1.Cluster{}
+
+	tests := []struct {
+		name       string
+		engineName string
+		engineVer  string
+		tpKey      string
+	}{
+		{
+			name:       "vllm",
+			engineName: v1.EngineNameVLLM,
+			engineVer:  "v0.11.2",
+			tpKey:      "tensor_parallel_size",
+		},
+		{
+			name:       "sglang",
+			engineName: v1.EngineNameSGLang,
+			engineVer:  "v0.5.10",
+			tpKey:      "tp_size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gpu := "2"
+			endpoint := &v1.Endpoint{
+				Metadata: &v1.Metadata{Workspace: "test", Name: "test-endpoint"},
+				Spec: &v1.EndpointSpec{
+					Engine:    &v1.EndpointEngineSpec{Engine: tt.engineName, Version: tt.engineVer},
+					Resources: &v1.ResourceSpec{GPU: &gpu},
+					Replicas:  v1.ReplicaSpec{Num: pointy.Int(1)},
+					Model:     &v1.ModelSpec{Name: "test-model"},
+				},
+			}
+			endpoint.Spec.Resources.SetAcceleratorType(customAcceleratorType)
+
+			mgr := acceleratormocks.NewMockManager(t)
+			mgr.EXPECT().GetConverter(customAcceleratorType).
+				Return(customRayResourceConverter{}, true)
+
+			app, err := EndpointToApplication(endpoint, deployedCluster, modelRegistry, nil, nil, mgr)
+			require.NoError(t, err)
+
+			engineArgs, ok := app.Args["engine_args"].(map[string]interface{})
+			require.True(t, ok)
+			assert.Equal(t, 2, engineArgs[tt.tpKey])
+
+			deploymentOptions, ok := app.Args["deployment_options"].(map[string]interface{})
+			require.True(t, ok)
+			backend, ok := deploymentOptions["backend"].(map[string]interface{})
+			require.True(t, ok)
+			assert.Equal(t, float64(0), backend["num_gpus"])
+			assert.Equal(t, map[string]float64{"NPU": 2}, backend["resources"])
 		})
 	}
 }

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -34,7 +34,7 @@ type customRayResourceConverter struct{}
 
 func (customRayResourceConverter) ConvertToRay(*v1.ResourceSpec) (*v1.RayResourceSpec, error) {
 	return &v1.RayResourceSpec{
-		Resources: map[string]float64{"NPU": 2},
+		Resources: map[string]float64{"custom_accelerator": 2},
 	}, nil
 }
 
@@ -2307,7 +2307,7 @@ func TestEndpointToApplication_TensorParallelSizeUsesRequestedGPUCount(t *testin
 			backend, ok := deploymentOptions["backend"].(map[string]interface{})
 			require.True(t, ok)
 			assert.Equal(t, float64(0), backend["num_gpus"])
-			assert.Equal(t, map[string]float64{"NPU": 2}, backend["resources"])
+			assert.Equal(t, map[string]float64{"custom_accelerator": 2}, backend["resources"])
 		})
 	}
 }


### PR DESCRIPTION
## Issue

NEU-607

## Summary

Use the Endpoint GPU request as the source for Ray tensor-parallel defaults when an accelerator converter schedules devices through Ray custom resources rather than `num_gpus`.

## Changes

- Pass `ResourceSpec.GetGPUCount()` to the Ray auto-TP defaulting helper.
- Add vLLM and SGLang regression coverage for a custom-resource converter with `NumGPUs=0`.
- Assert the fix preserves the original Ray scheduling resources.

## Test Plan

### Unit test

- `go test ./internal/orchestrator -run '^TestEndpointToApplication_TensorParallelSize' -count=1`
- `go test ./internal/orchestrator -count=1`
- `go vet ./internal/orchestrator`
- `golangci-lint v1.64.6 run ./internal/orchestrator`

### DB test

- Not applicable: no database or migration changes.

### E2E test

- Not run at the user's explicit request. No manual substitute was performed; custom-accelerator runtime behavior remains unverified in a live SSH/Ray environment.

## Risk & Rollback

No schema or API change. Roll back by reverting the single TP default source change and its regression test.