### PR TITLE
fix: prevent node agent control-plane scheduling

### DIFF
--- a/internal/cluster/component/metrics/manifests.go
+++ b/internal/cluster/component/metrics/manifests.go
@@ -327,8 +327,6 @@ spec:
         neutree.ai/cluster-version: {{ .ClusterVersion }}
     spec:
       serviceAccountName: {{ .NeutreeNodeAgentMetricsName }}
-      tolerations:
-      - operator: Exists
       imagePullSecrets:
       - name: {{ .ImagePullSecret }}
       containers:

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -526,6 +526,7 @@ func TestBuildMetricsResourcesIncludesNodeAgentDaemonSet(t *testing.T) {
 		nodeAgent.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, "neutree-node-agent", nodeAgent.Spec.Template.Spec.ServiceAccountName)
 	assert.Assert(t, !nodeAgent.Spec.Template.Spec.HostNetwork)
+	assert.Equal(t, 0, len(nodeAgent.Spec.Template.Spec.Tolerations))
 	assert.Equal(t, "test-image-pull-secret", nodeAgent.Spec.Template.Spec.ImagePullSecrets[0].Name)
 	assert.Equal(t, int32(19101), nodeAgent.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 	assert.Equal(t, "500m", nodeAgent.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())

--- a/tests/e2e/cluster_k8s_config_test.go
+++ b/tests/e2e/cluster_k8s_config_test.go
@@ -148,6 +148,11 @@ var _ = Describe("K8s Cluster Config", Ordered, Label("cluster", "k8s", "config"
 			assertK8sMetricsResources(ctx, k8sH, namespace, cluster.Spec.Version)
 		})
 
+		// TestRail: C2739216
+		It("should not schedule node-agent on tainted control-plane nodes", Label("metrics", "control-plane-taint", "C2739216"), func() {
+			assertK8sNodeAgentControlPlaneScheduling(context.Background(), k8sH, namespace, cluster.Spec.Version)
+		})
+
 		It("should create router resources (SA, Role, RoleBinding, Deployment, Service)", Label("C2612779"), func() {
 			ctx := context.Background()
 

--- a/tests/e2e/cluster_metrics_helper_test.go
+++ b/tests/e2e/cluster_metrics_helper_test.go
@@ -156,7 +156,7 @@ func assertK8sNodeAgentControlPlaneScheduling(
 	}
 
 	if len(controlPlaneNodes) == 0 {
-		Skip("requires a control-plane node with node-role.kubernetes.io/control-plane:NoSchedule taint")
+		Skip("requires a control-plane node with a control-plane NoSchedule taint")
 	}
 
 	if len(untaintedWorkerNodes) == 0 {
@@ -190,7 +190,8 @@ func assertK8sNodeAgentControlPlaneScheduling(
 
 func hasControlPlaneNoScheduleTaint(node corev1.Node) bool {
 	for _, taint := range node.Spec.Taints {
-		if taint.Key == "node-role.kubernetes.io/control-plane" && taint.Effect == corev1.TaintEffectNoSchedule {
+		if (taint.Key == "node-role.kubernetes.io/control-plane" || taint.Key == "node-role.kubernetes.io/master") &&
+			taint.Effect == corev1.TaintEffectNoSchedule {
 			return true
 		}
 	}

--- a/tests/e2e/cluster_metrics_helper_test.go
+++ b/tests/e2e/cluster_metrics_helper_test.go
@@ -143,11 +143,13 @@ func assertK8sNodeAgentControlPlaneScheduling(
 
 	controlPlaneNodes := make(map[string]struct{})
 	untaintedWorkerNodes := make(map[string]struct{})
+
 	for _, node := range nodes {
 		if hasControlPlaneNoScheduleTaint(node) {
 			controlPlaneNodes[node.Name] = struct{}{}
 			continue
 		}
+
 		if isUntaintedWorkerNode(node) {
 			untaintedWorkerNodes[node.Name] = struct{}{}
 		}
@@ -156,6 +158,7 @@ func assertK8sNodeAgentControlPlaneScheduling(
 	if len(controlPlaneNodes) == 0 {
 		Skip("requires a control-plane node with node-role.kubernetes.io/control-plane:NoSchedule taint")
 	}
+
 	if len(untaintedWorkerNodes) == 0 {
 		Skip("requires an untainted worker node")
 	}
@@ -167,10 +170,12 @@ func assertK8sNodeAgentControlPlaneScheduling(
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should list node-agent pods")
 
 	var readyWorkerPod *corev1.Pod
+
 	for i := range pods {
 		pod := &pods[i]
 		ExpectWithOffset(1, controlPlaneNodes).NotTo(HaveKey(pod.Spec.NodeName),
 			"node-agent pod %s must not run on a control-plane node", pod.Name)
+
 		if _, ok := untaintedWorkerNodes[pod.Spec.NodeName]; ok && isPodReady(pod) {
 			readyWorkerPod = pod
 			break
@@ -201,6 +206,7 @@ func isUntaintedWorkerNode(node corev1.Node) bool {
 	if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
 		return false
 	}
+
 	if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
 		return false
 	}

--- a/tests/e2e/cluster_metrics_helper_test.go
+++ b/tests/e2e/cluster_metrics_helper_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -125,6 +126,100 @@ func assertK8sMetricsResources(
 	}
 
 	assertK8sKubeStateMetricsResources(ctx, k8sH, namespace, clusterVersion)
+}
+
+func assertK8sNodeAgentControlPlaneScheduling(
+	ctx context.Context,
+	k8sH *K8sHelper,
+	namespace string,
+	clusterVersion string,
+) {
+	if !clusterVersionSupportsManagedMetricsExporters(clusterVersion) {
+		Skip("node-agent control-plane scheduling check requires managed metrics exporters")
+	}
+
+	nodes, err := k8sH.ListNodes(ctx, "")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should list Kubernetes nodes")
+
+	controlPlaneNodes := make(map[string]struct{})
+	untaintedWorkerNodes := make(map[string]struct{})
+	for _, node := range nodes {
+		if hasControlPlaneNoScheduleTaint(node) {
+			controlPlaneNodes[node.Name] = struct{}{}
+			continue
+		}
+		if isUntaintedWorkerNode(node) {
+			untaintedWorkerNodes[node.Name] = struct{}{}
+		}
+	}
+
+	if len(controlPlaneNodes) == 0 {
+		Skip("requires a control-plane node with node-role.kubernetes.io/control-plane:NoSchedule taint")
+	}
+	if len(untaintedWorkerNodes) == 0 {
+		Skip("requires an untainted worker node")
+	}
+
+	nodeAgent := eventuallyDaemonSetReady(ctx, k8sH, namespace, "neutree-node-agent")
+	ExpectWithOffset(1, nodeAgent.Spec.Template.Spec.Tolerations).To(BeEmpty())
+
+	pods, err := k8sH.ListPods(ctx, namespace, "app=neutree-node-agent")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should list node-agent pods")
+
+	var readyWorkerPod *corev1.Pod
+	for i := range pods {
+		pod := &pods[i]
+		ExpectWithOffset(1, controlPlaneNodes).NotTo(HaveKey(pod.Spec.NodeName),
+			"node-agent pod %s must not run on a control-plane node", pod.Name)
+		if _, ok := untaintedWorkerNodes[pod.Spec.NodeName]; ok && isPodReady(pod) {
+			readyWorkerPod = pod
+			break
+		}
+	}
+
+	ExpectWithOffset(1, readyWorkerPod).NotTo(BeNil(), "an untainted worker must have a ready node-agent pod")
+	health, err := k8sH.PodProxyGetRaw(ctx, namespace, readyWorkerPod.Name, "19101", "/health")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "node-agent /health should be reachable on an untainted worker")
+	ExpectWithOffset(1, string(health)).To(ContainSubstring(`"status":"ok"`))
+}
+
+func hasControlPlaneNoScheduleTaint(node corev1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "node-role.kubernetes.io/control-plane" && taint.Effect == corev1.TaintEffectNoSchedule {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isUntaintedWorkerNode(node corev1.Node) bool {
+	if len(node.Spec.Taints) != 0 {
+		return false
+	}
+
+	if _, isControlPlane := node.Labels["node-role.kubernetes.io/control-plane"]; isControlPlane {
+		return false
+	}
+	if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
+		return false
+	}
+
+	return true
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }
 
 func assertK8sExternalAcceleratorExporterResources(


### PR DESCRIPTION
## Issue

NEU-549

## Summary

Prevent `neutree-node-agent` from scheduling on Kubernetes control-plane nodes tainted with `node-role.kubernetes.io/control-plane:NoSchedule`.

## Changes

- Remove the unconditional `operator: Exists` toleration from the controller-rendered `neutree-node-agent` DaemonSet.
- Add a rendered-resource regression test that requires an empty node-agent tolerations list.
- Add conditional Kubernetes E2E coverage for control-plane exclusion and untainted worker placement (TestRail `C2739216`).
- Limit the change to the community implementation; enterprise source, sync, build, and runtime validation are out of scope.

## Test Plan

### Unit test

- [x] `go test ./internal/cluster/component/metrics -count=1`
- [x] `go vet ./internal/cluster/component/metrics ./tests/e2e`

### DB test

- Not affected: no schema, query, or persistence behavior changed.

### E2E test

- [x] Manual TestRail `C2739216`: on a six-node leased Kubernetes environment, node-agent rendered with no tolerations, targeted the three untainted workers, and had no Pods on the three tainted control-plane nodes.

## Risk & Rollback

Custom tainted worker nodes no longer receive node-agent automatically; this is the approved behavior for NEU-549. Reverting this PR restores the previous broad toleration behavior.