### PR TITLE
fix: quote cluster metadata in manifests

### DIFF
--- a/internal/cluster/component/metrics/manifests.go
+++ b/internal/cluster/component/metrics/manifests.go
@@ -73,8 +73,8 @@ metadata:
   name: vmagent-node-reader-{{ .HashSuffix }}
   labels:
     app: vmagent
-    cluster: {{ .ClusterName }}
-    workspace: {{ .Workspace }}
+    cluster: {{ .ClusterName | quote }}
+    workspace: {{ .Workspace | quote }}
 rules:
 - apiGroups: [""]
   resources: ["nodes", "nodes/metrics", "nodes/proxy"]
@@ -93,8 +93,8 @@ metadata:
   name: vmagent-node-reader-{{ .HashSuffix }}
   labels:
     app: vmagent
-    cluster: {{ .ClusterName }}
-    workspace: {{ .Workspace }}
+    cluster: {{ .ClusterName | quote }}
+    workspace: {{ .Workspace | quote }}
 subjects:
 - kind: ServiceAccount
   name: vmagent-service-account
@@ -177,8 +177,8 @@ spec:
     metadata:
       labels:
         app: neutree-kube-state-metrics
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         neutree.ai/cluster-version: {{ .ClusterVersion }}
     spec:
       imagePullSecrets:
@@ -224,8 +224,8 @@ metadata:
   name: {{ .NeutreeNodeAgentMetricsName }}-{{ .HashSuffix }}
   labels:
     app: {{ .NeutreeNodeAgentMetricsName }}
-    cluster: {{ .ClusterName }}
-    workspace: {{ .Workspace }}
+    cluster: {{ .ClusterName | quote }}
+    workspace: {{ .Workspace | quote }}
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -243,8 +243,8 @@ metadata:
   name: {{ .NeutreeNodeAgentMetricsName }}-{{ .HashSuffix }}
   labels:
     app: {{ .NeutreeNodeAgentMetricsName }}
-    cluster: {{ .ClusterName }}
-    workspace: {{ .Workspace }}
+    cluster: {{ .ClusterName | quote }}
+    workspace: {{ .Workspace | quote }}
 subjects:
 - kind: ServiceAccount
   name: {{ .NeutreeNodeAgentMetricsName }}
@@ -268,14 +268,14 @@ spec:
   selector:
     matchLabels:
       app: {{ .NodeExporterName }}
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
   template:
     metadata:
       labels:
         app: {{ .NodeExporterName }}
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         neutree.ai/cluster-version: {{ .ClusterVersion }}
     spec:
       hostNetwork: true
@@ -316,14 +316,14 @@ spec:
   selector:
     matchLabels:
       app: {{ .NeutreeNodeAgentMetricsName }}
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
   template:
     metadata:
       labels:
         app: {{ .NeutreeNodeAgentMetricsName }}
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         neutree.ai/cluster-version: {{ .ClusterVersion }}
     spec:
       serviceAccountName: {{ .NeutreeNodeAgentMetricsName }}
@@ -395,8 +395,8 @@ metadata:
   namespace: {{ $.Namespace }}
   labels:
     app: {{ .AppLabel }}
-    cluster: {{ $.ClusterName }}
-    workspace: {{ $.Workspace }}
+    cluster: {{ $.ClusterName | quote }}
+    workspace: {{ $.Workspace | quote }}
     neutree.ai/cluster-version: {{ $.ClusterVersion }}
 data:
 {{ .ConfigFileData | toYaml | indent 2 }}
@@ -415,15 +415,15 @@ spec:
   selector:
     matchLabels:
       app: {{ .AppLabel }}
-      cluster: {{ $.ClusterName }}
-      workspace: {{ $.Workspace }}
+      cluster: {{ $.ClusterName | quote }}
+      workspace: {{ $.Workspace | quote }}
   template:
     metadata:
       labels:
         app: {{ .AppLabel }}
         neutree.ai/metrics-target: accelerator-exporter
-        cluster: {{ $.ClusterName }}
-        workspace: {{ $.Workspace }}
+        cluster: {{ $.ClusterName | quote }}
+        workspace: {{ $.Workspace | quote }}
         neutree.ai/cluster-version: {{ $.ClusterVersion }}
 {{ if .ConfigChecksum }}
       annotations:
