### PR TITLE
feat(db): model registry stats attribute and private model alias table (NEU-619)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,6 +240,8 @@ db-test: ## Run database tests with isolated PostgreSQL
 	@echo "Running seed..."
 	@cd db && docker compose -f docker-compose.test.yml run --rm seed || \
 		(docker compose -f docker-compose.test.yml down -v && exit 1)
+	@echo "Starting PostgREST..."
+	@cd db && docker compose -f docker-compose.test.yml up -d postgrest
 	@echo "Running database tests..."
 	@cd db/dbtest && go test -v ./... || (cd .. && docker compose -f docker-compose.test.yml down -v && exit 1)
 	@echo "Cleaning up test database..."

--- a/api/v1/api_gen.go
+++ b/api/v1/api_gen.go
@@ -554,6 +554,7 @@ type ApiModelRegistryStatus struct {
 	Phase              string      `json:"phase"`
 	LastTransitionTime interface{} `json:"last_transition_time"`
 	ErrorMessage       string      `json:"error_message"`
+	Stats              interface{} `json:"stats"`
 }
 
 type ApiEngineVersion struct {

--- a/api/v1/model_alias_types.go
+++ b/api/v1/model_alias_types.go
@@ -9,8 +9,11 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-// maxModelAliasLength bounds the normalized alias. It is deliberately far above
-// maxModelNameLength: an alias is a display name, not a BentoML tag.
+// maxModelAliasLength bounds the alias in its NFKC-normalized, whitespace-
+// trimmed form -- equivalently its lowercased form, since strings.ToLower maps
+// rune to rune (simple case mapping, no special casing) and so cannot change the
+// count. It is deliberately far above maxModelNameLength: an alias is a display
+// name, not a BentoML tag.
 const maxModelAliasLength = 128
 
 // ModelAlias is a user-facing display name for one model version inside a

--- a/api/v1/model_alias_types.go
+++ b/api/v1/model_alias_types.go
@@ -1,0 +1,78 @@
+package v1
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// maxModelAliasLength bounds the normalized alias. It is deliberately far above
+// maxModelNameLength: an alias is a display name, not a BentoML tag.
+const maxModelAliasLength = 128
+
+// ModelAlias is a user-facing display name for one model version inside a
+// private model registry.
+//
+// The registry filesystem, not this table, decides which models exist. A row
+// whose (ModelName, ModelVersion) no longer resolves is an orphan: it is hidden
+// from reads and it does not reserve its alias, so a later write for the same
+// normalized alias overwrites it.
+type ModelAlias struct {
+	ID int `json:"id,omitempty"`
+	// ModelRegistryID references api.model_registries(id). Keying on the row id
+	// rather than the registry name means deleting and recreating a registry
+	// under the same name does not inherit the old registry's aliases.
+	ModelRegistryID int `json:"model_registry_id,omitempty"`
+	// Workspace duplicates the owning registry's workspace so RLS can check it
+	// without a join.
+	Workspace string `json:"workspace,omitempty"`
+	// ModelName and ModelVersion are the physical coordinates of the model.
+	ModelName    string `json:"model_name,omitempty"`
+	ModelVersion string `json:"model_version,omitempty"`
+	// Alias is the user input, stored verbatim; case and inner spacing are part
+	// of the display name.
+	Alias string `json:"alias,omitempty"`
+	// AliasNormalized is what uniqueness compares. Always set it with
+	// NormalizeModelAlias; the database does not derive it.
+	AliasNormalized string `json:"alias_normalized,omitempty"`
+}
+
+// NormalizeModelAlias returns the comparison form of an alias: NFKC, then outer
+// whitespace trimmed, then lowercased.
+//
+// It is computed here rather than by a Postgres expression index because
+// Postgres' lower() is not a full Unicode casefold and NFKC needs an extension.
+// It also deliberately does not reuse ValidateModelName's rules, which force
+// lowercase physical names limited to 63 characters.
+func NormalizeModelAlias(alias string) string {
+	return strings.ToLower(trimModelAlias(alias))
+}
+
+// ValidateModelAlias checks an alias as typed by the user, before it is stored.
+func ValidateModelAlias(alias string) error {
+	for _, r := range alias {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("model alias must not contain control characters")
+		}
+	}
+
+	trimmed := trimModelAlias(alias)
+	if trimmed == "" {
+		return fmt.Errorf("model alias must not be empty after trimming whitespace")
+	}
+
+	if utf8.RuneCountInString(trimmed) > maxModelAliasLength {
+		return fmt.Errorf("model alias must be at most %d characters", maxModelAliasLength)
+	}
+
+	return nil
+}
+
+// trimModelAlias applies NFKC first so that compatibility whitespace (a
+// no-break space, say) becomes ordinary whitespace and is then trimmed.
+func trimModelAlias(alias string) string {
+	return strings.TrimSpace(norm.NFKC.String(alias))
+}

--- a/api/v1/model_alias_types.go
+++ b/api/v1/model_alias_types.go
@@ -14,7 +14,7 @@ import (
 const maxModelAliasLength = 128
 
 // ModelAlias is a user-facing display name for one model version inside a
-// private model registry.
+// private model registry. A model version carries at most one alias.
 //
 // The registry filesystem, not this table, decides which models exist. A row
 // whose (ModelName, ModelVersion) no longer resolves is an orphan: it is hidden
@@ -26,8 +26,10 @@ type ModelAlias struct {
 	// rather than the registry name means deleting and recreating a registry
 	// under the same name does not inherit the old registry's aliases.
 	ModelRegistryID int `json:"model_registry_id,omitempty"`
-	// Workspace duplicates the owning registry's workspace so RLS can check it
-	// without a join.
+	// Workspace is the owning registry's workspace. It is read-only: a database
+	// trigger derives it from ModelRegistryID on every write, so anything set
+	// here is discarded. Authorization keys off the registry's workspace, never
+	// off this column.
 	Workspace string `json:"workspace,omitempty"`
 	// ModelName and ModelVersion are the physical coordinates of the model.
 	ModelName    string `json:"model_name,omitempty"`

--- a/api/v1/model_alias_types_test.go
+++ b/api/v1/model_alias_types_test.go
@@ -1,0 +1,89 @@
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeModelAlias(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"already normalized", "qwen3", "qwen3"},
+		{"uppercase", "Qwen3", "qwen3"},
+		{"surrounding whitespace", " Qwen3 ", "qwen3"},
+		{"tab and newline are whitespace too", "\tQwen3\n", "qwen3"},
+		{"inner spacing is preserved", "Qwen 3 Chat", "qwen 3 chat"},
+		{"NFKC folds fullwidth forms", "Ｑｗｅｎ３", "qwen3"},
+		{"NFKC folds a no-break space into trimmable whitespace", " Qwen3 ", "qwen3"},
+		{"NFKC composes decomposed accents", "Café", "café"},
+		{"empty stays empty", "   ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NormalizeModelAlias(tt.input))
+		})
+	}
+}
+
+// The whole point of the normalized column is that these three spellings
+// collide, so the unique index rejects the second one. db/dbtest asserts the
+// database half; this asserts the Go half that feeds it.
+func TestNormalizeModelAliasCollides(t *testing.T) {
+	normalized := NormalizeModelAlias("Qwen3")
+
+	for _, variant := range []string{"qwen3", " Qwen3 ", "QWEN3", "Ｑｗｅｎ３"} {
+		assert.Equal(t, normalized, NormalizeModelAlias(variant), "variant %q should collide with %q", variant, "Qwen3")
+	}
+
+	assert.NotEqual(t, normalized, NormalizeModelAlias("Qwen 3"), "inner spacing is significant")
+}
+
+func TestValidateModelAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{name: "plain", input: "Qwen3"},
+		{name: "inner spaces", input: "Qwen 3 Chat"},
+		{name: "surrounding whitespace is tolerated", input: "  Qwen3  "},
+		{name: "mixed script", input: "通义千问 3"},
+		{name: "at the length limit", input: strings.Repeat("a", maxModelAliasLength)},
+		{name: "empty", input: "", wantErr: "empty"},
+		{name: "whitespace only", input: "   ", wantErr: "empty"},
+		{name: "over the length limit", input: strings.Repeat("a", maxModelAliasLength+1), wantErr: "at most"},
+		{name: "control character", input: "Qwen\x003", wantErr: "control characters"},
+		{name: "newline", input: "Qwen\n3", wantErr: "control characters"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateModelAlias(tt.input)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// An alias is a display name, so it must not inherit the physical-name rules:
+// ValidateModelName forces lowercase and caps at 63 characters.
+func TestValidateModelAliasIsNotValidateModelName(t *testing.T) {
+	assert.NoError(t, ValidateModelAlias("Qwen3 Chat"))
+	assert.Error(t, ValidateModelName("Qwen3 Chat"))
+
+	long := strings.Repeat("a", 100)
+	assert.NoError(t, ValidateModelAlias(long))
+	assert.Error(t, ValidateModelName(long))
+}

--- a/api/v1/model_alias_types_test.go
+++ b/api/v1/model_alias_types_test.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,9 +20,9 @@ func TestNormalizeModelAlias(t *testing.T) {
 		{"surrounding whitespace", " Qwen3 ", "qwen3"},
 		{"tab and newline are whitespace too", "\tQwen3\n", "qwen3"},
 		{"inner spacing is preserved", "Qwen 3 Chat", "qwen 3 chat"},
-		{"NFKC folds fullwidth forms", "Ｑｗｅｎ３", "qwen3"},
-		{"NFKC folds a no-break space into trimmable whitespace", " Qwen3 ", "qwen3"},
-		{"NFKC composes decomposed accents", "Café", "café"},
+		{"NFKC folds fullwidth forms", "\uff31\uff57\uff45\uff4e\uff13", "qwen3"},
+		{"NFKC folds a no-break space into trimmable whitespace", "\u00a0Qwen3\u00a0", "qwen3"},
+		{"NFKC composes decomposed accents", "Cafe\u0301", "caf\u00e9"},
 		{"empty stays empty", "   ", ""},
 	}
 
@@ -74,6 +75,37 @@ func TestValidateModelAlias(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
+	}
+}
+
+// The length bound is checked on the trimmed form while the constant is
+// described in terms of the normalized one. That is only sound because
+// lowercasing cannot change the rune count: strings.ToLower applies
+// unicode.ToLower rune by rune (simple case mapping), so unlike full Unicode
+// lowercasing it never expands U+0130 into "i" + combining dot. Pinned here so
+// the two forms cannot silently drift apart.
+func TestModelAliasLengthBoundIsTheSameOnEitherForm(t *testing.T) {
+	inputs := []string{
+		"Qwen3",
+		"\u0130stanbul", // U+0130 capital I with dot above
+		"\u01c5",        // U+01C5 titlecase digraph
+		"\u1e68",        // U+1E68 S with dot above and below
+		"\u1e9estra\u00dfe", // U+1E9E capital sharp s
+		strings.Repeat("\u0130", maxModelAliasLength),
+		strings.Repeat("\u0130", maxModelAliasLength+1),
+	}
+
+	for _, in := range inputs {
+		trimmed := trimModelAlias(in)
+		normalized := NormalizeModelAlias(in)
+
+		assert.Equal(t, utf8.RuneCountInString(trimmed), utf8.RuneCountInString(normalized),
+			"lowercasing must not change the rune count of %q", in)
+
+		overTrimmed := utf8.RuneCountInString(trimmed) > maxModelAliasLength
+		overNormalized := utf8.RuneCountInString(normalized) > maxModelAliasLength
+		assert.Equal(t, overTrimmed, overNormalized,
+			"the bound must reject %q on both forms or on neither", in)
 	}
 }
 

