### PR TITLE
feat(make): add deploy-remote for hot-replacing a control-plane binary on a remote host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,33 @@ docker-test-core: ## Redeploy local neutree-core for testing
 docker-test-node-agent: ## Build local neutree-node-agent binary for testing
 	$(MAKE) build-neutree-node-agent
 
+# Remote counterpart of docker-test-api / docker-test-core: same idea, but the
+# container lives on another host and the swap is checked instead of assumed.
+# Required: HOST, COMP. Optional: CONTAINER, REMOTE_BIN, BACKUP_DIR, HEALTH_URL,
+# SETTLE, SSH_OPTS. Leave REMOTE_BIN empty for a stock container (docker cp);
+# set it to the bind-mounted directory on the remote host when the binary is
+# mounted in. See contributing/testing.md.
+CONTAINER ?= $(COMP)
+REMOTE_BIN ?=
+BACKUP_DIR ?= /var/tmp/neutree-deploy-remote
+HEALTH_URL ?=
+SETTLE ?= 10
+SSH_OPTS ?=
+
+DEPLOY_REMOTE_ENV = \
+	HOST="$(HOST)" COMP="$(COMP)" CONTAINER="$(CONTAINER)" REMOTE_BIN="$(REMOTE_BIN)" \
+	BACKUP_DIR="$(BACKUP_DIR)" HEALTH_URL="$(HEALTH_URL)" SETTLE="$(SETTLE)" \
+	SSH_OPTS="$(SSH_OPTS)" LOCAL_BIN="bin/$(COMP)" EXPECT_COMMIT="$(GIT_COMMIT)"
+
+.PHONY: deploy-remote
+deploy-remote: ## Build COMP and hot-replace it in a container on HOST, with backup and verification
+	$(MAKE) build-$(COMP)
+	@$(DEPLOY_REMOTE_ENV) bash scripts/deploy-remote.sh deploy
+
+.PHONY: deploy-remote-rollback
+deploy-remote-rollback: ## Restore the binary deploy-remote backed up on HOST and restart the container
+	@$(DEPLOY_REMOTE_ENV) bash scripts/deploy-remote.sh rollback
+
 .PHONY: docker-test-db-scripts
 docker-test-db-scripts: ## Overwrite db scripts for testing, and restart related services
 	docker cp db copy-db-scripts:/

--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,15 @@ docker-test-node-agent: ## Build local neutree-node-agent binary for testing
 # SETTLE, SSH_OPTS. Leave REMOTE_BIN empty for a stock container (docker cp);
 # set it to the bind-mounted directory on the remote host when the binary is
 # mounted in. See contributing/testing.md.
+#
+# The binary is built on the machine running make, and build-$(COMP) does not
+# pin GOOS/GOARCH. When HOST's OS or CPU architecture differs from this
+# machine's, cross-compile by exporting them for the whole invocation:
+#
+#     GOOS=linux GOARCH=amd64 make deploy-remote HOST=root@10.0.0.5 COMP=neutree-api
+#
+# deploy-remote.sh refuses to ship a binary that does not match HOST, so a
+# forgotten GOARCH fails before anything on the host is touched.
 CONTAINER ?= $(COMP)
 REMOTE_BIN ?=
 BACKUP_DIR ?= /var/tmp/neutree-deploy-remote

--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ make db-test
 # Quick iteration: rebuild and restart local containers
 make docker-test-api
 make docker-test-core
