### PR TITLE
fix: support v1.2 CLI core launch

### DIFF
--- a/cmd/neutree-cli/app/cmd/launch/core_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/core_test.go
@@ -252,41 +252,57 @@ func TestValidateNeutreeCoreVersionCompatibility(t *testing.T) {
 		wantErr       string
 	}{
 		{
-			name:          "allows target version in same v1.1 release line",
-			cliVersion:    "v1.1.0-nightly-20260608",
-			targetVersion: "v1.1.0-nightly-20260609",
+			name:          "allows target version in same v1.2 release line",
+			cliVersion:    "v1.2.0-nightly-20260729",
+			targetVersion: "v1.2.0-nightly-20260730",
+		},
+		{
+			name:          "allows enterprise version in same v1.2 release line",
+			cliVersion:    "v1.2.0-enterprise",
+			targetVersion: "v1.2.0-enterprise",
+		},
+		{
+			name:          "allows v1.2 release target",
+			cliVersion:    "v1.2.0-nightly-20260729",
+			targetVersion: "v1.2.0",
 		},
 		{
 			name:          "allows git describe prerelease version in same release line",
-			cliVersion:    "v1.1.0-nightly-20260608-5-g1e6a9fc8",
-			targetVersion: "v1.1.0-nightly-20260609",
+			cliVersion:    "v1.2.0-nightly-20260729-5-g1e6a9fc8",
+			targetVersion: "v1.2.0-nightly-20260730",
 		},
 		{
 			name:          "git describe CLI keeps development build flexibility",
-			cliVersion:    "v1.1.0-nightly-20260608-5-g1e6a9fc8",
+			cliVersion:    "v1.2.0-nightly-20260729-5-g1e6a9fc8",
 			targetVersion: fallbackNeutreeCoreVersion,
 		},
 		{
-			name:          "rejects target version below v1.1 release line",
-			cliVersion:    "v1.1.0-nightly-20260608",
-			targetVersion: "v1.0.1",
+			name:          "rejects target version below v1.2 release line",
+			cliVersion:    "v1.2.0-nightly-20260729",
+			targetVersion: "v1.1.0-nightly-20260728",
 			wantErr:       "not compatible",
 		},
 		{
-			name:          "rejects target version above v1.1 release line",
-			cliVersion:    "v1.1.0-nightly-20260608",
-			targetVersion: "v1.2.0",
+			name:          "rejects target version at v1.3 release-line boundary",
+			cliVersion:    "v1.2.0-nightly-20260729",
+			targetVersion: "v1.3.0-0",
+			wantErr:       "not compatible",
+		},
+		{
+			name:          "rejects target version above v1.2 release line",
+			cliVersion:    "v1.2.0-nightly-20260729",
+			targetVersion: "v1.3.0-nightly-20260730",
 			wantErr:       "not compatible",
 		},
 		{
 			name:          "rejects previous release line because only current release policy is configured",
-			cliVersion:    "v1.0.1-enterprise",
-			targetVersion: "v1.0.1-enterprise",
+			cliVersion:    "v1.1.0-enterprise",
+			targetVersion: "v1.1.0-enterprise",
 			wantErr:       "no configured",
 		},
 		{
 			name:          "rejects invalid target version",
-			cliVersion:    "v1.1.0-nightly-20260608",
+			cliVersion:    "v1.2.0-nightly-20260729",
 			targetVersion: "not-a-version",
 			wantErr:       "invalid target version",
 		},
@@ -325,13 +341,13 @@ func TestDefaultNeutreeCoreVersion(t *testing.T) {
 	}{
 		{
 			name:       "exact nightly tag defaults to CLI app version",
-			cliVersion: "v1.1.0-nightly-20260610",
-			want:       "v1.1.0-nightly-20260610",
+			cliVersion: "v1.2.0-nightly-20260729",
+			want:       "v1.2.0-nightly-20260729",
 		},
 		{
 			name:       "exact enterprise tag defaults to CLI app version",
-			cliVersion: "v1.1.0-enterprise",
-			want:       "v1.1.0-enterprise",
+			cliVersion: "v1.2.0-enterprise",
+			want:       "v1.2.0-enterprise",
 		},
 		{
 			name:       "git describe commit suffix falls back",
@@ -457,6 +473,35 @@ func TestInstallNeutreeCoreSingleNodeByDocker(t *testing.T) {
 	}
 }
 
+func TestInstallNeutreeCoreSingleNodeByDockerAllowsCurrentReleaseVersion(t *testing.T) {
+	oldGetCLIAppVersion := getCLIAppVersion
+	getCLIAppVersion = func() string {
+		return "v1.2.0-nightly-20260729"
+	}
+	t.Cleanup(func() {
+		getCLIAppVersion = oldGetCLIAppVersion
+	})
+
+	mockExecutor := &mocks.MockExecutor{}
+	mockExecutor.On("Execute", mock.Anything, "docker", mock.MatchedBy(func(args []string) bool {
+		return args[0] == "compose" && args[1] == "-p"
+	})).Return([]byte("success"), nil)
+
+	err := installNeutreeCoreSingleNodeByDocker(mockExecutor, neutreeCoreInstallOptions{
+		commonOptions: &commonOptions{
+			workDir:    t.TempDir(),
+			nodeIP:     "192.168.1.1",
+			deployType: constants.DeployTypeLocal,
+			deployMode: constants.DeployModeSingle,
+		},
+		jwtSecret: "test-secret",
+		version:   "v1.2.0-nightly-20260730",
+	})
+
+	require.NoError(t, err)
+	mockExecutor.AssertExpectations(t)
+}
+
 func TestInstallNeutreeCoreSingleNodeByDockerRejectsIncompatibleVersionBeforeMutation(t *testing.T) {
 	tempDir := t.TempDir()
 	composeDir := filepath.Join(tempDir, "neutree-core")
@@ -468,7 +513,7 @@ func TestInstallNeutreeCoreSingleNodeByDockerRejectsIncompatibleVersionBeforeMut
 
 	oldGetCLIAppVersion := getCLIAppVersion
 	getCLIAppVersion = func() string {
-		return "v1.1.0-nightly-20260608"
+		return "v1.2.0-nightly-20260729"
 	}
 	t.Cleanup(func() {
 		getCLIAppVersion = oldGetCLIAppVersion
@@ -483,7 +528,7 @@ func TestInstallNeutreeCoreSingleNodeByDockerRejectsIncompatibleVersionBeforeMut
 			deployMode: constants.DeployModeSingle,
 		},
 		jwtSecret: "test-secret",
-		version:   "v1.2.0",
+		version:   "v1.1.0-nightly-20260728",
 	})
 
 	require.Error(t, err)
@@ -544,7 +589,7 @@ func TestInstallNeutreeCoreSingleNodeByDockerDryRunDoesNotOverwriteExistingCompo
 
 	oldGetCLIAppVersion := getCLIAppVersion
 	getCLIAppVersion = func() string {
-		return "v1.1.0-nightly-20260608"
+		return "v1.2.0-nightly-20260729"
 	}
 	t.Cleanup(func() {
 		getCLIAppVersion = oldGetCLIAppVersion
@@ -562,7 +607,7 @@ func TestInstallNeutreeCoreSingleNodeByDockerDryRunDoesNotOverwriteExistingCompo
 				dryRun:     true,
 			},
 			jwtSecret: "test-secret",
-			version:   "v1.1.0",
+			version:   "v1.2.0-nightly-20260730",
 		})
 	})
 