--- a/api/v1/model_alias_types_test.go
+++ b/api/v1/model_alias_types_test.go
@@ -87,9 +87,9 @@ func TestValidateModelAlias(t *testing.T) {
 func TestModelAliasLengthBoundIsTheSameOnEitherForm(t *testing.T) {
 	inputs := []string{
 		"Qwen3",
-		"\u0130stanbul", // U+0130 capital I with dot above
-		"\u01c5",        // U+01C5 titlecase digraph
-		"\u1e68",        // U+1E68 S with dot above and below
+		"\u0130stanbul",     // U+0130 capital I with dot above
+		"\u01c5",            // U+01C5 titlecase digraph
+		"\u1e68",            // U+1E68 S with dot above and below
 		"\u1e9estra\u00dfe", // U+1E9E capital sharp s
 		strings.Repeat("\u0130", maxModelAliasLength),
 		strings.Repeat("\u0130", maxModelAliasLength+1),

--- a/api/v1/model_registry_types.go
+++ b/api/v1/model_registry_types.go
@@ -44,10 +44,25 @@ type ModelRegistrySpec struct {
 	Credentials string            `json:"credentials" api:"-"`
 }
 
+// ModelRegistryStats is a cached summary of what a registry currently holds. It
+// is a projection refreshed out of band, not authoritative data.
+type ModelRegistryStats struct {
+	// ModelCount is the number of models visible in the registry.
+	ModelCount int `json:"model_count"`
+	// StorageBytes is the total on-disk size of those models.
+	StorageBytes int64 `json:"storage_bytes"`
+	// StatsUpdatedAt is when the counters above were last refreshed (RFC3339).
+	StatsUpdatedAt string `json:"stats_updated_at,omitempty"`
+}
+
 type ModelRegistryStatus struct {
 	ErrorMessage       string             `json:"error_message,omitempty"`
 	LastTransitionTime string             `json:"last_transition_time,omitempty"`
 	Phase              ModelRegistryPhase `json:"phase,omitempty"`
+	// Stats is written by the statistics path, not by the connectivity
+	// reconcile. PostgREST replaces a composite-type column as a whole, so every
+	// writer of this status has to carry Stats forward or it is nulled out.
+	Stats *ModelRegistryStats `json:"stats,omitempty"`
 }
 
 type ModelRegistry struct {

--- a/controllers/model_registry_controller.go
+++ b/controllers/model_registry_controller.go
@@ -172,5 +172,13 @@ func (c *ModelRegistryController) updateStatus(obj *v1.ModelRegistry, phase v1.M
 		ErrorMessage:       FormatErrorForStatus(err),
 	}
 
+	// PostgREST replaces a composite-type column as a whole, so any attribute
+	// missing from the PATCH body is nulled rather than left alone. Carry
+	// forward the attributes this reconcile does not own; otherwise every phase
+	// or error transition wipes them. Same reason as ClusterController.updateStatus.
+	if obj.Status != nil {
+		newStatus.Stats = obj.Status.Stats
+	}
+
 	return c.storage.UpdateModelRegistry(strconv.Itoa(obj.ID), &v1.ModelRegistry{Status: newStatus})
 }

--- a/controllers/model_registry_controller_test.go
+++ b/controllers/model_registry_controller_test.go
@@ -376,6 +376,83 @@ func TestModelRegistryController_Sync_Failed(t *testing.T) {
 	}
 }
 
+// Regression test for the status write-back defect bundled with NEU-619.
+//
+// updateStatus rebuilds the status struct from scratch, and PostgREST replaces a
+// composite-type column as a whole rather than merging attribute by attribute.
+// Every attribute the reconcile leaves out of the PATCH body is therefore nulled
+// in the database. Before the carry-forward, each of the transitions below wiped
+// the statistics that the (separate) statistics path had written.
+func TestModelRegistryController_UpdateStatus_CarriesStatsForward(t *testing.T) {
+	stats := func() *v1.ModelRegistryStats {
+		return &v1.ModelRegistryStats{
+			ModelCount:     3,
+			StorageBytes:   4096,
+			StatsUpdatedAt: "2026-01-01T00:00:00Z",
+		}
+	}
+
+	testModelRegistry := func(phase v1.ModelRegistryPhase) *v1.ModelRegistry {
+		return &v1.ModelRegistry{
+			ID:       1,
+			Metadata: &v1.Metadata{Name: "test"},
+			Status:   &v1.ModelRegistryStatus{Phase: phase, Stats: stats()},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		input     *v1.ModelRegistry
+		wantPhase v1.ModelRegistryPhase
+		mockSetup func(*modelregistrymocks.MockModelRegistry)
+		wantErr   bool
+	}{
+		{
+			name:      "Connected -> Failed (health check failed)",
+			input:     testModelRegistry(v1.ModelRegistryPhaseCONNECTED),
+			wantPhase: v1.ModelRegistryPhaseFAILED,
+			mockSetup: func(m *modelregistrymocks.MockModelRegistry) {
+				m.On("HealthyCheck").Return(assert.AnError)
+			},
+			wantErr: true,
+		},
+		{
+			name:      "Failed -> Connected (reconnect succeeded)",
+			input:     testModelRegistry(v1.ModelRegistryPhaseFAILED),
+			wantPhase: v1.ModelRegistryPhaseCONNECTED,
+			mockSetup: func(m *modelregistrymocks.MockModelRegistry) {
+				m.On("Disconnect").Return(nil)
+				m.On("Connect").Return(nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := &storagemocks.MockStorage{}
+			mockModel := &modelregistrymocks.MockModelRegistry{}
+			tt.mockSetup(mockModel)
+
+			mockStorage.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
+				obj := args.Get(1).(*v1.ModelRegistry)
+				assert.Equal(t, tt.wantPhase, obj.Status.Phase)
+				assert.Equal(t, stats(), obj.Status.Stats, "status write-back must not drop stats")
+			}).Return(nil)
+
+			c := newTestModelRegistryController(mockStorage, mockModel)
+			err := c.sync(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockStorage.AssertExpectations(t)
+			mockModel.AssertExpectations(t)
+		})
+	}
+}
+
 func TestModelRegistryController_Reconcile(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/db/dbtest/model_alias_test.go
+++ b/db/dbtest/model_alias_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"strconv"
-	"strings"
+
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,45 +39,6 @@ func aliasesOfRegistry(t *testing.T, s storage.Storage, registryID int) []v1.Mod
 	return got
 }
 
-// createUserInWorkspace creates a user holding permissions in one workspace
-// only, so the tests can tell a permission check from a workspace check.
-func createUserInWorkspace(t *testing.T, tx *sql.Tx, username, email, workspace string, permissions []string) string {
-	t.Helper()
-	ctx := context.Background()
-
-	user := CreateTestUser(t, username, email, "password123")
-
-	roleName := username + "-role"
-	permissionsArray := "ARRAY['" + strings.Join(permissions, "','") + "']::api.permission_action[]"
-
-	_, err := tx.ExecContext(ctx, `
-		INSERT INTO api.roles (api_version, kind, metadata, spec)
-		VALUES (
-			'v1',
-			'Role',
-			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
-			ROW(NULL, `+permissionsArray+`)::api.role_spec
-		)
-	`, roleName)
-	if err != nil {
-		t.Fatalf("failed to create role %s: %v", roleName, err)
-	}
-
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO api.role_assignments (api_version, kind, metadata, spec)
-		VALUES (
-			'v1',
-			'RoleAssignment',
-			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
-			ROW($2::uuid, $3, FALSE, $4)::api.role_assignment_spec
-		)
-	`, username+"-role-assignment", user.ID, workspace, roleName)
-	if err != nil {
-		t.Fatalf("failed to assign role %s in workspace %s: %v", roleName, workspace, err)
-	}
-
-	return user.ID
-}
 
 // TestModelAliasUniqueWithinRegistry covers the constraint the table exists for:
 // an alias is unique inside one registry, compared on the normalized form, and
@@ -181,39 +142,36 @@ func TestModelAliasOrphanRowCanBeTakenOver(t *testing.T) {
 	assert.Equal(t, "Qwen3", after[0].Alias)
 }
 
-// TestModelAliasRLS checks the policies added with the table: reads need
-// model:read and writes need model:push, both scoped by the row's workspace.
-// The permission actions themselves already exist (042); no new action is added.
+// TestModelAliasRLS checks the policies shipped with the table: reads need
+// model:read and writes need model:push. Both actions already exist (042); the
+// table adds no new permission action.
+//
+// Role assignments are global in this schema -- api.has_permission only looks at
+// assignments with global = TRUE, and a trigger rejects workspace-scoped ones
+// (error 10041) -- so what is asserted here is the action half of the policies.
+// The workspace column is carried for the same reason the other workspaced
+// tables carry it: it is the argument the policies pass to api.has_permission.
 func TestModelAliasRLS(t *testing.T) {
 	db := GetTestDB(t)
 	s := NewTestStorage(t)
 	ctx := context.Background()
 
-	const (
-		workspace      = "alias-rls-ws"
-		otherWorkspace = "alias-rls-other-ws"
-	)
+	const workspace = "default"
 
-	registryID := createTestModelRegistryInWorkspace(t, db, s, "alias-rls", workspace)
-
-	var (
-		reader   string // model:read in workspace
-		pusher   string // model:read + model:push in workspace
-		outsider string // model:read + model:push, but in another workspace
-	)
+	registryID := createTestModelRegistry(t, db, s, "alias-rls")
 
 	tx, err := db.BeginTx(ctx, nil)
 	require.NoError(t, err)
 
-	reader = createUserInWorkspace(t, tx, "alias-reader", "alias-reader@example.com", workspace, []string{"model:read"})
-	pusher = createUserInWorkspace(t, tx, "alias-pusher", "alias-pusher@example.com", workspace, []string{"model:read", "model:push"})
-	outsider = createUserInWorkspace(t, tx, "alias-outsider", "alias-outsider@example.com", otherWorkspace, []string{"model:read", "model:push"})
+	reader := createUserWithPermissions(t, tx, "alias-reader", "alias-reader@example.com", []string{"model:read"})
+	pusher := createUserWithPermissions(t, tx, "alias-pusher", "alias-pusher@example.com", []string{"model:read", "model:push"})
+	stranger := createUserWithPermissions(t, tx, "alias-stranger", "alias-stranger@example.com", []string{"cluster:read"})
 
 	require.NoError(t, tx.Commit())
 
 	t.Cleanup(func() {
-		_, _ = db.ExecContext(ctx, `DELETE FROM api.role_assignments WHERE (spec).user_id IN ($1::uuid, $2::uuid, $3::uuid)`, reader, pusher, outsider)
-		_, _ = db.ExecContext(ctx, `DELETE FROM api.roles WHERE (metadata).name LIKE 'alias-%-role'`)
+		_, _ = db.ExecContext(ctx, `DELETE FROM api.role_assignments WHERE (spec).user_id IN ($1::uuid, $2::uuid, $3::uuid)`, reader, pusher, stranger)
+		_, _ = db.ExecContext(ctx, `DELETE FROM api.roles WHERE (metadata).name IN ('alias-reader-role', 'alias-pusher-role', 'alias-stranger-role')`)
 	})
 
 	insert := func(userID, alias string) error {
@@ -246,15 +204,15 @@ func TestModelAliasRLS(t *testing.T) {
 		assert.Error(t, insert(reader, "ReadOnlyAttempt"))
 	})
 
-	t.Run("another workspace may not write here", func(t *testing.T) {
-		assert.Error(t, insert(outsider, "OutsiderAttempt"))
+	t.Run("no model permission may not write", func(t *testing.T) {
+		assert.Error(t, insert(stranger, "StrangerAttempt"))
 	})
 
 	t.Run("model:read may read", func(t *testing.T) {
 		assert.Equal(t, 1, countVisible(reader))
 	})
 
-	t.Run("another workspace sees nothing", func(t *testing.T) {
-		assert.Equal(t, 0, countVisible(outsider))
+	t.Run("no model permission sees nothing", func(t *testing.T) {
+		assert.Equal(t, 0, countVisible(stranger))
 	})
 }

--- a/db/dbtest/model_alias_test.go
+++ b/db/dbtest/model_alias_test.go
@@ -218,11 +218,14 @@ func TestModelAliasOrphanRowCanBeTakenOver(t *testing.T) {
 // The workspace the policies pass to api.has_permission is the owning
 // registry's, looked up through public.model_registry_workspace, never the row's
 // own column -- see TestModelAliasWorkspaceIsDerivedFromRegistry for why the
-// column cannot be trusted. Whether a workspace mismatch is refused is not
-// observable here: api.has_permission ignores its workspace argument and only
-// consults role assignments with global = TRUE (a trigger rejects
-// workspace-scoped ones, error 10041), which is true of every workspaced table
-// in this schema. What is asserted here is therefore the action half.
+// column cannot be trusted.
+//
+// Only the action half of the policies is asserted here. This schema caps a
+// deployment at one workspace (021), so api.has_permission does not consume the
+// workspace argument and a trigger rejects workspace-scoped role assignments
+// outright (error 10041) -- there is no second workspace for a caller to be
+// refused from. That the policies nevertheless hand it the registry's real
+// workspace is what TestModelAliasWorkspaceIsDerivedFromRegistry pins down.
 func TestModelAliasRLS(t *testing.T) {
 	db := GetTestDB(t)
 	s := NewTestStorage(t)

--- a/db/dbtest/model_alias_test.go
+++ b/db/dbtest/model_alias_test.go
@@ -80,8 +80,8 @@ func TestModelAliasNormalizationVariantsCollide(t *testing.T) {
 		{"lowercase", "qwen3"},
 		{"uppercase", "QWEN3"},
 		{"surrounding whitespace", " Qwen3 "},
-		{"no-break space (NFKC folds it to a trimmable space)", " Qwen3 "},
-		{"fullwidth (NFKC)", "Ｑｗｅｎ３"},
+		{"no-break space (NFKC folds it to a trimmable space)", "\u00a0Qwen3\u00a0"},
+		{"fullwidth (NFKC)", "\uff31\uff57\uff45\uff4e\uff13"},
 	}
 
 	for _, tt := range variants {
@@ -131,17 +131,20 @@ func TestModelAliasWorkspaceIsDerivedFromRegistry(t *testing.T) {
 
 	registryID := createTestModelRegistry(t, db, s, "alias-workspace-derived")
 
-	forged := newAlias(registryID, "qwen3", "v1", "Qwen3")
-	forged.Workspace = "someone-elses-workspace"
-	require.NoError(t, s.CreateModelAlias(forged))
+	// Straight SQL rather than the Go client: pkg/storage strips Workspace
+	// before sending, but the guarantee has to hold for anyone talking to
+	// PostgREST directly, which is the case that actually matters.
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO api.model_aliases (model_registry_id, workspace, model_name, model_version, alias, alias_normalized)
+		VALUES ($1, 'someone-elses-workspace', 'qwen3', 'v1', 'Qwen3', 'qwen3')`, registryID)
+	require.NoError(t, err)
 
 	stored := aliasesOfRegistry(t, s, registryID)
 	require.Len(t, stored, 1)
 	assert.Equal(t, "default", stored[0].Workspace, "the registry's workspace wins over the one supplied by the client")
 
-	// The same on update, and straight through SQL so the check is on the
-	// database rather than on anything the Go client does or does not send.
-	_, err := db.ExecContext(ctx,
+	// The same on update.
+	_, err = db.ExecContext(ctx,
 		`UPDATE api.model_aliases SET workspace = 'someone-elses-workspace' WHERE id = $1`, stored[0].ID)
 	require.NoError(t, err)
 
@@ -149,6 +152,18 @@ func TestModelAliasWorkspaceIsDerivedFromRegistry(t *testing.T) {
 	require.NoError(t, db.QueryRowContext(ctx,
 		`SELECT workspace FROM api.model_aliases WHERE id = $1`, stored[0].ID).Scan(&workspace))
 	assert.Equal(t, "default", workspace, "an update cannot move a row into another workspace either")
+
+	// And the storage layer does not present the field as writable in the first place.
+	viaClient := newAlias(registryID, "llama", "v1", "Llama")
+	viaClient.Workspace = "someone-elses-workspace"
+	require.NoError(t, s.CreateModelAlias(viaClient))
+
+	after := aliasesOfRegistry(t, s, registryID)
+	require.Len(t, after, 2)
+
+	for _, a := range after {
+		assert.Equal(t, "default", a.Workspace)
+	}
 }
 
 // TestModelAliasCascadeOnRegistryDelete: the foreign key removes a whole class

--- a/db/dbtest/model_alias_test.go
+++ b/db/dbtest/model_alias_test.go
@@ -39,7 +39,6 @@ func aliasesOfRegistry(t *testing.T, s storage.Storage, registryID int) []v1.Mod
 	return got
 }
 
-
 // TestModelAliasUniqueWithinRegistry covers the constraint the table exists for:
 // an alias is unique inside one registry, compared on the normalized form, and
 // two registries are free to use the same alias.

--- a/db/dbtest/model_alias_test.go
+++ b/db/dbtest/model_alias_test.go
@@ -174,6 +174,9 @@ func TestModelAliasRLS(t *testing.T) {
 		_, _ = db.ExecContext(ctx, `DELETE FROM api.roles WHERE (metadata).name IN ('alias-reader-role', 'alias-pusher-role', 'alias-stranger-role')`)
 	})
 
+	// executeAsUser never commits, so a write here is only ever an
+	// allowed/denied probe. The row the read probes look for is seeded on the
+	// admin connection below, which is superuser and bypasses RLS.
 	insert := func(userID, alias string) error {
 		return executeAsUser(t, db, userID, func(tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, `
@@ -184,6 +187,11 @@ func TestModelAliasRLS(t *testing.T) {
 			return err
 		})
 	}
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO api.model_aliases (model_registry_id, workspace, model_name, model_version, alias, alias_normalized)
+		VALUES ($1, $2, 'qwen3', 'v1', 'Qwen3', 'qwen3')`, registryID, workspace)
+	require.NoError(t, err)
 
 	countVisible := func(userID string) int {
 		var n int
@@ -197,7 +205,7 @@ func TestModelAliasRLS(t *testing.T) {
 	}
 
 	t.Run("model:push may write", func(t *testing.T) {
-		require.NoError(t, insert(pusher, "Qwen3"))
+		require.NoError(t, insert(pusher, "PusherAlias"))
 	})
 
 	t.Run("model:read alone may not write", func(t *testing.T) {

--- a/db/dbtest/model_alias_test.go
+++ b/db/dbtest/model_alias_test.go
@@ -1,0 +1,260 @@
+package dbtest
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// newAlias builds a ModelAlias with alias_normalized derived the way the
+// application derives it, so these tests exercise the Go rule and the database
+// index together rather than one in isolation.
+func newAlias(registryID int, workspace, model, version, alias string) *v1.ModelAlias {
+	return &v1.ModelAlias{
+		ModelRegistryID: registryID,
+		Workspace:       workspace,
+		ModelName:       model,
+		ModelVersion:    version,
+		Alias:           alias,
+		AliasNormalized: v1.NormalizeModelAlias(alias),
+	}
+}
+
+func aliasesOfRegistry(t *testing.T, s storage.Storage, registryID int) []v1.ModelAlias {
+	t.Helper()
+
+	got, err := s.ListModelAlias(storage.ListOption{
+		Filters: []storage.Filter{{Column: "model_registry_id", Operator: "eq", Value: strconv.Itoa(registryID)}},
+	})
+	require.NoError(t, err)
+
+	return got
+}
+
+// createUserInWorkspace creates a user holding permissions in one workspace
+// only, so the tests can tell a permission check from a workspace check.
+func createUserInWorkspace(t *testing.T, tx *sql.Tx, username, email, workspace string, permissions []string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	user := CreateTestUser(t, username, email, "password123")
+
+	roleName := username + "-role"
+	permissionsArray := "ARRAY['" + strings.Join(permissions, "','") + "']::api.permission_action[]"
+
+	_, err := tx.ExecContext(ctx, `
+		INSERT INTO api.roles (api_version, kind, metadata, spec)
+		VALUES (
+			'v1',
+			'Role',
+			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
+			ROW(NULL, `+permissionsArray+`)::api.role_spec
+		)
+	`, roleName)
+	if err != nil {
+		t.Fatalf("failed to create role %s: %v", roleName, err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO api.role_assignments (api_version, kind, metadata, spec)
+		VALUES (
+			'v1',
+			'RoleAssignment',
+			ROW($1, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata,
+			ROW($2::uuid, $3, FALSE, $4)::api.role_assignment_spec
+		)
+	`, username+"-role-assignment", user.ID, workspace, roleName)
+	if err != nil {
+		t.Fatalf("failed to assign role %s in workspace %s: %v", roleName, workspace, err)
+	}
+
+	return user.ID
+}
+
+// TestModelAliasUniqueWithinRegistry covers the constraint the table exists for:
+// an alias is unique inside one registry, compared on the normalized form, and
+// two registries are free to use the same alias.
+func TestModelAliasUniqueWithinRegistry(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	registryA := createTestModelRegistry(t, db, s, "alias-unique-a")
+	registryB := createTestModelRegistry(t, db, s, "alias-unique-b")
+
+	require.NoError(t, s.CreateModelAlias(newAlias(registryA, "default", "qwen3", "v1", "Qwen3")))
+
+	err := s.CreateModelAlias(newAlias(registryA, "default", "llama", "v1", "qwen3"))
+	require.Error(t, err, "a second alias normalizing to qwen3 must be rejected by the unique index")
+
+	// The same alias in a different registry is fine: uniqueness is per registry.
+	require.NoError(t, s.CreateModelAlias(newAlias(registryB, "default", "qwen3", "v1", "Qwen3")))
+
+	assert.Len(t, aliasesOfRegistry(t, s, registryA), 1)
+	assert.Len(t, aliasesOfRegistry(t, s, registryB), 1)
+}
+
+// TestModelAliasNormalizationVariantsCollide is the case-, whitespace- and
+// NFKC-insensitivity requirement: every spelling below has to collide with the
+// alias already stored.
+func TestModelAliasNormalizationVariantsCollide(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	registryID := createTestModelRegistry(t, db, s, "alias-normalization")
+
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "qwen3", "v1", "Qwen3")))
+
+	variants := []struct {
+		name  string
+		alias string
+	}{
+		{"identical", "Qwen3"},
+		{"lowercase", "qwen3"},
+		{"uppercase", "QWEN3"},
+		{"surrounding whitespace", " Qwen3 "},
+		{"no-break space (NFKC folds it to a trimmable space)", " Qwen3 "},
+		{"fullwidth (NFKC)", "Ｑｗｅｎ３"},
+	}
+
+	for _, tt := range variants {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Error(t, s.CreateModelAlias(newAlias(registryID, "default", "llama", "v1", tt.alias)),
+				"alias %q normalizes to %q and must collide", tt.alias, v1.NormalizeModelAlias(tt.alias))
+		})
+	}
+
+	// Inner spacing is part of the display name, so this one is a different alias.
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "qwen3", "v1", "Qwen 3")))
+	assert.Len(t, aliasesOfRegistry(t, s, registryID), 2)
+}
+
+// TestModelAliasCascadeOnRegistryDelete: the foreign key removes a whole class
+// of orphan rows when a registry goes away.
+func TestModelAliasCascadeOnRegistryDelete(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	registryID := createTestModelRegistry(t, db, s, "alias-cascade")
+
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "qwen3", "v1", "Qwen3")))
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "llama", "v1", "Llama")))
+	require.Len(t, aliasesOfRegistry(t, s, registryID), 2)
+
+	_, err := db.Exec("DELETE FROM api.model_registries WHERE id = $1", registryID)
+	require.NoError(t, err)
+
+	assert.Empty(t, aliasesOfRegistry(t, s, registryID), "aliases must go with their registry")
+}
+
+// TestModelAliasOrphanRowCanBeTakenOver: the table is a projection of the
+// registry filesystem, so a row whose model was removed out of band must not
+// reserve its alias forever. Repointing it at a live model is the takeover.
+func TestModelAliasOrphanRowCanBeTakenOver(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	registryID := createTestModelRegistry(t, db, s, "alias-orphan")
+
+	// "removed-model" is gone from the registry as far as this test is
+	// concerned; the alias row is the leftover.
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "removed-model", "v1", "Qwen3")))
+
+	existing := aliasesOfRegistry(t, s, registryID)
+	require.Len(t, existing, 1)
+
+	takeover := newAlias(registryID, "default", "qwen3", "v2", "Qwen3")
+	require.NoError(t, s.UpdateModelAlias(strconv.Itoa(existing[0].ID), takeover),
+		"an orphaned row must not block a new alias with the same normalized form")
+
+	after := aliasesOfRegistry(t, s, registryID)
+	require.Len(t, after, 1, "the takeover overwrites the orphan instead of adding a row")
+	assert.Equal(t, "qwen3", after[0].ModelName)
+	assert.Equal(t, "v2", after[0].ModelVersion)
+	assert.Equal(t, "Qwen3", after[0].Alias)
+}
+
+// TestModelAliasRLS checks the policies added with the table: reads need
+// model:read and writes need model:push, both scoped by the row's workspace.
+// The permission actions themselves already exist (042); no new action is added.
+func TestModelAliasRLS(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+	ctx := context.Background()
+
+	const (
+		workspace      = "alias-rls-ws"
+		otherWorkspace = "alias-rls-other-ws"
+	)
+
+	registryID := createTestModelRegistryInWorkspace(t, db, s, "alias-rls", workspace)
+
+	var (
+		reader   string // model:read in workspace
+		pusher   string // model:read + model:push in workspace
+		outsider string // model:read + model:push, but in another workspace
+	)
+
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+
+	reader = createUserInWorkspace(t, tx, "alias-reader", "alias-reader@example.com", workspace, []string{"model:read"})
+	pusher = createUserInWorkspace(t, tx, "alias-pusher", "alias-pusher@example.com", workspace, []string{"model:read", "model:push"})
+	outsider = createUserInWorkspace(t, tx, "alias-outsider", "alias-outsider@example.com", otherWorkspace, []string{"model:read", "model:push"})
+
+	require.NoError(t, tx.Commit())
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(ctx, `DELETE FROM api.role_assignments WHERE (spec).user_id IN ($1::uuid, $2::uuid, $3::uuid)`, reader, pusher, outsider)
+		_, _ = db.ExecContext(ctx, `DELETE FROM api.roles WHERE (metadata).name LIKE 'alias-%-role'`)
+	})
+
+	insert := func(userID, alias string) error {
+		return executeAsUser(t, db, userID, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, `
+				INSERT INTO api.model_aliases (model_registry_id, workspace, model_name, model_version, alias, alias_normalized)
+				VALUES ($1, $2, 'qwen3', 'v1', $3, $4)`,
+				registryID, workspace, alias, v1.NormalizeModelAlias(alias))
+
+			return err
+		})
+	}
+
+	countVisible := func(userID string) int {
+		var n int
+
+		require.NoError(t, executeAsUser(t, db, userID, func(tx *sql.Tx) error {
+			return tx.QueryRowContext(ctx,
+				`SELECT count(*) FROM api.model_aliases WHERE model_registry_id = $1`, registryID).Scan(&n)
+		}))
+
+		return n
+	}
+
+	t.Run("model:push may write", func(t *testing.T) {
+		require.NoError(t, insert(pusher, "Qwen3"))
+	})
+
+	t.Run("model:read alone may not write", func(t *testing.T) {
+		assert.Error(t, insert(reader, "ReadOnlyAttempt"))
+	})
+
+	t.Run("another workspace may not write here", func(t *testing.T) {
+		assert.Error(t, insert(outsider, "OutsiderAttempt"))
+	})
+
+	t.Run("model:read may read", func(t *testing.T) {
+		assert.Equal(t, 1, countVisible(reader))
+	})
+
+	t.Run("another workspace sees nothing", func(t *testing.T) {
+		assert.Equal(t, 0, countVisible(outsider))
+	})
+}

--- a/db/dbtest/model_alias_test.go
+++ b/db/dbtest/model_alias_test.go
@@ -16,11 +16,11 @@ import (
 
 // newAlias builds a ModelAlias with alias_normalized derived the way the
 // application derives it, so these tests exercise the Go rule and the database
-// index together rather than one in isolation.
-func newAlias(registryID int, workspace, model, version, alias string) *v1.ModelAlias {
+// index together rather than one in isolation. Workspace is left unset on
+// purpose: the database derives it from the registry.
+func newAlias(registryID int, model, version, alias string) *v1.ModelAlias {
 	return &v1.ModelAlias{
 		ModelRegistryID: registryID,
-		Workspace:       workspace,
 		ModelName:       model,
 		ModelVersion:    version,
 		Alias:           alias,
@@ -49,13 +49,13 @@ func TestModelAliasUniqueWithinRegistry(t *testing.T) {
 	registryA := createTestModelRegistry(t, db, s, "alias-unique-a")
 	registryB := createTestModelRegistry(t, db, s, "alias-unique-b")
 
-	require.NoError(t, s.CreateModelAlias(newAlias(registryA, "default", "qwen3", "v1", "Qwen3")))
+	require.NoError(t, s.CreateModelAlias(newAlias(registryA, "qwen3", "v1", "Qwen3")))
 
-	err := s.CreateModelAlias(newAlias(registryA, "default", "llama", "v1", "qwen3"))
+	err := s.CreateModelAlias(newAlias(registryA, "llama", "v1", "qwen3"))
 	require.Error(t, err, "a second alias normalizing to qwen3 must be rejected by the unique index")
 
 	// The same alias in a different registry is fine: uniqueness is per registry.
-	require.NoError(t, s.CreateModelAlias(newAlias(registryB, "default", "qwen3", "v1", "Qwen3")))
+	require.NoError(t, s.CreateModelAlias(newAlias(registryB, "qwen3", "v1", "Qwen3")))
 
 	assert.Len(t, aliasesOfRegistry(t, s, registryA), 1)
 	assert.Len(t, aliasesOfRegistry(t, s, registryB), 1)
@@ -70,7 +70,7 @@ func TestModelAliasNormalizationVariantsCollide(t *testing.T) {
 
 	registryID := createTestModelRegistry(t, db, s, "alias-normalization")
 
-	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "qwen3", "v1", "Qwen3")))
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "qwen3", "v1", "Qwen3")))
 
 	variants := []struct {
 		name  string
@@ -86,14 +86,69 @@ func TestModelAliasNormalizationVariantsCollide(t *testing.T) {
 
 	for _, tt := range variants {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Error(t, s.CreateModelAlias(newAlias(registryID, "default", "llama", "v1", tt.alias)),
+			assert.Error(t, s.CreateModelAlias(newAlias(registryID, "llama", "v1", tt.alias)),
 				"alias %q normalizes to %q and must collide", tt.alias, v1.NormalizeModelAlias(tt.alias))
 		})
 	}
 
-	// Inner spacing is part of the display name, so this one is a different alias.
-	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "qwen3", "v1", "Qwen 3")))
+	// Inner spacing is part of the display name, so this one is a different
+	// alias. It goes on a different model version because a model version
+	// carries at most one alias.
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "qwen3", "v2", "Qwen 3")))
 	assert.Len(t, aliasesOfRegistry(t, s, registryID), 2)
+}
+
+// TestModelAliasOnePerModelVersion: the requirement is a single display name per
+// model, so a second alias for the same model version is rejected. Without this
+// the read path -- which joins aliases onto the live model list -- would have no
+// defined winner.
+func TestModelAliasOnePerModelVersion(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	registryID := createTestModelRegistry(t, db, s, "alias-one-per-model")
+
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "qwen3", "v1", "Qwen3")))
+
+	assert.Error(t, s.CreateModelAlias(newAlias(registryID, "qwen3", "v1", "Qwen3 Chat")),
+		"a model version must not accumulate a second alias")
+
+	// A different version of the same model is a different model, so it may
+	// carry its own alias.
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "qwen3", "v2", "Qwen3 Chat")))
+	assert.Len(t, aliasesOfRegistry(t, s, registryID), 2)
+}
+
+// TestModelAliasWorkspaceIsDerivedFromRegistry: the workspace column must not be
+// something a client can choose. It is denormalized for reads, but a write that
+// names a different workspace has that value discarded and replaced with the
+// owning registry's -- so it cannot be used to plant a row that authorizes
+// against one workspace while occupying a unique-index slot in another.
+func TestModelAliasWorkspaceIsDerivedFromRegistry(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+	ctx := context.Background()
+
+	registryID := createTestModelRegistry(t, db, s, "alias-workspace-derived")
+
+	forged := newAlias(registryID, "qwen3", "v1", "Qwen3")
+	forged.Workspace = "someone-elses-workspace"
+	require.NoError(t, s.CreateModelAlias(forged))
+
+	stored := aliasesOfRegistry(t, s, registryID)
+	require.Len(t, stored, 1)
+	assert.Equal(t, "default", stored[0].Workspace, "the registry's workspace wins over the one supplied by the client")
+
+	// The same on update, and straight through SQL so the check is on the
+	// database rather than on anything the Go client does or does not send.
+	_, err := db.ExecContext(ctx,
+		`UPDATE api.model_aliases SET workspace = 'someone-elses-workspace' WHERE id = $1`, stored[0].ID)
+	require.NoError(t, err)
+
+	var workspace string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT workspace FROM api.model_aliases WHERE id = $1`, stored[0].ID).Scan(&workspace))
+	assert.Equal(t, "default", workspace, "an update cannot move a row into another workspace either")
 }
 
 // TestModelAliasCascadeOnRegistryDelete: the foreign key removes a whole class
@@ -104,8 +159,8 @@ func TestModelAliasCascadeOnRegistryDelete(t *testing.T) {
 
 	registryID := createTestModelRegistry(t, db, s, "alias-cascade")
 
-	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "qwen3", "v1", "Qwen3")))
-	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "llama", "v1", "Llama")))
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "qwen3", "v1", "Qwen3")))
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "llama", "v1", "Llama")))
 	require.Len(t, aliasesOfRegistry(t, s, registryID), 2)
 
 	_, err := db.Exec("DELETE FROM api.model_registries WHERE id = $1", registryID)