+
+# Same, against a container on a remote host (backs up + verifies the swap)
+make deploy-remote HOST=root@10.0.0.5 COMP=neutree-api
 ```
+
+See [`contributing/testing.md`](contributing/testing.md#iterating-against-a-running-control-plane)
+for the remote deployment options and rollback.
 
 ## Roadmap
 

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -45,7 +45,7 @@ If the component differs between Compose and Helm, document the reason in the PR
 | [`architecture-neutree-api.md`](architecture-neutree-api.md) | neutree-api process role, route topology, authentication |
 | [`architecture-neutree-core.md`](architecture-neutree-core.md) | neutree-core process role, controller pattern (idempotent / spec-status / soft-delete), reconcile cadence, cluster modes, vendor plugin pairs |
 | [`architecture-neutree-cli.md`](architecture-neutree-cli.md) | neutree-cli process role, subcommand groups, authentication, deploy mode, engine package import |
-| [`testing.md`](testing.md) | Unit (testify + mockery), Python co-location, DB integration, E2E (Ginkgo), impl/test file pairs |
+| [`testing.md`](testing.md) | Unit (testify + mockery), Python co-location, DB integration, E2E (Ginkgo), impl/test file pairs, deploying a build to a running control plane |
 | [`coding-standards.md`](coding-standards.md) | golangci-lint rules, import organization, commit convention, lint fix cheatsheet |
 | [`database.md`](database.md) | PostgREST + RLS model, migration rules (incl. pairing), auth token layers, common errors |
 | [`playbooks.md`](playbooks.md) | Step-by-step checklists — new engine version, new resource type |

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -47,3 +47,86 @@ Ginkgo + Gomega.
 - **Profile-driven**: infrastructure config lives under `E2E_PROFILE_PATH`; never hard-code environment details.
 - **Test data isolation**: use run-id-suffixed resource names, register `DeferCleanup` for anything created.
 
+## Iterating Against a Running Control Plane
+
+Some changes can only be exercised against a real deployment — the control plane
+needs PostgreSQL / PostgREST / GoTrue, and the orchestrators need a real cluster.
+The loop is: build a static binary, swap it into the running container, restart,
+check it came back healthy.
+
+### Local containers
+
+`make docker-test-api` / `make docker-test-core` rebuild the binary and
+`docker cp` it into a container on the **local** Docker daemon, then restart it.
+No backup, no verification — they are meant for a throwaway local stack.
+
+### Remote hosts
+
+`make deploy-remote` does the same against a container on another host over SSH,
+and adds the parts you want when the target is not disposable: it backs the
+current binary up first, verifies the transfer, installs it without tripping
+`ETXTBSY`, and checks the container actually came back.
+
+```bash
+# Stock container — the binary lives in the container's own filesystem
+make deploy-remote HOST=root@10.0.0.5 COMP=neutree-api
+
+# Bind-mount deployment — REMOTE_BIN is the host directory mounted into the container
+make deploy-remote HOST=root@10.0.0.5 COMP=neutree-core REMOTE_BIN=/opt/neutree/bin
+
+# Undo it
+make deploy-remote-rollback HOST=root@10.0.0.5 COMP=neutree-api
+```
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `HOST` | *(required)* | SSH target, e.g. `root@10.0.0.5`. |
+| `COMP` | *(required)* | `neutree-api` or `neutree-core`. Also the default container name and the in-container binary path (`/$(COMP)`). |
+| `REMOTE_BIN` | *(empty)* | **Empty → `docker cp` mode.** Set → bind-mount mode; the directory on `HOST` mounted into the container, where `$(REMOTE_BIN)/$(COMP)` is the file the container executes. |
+| `CONTAINER` | `$(COMP)` | Container name, when it differs from the component name. |
+| `BACKUP_DIR` | `/var/tmp/neutree-deploy-remote` | Where the previous binary is kept on `HOST`. Deliberately outside `REMOTE_BIN` so backups are not visible inside the container. |
+| `HEALTH_URL` | *(empty)* | HTTP probe, curled **from `HOST`** after the restart. Skipped (loudly) when empty, because the right URL and port are deployment-specific. |
+| `SETTLE` | `10` | Seconds to wait after the restart before checking — long enough for a crash loop to show itself. |
+| `SSH_OPTS` | *(empty)* | Extra flags for `ssh`/`scp`, e.g. `-i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no`. |
+
+**Which mode do I want?** `docker cp` mode is the default because it matches a
+stock `neutree-cli launch` / Compose deployment, where the binary ships inside
+the image. Bind-mount mode only applies if whoever set the host up mounted a
+host directory over the binary. `docker inspect -f '{{json .HostConfig.Binds}}'
+<container>` tells you which one you are looking at; if the binary path is not
+in there, leave `REMOTE_BIN` empty.
+
+Why each step is there — every one of these has bitten someone:
+
+- **Backup before touching anything.** `deploy-remote-rollback` restores it and
+  restarts. Nothing else in the flow can un-break a bad binary.
+- **`chmod 755` after transfer.** `scp` propagates the *local* file's mode, so a
+  binary that lost its executable bit locally arrives non-executable and the
+  container comes back up with a permission denied on exec. `curl` writes `0644`
+  by default, as do most archive extractions, so this bites whenever `bin/$(COMP)`
+  came from somewhere other than a local `go build`. Setting the bit explicitly
+  makes the target independent of how the binary was produced.
+- **Stage to a temp file, then `mv -f`.** Writing over a running executable in
+  place fails with `ETXTBSY` (`cp: cannot create regular file ...: Text file
+  busy`). A rename swaps the directory entry instead, which the running process
+  does not care about. The temp file is staged *inside* `REMOTE_BIN` on purpose:
+  across a filesystem boundary `mv` degrades from `rename(2)` to a copy, which
+  still gets past `ETXTBSY` — GNU `mv` unlinks the target and retries — but is
+  no longer atomic, leaving a window where the binary is missing or half-written.
+- **Checksum both ends.** A truncated transfer otherwise shows up as a confusing
+  crash loop.
+- **`RestartCount` must not move.** Not `== 0`: the count is cumulative over the
+  container's whole life and `docker restart` does not reset it, so any host
+  that ever had a crash fails an absolute check. What matters is that the
+  restart policy did not kick in *after* the deploy.
+- **`--version` must report the commit just built.** This is what catches "the
+  swap silently didn't take". It relies on the version ldflags in
+  `GO_BUILD_ARGS`, which is why the target builds through `make build-$(COMP)`.
+  A binary built with a bare `go build` reports `Git Commit: unknown` and fails
+  this check — that is the check working, not a bug.
+- **Logs scanned for `panic:` / fatal.** A process can be `Running` and still
+  have logged a fatal error on a background goroutine.
+
+The target carries no environment-specific defaults: `HOST` and `COMP` have to
+be supplied on every invocation.
+

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -96,8 +96,21 @@ host directory over the binary. `docker inspect -f '{{json .HostConfig.Binds}}'
 <container>` tells you which one you are looking at; if the binary path is not
 in there, leave `REMOTE_BIN` empty.
 
+**Deploying to a different architecture.** The binary is built on the machine
+running `make`, and `build-$(COMP)` does not pin `GOOS`/`GOARCH`. Deploying from
+an arm64 laptop to an amd64 host therefore ships something the target cannot
+exec. Export them for the whole invocation:
+
+```bash
+GOOS=linux GOARCH=amd64 make deploy-remote HOST=root@10.0.0.5 COMP=neutree-api
+```
+
 Why each step is there — every one of these has bitten someone:
 
+- **Architecture checked before anything is touched.** The ELF header of the
+  binary is compared against `uname -m` on `HOST`. Without it a forgotten
+  `GOARCH` only surfaces once the container restarts into a crash loop — you
+  find out by causing an outage.
 - **Backup before touching anything.** `deploy-remote-rollback` restores it and
   restarts. Nothing else in the flow can un-break a bad binary.
 - **`chmod 755` after transfer.** `scp` propagates the *local* file's mode, so a

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# Hot-replace a neutree control-plane binary in a container on a remote host,
+# then verify the replacement took and the process is healthy.
+#
+# Driven by `make deploy-remote` / `make deploy-remote-rollback`; see
+# contributing/testing.md for the operator-facing documentation.
+#
+# Two container shapes are supported, selected by REMOTE_BIN:
+#
+#   REMOTE_BIN unset  -> docker cp mode. The binary lives in the container's
+#                        own filesystem. This is what `docker-test-api` and
+#                        `docker-test-core` do, and what a stock compose
+#                        deployment looks like.
+#   REMOTE_BIN set    -> bind-mount mode. REMOTE_BIN is a directory on the
+#                        remote host bind-mounted into the container, and
+#                        $REMOTE_BIN/$COMP is the file the container executes.
+#
+set -euo pipefail
+
+ACTION="${1:-}"
+
+: "${HOST:?HOST is required, e.g. HOST=root@10.0.0.5}"
+: "${COMP:?COMP is required, e.g. COMP=neutree-api}"
+
+CONTAINER="${CONTAINER:-$COMP}"
+LOCAL_BIN="${LOCAL_BIN:-bin/$COMP}"
+REMOTE_BIN="${REMOTE_BIN:-}"
+BACKUP_DIR="${BACKUP_DIR:-/var/tmp/neutree-deploy-remote}"
+HEALTH_URL="${HEALTH_URL:-}"
+SETTLE="${SETTLE:-10}"
+EXPECT_COMMIT="${EXPECT_COMMIT:-}"
+SSH_OPTS="${SSH_OPTS:-}"
+
+BACKUP="$BACKUP_DIR/$COMP.bak"
+
+# In bind-mount mode the staging file must live in the *same directory* as the
+# target, or `mv` crosses a filesystem boundary and degrades from rename(2) to a
+# copy. That still gets past ETXTBSY (GNU mv unlinks the target and retries),
+# but the swap stops being atomic: there is a window where the target is missing
+# or half-written, and a container restarting inside it comes up broken.
+if [ -n "$REMOTE_BIN" ]; then
+	STAGE="$REMOTE_BIN/.$COMP.deploy-remote.new"
+	MODE="bind-mount ($REMOTE_BIN/$COMP)"
+else
+	STAGE="$BACKUP_DIR/$COMP.new"
+	MODE="docker cp ($CONTAINER:/$COMP)"
+fi
+
+# shellcheck disable=SC2086
+remote() { ssh $SSH_OPTS "$HOST" "$@"; }
+log() { printf '\n==> %s\n' "$*"; }
+
+# Set once a backup exists, so every subsequent bail-out tells the operator how
+# to undo the deploy.
+ON_FAIL=""
+fail() {
+	printf '\nERROR: %s\n' "$*" >&2
+	[ -n "$ON_FAIL" ] && "$ON_FAIL"
+	exit 1
+}
+
+rollback_hint() {
+	cat >&2 <<-EOF
+
+		Roll back with:
+
+		    make deploy-remote-rollback HOST=$HOST COMP=$COMP${CONTAINER:+ CONTAINER=$CONTAINER}${REMOTE_BIN:+ REMOTE_BIN=$REMOTE_BIN}
+
+		The previous binary is preserved at $HOST:$BACKUP.
+	EOF
+}
+
+preflight() {
+	remote "command -v docker >/dev/null" || fail "docker not found on $HOST"
+	remote "docker inspect $CONTAINER >/dev/null 2>&1" ||
+		fail "container '$CONTAINER' does not exist on $HOST"
+	if [ -n "$REMOTE_BIN" ]; then
+		remote "test -f '$REMOTE_BIN/$COMP'" ||
+			fail "$HOST:$REMOTE_BIN/$COMP does not exist — is this really a bind-mount deployment?"
+	fi
+}
+
+# Install $STAGE (already staged and chmod'ed on the remote host) as the live
+# binary, then restart the container.
+install_and_restart() {
+	if [ -n "$REMOTE_BIN" ]; then
+		# Atomic rename. Overwriting a running executable in place would fail
+		# with ETXTBSY; rename swaps the directory entry instead.
+		log "Installing via atomic rename: $STAGE -> $REMOTE_BIN/$COMP"
+		remote "mv -f '$STAGE' '$REMOTE_BIN/$COMP'"
+	else
+		log "Installing via docker cp: $STAGE -> $CONTAINER:/$COMP"
+		remote "docker cp '$STAGE' '$CONTAINER:/$COMP' && rm -f '$STAGE'"
+	fi
+
+	log "Restarting $CONTAINER"
+	remote "docker restart '$CONTAINER'"
+}
+
+# $1: restart count observed before the restart
+# $2: "check-commit" to additionally assert --version reports $EXPECT_COMMIT
+verify() {
+	local before_restarts="$1" check_commit="${2:-}"
+
+	log "Waiting ${SETTLE}s for $CONTAINER to settle"
+	sleep "$SETTLE"
+
+	local running after_restarts
+	running=$(remote "docker inspect -f '{{.State.Running}}' '$CONTAINER'")
+	[ "$running" = "true" ] || fail "$CONTAINER is not running (State.Running=$running)"
+	echo "    running:       true"
+
+	# RestartCount is cumulative over the container's whole life and is *not*
+	# reset by `docker restart`, so an absolute `== 0` check breaks on any
+	# container that ever crashed. What actually matters is that the restart
+	# policy did not kick in after our restart, i.e. the count did not move.
+	after_restarts=$(remote "docker inspect -f '{{.RestartCount}}' '$CONTAINER'")
+	[ "$after_restarts" = "$before_restarts" ] ||
+		fail "$CONTAINER is crash-looping: RestartCount went $before_restarts -> $after_restarts"
+	echo "    RestartCount:  $after_restarts (unchanged)"
+
+	local version
+	version=$(remote "docker exec '$CONTAINER' '/$COMP' --version") ||
+		fail "'$COMP --version' failed inside $CONTAINER"
+	echo "$version" | sed 's/^/    | /'
+
+	if [ "$check_commit" = "check-commit" ] && [ -n "$EXPECT_COMMIT" ]; then
+		echo "$version" | grep -q "$EXPECT_COMMIT" ||
+			fail "$CONTAINER reports a different build than the one just deployed
+       (expected git commit '$EXPECT_COMMIT').
+       Binaries built outside 'make build-$COMP' carry no version ldflags and
+       report 'Git Commit: unknown', which also fails this check."
+		echo "    git commit:    $EXPECT_COMMIT (matches)"
+	fi
+
+	if [ -n "$HEALTH_URL" ]; then
+		local code
+		# Probe from the remote host: the container's ports are usually not
+		# reachable from wherever make is running.
+		code=$(remote "curl -fsS -o /dev/null -w '%{http_code}' --max-time 10 '$HEALTH_URL'") ||
+			fail "health probe failed: $HEALTH_URL"
+		echo "    health:        $HEALTH_URL -> $code"
+	else
+		echo "    health:        SKIPPED (pass HEALTH_URL=... to probe)"
+	fi
+
+	local logs
+	logs=$(remote "docker logs --since ${SETTLE}s '$CONTAINER' 2>&1 | tail -40")
+	if echo "$logs" | grep -qE 'panic:|fatal error:|^F[0-9]{4}'; then
+		echo "$logs" | sed 's/^/    | /' >&2
+		fail "$CONTAINER logged a panic or fatal error after restart"
+	fi
+	echo "    logs:          clean"
+	echo "$logs" | tail -10 | sed 's/^/    | /'
+}
+
+do_deploy() {
+	[ -f "$LOCAL_BIN" ] || fail "$LOCAL_BIN not found — build it first"
+	preflight
+
+	local before_restarts local_sum remote_sum
+	before_restarts=$(remote "docker inspect -f '{{.RestartCount}}' '$CONTAINER'")
+
+	log "Deploying $LOCAL_BIN to $HOST via $MODE"
+
+	# Back up first, so there is always something to roll back to. The backup
+	# lives outside REMOTE_BIN so it is not exposed inside the container.
+	log "Backing up current binary to $HOST:$BACKUP"
+	remote "mkdir -p '$BACKUP_DIR'"
+	if [ -n "$REMOTE_BIN" ]; then
+		remote "cp -a '$REMOTE_BIN/$COMP' '$BACKUP'"
+	else
+		remote "docker cp '$CONTAINER:/$COMP' '$BACKUP'"
+	fi
+	remote "chmod 755 '$BACKUP'"
+	ON_FAIL=rollback_hint
+
+	log "Transferring to $HOST:$STAGE"
+	remote "mkdir -p \"\$(dirname '$STAGE')\""
+	# shellcheck disable=SC2086
+	scp $SSH_OPTS -q "$LOCAL_BIN" "$HOST:$STAGE"
+
+	# scp propagates the *local* file's mode, so a binary that lost its
+	# executable bit locally lands non-executable here and the container comes
+	# back up with a permission denied on exec. curl writes 0644 by default, as
+	# do most archive extractions. Setting it explicitly makes this independent
+	# of how LOCAL_BIN was produced.
+	remote "chmod 755 '$STAGE'"
+
+	local_sum=$(sha256sum "$LOCAL_BIN" | cut -d' ' -f1)
+	remote_sum=$(remote "sha256sum '$STAGE'" | cut -d' ' -f1)
+	[ "$local_sum" = "$remote_sum" ] ||
+		fail "checksum mismatch after transfer: local $local_sum != remote $remote_sum"
+	echo "    sha256:        $local_sum (verified)"
+
+	install_and_restart
+
+	log "Verifying"
+	verify "$before_restarts" check-commit
+
+	log "Deployed $COMP to $HOST ($MODE)"
+	rollback_hint
+}
+
+do_rollback() {
+	preflight
+	remote "test -f '$BACKUP'" || fail "no backup at $HOST:$BACKUP — nothing to roll back to"
+
+	local before_restarts
+	before_restarts=$(remote "docker inspect -f '{{.RestartCount}}' '$CONTAINER'")
+
+	log "Rolling $CONTAINER back to $HOST:$BACKUP via $MODE"
+	remote "cp -a '$BACKUP' '$STAGE' && chmod 755 '$STAGE'"
+	install_and_restart
+
+	log "Verifying"
+	# No commit assertion here: the point of a rollback is to run the *old*
+	# build, which by definition does not report the working tree's commit.
+	verify "$before_restarts"
+
+	log "Rolled back $COMP on $HOST"
+}
+
+case "$ACTION" in
+deploy) do_deploy ;;
+rollback) do_rollback ;;
+*) fail "usage: $0 deploy|rollback (driven by 'make deploy-remote' / 'make deploy-remote-rollback')" ;;
+esac

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -81,6 +81,40 @@ preflight() {
 	fi
 }
 
+# `make deploy-remote` builds the binary on whatever machine make runs on, and
+# build-$COMP does not pin GOOS/GOARCH — so an arm64 laptop deploying to an
+# amd64 host produces something the target cannot exec. Left unchecked that only
+# surfaces after the restart, as a crash loop: you find out by causing an outage.
+#
+# Read the ELF header of the file about to be shipped — magic at bytes 0-3,
+# e_machine at 18-19, little-endian — and compare it with the host's `uname -m`.
+# Inspecting the artifact rather than `go env` also covers a binary that was
+# built somewhere else entirely.
+check_arch() {
+	local header machine remote_arch
+	header=$(od -An -tx1 -N20 "$LOCAL_BIN" | tr -d ' \n')
+	[ "${header:0:8}" = "7f454c46" ] ||
+		fail "$LOCAL_BIN is not an ELF binary — built for a non-Linux GOOS?
+       Cross-compile for the target: GOOS=linux GOARCH=<arch> make build-$COMP"
+
+	machine="${header:36:4}"
+	remote_arch=$(remote "uname -m")
+	case "$remote_arch:$machine" in
+	x86_64:3e00 | aarch64:b700 | arm64:b700)
+		echo "    arch:          $remote_arch (matches)"
+		;;
+	x86_64:* | aarch64:* | arm64:*)
+		fail "$LOCAL_BIN was not built for the architecture of $HOST ($remote_arch).
+       Cross-compile for the target: GOOS=linux GOARCH=<arch> make build-$COMP"
+		;;
+	*)
+		# Some other architecture: nothing to assert against, and guessing would
+		# be worse than the crash loop this check exists to avoid.
+		echo "    arch:          $remote_arch (unrecognised, not checked)"
+		;;
+	esac
+}
+
 # Install $STAGE (already staged and chmod'ed on the remote host) as the live
 # binary, then restart the container.
 install_and_restart() {
@@ -163,6 +197,7 @@ do_deploy() {
 	before_restarts=$(remote "docker inspect -f '{{.RestartCount}}' '$CONTAINER'")
 
 	log "Deploying $LOCAL_BIN to $HOST via $MODE"
+	check_arch
 
 	# Back up first, so there is always something to roll back to. The backup
 	# lives outside REMOTE_BIN so it is not exposed inside the container.


### PR DESCRIPTION
## Problem

`docker-test-api` / `docker-test-core` only work against the local Docker
daemon. Deploying a build to a remote dev host has been an ad-hoc sequence of
`scp` / `docker cp` / `docker restart` passed around by word of mouth. Every
safeguard in that sequence exists because of a specific failure, and every one
of them is easy to forget.

## What this adds

`make deploy-remote HOST=... COMP=...` and `make deploy-remote-rollback`, next
to the existing `docker-test-*` targets, implemented in
`scripts/deploy-remote.sh`.

```bash
# Stock container — the binary lives in the container's own filesystem
make deploy-remote HOST=root@10.0.0.5 COMP=neutree-api

