### PR TITLE
fix: limit Ray download status to built-in engines

### DIFF
--- a/api/v1/engine_types.go
+++ b/api/v1/engine_types.go
@@ -21,6 +21,17 @@ const (
 	EngineNameSGLang   = "sglang"
 )
 
+// IsBuiltInModelDownloaderEngine reports whether engine uses Neutree's
+// built-in model downloader.
+func IsBuiltInModelDownloaderEngine(name string) bool {
+	switch name {
+	case EngineNameVLLM, EngineNameLlamaCpp, EngineNameSGLang:
+		return true
+	default:
+		return false
+	}
+}
+
 // knownModelTasks is the canonical set of task identifiers consumed by Neutree
 // engine deploy templates (vLLM / llama-cpp). Values outside this set are
 // silently ignored by the templates and must be rejected at ingestion time

--- a/api/v1/engine_types_test.go
+++ b/api/v1/engine_types_test.go
@@ -412,6 +412,27 @@ func TestIsKnownModelTask(t *testing.T) {
 	}
 }
 
+func TestIsBuiltInModelDownloaderEngine(t *testing.T) {
+	tests := []struct {
+		name   string
+		engine string
+		want   bool
+	}{
+		{name: "vllm", engine: EngineNameVLLM, want: true},
+		{name: "llama-cpp", engine: EngineNameLlamaCpp, want: true},
+		{name: "sglang", engine: EngineNameSGLang, want: true},
+		{name: "custom engine", engine: "custom-engine", want: false},
+		{name: "empty engine", engine: "", want: false},
+		{name: "case variant", engine: "VLLM", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsBuiltInModelDownloaderEngine(tt.engine))
+		})
+	}
+}
+
 func TestKnownModelTasks(t *testing.T) {
 	got := KnownModelTasks()
 

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -649,6 +649,42 @@ func resolveRayStartupModelDownloadStatus(
 	return phase, modelDownloadCompleted, false, nil
 }
 
+func buildRayApplicationErrorMessage(
+	phase v1.EndpointPhase,
+	status dashboard.RayServeApplicationStatus,
+	errorMessages []string,
+) string {
+	if status.Message != "" {
+		errorMessages = append(errorMessages, status.Message)
+	}
+
+	if len(status.Deployments) == 0 {
+		errorMessages = append(errorMessages, "No deployments found for the application")
+	}
+
+	for _, deployment := range status.Deployments {
+		if deployment.Status != dashboard.DeploymentStatusHealthy && deployment.Message != "" {
+			errorMessages = append(errorMessages, fmt.Sprintf("Deployment %s: %s", deployment.Name, deployment.Message))
+		}
+	}
+
+	errorMessage := strings.Join(errorMessages, "; ")
+	if errorMessage == "" {
+		return ""
+	}
+
+	switch phase {
+	case v1.EndpointPhaseDEPLOYING:
+		return "Endpoint deploying in progress: " + errorMessage
+	case v1.EndpointPhaseMODELDOWNLOADING:
+		return "Endpoint model download in progress: " + errorMessage
+	case v1.EndpointPhaseFAILED:
+		return "Endpoint failed: " + errorMessage
+	default:
+		return errorMessage
+	}
+}
+
 // GetEndpointStatus retrieves the status of a specific endpoint from Ray Serve.
 func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.EndpointStatus, error) {
 	// Placeholder implementation: Get all apps and check if ours exists.
@@ -716,8 +752,10 @@ func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.Endpoint
 
 	currentModelHash := ""
 	modelDownloadCompleted := false
+
 	if isBuiltInModelDownloaderEngine {
 		var hashErr error
+
 		currentModelHash, hashErr = util.ComputeEndpointModelHash(endpoint)
 		if hashErr != nil {
 			klog.Warningf("failed to compute endpoint %s model hash: %v", endpoint.Metadata.WorkspaceName(), hashErr)
@@ -772,35 +810,7 @@ func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.Endpoint
 		errorMessages = append(errorMessages, modelDownloadMessages...)
 	}
 
-	// Merge Ray Serve error messages
-	if status.Message != "" {
-		errorMessages = append(errorMessages, status.Message)
-	}
-
-	if len(status.Deployments) == 0 {
-		errorMessages = append(errorMessages, "No deployments found for the application")
-	}
-
-	// merge Ray Serve error messages
-	for _, deployment := range status.Deployments {
-		if deployment.Status != dashboard.DeploymentStatusHealthy && deployment.Message != "" {
-			errorMessages = append(errorMessages, fmt.Sprintf("Deployment %s: %s", deployment.Name, deployment.Message))
-		}
-	}
-
-	errorMsg := strings.Join(errorMessages, "; ")
-	// Add prefix to error message based on phase
-	if errorMsg != "" {
-		switch phase {
-		// no prefix
-		case v1.EndpointPhaseDEPLOYING:
-			errorMsg = "Endpoint deploying in progress: " + errorMsg
-		case v1.EndpointPhaseMODELDOWNLOADING:
-			errorMsg = "Endpoint model download in progress: " + errorMsg
-		case v1.EndpointPhaseFAILED:
-			errorMsg = "Endpoint failed: " + errorMsg
-		}
-	}
+	errorMsg := buildRayApplicationErrorMessage(phase, status, errorMessages)
 
 	endpointStatus := &v1.EndpointStatus{
 		Phase:        phase,

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -710,12 +710,22 @@ func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.Endpoint
 
 	proxyReady := allProxiesHealthy(currentAppsResp.Proxies)
 
-	currentModelHash, hashErr := util.ComputeEndpointModelHash(endpoint)
-	if hashErr != nil {
-		klog.Warningf("failed to compute endpoint %s model hash: %v", endpoint.Metadata.WorkspaceName(), hashErr)
+	isBuiltInModelDownloaderEngine := endpoint.Spec != nil &&
+		endpoint.Spec.Engine != nil &&
+		v1.IsBuiltInModelDownloaderEngine(endpoint.Spec.Engine.Engine)
+
+	currentModelHash := ""
+	modelDownloadCompleted := false
+	if isBuiltInModelDownloaderEngine {
+		var hashErr error
+		currentModelHash, hashErr = util.ComputeEndpointModelHash(endpoint)
+		if hashErr != nil {
+			klog.Warningf("failed to compute endpoint %s model hash: %v", endpoint.Metadata.WorkspaceName(), hashErr)
+		}
+
+		modelDownloadCompleted = currentModelDownloadHashMatches(endpoint, currentModelHash)
 	}
 
-	modelDownloadCompleted := currentModelDownloadHashMatches(endpoint, currentModelHash)
 	modelDownloadIncomplete := false
 
 	// Basic status mapping
@@ -748,17 +758,19 @@ func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.Endpoint
 			ErrorMessage: "",
 			Resources:    resources,
 		}
-		if currentModelHash != "" {
+		if isBuiltInModelDownloaderEngine && currentModelHash != "" {
 			setModelDownloadStatus(endpointStatus, true, currentModelHash)
 		}
 
 		return endpointStatus, nil
 	}
 
-	var modelDownloadMessages []string
-	phase, modelDownloadCompleted, modelDownloadIncomplete, modelDownloadMessages =
-		resolveRayStartupModelDownloadStatus(dashboardService, status, phase, modelDownloadCompleted)
-	errorMessages = append(errorMessages, modelDownloadMessages...)
+	if isBuiltInModelDownloaderEngine {
+		var modelDownloadMessages []string
+		phase, modelDownloadCompleted, modelDownloadIncomplete, modelDownloadMessages =
+			resolveRayStartupModelDownloadStatus(dashboardService, status, phase, modelDownloadCompleted)
+		errorMessages = append(errorMessages, modelDownloadMessages...)
+	}
 
 	// Merge Ray Serve error messages
 	if status.Message != "" {
@@ -796,7 +808,7 @@ func (o *RayOrchestrator) GetEndpointStatus(endpoint *v1.Endpoint) (*v1.Endpoint
 		Resources:    resources,
 	}
 
-	if currentModelHash != "" {
+	if isBuiltInModelDownloaderEngine && currentModelHash != "" {
 		if modelDownloadCompleted {
 			setModelDownloadStatus(endpointStatus, true, currentModelHash)
 		} else if modelDownloadIncomplete {

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2428,6 +2428,9 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 				Name:      "chat-model",
 			},
 			Spec: &v1.EndpointSpec{
+				Engine: &v1.EndpointEngineSpec{
+					Engine: v1.EngineNameVLLM,
+				},
 				Model: &v1.ModelSpec{
 					Registry: "test-registry",
 					Name:     "test-model",
@@ -2450,6 +2453,8 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 		expectCurrentModelHash       bool
 		expectedModelDownloadHash    *string
 		expectModelDownloadHashEmpty bool
+		expectModelDownloadHashNil   bool
+		expectEmptyErrorMsg          bool
 		expectErrorMsg               string
 		expectError                  bool
 	}{
@@ -2560,6 +2565,77 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 			expectedPhase:  v1.EndpointPhaseDEPLOYING,
 			expectErrorMsg: "Endpoint deploying in progress",
 			expectError:    false,
+		},
+		{
+			name: "return Deploying without downloader status for custom engine",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Spec.Engine.Engine = "custom-engine"
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            dashboard.ApplicationStatusDeploying,
+							DeployedAppConfig: existingApp,
+							Deployments: map[string]dashboard.Deployment{
+								"BACKEND": {
+									Name:   "BACKEND",
+									Status: "UPDATING",
+									Replicas: []dashboard.Replica{{
+										ActorID:   "actor-1",
+										ReplicaID: "backend-replica-1",
+									}},
+								},
+							},
+						},
+					},
+				}, nil)
+				// No GetActorLog expectation: any log inspection is an unexpected mock call.
+			},
+			expectedPhase:              v1.EndpointPhaseDEPLOYING,
+			expectModelDownloadHashNil: true,
+			expectEmptyErrorMsg:        true,
+			expectError:                false,
+		},
+		{
+			name: "return Running without downloader status for custom engine",
+			inputEndpoint: func() *v1.Endpoint {
+				ep := newEndpoint()
+				ep.Spec.Engine.Engine = "custom-engine"
+				return ep
+			},
+			setupMock: func(mockDashboard *dashboardmocks.MockDashboardService) {
+				existingApp := &dashboard.RayServeApplication{
+					Name:        applicationName,
+					RoutePrefix: "/production/chat-model",
+					ImportPath:  "old.import.path",
+					Args:        map[string]interface{}{"old": "config"},
+				}
+
+				mockDashboard.On("GetServeApplications").Return(&dashboard.RayServeApplicationsResponse{
+					Applications: map[string]dashboard.RayServeApplicationStatus{
+						applicationName: {
+							Status:            dashboard.ApplicationStatusRunning,
+							DeployedAppConfig: existingApp,
+						},
+					},
+					Proxies: map[string]dashboard.ProxyStatus{
+						"proxy-actor": {Status: dashboard.ProxyStatusHealthy},
+					},
+				}, nil)
+			},
+			expectedPhase:              v1.EndpointPhaseRUNNING,
+			expectModelDownloadHashNil: true,
+			expectError:                false,
 		},
 		{
 			name: "return ModelDownloading for application in DEPLOYING status before current model download completion",
@@ -3855,6 +3931,12 @@ func TestRayOrchestrator_GetEndpointStatus(t *testing.T) {
 				if tt.expectModelDownloadHashEmpty {
 					require.NotNil(t, status.ModelDownloadCompletedHash)
 					assert.Empty(t, *status.ModelDownloadCompletedHash)
+				}
+				if tt.expectModelDownloadHashNil {
+					assert.Nil(t, status.ModelDownloadCompletedHash)
+				}
+				if tt.expectEmptyErrorMsg {
+					assert.Empty(t, status.ErrorMessage)
 				}
 				if tt.expectErrorMsg != "" {
 					assert.Contains(t, status.ErrorMessage, tt.expectErrorMsg)


### PR DESCRIPTION
## Issue

NEU-601

## Summary

Restrict Ray startup model-download status detection to engines that use Neutree built-in downloading.

## Changes

- Add an explicit built-in downloader engine allowlist.
- Skip model hash updates and Ray actor-log probing for external engines.
- Preserve existing downloader status behavior for vLLM, llama.cpp, and SGLang.

## Test Plan

- Unit test: `go test ./api/v1 ./internal/orchestrator` passed.
- DB test: not affected; no database or schema changes.
- E2E test: not run per explicit user instruction. TestRail cases `C2738127` and `C2738128` record future regression coverage.

## Risk & Rollback

No schema or API contract changes. Roll back by reverting this commit; built-in downloader status behavior remains unchanged.