--- a/cmd/neutree-cli/app/cmd/launch/core_version.go
+++ b/cmd/neutree-cli/app/cmd/launch/core_version.go
@@ -27,10 +27,10 @@ var (
 	}
 
 	neutreeCoreCompatibilityPolicyForCurrentRelease = neutreeCoreCompatibilityPolicy{
-		cliMin:    "v1.1.0-0",
-		cliMax:    "v1.2.0-0",
-		targetMin: "v1.1.0-0",
-		targetMax: "v1.2.0-0",
+		cliMin:    "v1.2.0-0",
+		cliMax:    "v1.3.0-0",
+		targetMin: "v1.2.0-0",
+		targetMax: "v1.3.0-0",
 	}
 )
 


### PR DESCRIPTION
## Issue

NEU-610 - v1.2 nightly neutree-cli cannot launch same-version Docker Neutree Core.

## Summary

Update the single current-release CLI/Core compatibility policy to the v1.2 release line. The former exclusive upper boundary rejected v1.2 nightly and enterprise prerelease tags before `launch neutree-core` could render or invoke Docker.

## Changes

- Move the CLI and Core target window to `[v1.2.0-0, v1.3.0-0)`.
- Add v1.2 nightly, enterprise, release, lower/upper boundary, pre-mutation, and released-CLI success-path regression coverage.
- Preserve development-build flexibility and the existing single-policy implementation.

## Test Plan

- Unit test
  - `go test ./cmd/neutree-cli/app/cmd/launch -count=1` passed.
  - `make test` passed.
  - `make lint` passed.
  - `make build-neutree-cli` passed.
- DB test
  - Not affected: no database, migration, or storage contract changes; `make db-test` was not required.
- E2E test
  - Manual dry-run validation passed (each same-tag success invocation completed in under one second after build): community v1.2 nightly and enterprise-tag v1.2 nightly both rendered successfully without persistent Compose or Docker mutation.
  - Community v1.2 CLI rejected v1.1 and v1.3 targets before persistent Compose or Docker mutation.
  - No code-backed E2E was added: the PR CI environment has no control-plane E2E profile or release-artifact setup for injected v1.2 release tags, so manual verification was required for this release-artifact compatibility case.
  - The enterprise standard asset path is independently blocked after compatibility validation by missing `deploy/docker/neutree-core/vector/vector.yml`; no out-of-scope production change is included.

## Risk & Rollback

No DB schema, API, deployment manifest, CI/release workflow, or enterprise source change. The compatibility policy intentionally supports only v1.2 targets; v1.1 and v1.3 remain rejected. Roll back by reverting this PR, which restores the prior v1.1 policy.