@@ -125,12 +180,12 @@ func TestModelAliasOrphanRowCanBeTakenOver(t *testing.T) {
 
 	// "removed-model" is gone from the registry as far as this test is
 	// concerned; the alias row is the leftover.
-	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "default", "removed-model", "v1", "Qwen3")))
+	require.NoError(t, s.CreateModelAlias(newAlias(registryID, "removed-model", "v1", "Qwen3")))
 
 	existing := aliasesOfRegistry(t, s, registryID)
 	require.Len(t, existing, 1)
 
-	takeover := newAlias(registryID, "default", "qwen3", "v2", "Qwen3")
+	takeover := newAlias(registryID, "qwen3", "v2", "Qwen3")
 	require.NoError(t, s.UpdateModelAlias(strconv.Itoa(existing[0].ID), takeover),
 		"an orphaned row must not block a new alias with the same normalized form")
 
@@ -145,17 +200,18 @@ func TestModelAliasOrphanRowCanBeTakenOver(t *testing.T) {
 // model:read and writes need model:push. Both actions already exist (042); the
 // table adds no new permission action.
 //
-// Role assignments are global in this schema -- api.has_permission only looks at
-// assignments with global = TRUE, and a trigger rejects workspace-scoped ones
-// (error 10041) -- so what is asserted here is the action half of the policies.
-// The workspace column is carried for the same reason the other workspaced
-// tables carry it: it is the argument the policies pass to api.has_permission.
+// The workspace the policies pass to api.has_permission is the owning
+// registry's, looked up through public.model_registry_workspace, never the row's
+// own column -- see TestModelAliasWorkspaceIsDerivedFromRegistry for why the
+// column cannot be trusted. Whether a workspace mismatch is refused is not
+// observable here: api.has_permission ignores its workspace argument and only
+// consults role assignments with global = TRUE (a trigger rejects
+// workspace-scoped ones, error 10041), which is true of every workspaced table
+// in this schema. What is asserted here is therefore the action half.
 func TestModelAliasRLS(t *testing.T) {
 	db := GetTestDB(t)
 	s := NewTestStorage(t)
 	ctx := context.Background()
-
-	const workspace = "default"
 
 	registryID := createTestModelRegistry(t, db, s, "alias-rls")
 
@@ -176,20 +232,23 @@ func TestModelAliasRLS(t *testing.T) {
 	// executeAsUser never commits, so a write here is only ever an
 	// allowed/denied probe. The row the read probes look for is seeded on the
 	// admin connection below, which is superuser and bypasses RLS.
-	insert := func(userID, alias string) error {
+	// workspace is omitted: the trigger derives it. Each probe uses its own model
+	// version because a model version carries at most one alias, and a
+	// unique-index violation would otherwise be mistaken for an RLS refusal.
+	insert := func(userID, model, alias string) error {
 		return executeAsUser(t, db, userID, func(tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, `
-				INSERT INTO api.model_aliases (model_registry_id, workspace, model_name, model_version, alias, alias_normalized)
-				VALUES ($1, $2, 'qwen3', 'v1', $3, $4)`,
-				registryID, workspace, alias, v1.NormalizeModelAlias(alias))
+				INSERT INTO api.model_aliases (model_registry_id, model_name, model_version, alias, alias_normalized)
+				VALUES ($1, $2, 'v1', $3, $4)`,
+				registryID, model, alias, v1.NormalizeModelAlias(alias))
 
 			return err
 		})
 	}
 
 	_, err = db.ExecContext(ctx, `
-		INSERT INTO api.model_aliases (model_registry_id, workspace, model_name, model_version, alias, alias_normalized)
-		VALUES ($1, $2, 'qwen3', 'v1', 'Qwen3', 'qwen3')`, registryID, workspace)
+		INSERT INTO api.model_aliases (model_registry_id, model_name, model_version, alias, alias_normalized)
+		VALUES ($1, 'qwen3', 'v1', 'Qwen3', 'qwen3')`, registryID)
 	require.NoError(t, err)
 
 	countVisible := func(userID string) int {
@@ -204,15 +263,15 @@ func TestModelAliasRLS(t *testing.T) {
 	}
 
 	t.Run("model:push may write", func(t *testing.T) {
-		require.NoError(t, insert(pusher, "PusherAlias"))
+		require.NoError(t, insert(pusher, "pusher-model", "PusherAlias"))
 	})
 
 	t.Run("model:read alone may not write", func(t *testing.T) {
-		assert.Error(t, insert(reader, "ReadOnlyAttempt"))
+		assert.Error(t, insert(reader, "reader-model", "ReadOnlyAttempt"))
 	})
 
 	t.Run("no model permission may not write", func(t *testing.T) {
-		assert.Error(t, insert(stranger, "StrangerAttempt"))
+		assert.Error(t, insert(stranger, "stranger-model", "StrangerAttempt"))
 	})
 
 	t.Run("model:read may read", func(t *testing.T) {

--- a/db/dbtest/model_registry_stats_test.go
+++ b/db/dbtest/model_registry_stats_test.go
@@ -1,0 +1,173 @@
+package dbtest
+
+import (
+	"database/sql"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/controllers"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+	modelregistrymocks "github.com/neutree-ai/neutree/internal/model_registry/mocks"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// createTestModelRegistry inserts a model registry through PostgREST and
+// registers its removal. It returns the row id.
+func createTestModelRegistry(t *testing.T, db *sql.DB, s storage.Storage, name string) int {
+	t.Helper()
+
+	require.NoError(t, s.CreateModelRegistry(&v1.ModelRegistry{
+		APIVersion: "v1",
+		Kind:       "ModelRegistry",
+		Metadata:   &v1.Metadata{Name: name, Workspace: "default"},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "file://localhost/tmp/" + name,
+		},
+		Status: &v1.ModelRegistryStatus{Phase: v1.ModelRegistryPhaseCONNECTED},
+	}))
+
+	var id int
+	require.NoError(t, db.QueryRow(
+		"SELECT id FROM api.model_registries WHERE (metadata).name = $1 AND (metadata).workspace = 'default'",
+		name,
+	).Scan(&id))
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM api.model_registries WHERE id = $1", id)
+	})
+
+	return id
+}
+
+// TestModelRegistryStatusPatchReplacesWholeComposite pins down what PostgREST
+// does to a composite-type column when the PATCH body mentions only some of its
+// attributes. The answer -- the column is replaced, so unmentioned attributes
+// end up NULL -- is the entire reason status writers have to carry attributes
+// forward by hand (see ClusterController.updateStatus and
+// ModelRegistryController.updateStatus).
+//
+// If PostgREST ever merges attribute by attribute instead, this test fails and
+// that hand-written carry-forward can be deleted.
+func TestModelRegistryStatusPatchReplacesWholeComposite(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	id := createTestModelRegistry(t, db, s, "patch-semantics")
+
+	// Populate every attribute of the composite, including ones the Go struct
+	// used for the PATCH below does not send.
+	_, err := db.Exec(`UPDATE api.model_registries
+		SET status = ROW('Connected', '2026-01-01T00:00:00Z', 'previous failure',
+		                 '{"model_count": 3, "storage_bytes": 4096}'::jsonb)::api.model_registry_status
+		WHERE id = $1`, id)
+	require.NoError(t, err)
+
+	// A PATCH carrying only phase + last_transition_time.
+	require.NoError(t, s.UpdateModelRegistry(strconv.Itoa(id), &v1.ModelRegistry{
+		Status: &v1.ModelRegistryStatus{
+			Phase:              v1.ModelRegistryPhaseCONNECTED,
+			LastTransitionTime: "2026-02-02T00:00:00Z",
+		},
+	}))
+
+	var (
+		phaseSet, timeSet bool
+		errorMessageNull  bool
+		statsNull         bool
+	)
+
+	require.NoError(t, db.QueryRow(`SELECT
+			(status).phase IS NOT NULL,
+			(status).last_transition_time IS NOT NULL,
+			(status).error_message IS NULL,
+			(status).stats IS NULL
+		FROM api.model_registries WHERE id = $1`, id).
+		Scan(&phaseSet, &timeSet, &errorMessageNull, &statsNull))
+
+	assert.True(t, phaseSet, "attributes named in the PATCH body are written")
+	assert.True(t, timeSet, "attributes named in the PATCH body are written")
+	assert.True(t, errorMessageNull, "PostgREST replaces the whole composite: error_message should be nulled")
+	assert.True(t, statsNull, "PostgREST replaces the whole composite: stats should be nulled")
+}
+
+// TestModelRegistryStatsSurviveConnectivityReconcile is the regression test for
+// the status write-back defect bundled with NEU-619: it drives a real
+// connectivity reconcile against a real PostgREST and asserts the statistics
+// written by the (separate) statistics path are still there afterwards.
+//
+// Without the carry-forward in ModelRegistryController.updateStatus this fails.
+func TestModelRegistryStatsSurviveConnectivityReconcile(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	id := createTestModelRegistry(t, db, s, "stats-reconcile")
+
+	_, err := db.Exec(`UPDATE api.model_registries
+		SET status = ROW('Connected', '2026-01-01T00:00:00Z', NULL,
+		                 '{"model_count": 3, "storage_bytes": 4096, "stats_updated_at": "2026-01-01T00:00:00Z"}'::jsonb)::api.model_registry_status
+		WHERE id = $1`, id)
+	require.NoError(t, err)
+
+	obj, err := s.GetModelRegistry(strconv.Itoa(id))
+	require.NoError(t, err)
+	require.NotNil(t, obj.Status.Stats, "precondition: stats were stored")
+
+	// Stub out the registry backend so the reconcile is exercised without a real
+	// BentoML store: the connectivity check fails, which is what pushes the
+	// controller into a status write-back.
+	mockRegistry := modelregistrymocks.NewMockModelRegistry(t)
+	mockRegistry.On("HealthyCheck").Return(assert.AnError)
+
+	original := model_registry.NewModelRegistry
+	model_registry.NewModelRegistry = func(_ *v1.ModelRegistry) (model_registry.ModelRegistry, error) {
+		return mockRegistry, nil
+	}
+
+	defer func() { model_registry.NewModelRegistry = original }()
+
+	c, err := controllers.NewModelRegistryController(&controllers.ModelRegistryControllerOption{Storage: s})
+	require.NoError(t, err)
+
+	require.Error(t, c.Reconcile(obj), "the stubbed health check fails, so the reconcile reports an error")
+
+	after, err := s.GetModelRegistry(strconv.Itoa(id))
+	require.NoError(t, err)
+
+	assert.Equal(t, v1.ModelRegistryPhaseFAILED, after.Status.Phase, "the reconcile did write the status back")
+	require.NotNil(t, after.Status.Stats, "stats must survive a connectivity status write-back")
+	assert.Equal(t, 3, after.Status.Stats.ModelCount)
+	assert.Equal(t, int64(4096), after.Status.Stats.StorageBytes)
+	assert.Equal(t, "2026-01-01T00:00:00Z", after.Status.Stats.StatsUpdatedAt)
+}
+
+// TestModelRegistryStatsReadableThroughPostgREST checks the new attribute is
+// visible on the REST surface, not just in the table.
+func TestModelRegistryStatsReadableThroughPostgREST(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	id := createTestModelRegistry(t, db, s, "stats-readable")
+
+	require.NoError(t, s.UpdateModelRegistry(strconv.Itoa(id), &v1.ModelRegistry{
+		Status: &v1.ModelRegistryStatus{
+			Phase: v1.ModelRegistryPhaseCONNECTED,
+			Stats: &v1.ModelRegistryStats{
+				ModelCount:     7,
+				StorageBytes:   1 << 30,
+				StatsUpdatedAt: "2026-03-03T00:00:00Z",
+			},
+		},
+	}))
+
+	got, err := s.GetModelRegistry(strconv.Itoa(id))
+	require.NoError(t, err)
+	require.NotNil(t, got.Status.Stats)
+	assert.Equal(t, 7, got.Status.Stats.ModelCount)
+	assert.Equal(t, int64(1<<30), got.Status.Stats.StorageBytes)
+	assert.Equal(t, "2026-03-03T00:00:00Z", got.Status.Stats.StatsUpdatedAt)
+}

--- a/db/dbtest/model_registry_stats_test.go
+++ b/db/dbtest/model_registry_stats_test.go
@@ -20,16 +20,10 @@ import (
 func createTestModelRegistry(t *testing.T, db *sql.DB, s storage.Storage, name string) int {
 	t.Helper()
 
-	return createTestModelRegistryInWorkspace(t, db, s, name, "default")
-}
-
-func createTestModelRegistryInWorkspace(t *testing.T, db *sql.DB, s storage.Storage, name, workspace string) int {
-	t.Helper()
-
 	require.NoError(t, s.CreateModelRegistry(&v1.ModelRegistry{
 		APIVersion: "v1",
 		Kind:       "ModelRegistry",
-		Metadata:   &v1.Metadata{Name: name, Workspace: workspace},
+		Metadata:   &v1.Metadata{Name: name, Workspace: "default"},
 		Spec: &v1.ModelRegistrySpec{
 			Type: v1.BentoMLModelRegistryType,
 			Url:  "file://localhost/tmp/" + name,
@@ -39,8 +33,8 @@ func createTestModelRegistryInWorkspace(t *testing.T, db *sql.DB, s storage.Stor
 
 	var id int
 	require.NoError(t, db.QueryRow(
-		"SELECT id FROM api.model_registries WHERE (metadata).name = $1 AND (metadata).workspace = $2",
-		name, workspace,
+		"SELECT id FROM api.model_registries WHERE (metadata).name = $1 AND (metadata).workspace = 'default'",
+		name,
 	).Scan(&id))
 
 	t.Cleanup(func() {

--- a/db/dbtest/model_registry_stats_test.go
+++ b/db/dbtest/model_registry_stats_test.go
@@ -15,15 +15,21 @@ import (
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
-// createTestModelRegistry inserts a model registry through PostgREST and
-// registers its removal. It returns the row id.
+// createTestModelRegistry inserts a model registry in the default workspace
+// through PostgREST and registers its removal. It returns the row id.
 func createTestModelRegistry(t *testing.T, db *sql.DB, s storage.Storage, name string) int {
+	t.Helper()
+
+	return createTestModelRegistryInWorkspace(t, db, s, name, "default")
+}
+
+func createTestModelRegistryInWorkspace(t *testing.T, db *sql.DB, s storage.Storage, name, workspace string) int {
 	t.Helper()
 
 	require.NoError(t, s.CreateModelRegistry(&v1.ModelRegistry{
 		APIVersion: "v1",
 		Kind:       "ModelRegistry",
-		Metadata:   &v1.Metadata{Name: name, Workspace: "default"},
+		Metadata:   &v1.Metadata{Name: name, Workspace: workspace},
 		Spec: &v1.ModelRegistrySpec{
 			Type: v1.BentoMLModelRegistryType,
 			Url:  "file://localhost/tmp/" + name,
@@ -33,8 +39,8 @@ func createTestModelRegistry(t *testing.T, db *sql.DB, s storage.Storage, name s
 
 	var id int
 	require.NoError(t, db.QueryRow(
-		"SELECT id FROM api.model_registries WHERE (metadata).name = $1 AND (metadata).workspace = 'default'",
-		name,
+		"SELECT id FROM api.model_registries WHERE (metadata).name = $1 AND (metadata).workspace = $2",
+		name, workspace,
 	).Scan(&id))
 
 	t.Cleanup(func() {

--- a/db/dbtest/postgrest_helper.go
+++ b/db/dbtest/postgrest_helper.go
@@ -1,6 +1,7 @@
 package dbtest
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -56,7 +57,10 @@ func waitForPostgREST(t *testing.T) {
 				return
 			}
 
-			lastErr = nil
+			// Reached but not serving. Keep the status: it is the difference
+			// between "nothing is listening" and "PostgREST cannot reach the
+			// database", and only one of those is worth investigating here.
+			lastErr = fmt.Errorf("last response was HTTP %d", resp.StatusCode)
 		} else {
 			lastErr = err
 		}

--- a/db/dbtest/postgrest_helper.go
+++ b/db/dbtest/postgrest_helper.go
@@ -1,0 +1,68 @@
+package dbtest
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// TestJWTSecret is the secret db/docker-compose.test.yml hands to both GoTrue
+// and PostgREST.
+const TestJWTSecret = "test-jwt-secret-32-characters-min"
+
+// GetPostgRESTURL returns the base URL of the PostgREST instance started by
+// `make db-test`.
+func GetPostgRESTURL() string {
+	return getEnvOrDefault("POSTGREST_URL", "http://localhost:6432")
+}
+
+// NewTestStorage returns a storage client talking to the test PostgREST, using
+// the same service-role token the control plane uses. It blocks until PostgREST
+// answers, because the container is started right before the test run and needs
+// a moment to build its schema cache.
+func NewTestStorage(t *testing.T) storage.Storage {
+	t.Helper()
+
+	waitForPostgREST(t)
+
+	s, err := storage.New(storage.Options{
+		AccessURL: GetPostgRESTURL(),
+		Scheme:    "api",
+		JwtSecret: TestJWTSecret,
+	})
+	if err != nil {
+		t.Fatalf("failed to create storage client: %v", err)
+	}
+
+	return s
+}
+
+func waitForPostgREST(t *testing.T) {
+	t.Helper()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(60 * time.Second)
+
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(GetPostgRESTURL() + "/")
+		if err == nil {
+			resp.Body.Close()
+
+			if resp.StatusCode < http.StatusInternalServerError {
+				return
+			}
+
+			lastErr = nil
+		} else {
+			lastErr = err
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	t.Fatalf("PostgREST at %s did not become ready: %v", GetPostgRESTURL(), lastErr)
+}

--- a/db/docker-compose.test.yml
+++ b/db/docker-compose.test.yml
@@ -96,4 +96,4 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    restart: always
+    restart: "no"

--- a/db/docker-compose.test.yml
+++ b/db/docker-compose.test.yml
@@ -72,3 +72,28 @@ services:
     volumes:
       - ./seed:/seed
     restart: "no"
+
+  # PostgREST is what the control plane actually writes through, and part of its
+  # behaviour -- notably that a PATCH replaces a composite-type column as a whole
+  # instead of merging attribute by attribute -- cannot be reproduced with plain
+  # SQL. Brought up after seed so its schema cache reflects the migrated schema.
+  # Settings mirror deploy/docker/neutree-core/docker-compose.yml.
+  postgrest:
+    image: postgrest/postgrest:v14.0
+    container_name: neutree-postgrest-test
+    ports:
+      - "6432:6432"
+    environment:
+      PGRST_DB_URI: postgres://postgres:pgpassword@postgres:5432/neutree_test
+      PGRST_DB_SCHEMA: api
+      PGRST_SERVER_HOST: 0.0.0.0
+      PGRST_SERVER_PORT: 6432
+      PGRST_JWT_SECRET: test-jwt-secret-32-characters-min
+      PGRST_APP_SETTINGS_JWT_SECRET: test-jwt-secret-32-characters-min
+      PGRST_DB_EXTRA_SEARCH_PATH: auth
+      PGRST_DB_AGGREGATES_ENABLED: 1
+      PGRST_DB_ANON_ROLE: anonymous
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: always

--- a/db/migrations/081_model_registry_stats.down.sql
+++ b/db/migrations/081_model_registry_stats.down.sql
@@ -1,0 +1,1 @@
+ALTER TYPE api.model_registry_status DROP ATTRIBUTE IF EXISTS stats;

--- a/db/migrations/081_model_registry_stats.up.sql
+++ b/db/migrations/081_model_registry_stats.up.sql
@@ -1,0 +1,4 @@
+-- NEU-619: cached content statistics for a model registry (model count, storage
+-- footprint, refresh time). One JSONB attribute rather than three scalars, so
+-- later additions to the same status need no further migration.
+ALTER TYPE api.model_registry_status ADD ATTRIBUTE stats JSONB;

--- a/db/migrations/082_model_aliases.down.sql
+++ b/db/migrations/082_model_aliases.down.sql
@@ -1,2 +1,5 @@
--- Policies and indexes belong to the table and go with it.
+-- Policies, indexes and the trigger belong to the table and go with it.
 DROP TABLE IF EXISTS api.model_aliases;
+
+DROP FUNCTION IF EXISTS public.set_model_alias_workspace();
+DROP FUNCTION IF EXISTS public.model_registry_workspace(INT);

--- a/db/migrations/082_model_aliases.down.sql
+++ b/db/migrations/082_model_aliases.down.sql
@@ -1,0 +1,2 @@
+-- Policies and indexes belong to the table and go with it.
+DROP TABLE IF EXISTS api.model_aliases;

--- a/db/migrations/082_model_aliases.up.sql
+++ b/db/migrations/082_model_aliases.up.sql
@@ -1,0 +1,63 @@
+-- NEU-619: display aliases for models held in a private model registry.
+--
+-- Uniqueness is arbitrated by the database rather than by the application:
+-- registry connections are built per HTTP request against shared storage with
+-- no lock, so two concurrent renames can both pass an application-side check
+-- and both land. The unique index below is the only thing that cannot be raced.
+--
+-- The table is a projection, not the source of truth: the registry filesystem
+-- decides which models exist. Rows whose (model_name, model_version) has
+-- disappeared are not shown, and they must not block a new alias -- a write
+-- that collides with such a row overwrites it.
+CREATE TABLE api.model_aliases (
+    id SERIAL PRIMARY KEY,
+    model_registry_id INT NOT NULL REFERENCES api.model_registries(id) ON DELETE CASCADE,
+    -- Redundant copy of the registry's workspace so the RLS policies below can
+    -- call api.has_permission without a join, as on the other workspaced tables.
+    workspace TEXT NOT NULL,
+    -- Physical coordinates of the aliased model inside the registry.
+    model_name TEXT NOT NULL,
+    model_version TEXT NOT NULL,
+    -- alias keeps the user input verbatim: it is a display name, so case and
+    -- inner spacing are part of it. alias_normalized (NFKC -> trim -> lowercase)
+    -- is what uniqueness compares, and it is computed in Go: Postgres' lower()
+    -- is not a full Unicode casefold and NFKC would need an extra extension.
+    alias TEXT NOT NULL,
+    alias_normalized TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX model_aliases_registry_alias_normalized_unique_idx
+    ON api.model_aliases (model_registry_id, alias_normalized);
+
+-- The read path joins aliases onto the live model list and the model-delete
+-- path removes aliases by physical coordinates; both key off this index.
+CREATE INDEX model_aliases_registry_model_idx
+    ON api.model_aliases (model_registry_id, model_name, model_version);
+
+ALTER TABLE api.model_aliases ENABLE ROW LEVEL SECURITY;
+
+-- Aliases are part of a registry's model data, so they reuse the model
+-- permission actions defined in 042 rather than introducing new ones.
+CREATE POLICY "model alias read policy" ON api.model_aliases
+    FOR SELECT
+    USING (
+        api.has_permission(auth.uid(), 'model:read', workspace)
+    );
+
+CREATE POLICY "model alias create policy" ON api.model_aliases
+    FOR INSERT
+    WITH CHECK (
+        api.has_permission(auth.uid(), 'model:push', workspace)
+    );
+
+CREATE POLICY "model alias update policy" ON api.model_aliases
+    FOR UPDATE
+    USING (
+        api.has_permission(auth.uid(), 'model:push', workspace)
+    );
+
+CREATE POLICY "model alias delete policy" ON api.model_aliases
+    FOR DELETE
+    USING (
+        api.has_permission(auth.uid(), 'model:push', workspace)
+    );

--- a/db/migrations/082_model_aliases.up.sql
+++ b/db/migrations/082_model_aliases.up.sql
@@ -68,9 +68,22 @@ ALTER TABLE api.model_aliases ENABLE ROW LEVEL SECURITY;
 -- The policies authorize against the workspace of the referenced registry, not
 -- against the row's own workspace column. Two reasons the stored column must
 -- not be the authority: a client supplies it on write, and nothing propagates a
--- later change of the registry's workspace to rows already stored. Aliases are
--- part of a registry's model data, so they reuse the model actions from 042
--- rather than introducing new ones.
+-- later change of the registry's workspace to rows already stored.
+--
+-- api.has_permission is the single authorization primitive in this schema, and
+-- its signature is a stable contract: a policy is responsible for handing it the
+-- real workspace of the resource being guarded. This schema caps a deployment at
+-- one workspace (021), so the argument is not consumed today -- passing the
+-- correct value is the policy's job either way, not the primitive's.
+--
+-- Were these policies to authorize against the stored column instead, a caller
+-- holding model:push in one workspace could insert a row naming that workspace
+-- while pointing model_registry_id at a registry in another, taking a slot in
+-- the second registry's unique index in a row that registry's own users could
+-- neither see nor clear.
+--
+-- Aliases are part of a registry's model data, so they reuse the model actions
+-- from 042 rather than introducing new ones.
 CREATE POLICY "model alias read policy" ON api.model_aliases
     FOR SELECT
     USING (

--- a/db/migrations/082_model_aliases.up.sql
+++ b/db/migrations/082_model_aliases.up.sql
@@ -3,17 +3,28 @@
 -- Uniqueness is arbitrated by the database rather than by the application:
 -- registry connections are built per HTTP request against shared storage with
 -- no lock, so two concurrent renames can both pass an application-side check
--- and both land. The unique index below is the only thing that cannot be raced.
+-- and both land. The unique indexes below are the only thing that cannot be raced.
 --
 -- The table is a projection, not the source of truth: the registry filesystem
 -- decides which models exist. Rows whose (model_name, model_version) has
 -- disappeared are not shown, and they must not block a new alias -- a write
 -- that collides with such a row overwrites it.
+
+-- The owning registry's workspace, read past the registry's own RLS so it is
+-- available to the policies below. Lives in public rather than api because
+-- PostgREST only exposes the api schema, and this must not become a callable
+-- RPC. STABLE so the planner can cache it within a statement.
+CREATE FUNCTION public.model_registry_workspace(p_id INT)
+RETURNS TEXT AS $$
+    SELECT (metadata).workspace FROM api.model_registries WHERE id = p_id;
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
 CREATE TABLE api.model_aliases (
     id SERIAL PRIMARY KEY,
     model_registry_id INT NOT NULL REFERENCES api.model_registries(id) ON DELETE CASCADE,
-    -- Redundant copy of the registry's workspace so the RLS policies below can
-    -- call api.has_permission without a join, as on the other workspaced tables.
+    -- Denormalized copy of the owning registry's workspace, for reads and
+    -- filtering. It is derived by the trigger below and is NOT the value the
+    -- RLS policies authorize against -- see the comment on those policies.
     workspace TEXT NOT NULL,
     -- Physical coordinates of the aliased model inside the registry.
     model_name TEXT NOT NULL,
@@ -26,38 +37,60 @@ CREATE TABLE api.model_aliases (
     alias_normalized TEXT NOT NULL
 );
 
+-- An alias is unique within a registry...
 CREATE UNIQUE INDEX model_aliases_registry_alias_normalized_unique_idx
     ON api.model_aliases (model_registry_id, alias_normalized);
 
--- The read path joins aliases onto the live model list and the model-delete
--- path removes aliases by physical coordinates; both key off this index.
-CREATE INDEX model_aliases_registry_model_idx
+-- ...and a model version carries at most one alias. Without this a model could
+-- accumulate several display names and the read path -- which joins aliases
+-- onto the live model list -- would have no defined winner.
+CREATE UNIQUE INDEX model_aliases_registry_model_unique_idx
     ON api.model_aliases (model_registry_id, model_name, model_version);
+
+-- workspace is derived from the owning registry on every write, so a client
+-- cannot store a workspace the registry does not belong to. BEFORE triggers run
+-- ahead of NOT NULL and of the RLS WITH CHECK, so callers may omit it entirely.
+CREATE FUNCTION public.set_model_alias_workspace()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.workspace := public.model_registry_workspace(NEW.model_registry_id);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_model_alias_workspace
+    BEFORE INSERT OR UPDATE ON api.model_aliases
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_model_alias_workspace();
 
 ALTER TABLE api.model_aliases ENABLE ROW LEVEL SECURITY;
 
--- Aliases are part of a registry's model data, so they reuse the model
--- permission actions defined in 042 rather than introducing new ones.
+-- The policies authorize against the workspace of the referenced registry, not
+-- against the row's own workspace column. Two reasons the stored column must
+-- not be the authority: a client supplies it on write, and nothing propagates a
+-- later change of the registry's workspace to rows already stored. Aliases are
+-- part of a registry's model data, so they reuse the model actions from 042
+-- rather than introducing new ones.
 CREATE POLICY "model alias read policy" ON api.model_aliases
     FOR SELECT
     USING (
-        api.has_permission(auth.uid(), 'model:read', workspace)
+        api.has_permission(auth.uid(), 'model:read', public.model_registry_workspace(model_registry_id))
     );
 
 CREATE POLICY "model alias create policy" ON api.model_aliases
     FOR INSERT
     WITH CHECK (
-        api.has_permission(auth.uid(), 'model:push', workspace)
+        api.has_permission(auth.uid(), 'model:push', public.model_registry_workspace(model_registry_id))
     );
 
 CREATE POLICY "model alias update policy" ON api.model_aliases
     FOR UPDATE
     USING (
-        api.has_permission(auth.uid(), 'model:push', workspace)
+        api.has_permission(auth.uid(), 'model:push', public.model_registry_workspace(model_registry_id))
     );
 
 CREATE POLICY "model alias delete policy" ON api.model_aliases
     FOR DELETE
     USING (
-        api.has_permission(auth.uid(), 'model:push', workspace)
+        api.has_permission(auth.uid(), 'model:push', public.model_registry_workspace(model_registry_id))
     );

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	go.openly.dev/pointy v1.3.0
 	golang.org/x/crypto v0.40.0
 	golang.org/x/sync v0.16.0
+	golang.org/x/text v0.27.0
 	google.golang.org/grpc v1.67.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
@@ -160,7 +161,6 @@ require (
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/term v0.33.0 // indirect
-	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,7 +285,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=

--- a/pkg/storage/mocks/mock_storage.go
+++ b/pkg/storage/mocks/mock_storage.go
@@ -403,6 +403,52 @@ func (_c *MockStorage_CreateImageRegistry_Call) RunAndReturn(run func(*v1.ImageR
 	return _c
 }
 
+// CreateModelAlias provides a mock function with given fields: data
+func (_m *MockStorage) CreateModelAlias(data *v1.ModelAlias) error {
+	ret := _m.Called(data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateModelAlias")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.ModelAlias) error); ok {
+		r0 = rf(data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorage_CreateModelAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateModelAlias'
+type MockStorage_CreateModelAlias_Call struct {
+	*mock.Call
+}
+
+// CreateModelAlias is a helper method to define mock.On call
+//   - data *v1.ModelAlias
+func (_e *MockStorage_Expecter) CreateModelAlias(data interface{}) *MockStorage_CreateModelAlias_Call {
+	return &MockStorage_CreateModelAlias_Call{Call: _e.mock.On("CreateModelAlias", data)}
+}
+
+func (_c *MockStorage_CreateModelAlias_Call) Run(run func(data *v1.ModelAlias)) *MockStorage_CreateModelAlias_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*v1.ModelAlias))
+	})
+	return _c
+}
+
+func (_c *MockStorage_CreateModelAlias_Call) Return(_a0 error) *MockStorage_CreateModelAlias_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorage_CreateModelAlias_Call) RunAndReturn(run func(*v1.ModelAlias) error) *MockStorage_CreateModelAlias_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateModelCatalog provides a mock function with given fields: data
 func (_m *MockStorage) CreateModelCatalog(data *v1.ModelCatalog) error {
 	ret := _m.Called(data)
@@ -587,52 +633,6 @@ func (_c *MockStorage_CreateRoleAssignment_Call) RunAndReturn(run func(*v1.RoleA
 	return _c
 }
 
-// CreateStaticNodeCluster provides a mock function with given fields: data
-func (_m *MockStorage) CreateStaticNodeCluster(data *v1.StaticNodeCluster) error {
-	ret := _m.Called(data)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateStaticNodeCluster")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*v1.StaticNodeCluster) error); ok {
-		r0 = rf(data)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockStorage_CreateStaticNodeCluster_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateStaticNodeCluster'
-type MockStorage_CreateStaticNodeCluster_Call struct {
-	*mock.Call
-}
-
-// CreateStaticNodeCluster is a helper method to define mock.On call
-//   - data *v1.StaticNodeCluster
-func (_e *MockStorage_Expecter) CreateStaticNodeCluster(data interface{}) *MockStorage_CreateStaticNodeCluster_Call {
-	return &MockStorage_CreateStaticNodeCluster_Call{Call: _e.mock.On("CreateStaticNodeCluster", data)}
-}
-
-func (_c *MockStorage_CreateStaticNodeCluster_Call) Run(run func(data *v1.StaticNodeCluster)) *MockStorage_CreateStaticNodeCluster_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*v1.StaticNodeCluster))
-	})
-	return _c
-}
-
-func (_c *MockStorage_CreateStaticNodeCluster_Call) Return(_a0 error) *MockStorage_CreateStaticNodeCluster_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockStorage_CreateStaticNodeCluster_Call) RunAndReturn(run func(*v1.StaticNodeCluster) error) *MockStorage_CreateStaticNodeCluster_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CreateStaticNode provides a mock function with given fields: data
 func (_m *MockStorage) CreateStaticNode(data *v1.StaticNode) error {
 	ret := _m.Called(data)
@@ -675,6 +675,52 @@ func (_c *MockStorage_CreateStaticNode_Call) Return(_a0 error) *MockStorage_Crea
 }
 
 func (_c *MockStorage_CreateStaticNode_Call) RunAndReturn(run func(*v1.StaticNode) error) *MockStorage_CreateStaticNode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateStaticNodeCluster provides a mock function with given fields: data
+func (_m *MockStorage) CreateStaticNodeCluster(data *v1.StaticNodeCluster) error {
+	ret := _m.Called(data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateStaticNodeCluster")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.StaticNodeCluster) error); ok {
+		r0 = rf(data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorage_CreateStaticNodeCluster_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateStaticNodeCluster'
+type MockStorage_CreateStaticNodeCluster_Call struct {
+	*mock.Call
+}
+
+// CreateStaticNodeCluster is a helper method to define mock.On call
+//   - data *v1.StaticNodeCluster
+func (_e *MockStorage_Expecter) CreateStaticNodeCluster(data interface{}) *MockStorage_CreateStaticNodeCluster_Call {
+	return &MockStorage_CreateStaticNodeCluster_Call{Call: _e.mock.On("CreateStaticNodeCluster", data)}
+}
+
+func (_c *MockStorage_CreateStaticNodeCluster_Call) Run(run func(data *v1.StaticNodeCluster)) *MockStorage_CreateStaticNodeCluster_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*v1.StaticNodeCluster))
+	})
+	return _c
+}
+
+func (_c *MockStorage_CreateStaticNodeCluster_Call) Return(_a0 error) *MockStorage_CreateStaticNodeCluster_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorage_CreateStaticNodeCluster_Call) RunAndReturn(run func(*v1.StaticNodeCluster) error) *MockStorage_CreateStaticNodeCluster_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1043,6 +1089,52 @@ func (_c *MockStorage_DeleteImageRegistry_Call) Return(_a0 error) *MockStorage_D
 }
 
 func (_c *MockStorage_DeleteImageRegistry_Call) RunAndReturn(run func(string) error) *MockStorage_DeleteImageRegistry_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteModelAlias provides a mock function with given fields: id
+func (_m *MockStorage) DeleteModelAlias(id string) error {
+	ret := _m.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteModelAlias")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorage_DeleteModelAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteModelAlias'
+type MockStorage_DeleteModelAlias_Call struct {
+	*mock.Call
+}
+
+// DeleteModelAlias is a helper method to define mock.On call
+//   - id string
+func (_e *MockStorage_Expecter) DeleteModelAlias(id interface{}) *MockStorage_DeleteModelAlias_Call {
+	return &MockStorage_DeleteModelAlias_Call{Call: _e.mock.On("DeleteModelAlias", id)}
+}
+
+func (_c *MockStorage_DeleteModelAlias_Call) Run(run func(id string)) *MockStorage_DeleteModelAlias_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockStorage_DeleteModelAlias_Call) Return(_a0 error) *MockStorage_DeleteModelAlias_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorage_DeleteModelAlias_Call) RunAndReturn(run func(string) error) *MockStorage_DeleteModelAlias_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1812,6 +1904,64 @@ func (_c *MockStorage_GetImageRegistry_Call) RunAndReturn(run func(string) (*v1.
 	return _c
 }
 
+// GetModelAlias provides a mock function with given fields: id
+func (_m *MockStorage) GetModelAlias(id string) (*v1.ModelAlias, error) {
+	ret := _m.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetModelAlias")
+	}
+
+	var r0 *v1.ModelAlias
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*v1.ModelAlias, error)); ok {
+		return rf(id)
+	}
+	if rf, ok := ret.Get(0).(func(string) *v1.ModelAlias); ok {
+		r0 = rf(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.ModelAlias)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockStorage_GetModelAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetModelAlias'
+type MockStorage_GetModelAlias_Call struct {
+	*mock.Call
+}
+
+// GetModelAlias is a helper method to define mock.On call
+//   - id string
+func (_e *MockStorage_Expecter) GetModelAlias(id interface{}) *MockStorage_GetModelAlias_Call {
+	return &MockStorage_GetModelAlias_Call{Call: _e.mock.On("GetModelAlias", id)}
+}
+
+func (_c *MockStorage_GetModelAlias_Call) Run(run func(id string)) *MockStorage_GetModelAlias_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockStorage_GetModelAlias_Call) Return(_a0 *v1.ModelAlias, _a1 error) *MockStorage_GetModelAlias_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockStorage_GetModelAlias_Call) RunAndReturn(run func(string) (*v1.ModelAlias, error)) *MockStorage_GetModelAlias_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetModelCatalog provides a mock function with given fields: id
 func (_m *MockStorage) GetModelCatalog(id string) (*v1.ModelCatalog, error) {
 	ret := _m.Called(id)
@@ -2508,6 +2658,64 @@ func (_c *MockStorage_ListImageRegistry_Call) RunAndReturn(run func(storage.List
 	return _c
 }
 
+// ListModelAlias provides a mock function with given fields: option
+func (_m *MockStorage) ListModelAlias(option storage.ListOption) ([]v1.ModelAlias, error) {
+	ret := _m.Called(option)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListModelAlias")
+	}
+
+	var r0 []v1.ModelAlias
+	var r1 error
+	if rf, ok := ret.Get(0).(func(storage.ListOption) ([]v1.ModelAlias, error)); ok {
+		return rf(option)
+	}
+	if rf, ok := ret.Get(0).(func(storage.ListOption) []v1.ModelAlias); ok {
+		r0 = rf(option)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]v1.ModelAlias)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(storage.ListOption) error); ok {
+		r1 = rf(option)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockStorage_ListModelAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListModelAlias'
+type MockStorage_ListModelAlias_Call struct {
+	*mock.Call
+}
+
+// ListModelAlias is a helper method to define mock.On call
+//   - option storage.ListOption
+func (_e *MockStorage_Expecter) ListModelAlias(option interface{}) *MockStorage_ListModelAlias_Call {
+	return &MockStorage_ListModelAlias_Call{Call: _e.mock.On("ListModelAlias", option)}
+}
+
+func (_c *MockStorage_ListModelAlias_Call) Run(run func(option storage.ListOption)) *MockStorage_ListModelAlias_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(storage.ListOption))
+	})
+	return _c
+}
+
+func (_c *MockStorage_ListModelAlias_Call) Return(_a0 []v1.ModelAlias, _a1 error) *MockStorage_ListModelAlias_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockStorage_ListModelAlias_Call) RunAndReturn(run func(storage.ListOption) ([]v1.ModelAlias, error)) *MockStorage_ListModelAlias_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListModelCatalog provides a mock function with given fields: option
 func (_m *MockStorage) ListModelCatalog(option storage.ListOption) ([]v1.ModelCatalog, error) {
 	ret := _m.Called(option)
@@ -2740,64 +2948,6 @@ func (_c *MockStorage_ListRoleAssignment_Call) RunAndReturn(run func(storage.Lis
 	return _c
 }
 
-// ListStaticNodeCluster provides a mock function with given fields: option
-func (_m *MockStorage) ListStaticNodeCluster(option storage.ListOption) ([]v1.StaticNodeCluster, error) {
-	ret := _m.Called(option)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListStaticNodeCluster")
-	}
-
-	var r0 []v1.StaticNodeCluster
-	var r1 error
-	if rf, ok := ret.Get(0).(func(storage.ListOption) ([]v1.StaticNodeCluster, error)); ok {
-		return rf(option)
-	}
-	if rf, ok := ret.Get(0).(func(storage.ListOption) []v1.StaticNodeCluster); ok {
-		r0 = rf(option)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]v1.StaticNodeCluster)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(storage.ListOption) error); ok {
-		r1 = rf(option)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockStorage_ListStaticNodeCluster_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListStaticNodeCluster'
-type MockStorage_ListStaticNodeCluster_Call struct {
-	*mock.Call
-}
-
-// ListStaticNodeCluster is a helper method to define mock.On call
-//   - option storage.ListOption
-func (_e *MockStorage_Expecter) ListStaticNodeCluster(option interface{}) *MockStorage_ListStaticNodeCluster_Call {
-	return &MockStorage_ListStaticNodeCluster_Call{Call: _e.mock.On("ListStaticNodeCluster", option)}
-}
-
-func (_c *MockStorage_ListStaticNodeCluster_Call) Run(run func(option storage.ListOption)) *MockStorage_ListStaticNodeCluster_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(storage.ListOption))
-	})
-	return _c
-}
-
-func (_c *MockStorage_ListStaticNodeCluster_Call) Return(_a0 []v1.StaticNodeCluster, _a1 error) *MockStorage_ListStaticNodeCluster_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockStorage_ListStaticNodeCluster_Call) RunAndReturn(run func(storage.ListOption) ([]v1.StaticNodeCluster, error)) *MockStorage_ListStaticNodeCluster_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ListStaticNode provides a mock function with given fields: option
 func (_m *MockStorage) ListStaticNode(option storage.ListOption) ([]v1.StaticNode, error) {
 	ret := _m.Called(option)
@@ -2852,6 +3002,64 @@ func (_c *MockStorage_ListStaticNode_Call) Return(_a0 []v1.StaticNode, _a1 error
 }
 
 func (_c *MockStorage_ListStaticNode_Call) RunAndReturn(run func(storage.ListOption) ([]v1.StaticNode, error)) *MockStorage_ListStaticNode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListStaticNodeCluster provides a mock function with given fields: option
+func (_m *MockStorage) ListStaticNodeCluster(option storage.ListOption) ([]v1.StaticNodeCluster, error) {
+	ret := _m.Called(option)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListStaticNodeCluster")
+	}
+
+	var r0 []v1.StaticNodeCluster
+	var r1 error
+	if rf, ok := ret.Get(0).(func(storage.ListOption) ([]v1.StaticNodeCluster, error)); ok {
+		return rf(option)
+	}
+	if rf, ok := ret.Get(0).(func(storage.ListOption) []v1.StaticNodeCluster); ok {
+		r0 = rf(option)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]v1.StaticNodeCluster)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(storage.ListOption) error); ok {
+		r1 = rf(option)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockStorage_ListStaticNodeCluster_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListStaticNodeCluster'
+type MockStorage_ListStaticNodeCluster_Call struct {
+	*mock.Call
+}
+
+// ListStaticNodeCluster is a helper method to define mock.On call
+//   - option storage.ListOption
+func (_e *MockStorage_Expecter) ListStaticNodeCluster(option interface{}) *MockStorage_ListStaticNodeCluster_Call {
+	return &MockStorage_ListStaticNodeCluster_Call{Call: _e.mock.On("ListStaticNodeCluster", option)}
+}
+
+func (_c *MockStorage_ListStaticNodeCluster_Call) Run(run func(option storage.ListOption)) *MockStorage_ListStaticNodeCluster_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(storage.ListOption))
+	})
+	return _c
+}
+
+func (_c *MockStorage_ListStaticNodeCluster_Call) Return(_a0 []v1.StaticNodeCluster, _a1 error) *MockStorage_ListStaticNodeCluster_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockStorage_ListStaticNodeCluster_Call) RunAndReturn(run func(storage.ListOption) ([]v1.StaticNodeCluster, error)) *MockStorage_ListStaticNodeCluster_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3254,6 +3462,53 @@ func (_c *MockStorage_UpdateImageRegistry_Call) RunAndReturn(run func(string, *v
 	return _c
 }
 
+// UpdateModelAlias provides a mock function with given fields: id, data
+func (_m *MockStorage) UpdateModelAlias(id string, data *v1.ModelAlias) error {
+	ret := _m.Called(id, data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateModelAlias")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *v1.ModelAlias) error); ok {
+		r0 = rf(id, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorage_UpdateModelAlias_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateModelAlias'
+type MockStorage_UpdateModelAlias_Call struct {
+	*mock.Call
+}
+
+// UpdateModelAlias is a helper method to define mock.On call
+//   - id string
+//   - data *v1.ModelAlias
+func (_e *MockStorage_Expecter) UpdateModelAlias(id interface{}, data interface{}) *MockStorage_UpdateModelAlias_Call {
+	return &MockStorage_UpdateModelAlias_Call{Call: _e.mock.On("UpdateModelAlias", id, data)}
+}
+
+func (_c *MockStorage_UpdateModelAlias_Call) Run(run func(id string, data *v1.ModelAlias)) *MockStorage_UpdateModelAlias_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(*v1.ModelAlias))
+	})
+	return _c
+}
+
+func (_c *MockStorage_UpdateModelAlias_Call) Return(_a0 error) *MockStorage_UpdateModelAlias_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorage_UpdateModelAlias_Call) RunAndReturn(run func(string, *v1.ModelAlias) error) *MockStorage_UpdateModelAlias_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateModelCatalog provides a mock function with given fields: id, data
 func (_m *MockStorage) UpdateModelCatalog(id string, data *v1.ModelCatalog) error {
 	ret := _m.Called(id, data)
@@ -3442,53 +3697,6 @@ func (_c *MockStorage_UpdateRoleAssignment_Call) RunAndReturn(run func(string, *
 	return _c
 }
 
-// UpdateStaticNodeCluster provides a mock function with given fields: id, data
-func (_m *MockStorage) UpdateStaticNodeCluster(id string, data *v1.StaticNodeCluster) error {
-	ret := _m.Called(id, data)
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateStaticNodeCluster")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *v1.StaticNodeCluster) error); ok {
-		r0 = rf(id, data)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockStorage_UpdateStaticNodeCluster_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateStaticNodeCluster'
-type MockStorage_UpdateStaticNodeCluster_Call struct {
-	*mock.Call
-}
-
-// UpdateStaticNodeCluster is a helper method to define mock.On call
-//   - id string
-//   - data *v1.StaticNodeCluster
-func (_e *MockStorage_Expecter) UpdateStaticNodeCluster(id interface{}, data interface{}) *MockStorage_UpdateStaticNodeCluster_Call {
-	return &MockStorage_UpdateStaticNodeCluster_Call{Call: _e.mock.On("UpdateStaticNodeCluster", id, data)}
-}
-
-func (_c *MockStorage_UpdateStaticNodeCluster_Call) Run(run func(id string, data *v1.StaticNodeCluster)) *MockStorage_UpdateStaticNodeCluster_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(*v1.StaticNodeCluster))
-	})
-	return _c
-}
-
-func (_c *MockStorage_UpdateStaticNodeCluster_Call) Return(_a0 error) *MockStorage_UpdateStaticNodeCluster_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockStorage_UpdateStaticNodeCluster_Call) RunAndReturn(run func(string, *v1.StaticNodeCluster) error) *MockStorage_UpdateStaticNodeCluster_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // UpdateStaticNode provides a mock function with given fields: id, data
 func (_m *MockStorage) UpdateStaticNode(id string, data *v1.StaticNode) error {
 	ret := _m.Called(id, data)
@@ -3532,6 +3740,53 @@ func (_c *MockStorage_UpdateStaticNode_Call) Return(_a0 error) *MockStorage_Upda
 }
 
 func (_c *MockStorage_UpdateStaticNode_Call) RunAndReturn(run func(string, *v1.StaticNode) error) *MockStorage_UpdateStaticNode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateStaticNodeCluster provides a mock function with given fields: id, data