@@ -481,14 +481,14 @@ spec:
   selector:
     matchLabels:
       app: vmagent
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
   template:
     metadata:
       labels:
         app: vmagent
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         neutree.ai/cluster-version: {{ .ClusterVersion }}
     spec:
       affinity:

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -127,6 +127,33 @@ func TestBuildVMAgentDeployment(t *testing.T) {
 	t.Fatalf("vmagent deployment not found in resources")
 }
 
+func TestBuildMetricsResourcesWithNumericClusterMetadata(t *testing.T) {
+	metricsCmpt := &MetricsComponent{
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{Name: "123", Workspace: "456"},
+			Spec:     &v1.ClusterSpec{Version: "v1.1.0"},
+		},
+		namespace:       "test-namespace",
+		imagePrefix:     "test-image-prefix",
+		imagePullSecret: "test-image-pull-secret",
+	}
+
+	objs, err := metricsCmpt.GetMetricsResources(context.Background())
+	assert.NilError(t, err)
+
+	clusterRole := findMetricsClusterRoleByApp(t, objs, "vmagent")
+	assert.Equal(t, clusterRole.Labels["cluster"], "123")
+	assert.Equal(t, clusterRole.Labels["workspace"], "456")
+
+	vmagent := findMetricsDeployment(t, objs, "vmagent")
+	assert.Equal(t, vmagent.Spec.Template.Labels["cluster"], "123")
+	assert.Equal(t, vmagent.Spec.Template.Labels["workspace"], "456")
+
+	vmagentConfig := findMetricsConfigMap(t, objs, "vmagent-config")
+	assert.Assert(t, strings.Contains(vmagentConfig.Data["prometheus.yml"], "regex: \"123\""))
+	assert.Assert(t, strings.Contains(vmagentConfig.Data["prometheus.yml"], "replacement: \"456\""))
+}
+
 func TestBuildVMAgentConfigIncludesHAMiMonitorScrape(t *testing.T) {
 	metricsCmpt := &MetricsComponent{
 		cluster: &v1.Cluster{

--- a/internal/cluster/component/metrics/vmagent_config.go
+++ b/internal/cluster/component/metrics/vmagent_config.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"bytes"
 	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
 )
 
 const kubernetesVMAgentConfigTemplateText = `global:
@@ -24,10 +26,10 @@ scrape_configs:
   # Only scrape pods with cluster and workspace labels matching
   - source_labels: [__meta_kubernetes_pod_label_cluster]
     action: keep
-    regex: {{ .ClusterName }}
+    regex: {{ .ClusterName | quote }}
   - source_labels: [__meta_kubernetes_pod_label_workspace]
     action: keep
-    regex: {{ .Workspace }}
+    regex: {{ .Workspace | quote }}
   # Set the __address__ to pod IP and port 8000
   - source_labels: [__meta_kubernetes_pod_ip]
     action: replace
@@ -66,10 +68,10 @@ scrape_configs:
   # Only scrape pods with cluster and workspace labels matching
   - source_labels: [__meta_kubernetes_pod_label_cluster]
     action: keep
-    regex: {{ .ClusterName }}
+    regex: {{ .ClusterName | quote }}
   - source_labels: [__meta_kubernetes_pod_label_workspace]
     action: keep
-    regex: {{ .Workspace }}
+    regex: {{ .Workspace | quote }}
   # Set the __address__ to pod IP and port 8000
   - source_labels: [__meta_kubernetes_pod_ip]
     action: replace
@@ -130,9 +132,9 @@ scrape_configs:
     target_label: node
   # Add cluster and workspace labels
   - target_label: neutree_cluster
-    replacement: {{ .ClusterName }}
+    replacement: {{ .ClusterName | quote }}
   - target_label: workspace
-    replacement: {{ .Workspace }}
+    replacement: {{ .Workspace | quote }}
 {{ end }}
 {{ if .EnableNeutreeNodeAgentMetrics }}
 # Scrape Neutree normalized node and accelerator metrics.
@@ -164,9 +166,9 @@ scrape_configs:
     action: replace
     target_label: pod
   - target_label: neutree_cluster
-    replacement: {{ .ClusterName }}
+    replacement: {{ .ClusterName | quote }}
   - target_label: workspace
-    replacement: {{ .Workspace }}
+    replacement: {{ .Workspace | quote }}
 {{ end }}
 {{ range .AcceleratorExporters }}
 # Scrape accelerator exporter metrics from detected accelerator nodes.
@@ -198,9 +200,9 @@ scrape_configs:
     action: replace
     target_label: pod
   - target_label: neutree_cluster
-    replacement: {{ $.ClusterName }}
+    replacement: {{ $.ClusterName | quote }}
   - target_label: workspace
-    replacement: {{ $.Workspace }}
+    replacement: {{ $.Workspace | quote }}
   - target_label: accelerator_type
     replacement: {{ .AcceleratorType }}
 {{ end }}
@@ -228,9 +230,9 @@ scrape_configs:
     action: replace
     target_label: pod
   - target_label: neutree_cluster
-    replacement: {{ .ClusterName }}
+    replacement: {{ .ClusterName | quote }}
   - target_label: workspace
-    replacement: {{ .Workspace }}
+    replacement: {{ .Workspace | quote }}
 {{ end }}
 {{ if .EnableHAMiMonitorScrape }}
 # Scrape HAMi vGPU monitor metrics from the managed HAMi device-plugin pods
@@ -263,9 +265,9 @@ scrape_configs:
     target_label: monitor_pod
   # Add cluster and workspace labels
   - target_label: neutree_cluster
-    replacement: {{ .ClusterName }}
+    replacement: {{ .ClusterName | quote }}
   - target_label: workspace
-    replacement: {{ .Workspace }}
+    replacement: {{ .Workspace | quote }}
 {{ end }}
 {{ if .EnableKubeStateMetrics }}
 # Scrape kube-state-metrics for Neutree pod ownership labels.
@@ -294,13 +296,13 @@ scrape_configs:
     action: replace
     target_label: monitor_pod
   - target_label: neutree_cluster
-    replacement: {{ .ClusterName }}
+    replacement: {{ .ClusterName | quote }}
   - target_label: workspace
-    replacement: {{ .Workspace }}
+    replacement: {{ .Workspace | quote }}
 {{ end }}`
 
 var kubernetesVMAgentConfigTemplate = template.Must(
-	template.New("kubernetes-vmagent-config").Parse(kubernetesVMAgentConfigTemplateText),
+	template.New("kubernetes-vmagent-config").Funcs(sprig.TxtFuncMap()).Parse(kubernetesVMAgentConfigTemplateText),
 )
 
 func renderKubernetesVMAgentConfig(variables MetricsManifestVariables) (string, error) {

--- a/internal/cluster/component/router/manifests.go
+++ b/internal/cluster/component/router/manifests.go
@@ -60,14 +60,14 @@ spec:
   selector:
     matchLabels:
       app: router
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
   template:
     metadata:
       labels:
         app: router
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         neutree.ai/cluster-version: {{ .Version }}
     spec:
       affinity:
@@ -136,8 +136,8 @@ metadata:
 spec:
   selector:
     app: router
-    cluster: {{ .ClusterName }}
-    workspace: {{ .Workspace }}
+    cluster: {{ .ClusterName | quote }}
+    workspace: {{ .Workspace | quote }}
   ports:
   - name: http
     port: 8000

--- a/internal/cluster/component/router/route_resource_test.go
+++ b/internal/cluster/component/router/route_resource_test.go
@@ -6,6 +6,7 @@ import (
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -151,4 +152,40 @@ func Test_BuildRouterService(t *testing.T) {
 	}
 
 	t.Fatalf("router service not found in resources")
+}
+
+func TestBuildRouterResourcesWithNumericClusterMetadata(t *testing.T) {
+	routerComponent := &RouterComponent{
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{Name: "123", Workspace: "456"},
+			Spec:     &v1.ClusterSpec{Version: "1.0.0"},
+		},
+		namespace:       "test-namespace",
+		imagePrefix:     "test-image-prefix",
+		imagePullSecret: "test-image-pull-secret",
+	}
+
+	objs, err := routerComponent.GetRouteResources()
+	require.NoError(t, err)
+
+	for _, obj := range objs.Items {
+		switch obj.GetKind() {
+		case "Deployment":
+			deploymentData, err := json.Marshal(obj.Object)
+			assert.NoError(t, err)
+
+			deployment := &appsv1.Deployment{}
+			assert.NoError(t, json.Unmarshal(deploymentData, deployment))
+			assert.Equal(t, "123", deployment.Spec.Selector.MatchLabels["cluster"])
+			assert.Equal(t, "456", deployment.Spec.Template.Labels["workspace"])
+		case "Service":
+			serviceData, err := json.Marshal(obj.Object)
+			assert.NoError(t, err)
+
+			service := &corev1.Service{}
+			assert.NoError(t, json.Unmarshal(serviceData, service))
+			assert.Equal(t, "123", service.Spec.Selector["cluster"])
+			assert.Equal(t, "456", service.Spec.Selector["workspace"])
+		}
+	}
 }

--- a/internal/cluster/component/router/route_resource_test.go
+++ b/internal/cluster/component/router/route_resource_test.go
@@ -168,24 +168,33 @@ func TestBuildRouterResourcesWithNumericClusterMetadata(t *testing.T) {
 	objs, err := routerComponent.GetRouteResources()
 	require.NoError(t, err)
 
+	foundDeployment := false
+	foundService := false
 	for _, obj := range objs.Items {
 		switch obj.GetKind() {
 		case "Deployment":
+			foundDeployment = true
 			deploymentData, err := json.Marshal(obj.Object)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			deployment := &appsv1.Deployment{}
-			assert.NoError(t, json.Unmarshal(deploymentData, deployment))
+			require.NoError(t, json.Unmarshal(deploymentData, deployment))
 			assert.Equal(t, "123", deployment.Spec.Selector.MatchLabels["cluster"])
+			assert.Equal(t, "456", deployment.Spec.Selector.MatchLabels["workspace"])
+			assert.Equal(t, "123", deployment.Spec.Template.Labels["cluster"])
 			assert.Equal(t, "456", deployment.Spec.Template.Labels["workspace"])
 		case "Service":
+			foundService = true
 			serviceData, err := json.Marshal(obj.Object)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			service := &corev1.Service{}
-			assert.NoError(t, json.Unmarshal(serviceData, service))
+			require.NoError(t, json.Unmarshal(serviceData, service))
 			assert.Equal(t, "123", service.Spec.Selector["cluster"])
 			assert.Equal(t, "456", service.Spec.Selector["workspace"])
 		}
 	}
+
+	require.True(t, foundDeployment, "router deployment not found in resources")
+	require.True(t, foundService, "router service not found in resources")
 }

--- a/internal/engine/llama-cpp/v0.3.7/templates/kubernetes/default.yaml
+++ b/internal/engine/llama-cpp/v0.3.7/templates/kubernetes/default.yaml
@@ -18,8 +18,8 @@ spec:
       maxSurge: 0
   selector:
     matchLabels:
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
       endpoint: "{{ .EndpointName }}"
       app: inference
   template:
@@ -33,8 +33,8 @@ spec:
       labels:
         engine: {{ .EngineName }}
         engine_version: {{ .EngineVersion }}
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference

--- a/internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml
+++ b/internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml
@@ -18,8 +18,8 @@ spec:
       maxSurge: 0
   selector:
     matchLabels:
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
       endpoint: "{{ .EndpointName }}"
       app: inference
   template:
@@ -33,8 +33,8 @@ spec:
       labels:
         engine: {{ .EngineName }}
         engine_version: {{ .EngineVersion }}
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference

--- a/internal/engine/template_render_test.go
+++ b/internal/engine/template_render_test.go
@@ -167,6 +167,51 @@ func TestBuiltInKubernetesTemplatesPreserveNumericEndpointName(t *testing.T) {
 	}
 }
 
+func TestBuiltInKubernetesTemplatesPreserveNumericClusterMetadata(t *testing.T) {
+	templates := []struct {
+		name     string
+		template string
+	}{
+		{
+			name:     "vllm v0.11.2",
+			template: vllmV0_11_2DeployTemplate,
+		},
+		{
+			name:     "vllm v0.17.1",
+			template: vllmV0_17_1DeployTemplate,
+		},
+		{
+			name:     "vllm v0.24.0",
+			template: vllmV0_24_0DeployTemplate,
+		},
+		{
+			name:     "sglang v0.5.10",
+			template: sglangV0_5_10DeployTemplate,
+		},
+		{
+			name:     "llama.cpp v0.3.7",
+			template: llamaCppDefaultDeployTemplate,
+		},
+	}
+
+	for _, tc := range templates {
+		t.Run(tc.name, func(t *testing.T) {
+			vars := newTestVLLMVars("v0.17.1", "text-generation")
+			vars["ClusterName"] = "123"
+			vars["Workspace"] = "456"
+
+			objs, err := util.RenderKubernetesManifest(tc.template, vars)
+			require.NoError(t, err)
+
+			deployment := mustFindRenderedObjectByKind(t, objs.Items, "Deployment")
+			assertNestedString(t, deployment.Object, "123", "spec", "selector", "matchLabels", "cluster")
+			assertNestedString(t, deployment.Object, "456", "spec", "selector", "matchLabels", "workspace")
+			assertNestedString(t, deployment.Object, "123", "spec", "template", "metadata", "labels", "cluster")
+			assertNestedString(t, deployment.Object, "456", "spec", "template", "metadata", "labels", "workspace")
+		})
+	}
+}
+
 func TestVLLMTemplatePreservesListEngineArgs(t *testing.T) {
 	vars := newTestVLLMVars("v0.24.0", "text-generation")
 	vars["EngineArgs"] = map[string]any{

--- a/internal/engine/vllm/v0.11.2/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.11.2/templates/kubernetes/default.yaml
@@ -18,8 +18,8 @@ spec:
       maxSurge: 0
   selector:
     matchLabels:
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
       endpoint: "{{ .EndpointName }}"
       app: inference
   template:
@@ -33,8 +33,8 @@ spec:
       labels:
         engine: {{ .EngineName }}
         engine_version: {{ .EngineVersion }}
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference

--- a/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.17.1/templates/kubernetes/default.yaml
@@ -18,8 +18,8 @@ spec:
       maxSurge: 0
   selector:
     matchLabels:
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
       endpoint: "{{ .EndpointName }}"
       app: inference
   template:
@@ -33,8 +33,8 @@ spec:
       labels:
         engine: {{ .EngineName }}
         engine_version: {{ .EngineVersion }}
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference

--- a/internal/engine/vllm/v0.24.0/templates/kubernetes/default.yaml
+++ b/internal/engine/vllm/v0.24.0/templates/kubernetes/default.yaml
@@ -18,8 +18,8 @@ spec:
       maxSurge: 0
   selector:
     matchLabels:
-      cluster: {{ .ClusterName }}
-      workspace: {{ .Workspace }}
+      cluster: {{ .ClusterName | quote }}
+      workspace: {{ .Workspace | quote }}
       endpoint: "{{ .EndpointName }}"
       app: inference
   template:
@@ -33,8 +33,8 @@ spec:
       labels:
         engine: {{ .EngineName }}
         engine_version: {{ .EngineVersion }}
-        cluster: {{ .ClusterName }}
-        workspace: {{ .Workspace }}
+        cluster: {{ .ClusterName | quote }}
+        workspace: {{ .Workspace | quote }}
         endpoint: "{{ .EndpointName }}"
         routing_logic: {{ .RoutingLogic }}
         app: inference


### PR DESCRIPTION
## Issue

NEU-570

## Summary

Quote cluster and workspace metadata in Router, Metrics, and built-in engine Kubernetes YAML templates so numeric names are decoded as strings.

## Changes

- Quote Router labels and selectors derived from cluster metadata.
- Quote Metrics manifest and VMAgent configuration values derived from cluster metadata.
- Quote selector and Pod-label metadata in built-in llama.cpp, SGLang, and vLLM Kubernetes templates.
- Add regression tests for numeric cluster and workspace values across the affected renderers.

## Test Plan

- [x] Unit test: `go test ./internal/engine ./internal/cluster/component/router ./internal/cluster/component/metrics -count=1`
- [x] DB test: not affected
- [x] E2E test: not run by explicit user direction to keep this Trivial, unit-test-only change. Manual testing is not required.

## Risk & Rollback

Low risk. The change only forces string typing for existing template values. Revert either task-owned commit to restore the prior rendering behavior.