# Bind-mount deployment — REMOTE_BIN is the host directory mounted into the container
make deploy-remote HOST=root@10.0.0.5 COMP=neutree-core REMOTE_BIN=/opt/neutree/bin

make deploy-remote-rollback HOST=root@10.0.0.5 COMP=neutree-api
```

Both container shapes are supported, selected by `REMOTE_BIN`:

- **empty (default) → `docker cp` mode**, matching a stock `neutree-cli launch`
  / Compose deployment where the binary ships inside the image. This is the
  common case, hence the default.
- **set → bind-mount mode**, where `$(REMOTE_BIN)/$(COMP)` on the host is the
  file the container executes, installed with an atomic rename.

Everything is parameterised — `HOST`, `COMP`, `CONTAINER`, `REMOTE_BIN`,
`BACKUP_DIR`, `HEALTH_URL`, `SETTLE`, `SSH_OPTS` — and **no variable carries an
environment-specific default**. `HOST` and `COMP` must be supplied on every
invocation.

## The rules it encodes

Each of these was verified rather than assumed (see below):

- **Back up before touching anything.** `deploy-remote-rollback` restores it.
- **Checksum both ends** after transfer.
- **`chmod 755` after transfer.** `scp` propagates the *local* file's mode, so a
  binary that lost its executable bit locally arrives non-executable. `curl`
  writes `0644` by default, so this bites whenever `bin/$(COMP)` came from
  somewhere other than a local `go build`.
- **Stage to a temp file, then atomic `mv -f`.** Overwriting a running
  executable in place fails with `ETXTBSY`. The temp file is staged *inside*
  `REMOTE_BIN` so the rename cannot cross a filesystem boundary and degrade to a
  non-atomic copy.
- **Verify after restart:** container running, `RestartCount` unchanged,
  `--version` reporting the commit just built, optional HTTP probe run from the
  host, logs scanned for `panic:` / fatal.
- **Print the rollback command** on both success and failure.

Two deliberate departures from the folklore version of these rules:

1. **`RestartCount` is compared against its pre-deploy value, not asserted to be
   `0`.** The counter is cumulative over the container's whole lifetime and
   `docker restart` does not reset it, so an absolute `== 0` check fails on any
   host that has ever crash-looped. The delta is what actually distinguishes a
   crash loop from a healthy restart.
2. **The `--version` assertion needs the version ldflags**, which is why the
   target builds through `make build-$(COMP)` rather than a bare `go build`. A
   binary built without them reports `Git Commit: unknown` and fails the check —
   that is the check working.

## Docs

`contributing/testing.md` gains an "Iterating Against a Running Control Plane"
section covering both `docker-test-api` / `docker-test-core` (local, no
safeguards) and `deploy-remote` (remote, with them), a full variable table, how
to tell which container shape you are looking at, and the rationale for each
step. `README.md` and the `contributing/README.md` index point at it.

## Verification

Exercised against **throwaway containers** on a real remote host — two
containers started from the `neutree-api` image with `--network none` and
`--entrypoint sleep`, one per shape, plus a scratch HTTP endpoint for the probe.
No production container was restarted or modified.

| Case | Result |
|---|---|
| `docker cp` mode, deploy | binary `6362f73` → `1f19ce8`; checksum verified, `RestartCount` unchanged, `--version` matched, probe `200`, logs clean |
| `docker cp` mode, rollback | back to `6362f73`, all checks pass |
| bind-mount mode, deploy | atomic rename applied; container reports `1f19ce8` after restart, all checks pass |
| bind-mount mode, rollback | back to `6362f73`, all checks pass |
| wrong `EXPECT_COMMIT` | fails with exit 1, explains the ldflags caveat, prints the rollback command |
| `make -n deploy-remote` / `-rollback` | correct env passed through; `CONTAINER` defaults to `$(COMP)`, `REMOTE_BIN` defaults empty |

Mechanism checks run directly on the host:

- `cp` over a running executable → `cp: cannot create regular file ...: Text
  file busy`, exit 1. Temp file + `mv -f` → exit 0. **`ETXTBSY` rule confirmed.**
- `scp` of a `0755` file arrives `-rwxr-xr-x`, i.e. scp *does* preserve the mode;
  `curl -o` produces `0644`. The comment was corrected accordingly — the
  explicit `chmod` is what makes the target independent of how the local binary
  was produced.
- Cross-filesystem `mv` onto a running executable succeeds (GNU `mv` unlinks the
  target and retries), so the in-directory staging is about preserving
  **atomicity**, not about `ETXTBSY`. The comment was corrected accordingly.

The last two corrections are why the wording in the script and docs differs from
the rule of thumb this target came from.