+func (_m *MockStorage) UpdateStaticNodeCluster(id string, data *v1.StaticNodeCluster) error {
+	ret := _m.Called(id, data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateStaticNodeCluster")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, *v1.StaticNodeCluster) error); ok {
+		r0 = rf(id, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockStorage_UpdateStaticNodeCluster_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateStaticNodeCluster'
+type MockStorage_UpdateStaticNodeCluster_Call struct {
+	*mock.Call
+}
+
+// UpdateStaticNodeCluster is a helper method to define mock.On call
+//   - id string
+//   - data *v1.StaticNodeCluster
+func (_e *MockStorage_Expecter) UpdateStaticNodeCluster(id interface{}, data interface{}) *MockStorage_UpdateStaticNodeCluster_Call {
+	return &MockStorage_UpdateStaticNodeCluster_Call{Call: _e.mock.On("UpdateStaticNodeCluster", id, data)}
+}
+
+func (_c *MockStorage_UpdateStaticNodeCluster_Call) Run(run func(id string, data *v1.StaticNodeCluster)) *MockStorage_UpdateStaticNodeCluster_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(*v1.StaticNodeCluster))
+	})
+	return _c
+}
+
+func (_c *MockStorage_UpdateStaticNodeCluster_Call) Return(_a0 error) *MockStorage_UpdateStaticNodeCluster_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockStorage_UpdateStaticNodeCluster_Call) RunAndReturn(run func(string, *v1.StaticNodeCluster) error) *MockStorage_UpdateStaticNodeCluster_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/storage/model_alias_test.go
+++ b/pkg/storage/model_alias_test.go
@@ -1,0 +1,144 @@
+package storage
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+type recordedRequest struct {
+	method string
+	path   string
+	query  string
+	prefer string
+	body   string
+}
+
+// aliasTestServer answers every model_aliases request with an empty-ish payload
+// and records what it was asked, so the tests below can assert the request the
+// storage layer builds rather than a round-trip through a real database.
+func aliasTestServer(t *testing.T, payload string) (*httptest.Server, *[]recordedRequest) {
+	t.Helper()
+
+	var seen []recordedRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seen = append(seen, recordedRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			query:  r.URL.RawQuery,
+			prefer: r.Header.Get("Prefer"),
+			body:   string(body),
+		})
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(payload))
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server, &seen
+}
+
+// CreateModelAlias must issue a plain insert. If it ever asked PostgREST to
+// resolve duplicates (Prefer: resolution=merge-duplicates) the unique index on
+// (model_registry_id, alias_normalized) would stop rejecting a taken alias and
+// silently overwrite the existing row instead — which is the opposite of what
+// the table exists for.
+func TestCreateModelAlias_IsAPlainInsert(t *testing.T) {
+	server, seen := aliasTestServer(t, `[]`)
+	s := newTestStorage(t, server.URL)
+
+	require.NoError(t, s.CreateModelAlias(&v1.ModelAlias{
+		ModelRegistryID: 7,
+		ModelName:       "qwen3",
+		ModelVersion:    "v1",
+		Alias:           "Qwen3",
+		AliasNormalized: v1.NormalizeModelAlias("Qwen3"),
+	}))
+
+	require.Len(t, *seen, 1)
+	got := (*seen)[0]
+
+	assert.Equal(t, http.MethodPost, got.method)
+	assert.Equal(t, "/model_aliases", got.path)
+	assert.NotContains(t, got.prefer, "resolution=merge-duplicates",
+		"a duplicate alias must come back as an error, not silently replace the existing row")
+
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(got.body, "[")), &sent))
+	assert.Equal(t, "Qwen3", sent["alias"])
+	assert.Equal(t, "qwen3", sent["alias_normalized"])
+	assert.NotContains(t, sent, "workspace",
+		"workspace is derived by the database; sending it would imply the client picks it")
+}
+
+func TestModelAliasCRUDRequests(t *testing.T) {
+	t.Run("list filters by registry", func(t *testing.T) {
+		server, seen := aliasTestServer(t, `[{"id":1,"model_registry_id":7,"workspace":"default","alias":"Qwen3"}]`)
+		s := newTestStorage(t, server.URL)
+
+		got, err := s.ListModelAlias(ListOption{
+			Filters: []Filter{{Column: "model_registry_id", Operator: "eq", Value: "7"}},
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "Qwen3", got[0].Alias)
+		assert.Equal(t, "default", got[0].Workspace)
+
+		require.Len(t, *seen, 1)
+		assert.Equal(t, http.MethodGet, (*seen)[0].method)
+		assert.Contains(t, (*seen)[0].query, "model_registry_id=eq.7")
+	})
+
+	t.Run("get by id", func(t *testing.T) {
+		server, seen := aliasTestServer(t, `[{"id":3,"alias":"Qwen3"}]`)
+		s := newTestStorage(t, server.URL)
+
+		got, err := s.GetModelAlias("3")
+		require.NoError(t, err)
+		assert.Equal(t, 3, got.ID)
+		assert.Contains(t, (*seen)[0].query, "id=eq.3")
+	})
+
+	t.Run("get missing returns ErrResourceNotFound", func(t *testing.T) {
+		server, _ := aliasTestServer(t, `[]`)
+		s := newTestStorage(t, server.URL)
+
+		_, err := s.GetModelAlias("404")
+		assert.ErrorIs(t, err, ErrResourceNotFound)
+	})
+
+	t.Run("update patches one row", func(t *testing.T) {
+		server, seen := aliasTestServer(t, `[]`)
+		s := newTestStorage(t, server.URL)
+
+		require.NoError(t, s.UpdateModelAlias("3", &v1.ModelAlias{ModelName: "qwen3", ModelVersion: "v2"}))
+
+		require.Len(t, *seen, 1)
+		assert.Equal(t, http.MethodPatch, (*seen)[0].method)
+		assert.Contains(t, (*seen)[0].query, "id=eq.3")
+		assert.Contains(t, (*seen)[0].body, `"model_version":"v2"`)
+	})
+
+	t.Run("delete removes one row", func(t *testing.T) {
+		server, seen := aliasTestServer(t, `[]`)
+		s := newTestStorage(t, server.URL)
+
+		require.NoError(t, s.DeleteModelAlias("3"))
+
+		require.Len(t, *seen, 1)
+		assert.Equal(t, http.MethodDelete, (*seen)[0].method)
+		assert.Contains(t, (*seen)[0].query, "id=eq.3")
+	})
+}

--- a/pkg/storage/model_alias_test.go
+++ b/pkg/storage/model_alias_test.go
@@ -50,6 +50,28 @@ func aliasTestServer(t *testing.T, payload string) (*httptest.Server, *[]recorde
 	return server, &seen
 }
 
+// decodeInsertBody decodes an insert body, which PostgREST accepts either as a
+// bare object or as an array of them. It asserts the shape rather than guessing,
+// so a change in what the client sends surfaces here instead of silently
+// skipping the assertions that follow.
+func decodeInsertBody(t *testing.T, body string) map[string]any {
+	t.Helper()
+
+	trimmed := strings.TrimSpace(body)
+	if strings.HasPrefix(trimmed, "[") {
+		var rows []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(trimmed), &rows))
+		require.Len(t, rows, 1, "one alias per insert")
+
+		return rows[0]
+	}
+
+	var row map[string]any
+	require.NoError(t, json.Unmarshal([]byte(trimmed), &row))
+
+	return row
+}
+
 // CreateModelAlias must issue a plain insert. If it ever asked PostgREST to
 // resolve duplicates (Prefer: resolution=merge-duplicates) the unique index on
 // (model_registry_id, alias_normalized) would stop rejecting a taken alias and
