### PR TITLE
fix: normalize trailing slash in shared client URL

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"crypto/tls"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -87,7 +88,7 @@ func WithTimeout(timeout time.Duration) ClientOption {
 // NewClient creates a new neutree API client
 func NewClient(baseURL string, options ...ClientOption) *Client {
 	client := &Client{
-		baseURL: baseURL,
+		baseURL: strings.TrimRight(baseURL, "/"),
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnginesListNormalizesBaseURLTrailingSlash(t *testing.T) {
+func TestNormalizesBaseURLTrailingSlash(t *testing.T) {
 	tests := []struct {
 		name          string
 		baseURLSuffix string

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnginesListNormalizesBaseURLTrailingSlash(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseURLSuffix string
+		wantPath      string
+	}{
+		{
+			name:     "without trailing slash",
+			wantPath: "/api/v1/engines",
+		},
+		{
+			name:          "with trailing slash",
+			baseURLSuffix: "/",
+			wantPath:      "/api/v1/engines",
+		},
+		{
+			name:          "with path prefix and trailing slash",
+			baseURLSuffix: "/neutree/",
+			wantPath:      "/neutree/api/v1/engines",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, tt.wantPath, r.URL.Path)
+				_, err := w.Write([]byte("[]"))
+				require.NoError(t, err)
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(server.URL + tt.baseURLSuffix)
+			_, err := client.Engines.List(ListOptions{})
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Issue

NEU-569

## Summary

Fix the shared Go API client so a `--server-url` value with a trailing slash no longer produces `//api/v1/...` request paths during CLI engine import. The change normalizes the client base URL once in `client.NewClient` and adds focused regression coverage for plain, trailing-slash, and path-prefix inputs.

## Changes

- Trim trailing slashes when constructing `pkg/client.Client`.
- Add a table-driven regression test covering the shared `Engines.List` request path.
- Keep CLI flag handling and importer behavior unchanged; only the shared client constructor is touched.

## Test Plan

Unit test
- Passed: `go test ./pkg/client -run "^TestNormalizesBaseURLTrailingSlash$" -count=1 -v`
- Passed: `go test ./pkg/client/... ./cmd/neutree-cli/app/cmd/global ./cmd/neutree-cli/app/cmd/packageimport ./internal/cli/packageimport -count=1`
- Passed: `go vet ./pkg/client/... ./cmd/neutree-cli/app/cmd/global ./cmd/neutree-cli/app/cmd/packageimport ./internal/cli/packageimport`
- CI `pr-check`, `gateway-lua-test`, and `codecov/patch` passed.

DB test
- Not affected.

E2E test
- Passed manual Step 5 verification with PR-head CLI `f4cb1914` against community `v1.2.0-nightly-20260803`.
- `neutree-cli get engine -o json --server-url http://<control-plane>:3000/` exited `0`, returned valid JSON with three Engines, and did not return 404.
- Code E2E not added: the focused `pkg/client` request-path test proves the exact URL construction; manual E2E validates the real CLI/control-plane integration.

## Risk & Rollback

Risk is low because the change only normalizes the shared client base URL and preserves optional path prefixes. Roll back by reverting this commit if any unexpected client path regression appears.
