### PR TITLE
fix: emit parseable empty documents from `get -o json|yaml` (NEU-578)

### DIFF
--- a/cmd/neutree-cli/app/cmd/get/get.go
+++ b/cmd/neutree-cli/app/cmd/get/get.go
@@ -88,7 +88,7 @@ func runGet(opts *getOptions, args []string) error {
 		name = args[1]
 	}
 
-	printer := &resourcePrinter{kind: kind, format: opts.output}
+	printer := &resourcePrinter{kind: kind, format: opts.output, single: name != ""}
 
 	if opts.watch {
 		return runWatch(c, kind, name, opts, printer)
@@ -103,11 +103,8 @@ func runOnce(c *client.Client, kind, name string, opts *getOptions, printer *res
 		return err
 	}
 
-	if len(items) == 0 {
-		fmt.Printf("No %s resources found\n", strings.ToLower(kind))
-		return nil
-	}
-
+	// Empty results are handed to the printer like any other result so that
+	// machine formats emit a parseable empty document instead of prose.
 	return printer.print(items)
 }
 
@@ -178,12 +175,20 @@ func fetchResources(c *client.Client, kind, name, workspace string) ([]json.RawM
 
 // resourcePrinter handles output formatting with state (e.g., table header printed once).
 type resourcePrinter struct {
-	kind          string
-	format        string
+	kind   string
+	format string
+	// single reports whether a NAME was requested. It picks the output envelope,
+	// which follows the request form rather than the result count: a list request
+	// always renders a collection (even for one item), a named request always
+	// renders a bare object.
+	single        bool
 	headerPrinted bool
 	// out is the destination for rendered output; defaults to os.Stdout when nil
 	// (overridden in tests to capture output).
 	out io.Writer
+	// errOut receives human-readable notices that must stay off stdout;
+	// defaults to os.Stderr when nil.
+	errOut io.Writer
 }
 
 // writer returns the printer's output destination, defaulting to os.Stdout.
@@ -195,12 +200,27 @@ func (p *resourcePrinter) writer() io.Writer {
 	return os.Stdout
 }
 
+// errWriter returns the destination for human-readable notices, defaulting to os.Stderr.
+func (p *resourcePrinter) errWriter() io.Writer {
+	if p.errOut != nil {
+		return p.errOut
+	}
+
+	return os.Stderr
+}
+
 func (p *resourcePrinter) print(items []json.RawMessage) error {
+	// Formatters below never see a nil slice: an absent result and an empty one
+	// render identically, and a nil slice would otherwise encode as JSON `null`.
+	if items == nil {
+		items = []json.RawMessage{}
+	}
+
 	switch p.format {
 	case "json":
-		return printJSON(items)
+		return p.printJSON(items)
 	case "yaml":
-		return printYAML(items)
+		return p.printYAML(items)
 	case "table":
 		return p.printTable(items)
 	default:
@@ -221,6 +241,12 @@ func (p *resourcePrinter) printTable(items []json.RawMessage) error {
 		p.headerPrinted = true
 	}
 
+	// The "nothing here" notice is a human-readable aside, so it goes to stderr:
+	// stdout stays a clean, uniformly shaped stream across every output format.
+	if len(items) == 0 {
+		fmt.Fprintf(p.errWriter(), "No %s resources found\n", strings.ToLower(p.kind))
+	}
+
 	for _, item := range items {
 		name := client.ExtractMetadataField(item, "name")
 		id := client.ExtractID(item)
@@ -238,40 +264,75 @@ func (p *resourcePrinter) printTable(items []json.RawMessage) error {
 	return w.Flush()
 }
 
-func printJSON(items []json.RawMessage) error {
+func (p *resourcePrinter) printJSON(items []json.RawMessage) error {
 	var output any
-	if len(items) == 1 {
+
+	if p.single {
+		if len(items) == 0 {
+			return nil
+		}
+
 		output = items[0]
 	} else {
 		output = items
 	}
 
-	enc := json.NewEncoder(os.Stdout)
+	enc := json.NewEncoder(p.writer())
 	enc.SetIndent("", "  ")
 
 	return enc.Encode(output)
 }
 
-func printYAML(items []json.RawMessage) error {
-	for i, item := range items {
-		if i > 0 {
-			fmt.Println("---")
-		}
-
+// printYAML renders one YAML document, mirroring the JSON envelope: a list
+// request yields a sequence, a named request yields a mapping. A document
+// stream would be neither — an empty one parses as null rather than as a
+// collection, and a one-item one is indistinguishable from a named result.
+func (p *resourcePrinter) printYAML(items []json.RawMessage) error {
+	decode := func(item json.RawMessage) (any, error) {
 		var obj any
 		if err := json.Unmarshal(item, &obj); err != nil {
-			return fmt.Errorf("failed to parse JSON: %w", err)
+			return nil, fmt.Errorf("failed to parse JSON: %w", err)
 		}
 
-		out, err := yaml.Marshal(obj)
-		if err != nil {
-			return fmt.Errorf("failed to marshal YAML: %w", err)
-		}
-
-		fmt.Print(string(out))
+		return obj, nil
 	}
 
-	return nil
+	var output any
+
+	if p.single {
+		if len(items) == 0 {
+			return nil
+		}
+
+		obj, err := decode(items[0])
+		if err != nil {
+			return err
+		}
+
+		output = obj
+	} else {
+		list := make([]any, 0, len(items))
+
+		for _, item := range items {
+			obj, err := decode(item)
+			if err != nil {
+				return err
+			}
+
+			list = append(list, obj)
+		}
+
+		output = list
+	}
+
+	out, err := yaml.Marshal(output)
+	if err != nil {
+		return fmt.Errorf("failed to marshal YAML: %w", err)
+	}
+
+	_, err = fmt.Fprint(p.writer(), string(out))
+
+	return err
 }
 
 // --- utilities ---

--- a/cmd/neutree-cli/app/cmd/get/get_test.go
+++ b/cmd/neutree-cli/app/cmd/get/get_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestPrintTableIncludesIDColumn(t *testing.T) {
@@ -49,6 +50,187 @@ func TestPrintTableWorkspaceKindOmitsWorkspaceColumnButKeepsID(t *testing.T) {
 	assert.Equal(t, "default", row[0])
 	assert.Equal(t, "7", row[1])
 	assert.Equal(t, "READY", row[2])
+}
+
+// itemA and itemB stand in for resources returned by the API.
+var (
+	itemA = json.RawMessage(`{"id":1,"metadata":{"name":"a","workspace":"default"},"status":{"phase":"READY"}}`)
+	itemB = json.RawMessage(`{"id":2,"metadata":{"name":"b","workspace":"default"},"status":{"phase":"READY"}}`)
+)
+
+// TestOutputMatrix covers empty/single/multiple results across every output
+// format, asserting that machine formats always emit a parseable document and
+// that the envelope follows resourcePrinter.single (NEU-578).
+func TestOutputMatrix(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		single bool
+		items  []json.RawMessage
+		// assert inspects stdout; stderr is checked separately per case.
+		assert func(t *testing.T, stdout string)
+		stderr string
+	}{
+		{
+			name:   "json list empty is an empty array",
+			format: "json",
+			items:  []json.RawMessage{},
+			assert: func(t *testing.T, stdout string) {
+				var got []any
+				require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+				assert.Empty(t, got)
+			},
+		},
+		{
+			name:   "json list nil slice is an empty array not null",
+			format: "json",
+			items:  nil,
+			assert: func(t *testing.T, stdout string) {
+				assert.Equal(t, "[]", strings.TrimSpace(stdout))
+			},
+		},
+		{
+			name:   "json list of one stays an array",
+			format: "json",
+			items:  []json.RawMessage{itemA},
+			assert: func(t *testing.T, stdout string) {
+				var got []map[string]any
+				require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+				require.Len(t, got, 1)
+				assert.Equal(t, "a", got[0]["metadata"].(map[string]any)["name"])
+			},
+		},
+		{
+			name:   "json list of many is an array",
+			format: "json",
+			items:  []json.RawMessage{itemA, itemB},
+			assert: func(t *testing.T, stdout string) {
+				var got []map[string]any
+				require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+				assert.Len(t, got, 2)
+			},
+		},
+		{
+			name:   "json named request is a bare object",
+			format: "json",
+			single: true,
+			items:  []json.RawMessage{itemA},
+			assert: func(t *testing.T, stdout string) {
+				var got map[string]any
+				require.NoError(t, json.Unmarshal([]byte(stdout), &got))
+				assert.Equal(t, "a", got["metadata"].(map[string]any)["name"])
+			},
+		},
+		{
+			name:   "yaml list empty is an empty sequence",
+			format: "yaml",
+			items:  []json.RawMessage{},
+			assert: func(t *testing.T, stdout string) {
+				var got []any
+				require.NoError(t, yaml.Unmarshal([]byte(stdout), &got))
+				assert.NotNil(t, got, "empty YAML output must parse as a sequence, not null")
+				assert.Empty(t, got)
+			},
+		},
+		{
+			name:   "yaml list of one stays a sequence",
+			format: "yaml",
+			items:  []json.RawMessage{itemA},
+			assert: func(t *testing.T, stdout string) {
+				var got []map[string]any
+				require.NoError(t, yaml.Unmarshal([]byte(stdout), &got))
+				require.Len(t, got, 1)
+				assert.Equal(t, "a", got[0]["metadata"].(map[string]any)["name"])
+			},
+		},
+		{
+			name:   "yaml list of many is one sequence document",
+			format: "yaml",
+			items:  []json.RawMessage{itemA, itemB},
+			assert: func(t *testing.T, stdout string) {
+				var got []map[string]any
+				require.NoError(t, yaml.Unmarshal([]byte(stdout), &got))
+				assert.Len(t, got, 2)
+				assert.NotContains(t, stdout, "---", "list output must be one document, not a stream")
+
+				// A single document: the decoder sees exactly one and then EOF.
+				dec := yaml.NewDecoder(strings.NewReader(stdout))
+				require.NoError(t, dec.Decode(new(any)))
+				assert.Error(t, dec.Decode(new(any)))
+			},
+		},
+		{
+			name:   "yaml named request is a bare mapping",
+			format: "yaml",
+			single: true,
+			items:  []json.RawMessage{itemA},
+			assert: func(t *testing.T, stdout string) {
+				var got map[string]any
+				require.NoError(t, yaml.Unmarshal([]byte(stdout), &got))
+				assert.Equal(t, "a", got["metadata"].(map[string]any)["name"])
+			},
+		},
+		{
+			name:   "table empty keeps stdout structural and notices go to stderr",
+			format: "table",
+			items:  []json.RawMessage{},
+			assert: func(t *testing.T, stdout string) {
+				lines := strings.Split(strings.TrimSpace(stdout), "\n")
+				require.Len(t, lines, 1)
+				assert.Equal(t, []string{"NAME", "ID", "WORKSPACE", "PHASE", "AGE"}, strings.Fields(lines[0]))
+				assert.NotContains(t, stdout, "No ")
+			},
+			stderr: "No apikey resources found\n",
+		},
+		{
+			name:   "table non-empty writes nothing to stderr",
+			format: "table",
+			items:  []json.RawMessage{itemA},
+			assert: func(t *testing.T, stdout string) {
+				assert.Len(t, strings.Split(strings.TrimSpace(stdout), "\n"), 2)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			p := &resourcePrinter{
+				kind:   "ApiKey",
+				format: tt.format,
+				single: tt.single,
+				out:    &stdout,
+				errOut: &stderr,
+			}
+			require.NoError(t, p.print(tt.items))
+
+			tt.assert(t, stdout.String())
+			assert.Equal(t, tt.stderr, stderr.String())
+		})
+	}
+}
+
+// TestEmptyOutputDiffersAcrossFormats guards the shape of the original NEU-578
+// regression, which TestOutputMatrix cannot express per-format: every format
+// emitted byte-identical prose on an empty result. Only the cross-format
+// comparison lives here; what each format renders is asserted in the matrix.
+func TestEmptyOutputDiffersAcrossFormats(t *testing.T) {
+	rendered := map[string]string{}
+
+	for _, format := range []string{"table", "json", "yaml"} {
+		var stdout, stderr bytes.Buffer
+
+		p := &resourcePrinter{kind: "ModelCatalog", format: format, out: &stdout, errOut: &stderr}
+		require.NoError(t, p.print([]json.RawMessage{}))
+
+		rendered[format] = stdout.String()
+	}
+
+	assert.NotEqual(t, rendered["table"], rendered["json"])
+	assert.NotEqual(t, rendered["table"], rendered["yaml"])
+	// json and yaml legitimately coincide: `[]` is both valid JSON and a valid
+	// YAML flow sequence.
 }
 
 func TestFormatAge(t *testing.T) {


### PR DESCRIPTION
## Issue

NEU-578

## Summary

`neutree-cli get <KIND> -o json|yaml` printed `No <kind> resources found` on stdout whenever the list came back empty, so table/json/yaml produced byte-identical prose and strict parsers failed with `Unexpected token 'N'`. `runOnce()` returned before ever reaching the format dispatch. Empty results now flow through the printer like any other result, so every machine format emits a parseable document.

The root cause of the reported symptom is that the machine formats had no single rule for what they render. Both now pick their envelope from the **request form**, following kubectl: a list request always renders a collection, a named request always renders a bare object. Result count no longer enters into it. That also fixes a quieter bug in the same function — `printJSON` unwrapped to a bare object whenever `len(items) == 1`, so the top-level JSON type of `get endpoint -o json` flipped between array and object depending on how many resources happened to exist, and a script doing `jq '.[0]'` broke silently the moment a workspace was down to one endpoint.

The `--watch` path already called `printer.print()` directly, so it shared the same bug with different symptoms (`--watch -o json` emitted `[]`, `--watch -o yaml` emitted nothing). It is covered by the same fix.

## Changes

- `runOnce()`: drop the early `len(items) == 0` return; empty lists go to the printer.
- `resourcePrinter` gains `single` (set from `name != ""`), which selects the output envelope for both machine formats.
- `print()` normalizes a nil slice to `[]json.RawMessage{}` once, so no formatter has to care about nil vs. empty (`json.Encode` on a nil slice yields `null`, not `[]`).
- `printYAML`: a list request now renders one YAML sequence document instead of a `---`-separated stream, mirroring the JSON array. The old stream was neither shape — an empty one parses as `null` rather than as a collection (the scalar-vs-array failure reported during verification), and a one-item one was indistinguishable from a named result.
- `No <kind> resources found` moves into `printTable` and goes to **stderr**, following kubectl. stdout is now structural in all three formats, so `neutree-cli get X | wc -l` behaves consistently rather than only json/yaml being repaired. The table header is still printed (helm/docker behavior).
- `printJSON`/`printYAML` become printer methods writing to `p.writer()` instead of hardcoded `os.Stdout`; previously their output was uncapturable in tests.

The contract was checked against kubectl / helm / gh / aws / docker before being chosen: all five emit a parseable empty collection for machine formats, none puts the "nothing found" notice on stdout, and none varies the envelope by result count.

## Test Plan

- [x] Unit: `TestOutputMatrix` covers empty/single/multiple x table/json/yaml plus named-request cases (11 subtests), asserting through strict `json.Unmarshal`/`yaml.Unmarshal` into concrete types, with stderr checked separately. `TestEmptyOutputDiffersAcrossFormats` guards the original "three formats, identical bytes" regression. `go test ./cmd/neutree-cli/...` passes; `make lint` clean.
- [ ] E2E: not affected (CLI output formatting only; no server or API contract change).
- [ ] DB integration (`make db-test`): not affected.

## Risk & Rollback

No DB schema change, no API change, no server-side impact.

This is a deliberate stdout contract change for `neutree-cli get`. Three behaviors differ from before, all of them previously unparseable or unstable:

| | before | after |
|---|---|---|
| empty list, `-o json` / `-o yaml` | `No <kind> resources found` | `[]` |
| one-item list, `-o json` | bare object | array of one |
| multi-item list, `-o yaml` | `---` document stream | one sequence document |

Named requests (`get <KIND> <NAME>`) are unchanged: still a bare object/mapping, still exit 1 on not-found. Rollback is reverting the single commit.
