### PR TITLE
docs(contributing): document make prepare-build-cli in first-time setup

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -4,13 +4,32 @@ Engineering guide for human contributors and AI agents. Start here, then open th
 
 ## First-time Setup
 
-After cloning the repo, install the local git hooks:
+After cloning the repo, install the local git hooks and generate the embedded CLI manifests:
 
 ```bash
 make install-hooks
+make prepare-build-cli
 ```
 
-This enables the pre-commit gate (`gofmt` / `go vet` / architecture boundaries / migration-pair check / full lint / short tests on affected packages).
+`make install-hooks` enables the pre-commit gate (`gofmt` / `go vet` / architecture boundaries / migration-pair check / full lint / short tests on affected packages).
+
+`make prepare-build-cli` packs `deploy/docker/` into `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar` and `obs-stack.tar`. Those archives are `//go:embed`-ed by the launch manifests but are git-ignored build artifacts, so a fresh clone does not have them. Until you generate them, **any** build of the module fails:
+
+```
+cmd/neutree-cli/app/cmd/launch/manifests/core.go:7:12: pattern neutree-core.tar: no matching files found
+```
+
+That breaks `go build ./...`, `go test ./...`, and gopls / IDE indexing — not just the CLI target.
+
+The target is not a bare `tar`; it pulls in the deploy manifests first:
+
+```
+prepare-build-cli
+├── sync-deploy-manifests → bin/vendir sync   # fans deploy manifests out into deploy/docker/ and deploy/chart/
+└── tar deploy/docker/{neutree-core,obs-stack} → manifests/*.tar
+```
+
+Two consequences. First, `vendir` is a tool dependency: the `vendir` target curl-downloads the binary into `bin/` from GitHub releases when it is missing, so **the first run needs network access** (later runs do not — `vendir.yml` only declares local `directory:` sources, so `sync` itself copies from paths already in the repo). Second, because the tar step packs whatever `sync` just wrote, re-run `make prepare-build-cli` after changing anything under `deploy/` — a stale `.tar` embeds silently.
 
 ## Playbooks
 


### PR DESCRIPTION
## Problem

`.gitignore` ignores `cmd/neutree-cli/app/cmd/launch/manifests/*.tar`, while `manifests/core.go` and `manifests/obs_stack.go` `//go:embed neutree-core.tar` / `obs-stack.tar`. A fresh clone therefore has neither archive, and every build of the module stops at:

```
cmd/neutree-cli/app/cmd/launch/manifests/core.go:7:12: pattern neutree-core.tar: no matching files found
```

This is not limited to the CLI target — it also breaks `go test ./...` and makes gopls / IDE indexing report the error module-wide. `make prepare-build-cli` already generates both archives, but nothing in `contributing/` mentions it, so every newcomer hits this once.

## Change

Docs only. `## First-time Setup` now lists `make prepare-build-cli` alongside `make install-hooks`, with the failure it prevents and the target's actual dependency chain. No code or Makefile changes.

The chain matters because the target is not a bare `tar`:

```
prepare-build-cli
├── sync-deploy-manifests → bin/vendir sync
└── tar deploy/docker/{neutree-core,obs-stack} → manifests/*.tar
```

Two consequences are documented: `vendir` is a tool dependency curl-downloaded into `bin/` on first use (so the first run needs network — the `sync` itself does not, since `vendir.yml` declares only local `directory:` sources), and the target must be re-run after editing anything under `deploy/`, since a stale `.tar` embeds silently.

## Verification

Fresh `git clone` of `main` in a clean `golang:1.23` container:

- Before: `go build ./...` → `pattern neutree-core.tar: no matching files found`, exit 1.
- After running exactly the two documented commands: both exit 0, both `.tar` files are produced, the embed error is gone, and everything in `go list ./...` builds cleanly.
- Dependency chain checked on a second pristine clone: no `bin/` directory exists initially; `make prepare-build-cli` fetches `vendir 0.26.0` into `bin/`, runs `bin/vendir sync`, then packs both archives.

One caveat worth flagging separately: on pristine `main`, `go build ./...` still exits non-zero afterwards, for an unrelated pre-existing reason — `tests/e2e/cluster_metrics_helper.go` (a non-test file) references helpers defined in `tests/e2e/cluster_k8s_config_test.go`, so that package can never build under plain `go build`. It compiles fine when test files are included (`go vet ./tests/e2e/` exits 0). That is a separate issue from the embedded manifests and is left untouched here.