### PR TITLE
fix: retain static metrics components without remote write

### DIFF
--- a/internal/cluster/staticcluster/metrics_components.go
+++ b/internal/cluster/staticcluster/metrics_components.go
@@ -85,10 +85,6 @@ func buildMetricsComponents(
 	profile *v1.AcceleratorProfile,
 	metricsRemoteWriteURL string,
 ) []v1.NodeComponentSpec {
-	if !util.IsHTTPOrHTTPSURL(metricsRemoteWriteURL) {
-		return nil
-	}
-
 	components := []v1.NodeComponentSpec{buildNodeExporterComponent(cluster)}
 
 	if acceleratorExporterMode(cluster) == v1.ClusterAcceleratorExporterModeManaged {
@@ -99,7 +95,7 @@ func buildMetricsComponents(
 
 	components = append(components, buildNodeAgentComponent(cluster, node, profile))
 
-	if role == v1.StaticNodeRoleHead {
+	if role == v1.StaticNodeRoleHead && util.IsHTTPOrHTTPSURL(metricsRemoteWriteURL) {
 		components = append(components, buildVMAgentComponent(cluster, metricsRemoteWriteURL))
 	}
 

--- a/internal/cluster/staticcluster/planner_test.go
+++ b/internal/cluster/staticcluster/planner_test.go
@@ -462,7 +462,7 @@ func TestPlannerSkipsMetricsComponentsWithoutValidRemoteWriteURL(t *testing.T) {
 					v1.StaticNodeRoleHead,
 					v1.StaticNodePhaseReady,
 					true,
-					cpuAcceleratorStatus(),
+					nvidiaAcceleratorStatus(),
 					nil,
 				),
 				staticNodeStatusWithAccelerator(
@@ -476,21 +476,49 @@ func TestPlannerSkipsMetricsComponentsWithoutValidRemoteWriteURL(t *testing.T) {
 			}
 
 			nodes := plannedStaticNodes(t, &Planner{
+				AcceleratorProfileProvider: fakeAcceleratorProfileProvider{
+					profiles: map[string]*v1.AcceleratorProfile{
+						v1.AcceleratorTypeNVIDIAGPU.String(): {
+							AcceleratorType: v1.AcceleratorTypeNVIDIAGPU.String(),
+							MetricsExporter: &v1.AcceleratorExporterProfile{
+								Name:  "dcgm-exporter",
+								Image: "nvcr.io/nvidia/k8s/dcgm-exporter:test",
+								Port:  19400,
+							},
+						},
+					},
+				},
 				MetricsRemoteWriteURL: tt.metricsRemoteWriteURL,
 			}, cluster, currentNodes)
 
 			head := findStaticNode(nodes, "head-0")
 			require.NotNil(t, head)
-			assertNodeComponentNames(t, head.Spec.Components, []string{"ray-head"})
+			assertNodeComponentNames(t, head.Spec.Components, []string{
+				"ray-head",
+				nodeExporterComponentName,
+				acceleratorExporterComponentName,
+				nodeAgentComponentName,
+			})
+			assert.Nil(t, findComponent(head.Spec.Components, vmagentComponentName))
 			assertWarmImages(t, head.Spec.Warm.Images, map[string]string{
-				"ray-runtime": "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+				"ray-runtime":                    "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+				nodeExporterComponentName:        "registry.example.com/neutree/prometheus/node-exporter:v1.8.2",
+				nodeAgentComponentName:           "registry.example.com/neutree/neutree/neutree-node-agent:v1.1.0-rc.1",
+				acceleratorExporterComponentName: "registry.example.com/neutree/nvidia/k8s/dcgm-exporter:test",
 			})
 
 			worker := findStaticNode(nodes, "worker-0")
 			require.NotNil(t, worker)
-			assertNodeComponentNames(t, worker.Spec.Components, []string{"ray-worker"})
+			assertNodeComponentNames(t, worker.Spec.Components, []string{
+				"ray-worker",
+				nodeExporterComponentName,
+				nodeAgentComponentName,
+			})
+			assert.Nil(t, findComponent(worker.Spec.Components, vmagentComponentName))
 			assertWarmImages(t, worker.Spec.Warm.Images, map[string]string{
-				"ray-runtime": "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+				"ray-runtime":             "registry.example.com/neutree/neutree/neutree-serve:v1.2.0",
+				nodeExporterComponentName: "registry.example.com/neutree/prometheus/node-exporter:v1.8.2",
+				nodeAgentComponentName:    "registry.example.com/neutree/neutree/neutree-node-agent:v1.1.0-rc.1",
 			})
 		})
 	}


### PR DESCRIPTION
## Issue

NEU-535

## Summary

Keep static-node local metrics collectors deployed when no valid metrics remote-write URL is configured. Only the head-node vmagent requires a valid HTTP/HTTPS remote-write URL.

## Changes

- Keep node-exporter and neutree-node-agent for static nodes without a valid remote-write URL.
- Keep managed accelerator-exporter for eligible GPU static nodes.
- Add regression coverage for empty, malformed, and unsupported remote-write URLs.

## Test Plan

### Unit test

- [x] `go test ./internal/cluster/staticcluster -count=1`
- [x] `go vet ./internal/cluster/staticcluster`
- [x] `./bin/golangci-lint run ./internal/cluster/staticcluster/...`
- [x] Focused RED/GREEN regression test for invalid URLs.
- [ ] Full `go test ./...` is blocked by the pre-existing missing `neutree-core.tar` embed artifact.

### DB test

- [x] Not affected: no database schema or storage change.

### E2E test

- [x] Manual no-remote-write validation on a Community control plane with an NVIDIA T4 and StaticNode `v1.1.1`: Cluster reached `Running`; `node-exporter`, managed `accelerator-exporter`, and `neutree-node-agent` were running; head-node `vmagent` was absent.
- [ ] Full TestRail C2742642 and the existing valid-URL `cluster && ssh && lifecycle` regression were not run or passed. They are waived for this PR by explicit user risk acceptance because the independent `neutree-node-agent:v1.1.0-rc.1` `/v1/node/device-snapshot` timeout exceeds the existing 5-second E2E threshold despite healthy local metrics components.
- Manual testing beyond the recorded no-remote-write validation is waived for this PR with the same user-approved risk acceptance.

## Risk & Rollback

Low-risk planner-only change. Roll back by reverting this commit; valid remote-write behavior remains covered by existing tests.