@@ -75,8 +97,7 @@ func TestCreateModelAlias_IsAPlainInsert(t *testing.T) {
 	assert.NotContains(t, got.prefer, "resolution=merge-duplicates",
 		"a duplicate alias must come back as an error, not silently replace the existing row")
 
-	var sent map[string]any
-	require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(got.body, "[")), &sent))
+	sent := decodeInsertBody(t, got.body)
 	assert.Equal(t, "Qwen3", sent["alias"])
 	assert.Equal(t, "qwen3", sent["alias_normalized"])
 	assert.NotContains(t, sent, "workspace",

--- a/pkg/storage/postgrest.go
+++ b/pkg/storage/postgrest.go
@@ -196,6 +196,71 @@ func (s *postgrestStorage) GetModelRegistry(id string) (*v1.ModelRegistry, error
 	return &response[0], nil
 }
 
+func (s *postgrestStorage) ListModelAlias(option ListOption) ([]v1.ModelAlias, error) {
+	var response []v1.ModelAlias
+	err := s.genericList(MODEL_ALIAS_TABLE, &response, option)
+
+	return response, err
+}
+
+func (s *postgrestStorage) CreateModelAlias(data *v1.ModelAlias) error {
+	var (
+		err error
+	)
+
+	if _, _, err = s.postgrestClient.From(MODEL_ALIAS_TABLE).Insert(data, false, "", "", "").Execute(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *postgrestStorage) DeleteModelAlias(id string) error {
+	var (
+		err error
+	)
+
+	if _, _, err = s.postgrestClient.From(MODEL_ALIAS_TABLE).Delete("", "").Filter("id", "eq", id).Execute(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *postgrestStorage) UpdateModelAlias(id string, data *v1.ModelAlias) error {
+	var (
+		err error
+	)
+
+	if _, _, err = s.postgrestClient.From(MODEL_ALIAS_TABLE).Update(data, "", "").Filter("id", "eq", id).Execute(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *postgrestStorage) GetModelAlias(id string) (*v1.ModelAlias, error) {
+	var (
+		response []v1.ModelAlias
+		err      error
+	)
+
+	responseContent, _, err := s.postgrestClient.From(MODEL_ALIAS_TABLE).Select("*", "", false).Filter("id", "eq", id).Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = parseResponse(&response, responseContent); err != nil {
+		return nil, err
+	}
+
+	if len(response) == 0 {
+		return nil, ErrResourceNotFound
+	}
+
+	return &response[0], nil
+}
+
 func (s *postgrestStorage) ListCluster(option ListOption) ([]v1.Cluster, error) {
 	var response []v1.Cluster
 	err := s.genericList(CLUSTERS_TABLE, &response, option)

--- a/pkg/storage/postgrest.go
+++ b/pkg/storage/postgrest.go
@@ -203,12 +203,28 @@ func (s *postgrestStorage) ListModelAlias(option ListOption) ([]v1.ModelAlias, e
 	return response, err
 }
 
+// withoutDerivedFields returns a copy with the server-derived fields cleared, so
+// a caller round-tripping an object read from the database does not send them
+// back. Workspace is derived by a trigger from the referenced registry and is
+// what the RLS policies are protecting, so it must never look client-writable.
+func withoutDerivedFields(data *v1.ModelAlias) *v1.ModelAlias {
+	if data == nil {
+		return nil
+	}
+
+	sent := *data
+	sent.Workspace = ""
+
+	return &sent
+}
+
 func (s *postgrestStorage) CreateModelAlias(data *v1.ModelAlias) error {
 	var (
 		err error
 	)
 
-	if _, _, err = s.postgrestClient.From(MODEL_ALIAS_TABLE).Insert(data, false, "", "", "").Execute(); err != nil {
+	if _, _, err = s.postgrestClient.From(MODEL_ALIAS_TABLE).
+		Insert(withoutDerivedFields(data), false, "", "", "").Execute(); err != nil {
 		return err
 	}
 
@@ -232,7 +248,8 @@ func (s *postgrestStorage) UpdateModelAlias(id string, data *v1.ModelAlias) erro
 		err error
 	)
 
-	if _, _, err = s.postgrestClient.From(MODEL_ALIAS_TABLE).Update(data, "", "").Filter("id", "eq", id).Execute(); err != nil {
+	if _, _, err = s.postgrestClient.From(MODEL_ALIAS_TABLE).
+		Update(withoutDerivedFields(data), "", "").Filter("id", "eq", id).Execute(); err != nil {
 		return err
 	}
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -20,6 +20,7 @@ const (
 	IMAGE_REGISTRY_TABLE      = "image_registries"
 	CLUSTERS_TABLE            = "clusters"
 	MODEL_REGISTRY_TABLE      = "model_registries"
+	MODEL_ALIAS_TABLE         = "model_aliases"
 	MODEL_CATALOG_TABLE       = "model_catalogs"
 	ROLE_TABLE                = "roles"
 	ROLE_ASSIGNMENT_TABLE     = "role_assignments"
@@ -55,6 +56,23 @@ type ModelRegistryStorage interface {
 	GetModelRegistry(id string) (*v1.ModelRegistry, error)
 	// ListModelRegistry retrieves a list of model registries with optional filters.
 	ListModelRegistry(option ListOption) ([]v1.ModelRegistry, error)
+}
+
+type ModelAliasStorage interface {
+	// CreateModelAlias creates a new model alias in the database. The unique
+	// index on (model_registry_id, alias_normalized) rejects an alias already
+	// taken in the same registry, so a duplicate surfaces here as an error.
+	CreateModelAlias(data *v1.ModelAlias) error
+	// DeleteModelAlias deletes a model alias by its ID.
+	DeleteModelAlias(id string) error
+	// UpdateModelAlias updates an existing model alias in the database. This is
+	// how an alias is repointed at a different model, including taking over an
+	// orphaned row.
+	UpdateModelAlias(id string, data *v1.ModelAlias) error
+	// GetModelAlias retrieves a model alias by its ID.
+	GetModelAlias(id string) (*v1.ModelAlias, error)
+	// ListModelAlias retrieves a list of model aliases with optional filters.
+	ListModelAlias(option ListOption) ([]v1.ModelAlias, error)
 }
 
 type ClusterStorage interface {
@@ -209,6 +227,7 @@ type Storage interface {
 	ClusterStorage
 	ImageRegistryStorage
 	ModelRegistryStorage
+	ModelAliasStorage
 	RoleStorage
 	RoleAssignmentStorage
 	WorkspaceStorage


### PR DESCRIPTION
## What

Phase-one database groundwork for private model registry asset management (NEU-619): a statistics attribute on the model registry status, a table for private model aliases, and the Go types / storage CRUD that go with them.

### 1. Migration 081 — `api.model_registry_status.stats`

A single `JSONB` attribute holding model count, storage footprint and refresh time, rather than three scalar attributes. Two reasons:

- `endpoint_status.resources` (068), `static_node_status.allocations` (077) and `external_endpoint_status.upstream_status` (080) already established the composite-container + JSONB-leaf shape.
- The next phase adds public-registry availability and last-check time to this same status. With JSONB that needs no migration at all; with scalars every field would need one, plus a matching entry in the hand-written carry-forward list described below.

### 2. Migration 082 — `api.model_aliases`

Display aliases for models held in a private registry.

**Why a table rather than model.yaml labels.** Registry connections are built per HTTP request against shared storage with no lock, so two concurrent rename requests can both pass an application-side uniqueness check and both land. A unique index is the only arbiter that cannot be raced.

**Keyed on `model_registry_id`, not the registry name.** A foreign key with `ON DELETE CASCADE` removes a whole class of orphans, and deleting then recreating a registry under the same name no longer inherits the previous registry's aliases.

**Two unique indexes.** `(model_registry_id, alias_normalized)` makes an alias unique within a registry; `(model_registry_id, model_name, model_version)` makes a model version carry at most one alias. The second one matters because the read path joins aliases onto the live model list, and without it several display names for one model would leave no defined winner.

**Authorization never reads the row's `workspace` column.** The four policies resolve the workspace from the referenced registry through `public.model_registry_workspace`, a `SECURITY DEFINER` lookup deliberately placed outside the PostgREST-exposed `api` schema so it does not become a callable RPC (verified: `POST /rpc/model_registry_workspace` returns 404). The column itself is kept for reads but is derived by a `BEFORE` trigger, so a client cannot store a workspace the registry does not belong to.

Both halves are needed. Trusting the column would let a caller insert a row naming a workspace they hold `model:push` in while pointing `model_registry_id` at a registry in another workspace: the row would take a slot in the second registry's unique index while being invisible to — and unclearable by — that registry's own users. Deriving the column alone is not enough either, since nothing propagates a later change of a registry's workspace to rows already stored, so the stored copy can still drift out of step.

`api.has_permission` is the schema's single authorization primitive and its signature is a stable contract: handing it the real workspace of the resource being guarded is the policy's responsibility, not the primitive's. This schema caps a deployment at one workspace (021), so the argument is not consumed today — which is exactly why it is worth getting right at the policy rather than leaving it to whatever the caller happened to store.

That `BEFORE` triggers run ahead of both `NOT NULL` and the RLS `WITH CHECK` was verified against a live PostgreSQL rather than assumed.

**Normalization** is `NFKC -> trim -> lowercase`, computed in Go and written to `alias_normalized`. Postgres' `lower()` is not a full Unicode casefold and NFKC would need an extra extension, so an expression index would be subtly weaker. `alias` keeps the user input verbatim — it is a display name, so case and inner spacing are part of it. `ValidateModelName` is deliberately not reused: its lowercase-only, 63-character rules are for physical names and contradict the purpose of a display name.

**Orphan rows** are handled by policy, not by a GC job: the read path joins aliases onto the live model list and hides rows whose model is gone, and such a row does not reserve its alias — a colliding write takes it over. No new permission action; the policies reuse `model:read` and `model:push` from 042.

### 3. Bundled defect fix — status write-back wiped the new attribute

**This PR bundles one pre-existing defect fix; please review it separately.**

`ModelRegistryController.updateStatus` rebuilt the status struct from scratch and PATCHed it. PostgREST replaces a composite-type column as a whole rather than merging attribute by attribute, so every attribute missing from the PATCH body is nulled. `stats` would therefore have been erased by the reconcile.

Fixed by carrying `stats` forward from `obj.Status`, the same shape as the hand-written carry-forward in `ClusterController.updateStatus`.

**Regression cases:**

- `TestModelRegistryController_UpdateStatus_CarriesStatsForward` (`controllers/`) — unit level, both transitions.
- `TestModelRegistryStatsSurviveConnectivityReconcile` (`db/dbtest/`) — end to end: a real reconcile against a real PostgREST.

Both were verified to fail with the carry-forward removed, and to pass with it.

One correction to how this was originally described: the wipe is **not** a steady-state event every sync interval. `sync` skips the status write-back entirely when the phase and the error state are both unchanged, so the attribute is erased on each phase or error transition (Connected <-> Failed, error text appearing or clearing), not on every tick.

### 4. PostgREST semantics are now measured, not assumed

The carry-forward above rests on a claim about PostgREST that the codebase had only ever inferred from the existence of the cluster-controller workaround. `db/docker-compose.test.yml` now starts PostgREST, and `TestModelRegistryStatusPatchReplacesWholeComposite` asserts the behaviour directly: PATCH a composite column with a body naming only some attributes, and the unnamed ones come back NULL.

This is the first thing in `db/dbtest` that exercises PostgREST rather than plain SQL — the behaviour has no SQL equivalent, which is why it could not be tested before. If PostgREST ever starts merging attribute by attribute, that test fails and both hand-written carry-forward lists can be deleted.

No `NOTIFY pgrst` in either migration: `db/seed/999_notify_pgrst.sql` fires after every migration on both deployment paths, and the three migrations that do notify inline (062 / 070 / 078) all changed function signatures. Pure `ALTER TYPE ADD ATTRIBUTE` migrations (068 / 077 / 080) do not.

## Test

- `make db-test` — full suite green, 60 tests. New coverage: composite-column PATCH semantics, stats survival across a reconcile, stats readable through PostgREST, alias uniqueness per registry, normalization collisions (`Qwen3` / `qwen3` / ` Qwen3 ` / no-break space / fullwidth), cascade on registry delete, orphan takeover, one-alias-per-model-version, a client-supplied workspace being discarded in favour of the registry's, and the RLS policies. The last two were each confirmed to fail with their constraint removed.

  The tests assert the permission-action half only. This schema caps a deployment at one workspace (021), so `api.has_permission` does not consume the workspace argument and a trigger rejects workspace-scoped role assignments outright — there is no second workspace for a caller to be refused from. That the policies nevertheless hand it the registry's real workspace is what `TestModelAliasWorkspaceIsDerivedFromRegistry` pins down.
- `make test` — green (fmt, vet, lint, unit tests).
- Down migrations exercised by hand, which `db/dbtest` does not do: `82 -> 80` drops the table and the attribute cleanly and leaves the version undirty, and `up` again returns to 82.
- Upgrade safety: a control plane that predates this change writes a status body without `stats` and is accepted — that is exactly the PATCH in `TestModelRegistryStatusPatchReplacesWholeComposite`. It leaves `stats` NULL, which is the pre-feature state, and it never touches the new table.

## Scope

Database layer plus the inseparable Go types and storage layer. The alias business logic — HTTP surface, calling the uniqueness check, applying normalization, deleting aliases alongside models — is the follow-up ticket.



