### PR TITLE
feat(model-registry): checkpoint metadata, paging, aliases, stats and deletion references (NEU-620)

### DIFF
--- a/api/v1/endpoint_types.go
+++ b/api/v1/endpoint_types.go
@@ -12,23 +12,13 @@ type ModelSpec struct {
 	File     string `json:"file,omitempty"`
 	Version  string `json:"version,omitempty"`
 	Task     string `json:"task,omitempty"`
-	// Info carries display-only metadata about the model itself (parameter
-	// count, quantization, context length, architecture). It never
-	// participates in deployment composition — same advisory nature as the
-	// hardware-verified annotation. The model catalog card / show page renders
-	// it per variant. Optional and forward-compatible; legacy specs omit it.
+	// Info carries metadata about the model itself (parameter count,
+	// quantization, context length, architecture). It never participates in
+	// deployment composition — same advisory nature as the hardware-verified
+	// annotation. The model catalog card / show page renders it per variant.
+	// Optional and forward-compatible; legacy specs omit it. Defined in
+	// model_info_types.go.
 	Info *ModelInfo `json:"info,omitempty"`
-}
-
-// ModelInfo is display-only metadata describing the model checkpoint a variant
-// points at. It belongs to the model (not the catalog template), so it lives on
-// ModelSpec and is reused wherever a model is referenced. When the dedicated
-// model repository resource lands it can populate this same shape.
-type ModelInfo struct {
-	ParameterCount string `json:"parameter_count,omitempty"` // e.g. "72.7B"
-	Quantization   string `json:"quantization,omitempty"`    // e.g. "bf16" / "fp8"
-	ContextLength  string `json:"context_length,omitempty"`  // e.g. "32K" or token count
-	Architecture   string `json:"architecture,omitempty"`    // e.g. "dense" / "moe"
 }
 
 type EndpointEngineSpec struct {

--- a/api/v1/model_info_types.go
+++ b/api/v1/model_info_types.go
@@ -1,0 +1,212 @@
+package v1
+
+// Model info field provenance. Provenance is recorded per field rather than per
+// record: the UI has to mark the individual values a user typed, and a resource
+// estimator has to judge its confidence from the provenance of the specific
+// parameters it reads.
+const (
+	// ModelInfoSourceAuto marks a value read straight out of the checkpoint.
+	ModelInfoSourceAuto = "auto"
+	// ModelInfoSourceDerived marks a value computed from other checkpoint
+	// values by a documented convention rather than read directly.
+	ModelInfoSourceDerived = "derived"
+	// ModelInfoSourceManual marks a value supplied by a user.
+	ModelInfoSourceManual = "manual"
+)
+
+// Keys used in ModelInfo.FieldSources and ModelInfo.MissingFields. They are the
+// JSON names of the fields they describe, so a client can index the maps with
+// the same key it reads the value under.
+const (
+	ModelInfoFieldParameterCount        = "parameter_count"
+	ModelInfoFieldQuantization          = "quantization"
+	ModelInfoFieldContextLength         = "context_length"
+	ModelInfoFieldArchitecture          = "architecture"
+	ModelInfoFieldNumHiddenLayers       = "num_hidden_layers"
+	ModelInfoFieldNumAttentionHeads     = "num_attention_heads"
+	ModelInfoFieldNumKeyValueHeads      = "num_key_value_heads"
+	ModelInfoFieldHeadDim               = "head_dim"
+	ModelInfoFieldMaxPositionEmbeddings = "max_position_embeddings"
+	ModelInfoFieldIsMoE                 = "is_moe"
+	ModelInfoFieldNumExperts            = "num_experts"
+	ModelInfoFieldParameterDtype        = "parameter_dtype"
+	ModelInfoFieldQuantizationBits      = "quantization_bits"
+	// "token" here is a unit of text, not a credential — the secret scanner keys
+	// off the name.
+	ModelInfoFieldNumExpertsPerToken = "num_experts_per_token" //nolint:gosec
+)
+
+// ModelInfo is metadata describing the model checkpoint a variant points at. It
+// belongs to the model (not the catalog template), so it lives on ModelSpec and
+// is reused wherever a model is referenced.
+//
+// Two populations meet in this struct and they are not equally trustworthy: the
+// four display fields at the top are typed by hand into a catalog, while the
+// structured fields below them are read out of the checkpoint. FieldSources is
+// what tells them apart — consult it before presenting a value as a fact about
+// the checkpoint.
+//
+// Every field is optional and omitted when unset, so a spec that carries none of
+// them serializes exactly as it did before the structured fields existed.
+type ModelInfo struct {
+	// ParameterCount is the model's parameter count. A checkpoint-derived value
+	// is the exact total element count of the stored tensors, written as a plain
+	// decimal string; a hand-written catalog value is free-form (e.g. "72.7B").
+	ParameterCount string `json:"parameter_count,omitempty"`
+	// Quantization is a display label (e.g. "bf16" / "fp8"). It is never derived
+	// from a checkpoint — QuantizationBits is the parsed counterpart.
+	Quantization string `json:"quantization,omitempty"`
+	// ContextLength is the usable context window as a string (e.g. "32K" by hand,
+	// or the token count when read from the checkpoint).
+	ContextLength string `json:"context_length,omitempty"`
+	// Architecture is the model architecture (e.g. "dense" / "moe" by hand, or
+	// the checkpoint's architectures[0] such as "Qwen2ForCausalLM").
+	Architecture string `json:"architecture,omitempty"`
+
+	// The fields below are the structured shape of the checkpoint. They are
+	// pointers so that a legitimate zero stays distinguishable from "unknown";
+	// an unknown field is absent here and named in MissingFields.
+	NumHiddenLayers       *int   `json:"num_hidden_layers,omitempty"`
+	NumAttentionHeads     *int   `json:"num_attention_heads,omitempty"`
+	NumKeyValueHeads      *int   `json:"num_key_value_heads,omitempty"`
+	HeadDim               *int   `json:"head_dim,omitempty"`
+	MaxPositionEmbeddings *int   `json:"max_position_embeddings,omitempty"`
+	IsMoE                 *bool  `json:"is_moe,omitempty"`
+	NumExperts            *int   `json:"num_experts,omitempty"`
+	NumExpertsPerToken    *int   `json:"num_experts_per_token,omitempty"`
+	ParameterDtype        string `json:"parameter_dtype,omitempty"`
+	QuantizationBits      *int   `json:"quantization_bits,omitempty"`
+
+	// FieldSources maps a field key to how that field's value was established:
+	// ModelInfoSourceAuto, ModelInfoSourceDerived or ModelInfoSourceManual. A
+	// field carrying a value but no entry here has unknown provenance — a legacy
+	// catalog, typically.
+	FieldSources map[string]string `json:"field_sources,omitempty"`
+	// MissingFields names the fields that were looked for and not established.
+	// It is a convenience: it is exactly the set of known fields that hold no
+	// value and have no FieldSources entry. Fields that do not apply to the model
+	// at all (expert counts on a dense model, quantization bits on an unquantized
+	// one) are not listed.
+	MissingFields []string `json:"missing_fields,omitempty"`
+}
+
+// SetFieldSource records where field's value came from.
+func (i *ModelInfo) SetFieldSource(field, source string) {
+	if i.FieldSources == nil {
+		i.FieldSources = make(map[string]string)
+	}
+
+	i.FieldSources[field] = source
+}
+
+// MarkFieldMissing appends field to MissingFields unless it is already named
+// there, and drops any stale provenance for it.
+func (i *ModelInfo) MarkFieldMissing(field string) {
+	delete(i.FieldSources, field)
+
+	for _, existing := range i.MissingFields {
+		if existing == field {
+			return
+		}
+	}
+
+	i.MissingFields = append(i.MissingFields, field)
+}
+
+// MergeManual overlays user-supplied values on top of the receiver, marking
+// every field it takes as ModelInfoSourceManual and retracting it from
+// MissingFields.
+//
+// A user's value wins over a parsed one. Hand-filling a field is normally how a
+// gap gets closed, but when someone contradicts the checkpoint it is because
+// they know something the files do not say, and silently keeping the parsed
+// value would make the correction invisible.
+func (i *ModelInfo) MergeManual(manual *ModelInfo) {
+	if manual == nil {
+		return
+	}
+
+	i.mergeManualStrings(manual)
+	i.mergeManualNumbers(manual)
+
+	if manual.IsMoE != nil {
+		i.IsMoE = manual.IsMoE
+		i.takeManual(ModelInfoFieldIsMoE)
+	}
+}
+
+func (i *ModelInfo) mergeManualStrings(manual *ModelInfo) {
+	values := []struct {
+		field string
+		value string
+		into  *string
+	}{
+		{ModelInfoFieldParameterCount, manual.ParameterCount, &i.ParameterCount},
+		{ModelInfoFieldQuantization, manual.Quantization, &i.Quantization},
+		{ModelInfoFieldContextLength, manual.ContextLength, &i.ContextLength},
+		{ModelInfoFieldArchitecture, manual.Architecture, &i.Architecture},
+		{ModelInfoFieldParameterDtype, manual.ParameterDtype, &i.ParameterDtype},
+	}
+
+	for _, entry := range values {
+		if entry.value == "" {
+			continue
+		}
+
+		*entry.into = entry.value
+
+		i.takeManual(entry.field)
+	}
+}
+
+func (i *ModelInfo) mergeManualNumbers(manual *ModelInfo) {
+	numbers := []struct {
+		field string
+		value *int
+		into  **int
+	}{
+		{ModelInfoFieldNumHiddenLayers, manual.NumHiddenLayers, &i.NumHiddenLayers},
+		{ModelInfoFieldNumAttentionHeads, manual.NumAttentionHeads, &i.NumAttentionHeads},
+		{ModelInfoFieldNumKeyValueHeads, manual.NumKeyValueHeads, &i.NumKeyValueHeads},
+		{ModelInfoFieldHeadDim, manual.HeadDim, &i.HeadDim},
+		{ModelInfoFieldMaxPositionEmbeddings, manual.MaxPositionEmbeddings, &i.MaxPositionEmbeddings},
+		{ModelInfoFieldNumExperts, manual.NumExperts, &i.NumExperts},
+		{ModelInfoFieldNumExpertsPerToken, manual.NumExpertsPerToken, &i.NumExpertsPerToken},
+		{ModelInfoFieldQuantizationBits, manual.QuantizationBits, &i.QuantizationBits},
+	}
+
+	for _, entry := range numbers {
+		if entry.value == nil {
+			continue
+		}
+
+		*entry.into = entry.value
+
+		i.takeManual(entry.field)
+	}
+}
+
+func (i *ModelInfo) takeManual(field string) {
+	i.ClearFieldMissing(field)
+	i.SetFieldSource(field, ModelInfoSourceManual)
+}
+
+// ClearFieldMissing removes field from MissingFields, for when a later pass
+// establishes a value the earlier one could not.
+func (i *ModelInfo) ClearFieldMissing(field string) {
+	remaining := i.MissingFields[:0]
+
+	for _, existing := range i.MissingFields {
+		if existing != field {
+			remaining = append(remaining, existing)
+		}
+	}
+
+	if len(remaining) == 0 {
+		i.MissingFields = nil
+
+		return
+	}
+
+	i.MissingFields = remaining
+}

--- a/api/v1/model_info_types_test.go
+++ b/api/v1/model_info_types_test.go
@@ -53,3 +53,98 @@ func TestRecipeVariant_CarriesModelInfo(t *testing.T) {
 	assert.Equal(t, "27B", got.Model.Info.ParameterCount)
 	assert.Equal(t, "moe", got.Model.Info.Architecture)
 }
+
+// Every structured field added to ModelInfo is optional, so a spec written
+// before they existed has to survive a decode/encode cycle byte for byte. This
+// is the compatibility guard for the stored catalog and endpoint specs.
+func TestModelSpec_LegacyJSONRoundTripsByteForByte(t *testing.T) {
+	const legacy = `{"registry":"y","name":"x"}`
+
+	var spec ModelSpec
+	require.NoError(t, json.Unmarshal([]byte(legacy), &spec))
+
+	buf, err := json.Marshal(spec)
+	require.NoError(t, err)
+	assert.Equal(t, legacy, string(buf))
+}
+
+// A ModelInfo holding only the four hand-written display fields must serialize
+// exactly as it did before, so the structured fields cannot leak zero values
+// into an existing catalog.
+func TestModelInfo_DisplayOnlyJSONRoundTripsByteForByte(t *testing.T) {
+	const display = `{"parameter_count":"72.7B","quantization":"fp8","context_length":"32K","architecture":"dense"}`
+
+	var info ModelInfo
+	require.NoError(t, json.Unmarshal([]byte(display), &info))
+
+	buf, err := json.Marshal(info)
+	require.NoError(t, err)
+	assert.Equal(t, display, string(buf))
+}
+
+func TestModelInfo_StructuredFieldsRoundTrip(t *testing.T) {
+	layers, heads, kvHeads, headDim := 64, 40, 8, 128
+	maxPos, experts, expertsPerToken, bits := 32768, 128, 8, 4
+	isMoE := true
+
+	info := &ModelInfo{
+		ParameterCount:        "235093634560",
+		ContextLength:         "32768",
+		Architecture:          "Qwen3MoeForCausalLM",
+		NumHiddenLayers:       &layers,
+		NumAttentionHeads:     &heads,
+		NumKeyValueHeads:      &kvHeads,
+		HeadDim:               &headDim,
+		MaxPositionEmbeddings: &maxPos,
+		IsMoE:                 &isMoE,
+		NumExperts:            &experts,
+		NumExpertsPerToken:    &expertsPerToken,
+		ParameterDtype:        "bfloat16",
+		QuantizationBits:      &bits,
+		FieldSources: map[string]string{
+			ModelInfoFieldParameterCount: ModelInfoSourceAuto,
+			ModelInfoFieldHeadDim:        ModelInfoSourceDerived,
+			ModelInfoFieldQuantization:   ModelInfoSourceManual,
+		},
+		MissingFields: []string{ModelInfoFieldQuantizationBits},
+	}
+
+	buf, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	var got ModelInfo
+	require.NoError(t, json.Unmarshal(buf, &got))
+	assert.Equal(t, *info, got)
+}
+
+// A zero value must not claim knowledge it does not have: no field keys, and no
+// empty provenance containers either.
+func TestModelInfo_ZeroValueEmitsNothing(t *testing.T) {
+	buf, err := json.Marshal(ModelInfo{})
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(buf))
+}
+
+func TestModelInfo_FieldProvenanceBookkeeping(t *testing.T) {
+	var info ModelInfo
+
+	info.MarkFieldMissing(ModelInfoFieldHeadDim)
+	info.MarkFieldMissing(ModelInfoFieldParameterCount)
+	info.MarkFieldMissing(ModelInfoFieldHeadDim)
+	assert.Equal(t, []string{ModelInfoFieldHeadDim, ModelInfoFieldParameterCount}, info.MissingFields)
+
+	// A later pass that establishes a value has to retract the earlier claim
+	// that the field is unknown, otherwise the field is both set and missing.
+	info.SetFieldSource(ModelInfoFieldHeadDim, ModelInfoSourceManual)
+	info.ClearFieldMissing(ModelInfoFieldHeadDim)
+	assert.Equal(t, []string{ModelInfoFieldParameterCount}, info.MissingFields)
+	assert.Equal(t, ModelInfoSourceManual, info.FieldSources[ModelInfoFieldHeadDim])
+
+	// Marking a sourced field missing again drops the stale provenance.
+	info.MarkFieldMissing(ModelInfoFieldHeadDim)
+	assert.NotContains(t, info.FieldSources, ModelInfoFieldHeadDim)
+
+	info.ClearFieldMissing(ModelInfoFieldHeadDim)
+	info.ClearFieldMissing(ModelInfoFieldParameterCount)
+	assert.Nil(t, info.MissingFields)
+}

--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -15,12 +15,24 @@ const (
 var modelNameRegex = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$`)
 
 type ModelVersion struct {
-	Name         string            `json:"name"`
-	CreationTime string            `json:"creation_time"`
-	Size         string            `json:"size,omitempty"`
-	Module       string            `json:"module,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	Description  string            `json:"description,omitempty"`
+	Name         string `json:"name"`
+	CreationTime string `json:"creation_time"`
+	Size         string `json:"size,omitempty"`
+	Module       string `json:"module,omitempty"`
+	// Labels carries the labels written into the model's own descriptor
+	// (model.yaml for a BentoML-layout registry).
+	Labels map[string]string `json:"labels,omitempty"`
+	// Description is declared but not yet written by anything. It is reserved for
+	// a model-supplied description; nothing populates it today.
+	Description string `json:"description,omitempty"`
+	// Alias is the display name a user gave this version, if any. It is purely a
+	// label: it never reaches spec.model.name, so it never becomes the name a
+	// model is served under and never affects a stored path.
+	Alias string `json:"alias,omitempty"`
+	// Info is what the checkpoint states about itself, plus any hand-filled
+	// values. Only the detail read path fills it in — listings leave it nil
+	// rather than open every checkpoint.
+	Info *ModelInfo `json:"info,omitempty"`
 }
 
 type GeneralModel struct {

--- a/controllers/model_registry_controller.go
+++ b/controllers/model_registry_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -13,17 +14,22 @@ import (
 
 type ModelRegistryController struct {
 	storage storage.Storage
+	stats   model_registry.StatsAggregator
 
 	syncHandler func(modelRegistry *v1.ModelRegistry) error
 }
 
 type ModelRegistryControllerOption struct {
 	Storage storage.Storage
+	// StatsStaleAfter overrides how long collected registry counters stay usable
+	// before the tree is walked again. Zero uses the package default.
+	StatsStaleAfter time.Duration
 }
 
 func NewModelRegistryController(option *ModelRegistryControllerOption) (*ModelRegistryController, error) {
 	c := &ModelRegistryController{
 		storage: option.Storage,
+		stats:   model_registry.StatsAggregator{StaleAfter: option.StatsStaleAfter},
 	}
 
 	c.syncHandler = c.sync
@@ -45,63 +51,16 @@ func (c *ModelRegistryController) Reconcile(obj interface{}) error {
 func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 	var (
 		modelRegistry model_registry.ModelRegistry
+		// stats is what this reconcile will persist. It starts as whatever was
+		// observed, so a reconcile that does not measure the registry still writes
+		// the counters back — PostgREST replaces the whole status column.
+		stats          = currentStats(obj)
+		statsRefreshed bool
 	)
 
 	// Handle deletion early - bypass defer block for already-deleted resources
 	if obj.Metadata != nil && obj.Metadata.DeletionTimestamp != "" {
-		isForceDelete := v1.IsForceDelete(obj.Metadata.Annotations)
-
-		if obj.Status != nil && obj.Status.Phase == v1.ModelRegistryPhaseDELETED {
-			klog.Info("Model registry " + obj.Metadata.Name + " is already deleted, delete resource from storage")
-
-			err = c.storage.DeleteModelRegistry(strconv.Itoa(obj.ID))
-			if err != nil {
-				return errors.Wrapf(err, "failed to delete model registry %s/%s from DB",
-					obj.Metadata.Workspace, obj.Metadata.Name)
-			}
-
-			return nil
-		}
-
-		klog.Infof("Deleting model registry %s (force=%v)", obj.Metadata.Name, isForceDelete)
-
-		// For deletion, we need to track if it succeeds to set correct phase
-		deleteErr := func() error {
-			modelRegistry, err = model_registry.NewModelRegistry(obj)
-			if err == nil {
-				// only disconnect model registry when it config is correct.
-				if err = modelRegistry.Disconnect(); err != nil {
-					return errors.Wrapf(err, "failed to disconnect model registry %s/%s",
-						obj.Metadata.Workspace, obj.Metadata.Name)
-				}
-			}
-
-			return nil
-		}()
-
-		// Update status to DELETED if successful, or FAILED if not
-		// For force delete, always mark as DELETED even if there were errors
-		phase := v1.ModelRegistryPhaseDELETED
-		if deleteErr != nil && !isForceDelete {
-			phase = v1.ModelRegistryPhaseFAILED
-		}
-
-		updateErr := c.updateStatus(obj, phase, deleteErr)
-		if updateErr != nil {
-			klog.Errorf("failed to update model registry %s/%s status: %v",
-				obj.Metadata.Workspace, obj.Metadata.Name, updateErr)
-		}
-
-		LogForceDeletionWarning(isForceDelete, "model registry", obj.Metadata.Workspace, obj.Metadata.Name, deleteErr)
-
-		klog.Info("Model registry " + obj.Metadata.Name + " deletion processed")
-
-		// Return the original delete error if any, unless it's a force delete
-		if deleteErr != nil && !isForceDelete {
-			return deleteErr
-		}
-
-		return nil
+		return c.syncDeletion(obj)
 	}
 
 	// Defer block to handle status updates for non-deletion paths
@@ -112,13 +71,16 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 			phase = v1.ModelRegistryPhaseFAILED
 		}
 
-		// Skip update if already in correct phase and no error change
-		if obj.Status != nil && obj.Status.Phase == phase &&
+		// Skip update if already in correct phase, no error change, and the
+		// counters were not recomputed. The recomputation has to be written even
+		// when the counters came out identical: its timestamp is what stops the
+		// next reconcile, ten seconds later, from walking the model tree again.
+		if !statsRefreshed && obj.Status != nil && obj.Status.Phase == phase &&
 			(err != nil) == (obj.Status.ErrorMessage != "") {
 			return
 		}
 
-		updateErr := c.updateStatus(obj, phase, err)
+		updateErr := c.updateStatus(obj, phase, err, stats)
 		if updateErr != nil {
 			klog.Errorf("failed to update model registry %s/%s status: %v",
 				obj.Metadata.Workspace, obj.Metadata.Name, updateErr)
@@ -160,24 +122,97 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 			return errors.Wrapf(err, "health check failed for model registry %s/%s",
 				obj.Metadata.Workspace, obj.Metadata.Name)
 		}
+
+		// Measured only here, on a registry known to be reachable right now, and
+		// only when the previous counters have gone stale. This is also why an
+		// unreachable registry keeps its last known counters: the code that would
+		// overwrite them never runs.
+		stats, statsRefreshed = c.stats.Refresh(modelRegistry, stats, obj.Metadata.WorkspaceName())
 	}
 
 	return nil
 }
 
-func (c *ModelRegistryController) updateStatus(obj *v1.ModelRegistry, phase v1.ModelRegistryPhase, err error) error {
+// syncDeletion drives a registry marked for deletion to its final state. It
+// bypasses the status defer of the normal path: the phase here is decided by
+// whether the disconnect worked, not by the reconcile's error.
+func (c *ModelRegistryController) syncDeletion(obj *v1.ModelRegistry) error {
+	isForceDelete := v1.IsForceDelete(obj.Metadata.Annotations)
+
+	if obj.Status != nil && obj.Status.Phase == v1.ModelRegistryPhaseDELETED {
+		klog.Info("Model registry " + obj.Metadata.Name + " is already deleted, delete resource from storage")
+
+		if err := c.storage.DeleteModelRegistry(strconv.Itoa(obj.ID)); err != nil {
+			return errors.Wrapf(err, "failed to delete model registry %s/%s from DB",
+				obj.Metadata.Workspace, obj.Metadata.Name)
+		}
+
+		return nil
+	}
+
+	klog.Infof("Deleting model registry %s (force=%v)", obj.Metadata.Name, isForceDelete)
+
+	// For deletion, we need to track if it succeeds to set correct phase
+	deleteErr := func() error {
+		modelRegistry, err := model_registry.NewModelRegistry(obj)
+		if err != nil {
+			// only disconnect model registry when it config is correct.
+			return nil
+		}
+
+		if err = modelRegistry.Disconnect(); err != nil {
+			return errors.Wrapf(err, "failed to disconnect model registry %s/%s",
+				obj.Metadata.Workspace, obj.Metadata.Name)
+		}
+
+		return nil
+	}()
+
+	// Update status to DELETED if successful, or FAILED if not
+	// For force delete, always mark as DELETED even if there were errors
+	phase := v1.ModelRegistryPhaseDELETED
+	if deleteErr != nil && !isForceDelete {
+		phase = v1.ModelRegistryPhaseFAILED
+	}
+
+	updateErr := c.updateStatus(obj, phase, deleteErr, currentStats(obj))
+	if updateErr != nil {
+		klog.Errorf("failed to update model registry %s/%s status: %v",
+			obj.Metadata.Workspace, obj.Metadata.Name, updateErr)
+	}
+
+	LogForceDeletionWarning(isForceDelete, "model registry", obj.Metadata.Workspace, obj.Metadata.Name, deleteErr)
+
+	klog.Info("Model registry " + obj.Metadata.Name + " deletion processed")
+
+	// Return the original delete error if any, unless it's a force delete
+	if deleteErr != nil && !isForceDelete {
+		return deleteErr
+	}
+
+	return nil
+}
+
+func currentStats(obj *v1.ModelRegistry) *v1.ModelRegistryStats {
+	if obj.Status == nil {
+		return nil
+	}
+
+	return obj.Status.Stats
+}
+
+func (c *ModelRegistryController) updateStatus(obj *v1.ModelRegistry, phase v1.ModelRegistryPhase,
+	err error, stats *v1.ModelRegistryStats) error {
 	newStatus := &v1.ModelRegistryStatus{
 		LastTransitionTime: FormatStatusTime(),
 		Phase:              phase,
 		ErrorMessage:       FormatErrorForStatus(err),
-	}
-
-	// PostgREST replaces a composite-type column as a whole, so any attribute
-	// missing from the PATCH body is nulled rather than left alone. Carry
-	// forward the attributes this reconcile does not own; otherwise every phase
-	// or error transition wipes them. Same reason as ClusterController.updateStatus.
-	if obj.Status != nil {
-		newStatus.Stats = obj.Status.Stats
+		// PostgREST replaces a composite-type column as a whole, so any attribute
+		// missing from the PATCH body is nulled rather than left alone. Stats is
+		// therefore always passed in — carried forward from the observed object
+		// when this reconcile did not recompute it — or every phase or error
+		// transition wipes it. Same reason as ClusterController.updateStatus.
+		Stats: stats,
 	}
 
 	return c.storage.UpdateModelRegistry(strconv.Itoa(obj.ID), &v1.ModelRegistry{Status: newStatus})

--- a/controllers/model_registry_controller_test.go
+++ b/controllers/model_registry_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -205,6 +206,16 @@ func TestModelRegistryController_Sync_Connected(t *testing.T) {
 			input: testModelRegistry(),
 			mockSetup: func(input *v1.ModelRegistry, s *storagemocks.MockStorage, m *modelregistrymocks.MockModelRegistry) {
 				m.On("HealthyCheck").Return(nil)
+				// A registry with no counters yet is measured on the spot, and the
+				// result is written back even though the phase did not change.
+				m.On("CollectUsage").Return(&model_registry.RegistryUsage{ModelCount: 2, StorageBytes: 8192}, nil)
+				s.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
+					obj := args.Get(1).(*v1.ModelRegistry)
+					assert.Equal(t, v1.ModelRegistryPhaseCONNECTED, obj.Status.Phase)
+					assert.Equal(t, 2, obj.Status.Stats.ModelCount)
+					assert.Equal(t, int64(8192), obj.Status.Stats.StorageBytes)
+					assert.NotEmpty(t, obj.Status.Stats.StatsUpdatedAt)
+				}).Return(nil)
 			},
 		},
 		{
@@ -494,4 +505,93 @@ func TestModelRegistryController_Reconcile(t *testing.T) {
 			mockStorage.AssertExpectations(t)
 		})
 	}
+}
+
+// The reconcile loop runs every ten seconds; walking a model tree cannot. The
+// staleness timestamp is what holds it off, so it has to survive the write-back
+// as well as be consulted before the walk.
+func TestModelRegistryController_Sync_ThrottlesStatsCollection(t *testing.T) {
+	mockStorage := &storagemocks.MockStorage{}
+	mockModel := &modelregistrymocks.MockModelRegistry{}
+
+	mockModel.On("HealthyCheck").Return(nil)
+	mockModel.On("CollectUsage").Return(&model_registry.RegistryUsage{ModelCount: 1, StorageBytes: 64}, nil)
+
+	obj := &v1.ModelRegistry{
+		ID:       1,
+		Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
+		Status:   &v1.ModelRegistryStatus{Phase: v1.ModelRegistryPhaseCONNECTED},
+	}
+
+	// Feed the persisted status back in, the way the next reconcile would read it.
+	mockStorage.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
+		written := args.Get(1).(*v1.ModelRegistry) //nolint:errcheck
+		obj.Status = written.Status
+	}).Return(nil)
+
+	c := newTestModelRegistryController(mockStorage, mockModel)
+
+	for i := 0; i < 5; i++ {
+		assert.NoError(t, c.sync(obj))
+	}
+
+	mockModel.AssertNumberOfCalls(t, "CollectUsage", 1)
+	mockStorage.AssertNumberOfCalls(t, "UpdateModelRegistry", 1)
+	assert.Equal(t, 1, obj.Status.Stats.ModelCount)
+	assert.Equal(t, int64(64), obj.Status.Stats.StorageBytes)
+}
+
+// An unreachable registry must keep the counters it last reported. Zeroing them
+// would show a mount failure as an empty registry.
+func TestModelRegistryController_Sync_UnreachableRegistryKeepsStats(t *testing.T) {
+	previous := &v1.ModelRegistryStats{
+		ModelCount:     4,
+		StorageBytes:   2048,
+		StatsUpdatedAt: "2026-01-01T00:00:00Z",
+	}
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockModel := &modelregistrymocks.MockModelRegistry{}
+
+	mockModel.On("HealthyCheck").Return(assert.AnError)
+	mockStorage.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
+		written := args.Get(1).(*v1.ModelRegistry) //nolint:errcheck
+		assert.Equal(t, v1.ModelRegistryPhaseFAILED, written.Status.Phase)
+		assert.Equal(t, previous, written.Status.Stats)
+	}).Return(nil)
+
+	c := newTestModelRegistryController(mockStorage, mockModel)
+
+	err := c.sync(&v1.ModelRegistry{
+		ID:       1,
+		Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
+		Status:   &v1.ModelRegistryStatus{Phase: v1.ModelRegistryPhaseCONNECTED, Stats: previous},
+	})
+	assert.Error(t, err)
+
+	mockModel.AssertNotCalled(t, "CollectUsage")
+	mockStorage.AssertExpectations(t)
+}
+
+// A public registry reports ErrNotSupported rather than a failure, and gets no
+// stats block at all — its storage is not ours to measure.
+func TestModelRegistryController_Sync_PublicRegistryHasNoStats(t *testing.T) {
+	mockStorage := &storagemocks.MockStorage{}
+	mockModel := &modelregistrymocks.MockModelRegistry{}
+
+	mockModel.On("HealthyCheck").Return(nil)
+	mockModel.On("CollectUsage").Return(nil, errors.Wrap(model_registry.ErrNotSupported, "hugging face"))
+
+	c := newTestModelRegistryController(mockStorage, mockModel)
+
+	obj := &v1.ModelRegistry{
+		ID:       1,
+		Metadata: &v1.Metadata{Name: "public", Workspace: "default"},
+		Status:   &v1.ModelRegistryStatus{Phase: v1.ModelRegistryPhaseCONNECTED},
+	}
+	assert.NoError(t, c.sync(obj))
+
+	// Nothing measured, nothing to write: the phase did not change either.
+	mockStorage.AssertNotCalled(t, "UpdateModelRegistry", mock.Anything, mock.Anything)
+	assert.Nil(t, obj.Status.Stats)
 }

--- a/internal/cli/model/direct_push.go
+++ b/internal/cli/model/direct_push.go
@@ -109,6 +109,7 @@ func ReadImportedModelVersion(localNFSPath, name, version string) (*v1.ModelVers
 		CreationTime: meta.CreationTime,
 		Size:         meta.Size,
 		Module:       meta.Module,
+		Labels:       meta.Labels,
 	}, nil
 }
 

--- a/internal/model_registry/bentoml/bentoml.go
+++ b/internal/model_registry/bentoml/bentoml.go
@@ -29,26 +29,27 @@ import (
 )
 
 type Model struct {
-	Tag          string `json:"tag"`
-	Module       string `json:"module"`
-	Size         string `json:"size"`
-	CreationTime string `json:"creation_time"`
-}
-
-type ModelMeta struct {
-	Name         string `yaml:"name" json:"name"`
-	Version      string `yaml:"version" json:"version"`
-	Module       string `yaml:"module" json:"module"`
-	Size         string `yaml:"size" json:"size"`
-	CreationTime string `yaml:"creation_time" json:"creation_time"`
+	Tag          string            `json:"tag"`
+	Module       string            `json:"module"`
+	Size         string            `json:"size"`
+	CreationTime string            `json:"creation_time"`
+	Labels       map[string]string `json:"labels,omitempty"`
 }
 
 const (
 	ModelYAMLFileName = "model.yaml"
+	// ModelJSONFileName is the JSON spelling of the same descriptor; a store may
+	// hold either.
+	ModelJSONFileName = "model.json"
 )
 
-// GetModelDetail gets detailed information about a specific model
-func GetModelDetail(homePath, modelName, version string) (*ModelMeta, error) {
+// GetModelDetail gets detailed information about a specific model.
+//
+// It decodes the whole model.yaml. An earlier narrower struct dropped everything
+// but name/version/module/size/creation_time, which meant the labels and
+// metadata a user writes into model.yaml — and which the export/import round
+// trip faithfully preserves — could not be read back anywhere.
+func GetModelDetail(homePath, modelName, version string) (*ModelYAML, error) {
 	actualVersion := version
 
 	if version == v1.LatestVersion || version == "" {
@@ -78,12 +79,18 @@ func GetModelDetail(homePath, modelName, version string) (*ModelMeta, error) {
 		return nil, errors.Wrap(err, "failed to read model.yaml")
 	}
 
-	var meta ModelMeta
+	var meta ModelYAML
 	if err := yaml.Unmarshal(data, &meta); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal model.yaml")
 	}
 
 	return &meta, nil
+}
+
+// ModelDir returns the directory a model version's files live in. Both segments
+// are lowercased, matching the layout ImportModel writes.
+func ModelDir(homePath, modelName, version string) string {
+	return filepath.Join(homePath, "models", strings.ToLower(modelName), strings.ToLower(version))
 }
 
 // DeleteModel deletes a model from BentoML store
@@ -216,7 +223,7 @@ func GetModelPath(homePath, modelName, version string) (string, error) {
 	}
 
 	// Construct the path to the model directory
-	modelDir := filepath.Join(homePath, "models", strings.ToLower(meta.Name), strings.ToLower(meta.Version))
+	modelDir := ModelDir(homePath, meta.Name, meta.Version)
 	if _, err := os.Stat(modelDir); os.IsNotExist(err) {
 		return "", errors.New("model directory not found")
 	}
@@ -256,7 +263,7 @@ func ListModels(homePath string) ([]Model, error) {
 		}
 
 		name := d.Name()
-		if name != "model.yaml" && name != "model.json" {
+		if name != ModelYAMLFileName && name != ModelJSONFileName {
 			return nil
 		}
 
@@ -265,8 +272,7 @@ func ListModels(homePath string) ([]Model, error) {
 			return err
 		}
 
-		// Minimal superset of fields we care about
-		var meta ModelMeta
+		var meta ModelYAML
 
 		if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
 			if err := yaml.Unmarshal(raw, &meta); err != nil {
@@ -283,6 +289,7 @@ func ListModels(homePath string) ([]Model, error) {
 			Module:       meta.Module,
 			Size:         meta.Size,
 			CreationTime: meta.CreationTime,
+			Labels:       meta.Labels,
 		})
 
 		return nil
@@ -336,7 +343,11 @@ func GenerateVersion() (*string, error) {
 	return &lower, nil
 }
 
-func calculateDirectorySize(dir string) (int64, error) {
+// CalculateDirectorySize sums the size of every regular file under dir. It is
+// the only honest way to state what a model occupies: the size recorded in
+// model.yaml is a human-readable string baked in at push time, never recomputed,
+// and measured over a different set of files than the archive contains.
+func CalculateDirectorySize(dir string) (int64, error) {
 	var totalSize int64
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -355,7 +366,7 @@ func calculateDirectorySize(dir string) (int64, error) {
 }
 
 func CreateArchiveWithProgress(srcDir, modelName, version string, progressWriter io.Writer) (string, error) {
-	dirSize, err := calculateDirectorySize(srcDir)
+	dirSize, err := CalculateDirectorySize(srcDir)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to calculate directory size")
 	}
@@ -523,23 +534,26 @@ func CreateArchiveWithProgress(srcDir, modelName, version string, progressWriter
 	return tmpFile.Name(), nil
 }
 
+// ModelYAML is a model.yaml. The JSON tags matter as much as the YAML ones:
+// ListModels also reads model.json, and without them a snake_case key such as
+// creation_time would not bind.
 type ModelYAML struct {
-	Name       string                 `yaml:"name"`
-	Version    string                 `yaml:"version"`
-	Module     string                 `yaml:"module"`
-	Size       string                 `yaml:"size,omitempty"`
-	APIVersion string                 `yaml:"api_version"`
-	Signatures map[string]interface{} `yaml:"signatures"`
-	Labels     map[string]string      `yaml:"labels"`
-	Options    map[string]interface{} `yaml:"options"`
-	Metadata   map[string]interface{} `yaml:"metadata"`
+	Name       string                 `yaml:"name" json:"name"`
+	Version    string                 `yaml:"version" json:"version"`
+	Module     string                 `yaml:"module" json:"module"`
+	Size       string                 `yaml:"size,omitempty" json:"size,omitempty"`
+	APIVersion string                 `yaml:"api_version" json:"api_version"`
+	Signatures map[string]interface{} `yaml:"signatures" json:"signatures"`
+	Labels     map[string]string      `yaml:"labels" json:"labels"`
+	Options    map[string]interface{} `yaml:"options" json:"options"`
+	Metadata   map[string]interface{} `yaml:"metadata" json:"metadata"`
 	Context    struct {               // nested
-		FrameworkName    string            `yaml:"framework_name"`
-		FrameworkVersion map[string]string `yaml:"framework_versions"`
-		BentoVersion     string            `yaml:"bentoml_version"`
-		PythonVersion    string            `yaml:"python_version"`
-	} `yaml:"context"`
-	CreationTime string `yaml:"creation_time"`
+		FrameworkName    string            `yaml:"framework_name" json:"framework_name"`
+		FrameworkVersion map[string]string `yaml:"framework_versions" json:"framework_versions"`
+		BentoVersion     string            `yaml:"bentoml_version" json:"bentoml_version"`
+		PythonVersion    string            `yaml:"python_version" json:"python_version"`
+	} `yaml:"context" json:"context"`
+	CreationTime string `yaml:"creation_time" json:"creation_time"`
 }
 
 func FillMinimalModelYAML(y *ModelYAML, name, version, hfRepo string, size int64) error {

--- a/internal/model_registry/bentoml/model_info.go
+++ b/internal/model_registry/bentoml/model_info.go
@@ -1,0 +1,164 @@
+package bentoml
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// ModelInfoMetadataKey is the model.yaml metadata key holding the model info
+// fields a user filled in by hand. It lives in the model's own descriptor rather
+// than in a database row because it describes the checkpoint, travels with it
+// through export/import, and has no cross-model uniqueness to arbitrate.
+const ModelInfoMetadataKey = "neutree_model_info"
+
+// ReadManualModelInfo decodes the hand-filled model info out of a model.yaml
+// metadata map. Absent or empty metadata yields a nil result and no error: a
+// model nobody has annotated is the normal case.
+func ReadManualModelInfo(metadata map[string]interface{}) (*v1.ModelInfo, error) {
+	raw, ok := metadata[ModelInfoMetadataKey]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+
+	// The value arrives as whatever the YAML decoder produced, so it round-trips
+	// through JSON to land in the typed shape.
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		return nil, errors.Wrapf(err, "re-encode %s metadata", ModelInfoMetadataKey)
+	}
+
+	var info v1.ModelInfo
+	if err := json.Unmarshal(encoded, &info); err != nil {
+		return nil, errors.Wrapf(err, "decode %s metadata", ModelInfoMetadataKey)
+	}
+
+	return &info, nil
+}
+
+// WriteManualModelInfo replaces the hand-filled model info recorded for a model
+// version. A nil or empty info removes the block entirely.
+//
+// It rewrites only the metadata key: name, version and the on-disk location are
+// left exactly as they are, because they are what every deployment path resolves
+// against.
+func WriteManualModelInfo(homePath, modelName, version string, info *v1.ModelInfo) error {
+	model, err := GetModelDetail(homePath, modelName, version)
+	if err != nil {
+		return err
+	}
+
+	yamlPath := filepath.Join(ModelDir(homePath, model.Name, model.Version), ModelYAMLFileName)
+
+	raw, err := os.ReadFile(yamlPath)
+	if err != nil {
+		return errors.Wrap(err, "read model.yaml")
+	}
+
+	// Edited as a generic document rather than through ModelYAML: whatever the
+	// tool that wrote this descriptor put in it that ModelYAML does not model
+	// would otherwise be dropped on the way back out.
+	var document map[string]interface{}
+	if err := yaml.Unmarshal(raw, &document); err != nil {
+		return errors.Wrap(err, "unmarshal model.yaml")
+	}
+
+	if document == nil {
+		document = map[string]interface{}{}
+	}
+
+	metadata, ok := document["metadata"].(map[string]interface{})
+	if !ok || metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+
+	if info == nil || isEmptyModelInfo(info) {
+		delete(metadata, ModelInfoMetadataKey)
+	} else {
+		generic, err := genericModelInfo(info)
+		if err != nil {
+			return err
+		}
+
+		metadata[ModelInfoMetadataKey] = generic
+	}
+
+	document["metadata"] = metadata
+
+	out, err := yaml.Marshal(document)
+	if err != nil {
+		return errors.Wrap(err, "marshal model.yaml")
+	}
+
+	return writeFileAtomically(yamlPath, out)
+}
+
+// genericModelInfo renders the typed info as plain maps, via its JSON tags, so
+// the block reads the same in model.yaml as it does over the API.
+func genericModelInfo(info *v1.ModelInfo) (map[string]interface{}, error) {
+	encoded, err := json.Marshal(info)
+	if err != nil {
+		return nil, errors.Wrapf(err, "encode %s metadata", ModelInfoMetadataKey)
+	}
+
+	var generic map[string]interface{}
+	if err := json.Unmarshal(encoded, &generic); err != nil {
+		return nil, errors.Wrapf(err, "encode %s metadata", ModelInfoMetadataKey)
+	}
+
+	return generic, nil
+}
+
+// writeFileAtomically replaces path in one rename, so a reader of model.yaml
+// never observes a half-written descriptor.
+func writeFileAtomically(path string, content []byte) error {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*")
+	if err != nil {
+		return errors.Wrap(err, "create temp descriptor")
+	}
+
+	tmpName := tmp.Name()
+
+	defer func() {
+		// Harmless once the rename succeeded: the name no longer exists.
+		_ = os.Remove(tmpName)
+	}()
+
+	if _, err = tmp.Write(content); err != nil {
+		tmp.Close()
+
+		return errors.Wrap(err, "write temp descriptor")
+	}
+
+	if err = tmp.Sync(); err != nil {
+		tmp.Close()
+
+		return errors.Wrap(err, "sync temp descriptor")
+	}
+
+	if err = tmp.Close(); err != nil {
+		return errors.Wrap(err, "close temp descriptor")
+	}
+
+	if err = os.Chmod(tmpName, 0o644); err != nil {
+		return errors.Wrap(err, "chmod temp descriptor")
+	}
+
+	return errors.Wrap(os.Rename(tmpName, path), "replace descriptor")
+}
+
+func isEmptyModelInfo(info *v1.ModelInfo) bool {
+	encoded, err := json.Marshal(info)
+	if err != nil {
+		return false
+	}
+
+	return string(encoded) == "{}"
+}

--- a/internal/model_registry/bentoml/usage.go
+++ b/internal/model_registry/bentoml/usage.go
@@ -1,0 +1,100 @@
+package bentoml
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+)
+
+// Usage is what a BentoML store currently holds.
+type Usage struct {
+	// ModelCount is the number of distinct model names, matching what ListModels
+	// reports rather than the number of versions.
+	ModelCount int
+	// StorageBytes is the summed size of every file under the store.
+	StorageBytes int64
+}
+
+// CollectUsage walks the store at homePath and measures it.
+//
+// The byte total is a real traversal, not a sum of the size strings in each
+// model.yaml: those are human-readable, frozen at push time, and computed over a
+// file set that differs from what actually sits on disk. Walking is expensive on
+// a networked store, so callers are expected to throttle it rather than run it
+// on every reconcile.
+func CollectUsage(homePath string) (*Usage, error) {
+	root := filepath.Join(homePath, "models")
+
+	stat, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			klog.Warningf("Model store %s not found, reporting empty usage", root)
+
+			return &Usage{}, nil
+		}
+
+		return nil, errors.Wrap(err, "model store not found")
+	}
+
+	if !stat.IsDir() {
+		return nil, errors.Errorf("%s is not a directory", root)
+	}
+
+	usage := &Usage{}
+	names := make(map[string]struct{})
+
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		usage.StorageBytes += info.Size()
+
+		if d.Name() != ModelYAMLFileName && d.Name() != ModelJSONFileName {
+			return nil
+		}
+
+		// A descriptor sits at <root>/<name>/<version>/, so the first path
+		// segment below the root is the model name.
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		if name, _, found := cutPathSegment(rel); found {
+			names[name] = struct{}{}
+		}
+
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	usage.ModelCount = len(names)
+
+	return usage, nil
+}
+
+// cutPathSegment splits off the first path segment of rel.
+func cutPathSegment(rel string) (head, tail string, found bool) {
+	for i := 0; i < len(rel); i++ {
+		if os.IsPathSeparator(rel[i]) {
+			return rel[:i], rel[i+1:], true
+		}
+	}
+
+	return rel, "", false
+}

--- a/internal/model_registry/file_based.go
+++ b/internal/model_registry/file_based.go
@@ -3,7 +3,6 @@ package model_registry
 import (
 	"io"
 	"net/url"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"

--- a/internal/model_registry/file_based.go
+++ b/internal/model_registry/file_based.go
@@ -16,9 +16,6 @@ import (
 	"github.com/neutree-ai/neutree/internal/nfs"
 )
 
-// readmeFileName is the model card a private registry serves verbatim.
-const readmeFileName = "README.md"
-
 func convertBentoMLModelsToGeneralModels(bentomlModels []bentoml.Model, options ListOption) *ModelPage {
 	// Convert to GeneralModel format
 	generalModelMap := make(map[string]*v1.GeneralModel)
@@ -138,26 +135,6 @@ func (s *bentomlStore) GetModelDetail(name, version string) (*v1.ModelVersion, e
 	detail.Info.MergeManual(manual)
 
 	return detail, nil
-}
-
-func (s *bentomlStore) GetReadme(name, version string) (string, error) {
-	model, err := bentoml.GetModelDetail(s.path, name, version)
-	if err != nil {
-		return "", err
-	}
-
-	readmePath := filepath.Join(bentoml.ModelDir(s.path, model.Name, model.Version), readmeFileName)
-
-	content, err := os.ReadFile(readmePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", errors.Wrapf(ErrNotFound, "model %s:%s has no %s", name, version, readmeFileName)
-		}
-
-		return "", errors.Wrapf(err, "failed to read %s of model %s:%s", readmeFileName, name, version)
-	}
-
-	return string(content), nil
 }
 
 func (s *bentomlStore) DeleteModel(name, version string) error {

--- a/internal/model_registry/file_based.go
+++ b/internal/model_registry/file_based.go
@@ -3,17 +3,23 @@ package model_registry
 import (
 	"io"
 	"net/url"
+	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/model_registry/bentoml"
+	"github.com/neutree-ai/neutree/internal/model_registry/modelmeta"
 	"github.com/neutree-ai/neutree/internal/nfs"
 )
 
-func convertBentoMLModelsToGeneralModels(bentomlModels []bentoml.Model, options ListOption) []v1.GeneralModel {
+// readmeFileName is the model card a private registry serves verbatim.
+const readmeFileName = "README.md"
+
+func convertBentoMLModelsToGeneralModels(bentomlModels []bentoml.Model, options ListOption) *ModelPage {
 	// Convert to GeneralModel format
 	generalModelMap := make(map[string]*v1.GeneralModel)
 
@@ -43,6 +49,7 @@ func convertBentoMLModelsToGeneralModels(bentomlModels []bentoml.Model, options 
 			CreationTime: model.CreationTime,
 			Size:         model.Size,
 			Module:       model.Module,
+			Labels:       model.Labels,
 		})
 	}
 
@@ -52,31 +59,51 @@ func convertBentoMLModelsToGeneralModels(bentomlModels []bentoml.Model, options 
 		generalModels = append(generalModels, *model)
 	}
 
-	// Apply limit if specified
-	if options.Limit > 0 && len(generalModels) > options.Limit {
-		generalModels = generalModels[:options.Limit]
-	}
+	// Go randomises map iteration order, so the slice above comes out in a
+	// different order on every call. Sort by name before paging: without a
+	// stable order, offset/limit hand back overlapping pages that silently drop
+	// models, and even a bare limit returns a different subset each request.
+	sort.Slice(generalModels, func(i, j int) bool {
+		return generalModels[i].Name < generalModels[j].Name
+	})
 
-	return generalModels
+	return pageOf(generalModels, options)
 }
 
-// todo: Current model repository for local file types has not yet been fully designed
-// and will be improved after the design is completed.
-type localFile struct {
+// pageOf applies Offset and Limit. An offset past the end is an empty page, not
+// an error — a client paging a registry that shrank under it should see the end
+// of the list, not a failure.
+func pageOf(models []v1.GeneralModel, options ListOption) *ModelPage {
+	page := &ModelPage{Total: len(models)}
+
+	start := options.Offset
+	if start < 0 {
+		start = 0
+	}
+
+	if start > len(models) {
+		start = len(models)
+	}
+
+	end := len(models)
+	if options.Limit > 0 && start+options.Limit < end {
+		end = start + options.Limit
+	}
+
+	page.Models = models[start:end]
+
+	return page
+}
+
+// bentomlStore is the BentoML-layout model tree both file-based registries read:
+// the local one addresses it directly, the NFS one through its mount point.
+type bentomlStore struct {
 	path string
 }
 
-func (f *localFile) Connect() error {
-	return nil
-}
-
-func (f *localFile) Disconnect() error {
-	return nil
-}
-
-func (f *localFile) ListModels(options ListOption) ([]v1.GeneralModel, error) {
+func (s *bentomlStore) ListModels(options ListOption) (*ModelPage, error) {
 	// Get BentoML models
-	bentomlModels, err := bentoml.ListModels(f.path)
+	bentomlModels, err := bentoml.ListModels(s.path)
 	if err != nil {
 		return nil, err
 	}
@@ -85,34 +112,112 @@ func (f *localFile) ListModels(options ListOption) ([]v1.GeneralModel, error) {
 	return convertBentoMLModelsToGeneralModels(bentomlModels, options), nil
 }
 
-func (f *localFile) GetModelVersion(name, version string) (*v1.ModelVersion, error) {
-	bentomlModel, err := bentoml.GetModelDetail(f.path, name, version)
+func (s *bentomlStore) GetModelVersion(name, version string) (*v1.ModelVersion, error) {
+	model, err := bentoml.GetModelDetail(s.path, name, version)
 	if err != nil {
 		return nil, err
 	}
 
+	return modelVersionFromYAML(model), nil
+}
+
+func (s *bentomlStore) GetModelDetail(name, version string) (*v1.ModelVersion, error) {
+	model, err := bentoml.GetModelDetail(s.path, name, version)
+	if err != nil {
+		return nil, err
+	}
+
+	detail := modelVersionFromYAML(model)
+	detail.Info = modelmeta.Parse(bentoml.ModelDir(s.path, model.Name, model.Version))
+
+	manual, err := bentoml.ReadManualModelInfo(model.Metadata)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read hand-filled model info of %s:%s", name, version)
+	}
+
+	detail.Info.MergeManual(manual)
+
+	return detail, nil
+}
+
+func (s *bentomlStore) GetReadme(name, version string) (string, error) {
+	model, err := bentoml.GetModelDetail(s.path, name, version)
+	if err != nil {
+		return "", err
+	}
+
+	readmePath := filepath.Join(bentoml.ModelDir(s.path, model.Name, model.Version), readmeFileName)
+
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.Wrapf(ErrNotFound, "model %s:%s has no %s", name, version, readmeFileName)
+		}
+
+		return "", errors.Wrapf(err, "failed to read %s of model %s:%s", readmeFileName, name, version)
+	}
+
+	return string(content), nil
+}
+
+func (s *bentomlStore) DeleteModel(name, version string) error {
+	return bentoml.DeleteModel(s.path, name, version)
+}
+
+func (s *bentomlStore) ImportModel(reader io.Reader, name, version string, progress io.Writer) error {
+	return bentoml.ImportModel(s.path, reader, name, version, true, progress)
+}
+
+func (s *bentomlStore) ExportModel(name, version, outputPath string) error {
+	return bentoml.ExportModel(s.path, name, version, outputPath)
+}
+
+func (s *bentomlStore) GetModelPath(name, version string) (string, error) {
+	return bentoml.GetModelPath(s.path, name, version)
+}
+
+func (s *bentomlStore) CollectUsage() (*RegistryUsage, error) {
+	usage, err := bentoml.CollectUsage(s.path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegistryUsage{ModelCount: usage.ModelCount, StorageBytes: usage.StorageBytes}, nil
+}
+
+// SetManualModelInfo records the model info fields a user filled in by hand. The
+// block is replaced wholesale, so the caller sends the complete set of overrides
+// it wants kept.
+func (s *bentomlStore) SetManualModelInfo(name, version string, info *v1.ModelInfo) error {
+	return bentoml.WriteManualModelInfo(s.path, name, version, info)
+}
+
+// modelVersionFromYAML projects a model.yaml onto the API shape. Labels come
+// along: they are what a user writes into model.yaml, and until now both read
+// paths decoded into a struct that did not have them, so everything written
+// there was silently unreadable.
+func modelVersionFromYAML(model *bentoml.ModelYAML) *v1.ModelVersion {
 	return &v1.ModelVersion{
-		Name:         bentomlModel.Version,
-		CreationTime: bentomlModel.CreationTime,
-		Size:         bentomlModel.Size,
-		Module:       bentomlModel.Module,
-	}, nil
+		Name:         model.Version,
+		CreationTime: model.CreationTime,
+		Size:         model.Size,
+		Module:       model.Module,
+		Labels:       model.Labels,
+	}
 }
 
-func (f *localFile) DeleteModel(name, version string) error {
-	return bentoml.DeleteModel(f.path, name, version)
+// todo: Current model repository for local file types has not yet been fully designed
+// and will be improved after the design is completed.
+type localFile struct {
+	bentomlStore
 }
 
-func (f *localFile) ImportModel(reader io.Reader, name, version string, progress io.Writer) error {
-	return bentoml.ImportModel(f.path, reader, name, version, true, progress)
+func (f *localFile) Connect() error {
+	return nil
 }
 
-func (f *localFile) ExportModel(name, version, outputPath string) error {
-	return bentoml.ExportModel(f.path, name, version, outputPath)
-}
-
-func (f *localFile) GetModelPath(name, version string) (string, error) {
-	return bentoml.GetModelPath(f.path, name, version)
+func (f *localFile) Disconnect() error {
+	return nil
 }
 
 func (f *localFile) HealthyCheck() error {
@@ -129,79 +234,39 @@ func (f *localFile) GetNFSVersion() (string, error) {
 }
 
 type nfsFile struct {
-	targetPath    string
+	bentomlStore
+
 	nfsServerPath string
 }
 
 func (n *nfsFile) Connect() error {
-	return nfs.MountNFS(n.nfsServerPath, n.targetPath)
+	return nfs.MountNFS(n.nfsServerPath, n.path)
 }
 
 func (n *nfsFile) Disconnect() error {
-	return nfs.Unmount(n.targetPath)
-}
-
-func (n *nfsFile) ListModels(options ListOption) ([]v1.GeneralModel, error) {
-	// Get BentoML models
-	bentomlModels, err := bentoml.ListModels(n.targetPath)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert to GeneralModel format using the helper function
-	return convertBentoMLModelsToGeneralModels(bentomlModels, options), nil
-}
-
-func (n *nfsFile) GetModelVersion(name, version string) (*v1.ModelVersion, error) {
-	bentomlModel, err := bentoml.GetModelDetail(n.targetPath, name, version)
-	if err != nil {
-		return nil, err
-	}
-
-	return &v1.ModelVersion{
-		Name:         bentomlModel.Version,
-		CreationTime: bentomlModel.CreationTime,
-		Size:         bentomlModel.Size,
-		Module:       bentomlModel.Module,
-	}, nil
-}
-
-func (n *nfsFile) DeleteModel(name, version string) error {
-	return bentoml.DeleteModel(n.targetPath, name, version)
-}
-
-func (n *nfsFile) ImportModel(reader io.Reader, name, version string, progress io.Writer) error {
-	return bentoml.ImportModel(n.targetPath, reader, name, version, true, progress)
-}
-
-func (n *nfsFile) ExportModel(name, version, outputPath string) error {
-	return bentoml.ExportModel(n.targetPath, name, version, outputPath)
-}
-
-func (n *nfsFile) GetModelPath(name, version string) (string, error) {
-	return bentoml.GetModelPath(n.targetPath, name, version)
+	return nfs.Unmount(n.path)
 }
 
 func (n *nfsFile) HealthyCheck() error {
-	existed, err := nfs.IsMountExist(n.nfsServerPath, n.targetPath)
+	existed, err := nfs.IsMountExist(n.nfsServerPath, n.path)
 	if err != nil {
-		return errors.Wrapf(err, "failed to check NFS mount %s to %s", n.nfsServerPath, n.targetPath)
+		return errors.Wrapf(err, "failed to check NFS mount %s to %s", n.nfsServerPath, n.path)
 	}
 
 	if !existed {
-		return errors.Errorf("NFS mount %s to %s does not exist", n.nfsServerPath, n.targetPath)
+		return errors.Errorf("NFS mount %s to %s does not exist", n.nfsServerPath, n.path)
 	}
 
 	// Try to list models to verify functionality
-	if _, err := bentoml.ListModels(n.targetPath); err != nil {
-		return errors.Wrapf(err, "failed to list models at NFS path %s", n.targetPath)
+	if _, err := bentoml.ListModels(n.path); err != nil {
+		return errors.Wrapf(err, "failed to list models at NFS path %s", n.path)
 	}
 
 	return nil
 }
 
 func (n *nfsFile) GetNFSVersion() (string, error) {
-	return nfs.GetNFSVersion(n.nfsServerPath, n.targetPath)
+	return nfs.GetNFSVersion(n.nfsServerPath, n.path)
 }
 
 func newFileBased(registry *v1.ModelRegistry) (ModelRegistry, error) {
@@ -217,7 +282,7 @@ func newFileBased(registry *v1.ModelRegistry) (ModelRegistry, error) {
 		}
 
 		return &localFile{
-			path: modelRegistryURL.Path,
+			bentomlStore: bentomlStore{path: modelRegistryURL.Path},
 		}, nil
 	case string(v1.BentoMLModelRegistryConnectTypeNFS):
 		if modelRegistryURL.Host == "" || modelRegistryURL.Path == "" {
@@ -225,7 +290,7 @@ func newFileBased(registry *v1.ModelRegistry) (ModelRegistry, error) {
 		}
 
 		return &nfsFile{
-			targetPath:    filepath.Join("/mnt", registry.Key()),
+			bentomlStore:  bentomlStore{path: filepath.Join("/mnt", registry.Key())},
 			nfsServerPath: modelRegistryURL.Host + modelRegistryURL.Path,
 		}, nil
 	default:

--- a/internal/model_registry/file_based.go
+++ b/internal/model_registry/file_based.go
@@ -74,7 +74,7 @@ func convertBentoMLModelsToGeneralModels(bentomlModels []bentoml.Model, options 
 // an error — a client paging a registry that shrank under it should see the end
 // of the list, not a failure.
 func pageOf(models []v1.GeneralModel, options ListOption) *ModelPage {
-	page := &ModelPage{Total: len(models)}
+	page := &ModelPage{Total: KnownTotal(len(models))}
 
 	start := options.Offset
 	if start < 0 {

--- a/internal/model_registry/file_based_list_test.go
+++ b/internal/model_registry/file_based_list_test.go
@@ -65,7 +65,7 @@ func TestListModels_OrderIsStable(t *testing.T) {
 
 	assert.Equal(t, []string{"alpha", "beta", "delta", "gamma", "kappa", "mu", "omega", "zeta"},
 		modelNames(first.Models))
-	assert.Equal(t, 8, first.Total)
+	assert.Equal(t, 8, *first.Total)
 }
 
 // With a stable order, paging is coherent: consecutive pages neither overlap nor
@@ -122,7 +122,7 @@ func TestListModels_Paging(t *testing.T) {
 
 			assert.Equal(t, tt.wantNames, modelNames(page.Models))
 			// Total always counts everything that matched, never the page.
-			assert.Equal(t, 5, page.Total)
+			assert.Equal(t, 5, *page.Total)
 		})
 	}
 }
@@ -155,7 +155,7 @@ func TestListModels_SearchFiltersBeforePaging(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"qwen3-32b", "qwen3-8b"}, modelNames(page.Models))
-	assert.Equal(t, 2, page.Total)
+	assert.Equal(t, 2, *page.Total)
 }
 
 // Labels written into model.yaml used to be decoded into a struct that did not

--- a/internal/model_registry/file_based_list_test.go
+++ b/internal/model_registry/file_based_list_test.go
@@ -1,0 +1,340 @@
+package model_registry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// writeStoredModel lays down one model version in the BentoML layout the
+// file-based registries read.
+func writeStoredModel(t *testing.T, homePath, name, version string, labels map[string]string) string {
+	t.Helper()
+
+	dir := filepath.Join(homePath, "models", name, version)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	descriptor := fmt.Sprintf("name: %s\nversion: %s\nmodule: transformers\nsize: 1.0 kB\n"+
+		"creation_time: 2026-01-0%dT00:00:00.000000+00:00\n", name, version, len(version)%9+1)
+
+	if len(labels) > 0 {
+		descriptor += "labels:\n"
+		for key, value := range labels {
+			descriptor += fmt.Sprintf("  %s: %q\n", key, value)
+		}
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "model.yaml"), []byte(descriptor), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(homePath, "models", name, v1.LatestVersion),
+		[]byte(version), 0o600))
+
+	return dir
+}
+
+func storeWithModels(t *testing.T, names ...string) *localFile {
+	t.Helper()
+
+	home := t.TempDir()
+	for _, name := range names {
+		writeStoredModel(t, home, name, "v1", nil)
+	}
+
+	return &localFile{bentomlStore: bentomlStore{path: home}}
+}
+
+// Listing built a map and then sliced it, and Go randomises map iteration, so
+// the same store answered in a different order every call — and a truncated
+// answer was a different subset every call.
+func TestListModels_OrderIsStable(t *testing.T) {
+	store := storeWithModels(t, "zeta", "alpha", "mu", "beta", "omega", "gamma", "delta", "kappa")
+
+	first, err := store.ListModels(ListOption{})
+	require.NoError(t, err)
+
+	for i := 0; i < 20; i++ {
+		next, err := store.ListModels(ListOption{})
+		require.NoError(t, err)
+		require.Equal(t, first.Models, next.Models, "listing order changed between identical calls")
+	}
+
+	assert.Equal(t, []string{"alpha", "beta", "delta", "gamma", "kappa", "mu", "omega", "zeta"},
+		modelNames(first.Models))
+	assert.Equal(t, 8, first.Total)
+}
+
+// With a stable order, paging is coherent: consecutive pages neither overlap nor
+// skip, and together they reproduce the whole listing.
+func TestListModels_Paging(t *testing.T) {
+	store := storeWithModels(t, "alpha", "beta", "gamma", "delta", "epsilon")
+
+	tests := []struct {
+		name      string
+		option    ListOption
+		wantNames []string
+	}{
+		{
+			name:      "first page",
+			option:    ListOption{Limit: 2},
+			wantNames: []string{"alpha", "beta"},
+		},
+		{
+			name:      "second page",
+			option:    ListOption{Offset: 2, Limit: 2},
+			wantNames: []string{"delta", "epsilon"},
+		},
+		{
+			name:      "last partial page",
+			option:    ListOption{Offset: 4, Limit: 2},
+			wantNames: []string{"gamma"},
+		},
+		{
+			name:      "offset exactly at the end",
+			option:    ListOption{Offset: 5, Limit: 2},
+			wantNames: []string{},
+		},
+		{
+			name:      "offset past the end",
+			option:    ListOption{Offset: 500, Limit: 2},
+			wantNames: []string{},
+		},
+		{
+			name:      "limit past the end",
+			option:    ListOption{Offset: 3, Limit: 500},
+			wantNames: []string{"epsilon", "gamma"},
+		},
+		{
+			name:      "offset without limit",
+			option:    ListOption{Offset: 3},
+			wantNames: []string{"epsilon", "gamma"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			page, err := store.ListModels(tt.option)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantNames, modelNames(page.Models))
+			// Total always counts everything that matched, never the page.
+			assert.Equal(t, 5, page.Total)
+		})
+	}
+}
+
+func TestListModels_PagesCoverTheListingExactlyOnce(t *testing.T) {
+	store := storeWithModels(t, "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta")
+
+	var paged []string
+
+	for offset := 0; ; offset += 3 {
+		page, err := store.ListModels(ListOption{Offset: offset, Limit: 3})
+		require.NoError(t, err)
+
+		if len(page.Models) == 0 {
+			break
+		}
+
+		paged = append(paged, modelNames(page.Models)...)
+	}
+
+	whole, err := store.ListModels(ListOption{})
+	require.NoError(t, err)
+	assert.Equal(t, modelNames(whole.Models), paged)
+}
+
+func TestListModels_SearchFiltersBeforePaging(t *testing.T) {
+	store := storeWithModels(t, "qwen3-8b", "qwen3-32b", "llama-8b")
+
+	page, err := store.ListModels(ListOption{Search: "qwen3"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"qwen3-32b", "qwen3-8b"}, modelNames(page.Models))
+	assert.Equal(t, 2, page.Total)
+}
+
+// Labels written into model.yaml used to be decoded into a struct that did not
+// have them, so nothing anywhere could read them back. Both read paths must
+// surface them.
+func TestModelLabelsSurviveBothReadPaths(t *testing.T) {
+	home := t.TempDir()
+	labels := map[string]string{"team": "search", "tier": "gold"}
+	writeStoredModel(t, home, "qwen3", "v1", labels)
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	page, err := store.ListModels(ListOption{})
+	require.NoError(t, err)
+	require.Len(t, page.Models, 1)
+	require.Len(t, page.Models[0].Versions, 1)
+	assert.Equal(t, labels, page.Models[0].Versions[0].Labels)
+
+	detail, err := store.GetModelDetail("qwen3", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, labels, detail.Labels)
+
+	version, err := store.GetModelVersion("qwen3", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, labels, version.Labels)
+}
+
+func TestGetModelDetail_CarriesParsedCheckpointInfo(t *testing.T) {
+	home := t.TempDir()
+	dir := writeStoredModel(t, home, "qwen3", "v1", nil)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"),
+		[]byte(`{"architectures":["Qwen3ForCausalLM"],"num_hidden_layers":36,"hidden_size":4096,`+
+			`"num_attention_heads":32,"max_position_embeddings":40960,"torch_dtype":"bfloat16"}`), 0o600))
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	detail, err := store.GetModelDetail("qwen3", "v1")
+	require.NoError(t, err)
+	require.NotNil(t, detail.Info)
+	assert.Equal(t, "Qwen3ForCausalLM", detail.Info.Architecture)
+	assert.Equal(t, "40960", detail.Info.ContextLength)
+	assert.Equal(t, v1.ModelInfoSourceDerived, detail.Info.FieldSources[v1.ModelInfoFieldHeadDim])
+	assert.Contains(t, detail.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+
+	// A listing must not pay for the checkpoint parse.
+	page, err := store.ListModels(ListOption{})
+	require.NoError(t, err)
+	assert.Nil(t, page.Models[0].Versions[0].Info)
+}
+
+// Hand-filled values live in the model's own descriptor, so they have to come
+// back out of it on the next read, marked as the user's rather than the
+// checkpoint's.
+func TestManualModelInfoRoundTrips(t *testing.T) {
+	home := t.TempDir()
+	dir := writeStoredModel(t, home, "qwen3", "v1", map[string]string{"team": "search"})
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"),
+		[]byte(`{"architectures":["Qwen3ForCausalLM"],"num_hidden_layers":36}`), 0o600))
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	quantBits := 8
+	require.NoError(t, store.SetManualModelInfo("qwen3", "v1", &v1.ModelInfo{
+		ParameterCount:   "8000000000",
+		QuantizationBits: &quantBits,
+	}))
+
+	detail, err := store.GetModelDetail("qwen3", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "8000000000", detail.Info.ParameterCount)
+	assert.Equal(t, 8, *detail.Info.QuantizationBits)
+	assert.Equal(t, v1.ModelInfoSourceManual, detail.Info.FieldSources[v1.ModelInfoFieldParameterCount])
+	assert.NotContains(t, detail.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+	// The checkpoint still speaks for itself where the user said nothing.
+	assert.Equal(t, "Qwen3ForCausalLM", detail.Info.Architecture)
+	assert.Equal(t, v1.ModelInfoSourceAuto, detail.Info.FieldSources[v1.ModelInfoFieldArchitecture])
+	// Rewriting the descriptor must not disturb anything else in it.
+	assert.Equal(t, map[string]string{"team": "search"}, detail.Labels)
+
+	// Replacing the block wholesale is how a value gets removed.
+	require.NoError(t, store.SetManualModelInfo("qwen3", "v1", &v1.ModelInfo{}))
+
+	detail, err = store.GetModelDetail("qwen3", "v1")
+	require.NoError(t, err)
+	assert.Empty(t, detail.Info.ParameterCount)
+	assert.Contains(t, detail.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+}
+
+func TestSetManualModelInfo_LeavesPhysicalCoordinatesAlone(t *testing.T) {
+	home := t.TempDir()
+	writeStoredModel(t, home, "qwen3", "v1", nil)
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	before, err := store.GetModelPath("qwen3", "v1")
+	require.NoError(t, err)
+
+	require.NoError(t, store.SetManualModelInfo("qwen3", "v1", &v1.ModelInfo{Quantization: "fp8"}))
+
+	after, err := store.GetModelPath("qwen3", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+
+	version, err := store.GetModelVersion("qwen3", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "v1", version.Name)
+}
+
+func TestGetReadme(t *testing.T) {
+	home := t.TempDir()
+	dir := writeStoredModel(t, home, "qwen3", "v1", nil)
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	_, err := store.GetReadme("qwen3", "v1")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Qwen3\n"), 0o600))
+
+	content, err := store.GetReadme("qwen3", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "# Qwen3\n", content)
+}
+
+func TestCollectUsage(t *testing.T) {
+	home := t.TempDir()
+	dir := writeStoredModel(t, home, "qwen3", "v1", nil)
+	writeStoredModel(t, home, "qwen3", "v2", nil)
+	writeStoredModel(t, home, "llama", "v1", nil)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "model.safetensors"), make([]byte, 4096), 0o600))
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	usage, err := store.CollectUsage()
+	require.NoError(t, err)
+
+	// Two distinct names, three versions.
+	assert.Equal(t, 2, usage.ModelCount)
+	assert.Greater(t, usage.StorageBytes, int64(4096))
+
+	measured := directorySize(t, filepath.Join(home, "models"))
+	assert.Equal(t, measured, usage.StorageBytes)
+}
+
+func TestCollectUsage_EmptyStore(t *testing.T) {
+	store := &localFile{bentomlStore: bentomlStore{path: t.TempDir()}}
+
+	usage, err := store.CollectUsage()
+	require.NoError(t, err)
+	assert.Equal(t, 0, usage.ModelCount)
+	assert.Equal(t, int64(0), usage.StorageBytes)
+}
+
+func modelNames(models []v1.GeneralModel) []string {
+	names := make([]string, 0, len(models))
+	for _, model := range models {
+		names = append(names, model.Name)
+	}
+
+	return names
+}
+
+func directorySize(t *testing.T, dir string) int64 {
+	t.Helper()
+
+	var total int64
+
+	require.NoError(t, filepath.Walk(dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			total += info.Size()
+		}
+
+		return nil
+	}))
+
+	return total
+}

--- a/internal/model_registry/file_based_list_test.go
+++ b/internal/model_registry/file_based_list_test.go
@@ -264,22 +264,6 @@ func TestSetManualModelInfo_LeavesPhysicalCoordinatesAlone(t *testing.T) {
 	assert.Equal(t, "v1", version.Name)
 }
 
-func TestGetReadme(t *testing.T) {
-	home := t.TempDir()
-	dir := writeStoredModel(t, home, "qwen3", "v1", nil)
-
-	store := &localFile{bentomlStore: bentomlStore{path: home}}
-
-	_, err := store.GetReadme("qwen3", "v1")
-	assert.ErrorIs(t, err, ErrNotFound)
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Qwen3\n"), 0o600))
-
-	content, err := store.GetReadme("qwen3", "v1")
-	require.NoError(t, err)
-	assert.Equal(t, "# Qwen3\n", content)
-}
-
 func TestCollectUsage(t *testing.T) {
 	home := t.TempDir()
 	dir := writeStoredModel(t, home, "qwen3", "v1", nil)

--- a/internal/model_registry/file_based_test.go
+++ b/internal/model_registry/file_based_test.go
@@ -147,8 +147,8 @@ func Test_newNFSTypeModelRegistry(t *testing.T) {
 					t.Errorf("expected nfsFile type, got %T", registry)
 				}
 
-				if nfsFileRegistry.targetPath != tt.expectTarget {
-					t.Errorf("unexpected target path: got %v, want %v", nfsFileRegistry.targetPath, tt.expectTarget)
+				if nfsFileRegistry.path != tt.expectTarget {
+					t.Errorf("unexpected target path: got %v, want %v", nfsFileRegistry.path, tt.expectTarget)
 				}
 				if nfsFileRegistry.nfsServerPath != tt.expectNFS {
 					t.Errorf("unexpected NFS server path: got %v, want %v", nfsFileRegistry.nfsServerPath, tt.expectNFS)

--- a/internal/model_registry/hugging_face.go
+++ b/internal/model_registry/hugging_face.go
@@ -93,16 +93,25 @@ type HuggingFaceModel struct {
 	ModelID       string    `json:"modelId,omitempty"`
 }
 
-// ListModels retrieves all models from the Hugging Face Hub API by page.
+// ListModels retrieves the first page of models from the Hugging Face Hub API.
 //
-// The Hub does not report how many models match a search, so Total is the size
-// of the page that came back. A client cannot use it to compute a page count for
-// a public registry.
+// Offset is refused rather than ignored. The Hub's supported pagination is an
+// opaque, server-generated cursor carried in a Link header, which cannot express
+// "start at row N"; its `skip` parameter, which could, is documented by the Hub
+// itself as deprecated and rejects values past a few thousand. Silently serving
+// the first page for every offset would make a paging client believe it was
+// walking the catalogue while it re-read the same rows.
+//
+// The Hub also does not report how many models matched, so Total is unknown.
 func (hf *huggingFace) ListModels(option ListOption) (*ModelPage, error) {
 	var (
 		allHFModels []HuggingFaceModel
 		result      = []v1.GeneralModel{}
 	)
+
+	if option.Offset > 0 {
+		return nil, errors.Wrap(ErrNotSupported, "the Hugging Face Hub API cannot list models from an offset")
+	}
 
 	allHFModels, err := hf.getModelsList(option)
 	if err != nil {
@@ -121,7 +130,7 @@ func (hf *huggingFace) ListModels(option ListOption) (*ModelPage, error) {
 		})
 	}
 
-	return &ModelPage{Models: result, Total: len(result)}, nil
+	return &ModelPage{Models: result}, nil
 }
 
 // HealthyCheck checks the health of the Hugging Face Hub API.

--- a/internal/model_registry/hugging_face.go
+++ b/internal/model_registry/hugging_face.go
@@ -247,11 +247,6 @@ func (hf *huggingFace) GetModelDetail(name, version string) (*v1.ModelVersion, e
 	return nil, errHuggingFaceNotSupported
 }
 
-// GetReadme is not implemented for HuggingFace.
-func (hf *huggingFace) GetReadme(name, version string) (string, error) {
-	return "", errHuggingFaceNotSupported
-}
-
 // DeleteModel returns an error for HuggingFace as it's read-only
 func (hf *huggingFace) DeleteModel(name, version string) error {
 	return errHuggingFaceNotSupported

--- a/internal/model_registry/hugging_face.go
+++ b/internal/model_registry/hugging_face.go
@@ -33,10 +33,15 @@ var (
 )
 
 const (
-	listModelPath              = "/api/models"
-	whoamiPath                 = "/api/whoami-v2"
-	errHuggingFaceNotSupported = "operation not supported for Hugging Face registry"
+	listModelPath = "/api/models"
+	whoamiPath    = "/api/whoami-v2"
 )
+
+// errHuggingFaceNotSupported wraps ErrNotSupported so a caller can tell "a
+// public registry cannot do this" from "it tried and failed", and answer with a
+// clear refusal instead of a server error. Hugging Face is read-only here; the
+// write and detail operations are not implemented against it.
+var errHuggingFaceNotSupported = errors.Wrap(ErrNotSupported, "operation not supported for Hugging Face registry")
 
 type huggingFace struct {
 	apiToken string
@@ -89,10 +94,14 @@ type HuggingFaceModel struct {
 }
 
 // ListModels retrieves all models from the Hugging Face Hub API by page.
-func (hf *huggingFace) ListModels(option ListOption) ([]v1.GeneralModel, error) {
+//
+// The Hub does not report how many models match a search, so Total is the size
+// of the page that came back. A client cannot use it to compute a page count for
+// a public registry.
+func (hf *huggingFace) ListModels(option ListOption) (*ModelPage, error) {
 	var (
 		allHFModels []HuggingFaceModel
-		result      []v1.GeneralModel
+		result      = []v1.GeneralModel{}
 	)
 
 	allHFModels, err := hf.getModelsList(option)
@@ -112,7 +121,7 @@ func (hf *huggingFace) ListModels(option ListOption) ([]v1.GeneralModel, error) 
 		})
 	}
 
-	return result, nil
+	return &ModelPage{Models: result, Total: len(result)}, nil
 }
 
 // HealthyCheck checks the health of the Hugging Face Hub API.
@@ -220,27 +229,49 @@ func (hf *huggingFace) whoami() (string, error) {
 // Implement the remaining ModelRegistry interface methods with "not supported" errors
 
 func (hf *huggingFace) GetModelVersion(name, version string) (*v1.ModelVersion, error) {
-	return nil, errors.New(errHuggingFaceNotSupported)
+	return nil, errHuggingFaceNotSupported
+}
+
+// GetModelDetail is not implemented for HuggingFace: reading a public
+// checkpoint's files would mean downloading them.
+func (hf *huggingFace) GetModelDetail(name, version string) (*v1.ModelVersion, error) {
+	return nil, errHuggingFaceNotSupported
+}
+
+// GetReadme is not implemented for HuggingFace.
+func (hf *huggingFace) GetReadme(name, version string) (string, error) {
+	return "", errHuggingFaceNotSupported
 }
 
 // DeleteModel returns an error for HuggingFace as it's read-only
 func (hf *huggingFace) DeleteModel(name, version string) error {
-	return errors.New(errHuggingFaceNotSupported)
+	return errHuggingFaceNotSupported
 }
 
 // ImportModel returns an error for HuggingFace as it's read-only
 func (hf *huggingFace) ImportModel(reader io.Reader, name, version string, progress io.Writer) error {
-	return errors.New(errHuggingFaceNotSupported)
+	return errHuggingFaceNotSupported
 }
 
 // ExportModel returns an error for HuggingFace as it's read-only
 func (hf *huggingFace) ExportModel(name, version, outputPath string) error {
-	return errors.New(errHuggingFaceNotSupported)
+	return errHuggingFaceNotSupported
 }
 
 // GetModelPath returns an error for HuggingFace as it's read-only
 func (hf *huggingFace) GetModelPath(name, version string) (string, error) {
-	return "", errors.New(errHuggingFaceNotSupported)
+	return "", errHuggingFaceNotSupported
+}
+
+// SetManualModelInfo returns an error for HuggingFace as it's read-only
+func (hf *huggingFace) SetManualModelInfo(name, version string, info *v1.ModelInfo) error {
+	return errHuggingFaceNotSupported
+}
+
+// CollectUsage is not implemented for HuggingFace: the Hub's storage is not ours
+// to measure, and the model count is unbounded.
+func (hf *huggingFace) CollectUsage() (*RegistryUsage, error) {
+	return nil, errHuggingFaceNotSupported
 }
 
 func (hf *huggingFace) GetNFSVersion() (string, error) {

--- a/internal/model_registry/hugging_face_test.go
+++ b/internal/model_registry/hugging_face_test.go
@@ -269,11 +269,6 @@ func TestHuggingFace_UnsupportedOperationsAreTyped(t *testing.T) {
 		assert.ErrorIs(t, err, ErrNotSupported)
 	})
 
-	t.Run("GetReadme", func(t *testing.T) {
-		_, err := hf.GetReadme("qwen3", "latest")
-		assert.ErrorIs(t, err, ErrNotSupported)
-	})
-
 	t.Run("SetManualModelInfo", func(t *testing.T) {
 		assert.ErrorIs(t, hf.SetManualModelInfo("qwen3", "latest", &v1.ModelInfo{}), ErrNotSupported)
 	})

--- a/internal/model_registry/hugging_face_test.go
+++ b/internal/model_registry/hugging_face_test.go
@@ -257,3 +257,48 @@ func TestHuggingFace_HealthyCheck(t *testing.T) {
 		})
 	}
 }
+
+// A public registry refuses the operations it does not implement with a typed
+// error, so a caller can answer "this registry kind cannot do that" instead of
+// reporting a server failure.
+func TestHuggingFace_UnsupportedOperationsAreTyped(t *testing.T) {
+	hf := &huggingFace{url: "https://huggingface.co"}
+
+	t.Run("GetModelDetail", func(t *testing.T) {
+		_, err := hf.GetModelDetail("qwen3", "latest")
+		assert.ErrorIs(t, err, ErrNotSupported)
+	})
+
+	t.Run("GetReadme", func(t *testing.T) {
+		_, err := hf.GetReadme("qwen3", "latest")
+		assert.ErrorIs(t, err, ErrNotSupported)
+	})
+
+	t.Run("SetManualModelInfo", func(t *testing.T) {
+		assert.ErrorIs(t, hf.SetManualModelInfo("qwen3", "latest", &v1.ModelInfo{}), ErrNotSupported)
+	})
+
+	t.Run("CollectUsage", func(t *testing.T) {
+		_, err := hf.CollectUsage()
+		assert.ErrorIs(t, err, ErrNotSupported)
+	})
+
+	t.Run("GetModelVersion", func(t *testing.T) {
+		_, err := hf.GetModelVersion("qwen3", "latest")
+		assert.ErrorIs(t, err, ErrNotSupported)
+	})
+
+	t.Run("DeleteModel", func(t *testing.T) {
+		assert.ErrorIs(t, hf.DeleteModel("qwen3", "latest"), ErrNotSupported)
+	})
+
+	t.Run("GetModelPath", func(t *testing.T) {
+		_, err := hf.GetModelPath("qwen3", "latest")
+		assert.ErrorIs(t, err, ErrNotSupported)
+	})
+
+	// The wording predates the typed error and is kept so existing messages do
+	// not change.
+	_, err := hf.GetModelDetail("qwen3", "latest")
+	assert.Contains(t, err.Error(), "operation not supported for Hugging Face registry")
+}

--- a/internal/model_registry/hugging_face_test.go
+++ b/internal/model_registry/hugging_face_test.go
@@ -302,3 +302,44 @@ func TestHuggingFace_UnsupportedOperationsAreTyped(t *testing.T) {
 	_, err := hf.GetModelDetail("qwen3", "latest")
 	assert.Contains(t, err.Error(), "operation not supported for Hugging Face registry")
 }
+
+// Paging a public registry from an offset is refused rather than silently
+// answered with the first page. The Hub's own pagination is an opaque cursor
+// that cannot express "start at row N", and its deprecated skip parameter stops
+// working past a few thousand rows — so a client that believed an offset had
+// been honoured would re-read the same models while thinking it was advancing.
+func TestHuggingFace_ListModelsRefusesAnOffset(t *testing.T) {
+	hf := &huggingFace{url: "https://huggingface.co"}
+
+	page, err := hf.ListModels(ListOption{Offset: 10, Limit: 5})
+
+	assert.Nil(t, page)
+	assert.ErrorIs(t, err, ErrNotSupported)
+}
+
+// The Hub does not report how many models matched, so the total is unknown
+// rather than the size of the page that came back.
+func TestHuggingFace_ListModelsReportsAnUnknownTotal(t *testing.T) {
+	hf := &huggingFace{
+		url: "https://huggingface.co",
+		client: &http.Client{
+			Transport: &MockRoundTripper{
+				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+					assert.NotContains(t, req.URL.RawQuery, "offset")
+					assert.NotContains(t, req.URL.RawQuery, "skip")
+
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(bytes.NewBufferString(
+							`[{"modelId":"a"},{"modelId":"b"}]`)),
+					}, nil
+				},
+			},
+		},
+	}
+
+	page, err := hf.ListModels(ListOption{Limit: 2})
+	assert.NoError(t, err)
+	assert.Len(t, page.Models, 2)
+	assert.Nil(t, page.Total, "the Hub states no match count, so none may be invented")
+}

--- a/internal/model_registry/mocks/mock_model_registry.go
+++ b/internal/model_registry/mocks/mock_model_registry.go
@@ -24,6 +24,63 @@ func (_m *MockModelRegistry) EXPECT() *MockModelRegistry_Expecter {
 	return &MockModelRegistry_Expecter{mock: &_m.Mock}
 }
 
+// CollectUsage provides a mock function with no fields
+func (_m *MockModelRegistry) CollectUsage() (*model_registry.RegistryUsage, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CollectUsage")
+	}
+
+	var r0 *model_registry.RegistryUsage
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (*model_registry.RegistryUsage, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() *model_registry.RegistryUsage); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model_registry.RegistryUsage)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockModelRegistry_CollectUsage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CollectUsage'
+type MockModelRegistry_CollectUsage_Call struct {
+	*mock.Call
+}
+
+// CollectUsage is a helper method to define mock.On call
+func (_e *MockModelRegistry_Expecter) CollectUsage() *MockModelRegistry_CollectUsage_Call {
+	return &MockModelRegistry_CollectUsage_Call{Call: _e.mock.On("CollectUsage")}
+}
+
+func (_c *MockModelRegistry_CollectUsage_Call) Run(run func()) *MockModelRegistry_CollectUsage_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockModelRegistry_CollectUsage_Call) Return(_a0 *model_registry.RegistryUsage, _a1 error) *MockModelRegistry_CollectUsage_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockModelRegistry_CollectUsage_Call) RunAndReturn(run func() (*model_registry.RegistryUsage, error)) *MockModelRegistry_CollectUsage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Connect provides a mock function with no fields
 func (_m *MockModelRegistry) Connect() error {
 	ret := _m.Called()
@@ -209,6 +266,65 @@ func (_c *MockModelRegistry_ExportModel_Call) RunAndReturn(run func(string, stri
 	return _c
 }
 
+// GetModelDetail provides a mock function with given fields: name, version
+func (_m *MockModelRegistry) GetModelDetail(name string, version string) (*v1.ModelVersion, error) {
+	ret := _m.Called(name, version)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetModelDetail")
+	}
+
+	var r0 *v1.ModelVersion
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) (*v1.ModelVersion, error)); ok {
+		return rf(name, version)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) *v1.ModelVersion); ok {
+		r0 = rf(name, version)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.ModelVersion)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(name, version)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockModelRegistry_GetModelDetail_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetModelDetail'
+type MockModelRegistry_GetModelDetail_Call struct {
+	*mock.Call
+}
+
+// GetModelDetail is a helper method to define mock.On call
+//   - name string
+//   - version string
+func (_e *MockModelRegistry_Expecter) GetModelDetail(name interface{}, version interface{}) *MockModelRegistry_GetModelDetail_Call {
+	return &MockModelRegistry_GetModelDetail_Call{Call: _e.mock.On("GetModelDetail", name, version)}
+}
+
+func (_c *MockModelRegistry_GetModelDetail_Call) Run(run func(name string, version string)) *MockModelRegistry_GetModelDetail_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockModelRegistry_GetModelDetail_Call) Return(_a0 *v1.ModelVersion, _a1 error) *MockModelRegistry_GetModelDetail_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockModelRegistry_GetModelDetail_Call) RunAndReturn(run func(string, string) (*v1.ModelVersion, error)) *MockModelRegistry_GetModelDetail_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetModelPath provides a mock function with given fields: name, version
 func (_m *MockModelRegistry) GetModelPath(name string, version string) (string, error) {
 	ret := _m.Called(name, version)
@@ -380,6 +496,63 @@ func (_c *MockModelRegistry_GetNFSVersion_Call) RunAndReturn(run func() (string,
 	return _c
 }
 
+// GetReadme provides a mock function with given fields: name, version
+func (_m *MockModelRegistry) GetReadme(name string, version string) (string, error) {
+	ret := _m.Called(name, version)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReadme")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) (string, error)); ok {
+		return rf(name, version)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) string); ok {
+		r0 = rf(name, version)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(name, version)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockModelRegistry_GetReadme_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReadme'
+type MockModelRegistry_GetReadme_Call struct {
+	*mock.Call
+}
+
+// GetReadme is a helper method to define mock.On call
+//   - name string
+//   - version string
+func (_e *MockModelRegistry_Expecter) GetReadme(name interface{}, version interface{}) *MockModelRegistry_GetReadme_Call {
+	return &MockModelRegistry_GetReadme_Call{Call: _e.mock.On("GetReadme", name, version)}
+}
+
+func (_c *MockModelRegistry_GetReadme_Call) Run(run func(name string, version string)) *MockModelRegistry_GetReadme_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockModelRegistry_GetReadme_Call) Return(_a0 string, _a1 error) *MockModelRegistry_GetReadme_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockModelRegistry_GetReadme_Call) RunAndReturn(run func(string, string) (string, error)) *MockModelRegistry_GetReadme_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HealthyCheck provides a mock function with no fields
 func (_m *MockModelRegistry) HealthyCheck() error {
 	ret := _m.Called()
@@ -475,23 +648,23 @@ func (_c *MockModelRegistry_ImportModel_Call) RunAndReturn(run func(io.Reader, s
 }
 
 // ListModels provides a mock function with given fields: option
-func (_m *MockModelRegistry) ListModels(option model_registry.ListOption) ([]v1.GeneralModel, error) {
+func (_m *MockModelRegistry) ListModels(option model_registry.ListOption) (*model_registry.ModelPage, error) {
 	ret := _m.Called(option)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListModels")
 	}
 
-	var r0 []v1.GeneralModel
+	var r0 *model_registry.ModelPage
 	var r1 error
-	if rf, ok := ret.Get(0).(func(model_registry.ListOption) ([]v1.GeneralModel, error)); ok {
+	if rf, ok := ret.Get(0).(func(model_registry.ListOption) (*model_registry.ModelPage, error)); ok {
 		return rf(option)
 	}
-	if rf, ok := ret.Get(0).(func(model_registry.ListOption) []v1.GeneralModel); ok {
+	if rf, ok := ret.Get(0).(func(model_registry.ListOption) *model_registry.ModelPage); ok {
 		r0 = rf(option)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]v1.GeneralModel)
+			r0 = ret.Get(0).(*model_registry.ModelPage)
 		}
 	}
 
@@ -522,12 +695,60 @@ func (_c *MockModelRegistry_ListModels_Call) Run(run func(option model_registry.
 	return _c
 }
 
-func (_c *MockModelRegistry_ListModels_Call) Return(_a0 []v1.GeneralModel, _a1 error) *MockModelRegistry_ListModels_Call {
+func (_c *MockModelRegistry_ListModels_Call) Return(_a0 *model_registry.ModelPage, _a1 error) *MockModelRegistry_ListModels_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockModelRegistry_ListModels_Call) RunAndReturn(run func(model_registry.ListOption) ([]v1.GeneralModel, error)) *MockModelRegistry_ListModels_Call {
+func (_c *MockModelRegistry_ListModels_Call) RunAndReturn(run func(model_registry.ListOption) (*model_registry.ModelPage, error)) *MockModelRegistry_ListModels_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SetManualModelInfo provides a mock function with given fields: name, version, info
+func (_m *MockModelRegistry) SetManualModelInfo(name string, version string, info *v1.ModelInfo) error {
+	ret := _m.Called(name, version, info)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetManualModelInfo")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, *v1.ModelInfo) error); ok {
+		r0 = rf(name, version, info)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockModelRegistry_SetManualModelInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetManualModelInfo'
+type MockModelRegistry_SetManualModelInfo_Call struct {
+	*mock.Call
+}
+
+// SetManualModelInfo is a helper method to define mock.On call
+//   - name string
+//   - version string
+//   - info *v1.ModelInfo
+func (_e *MockModelRegistry_Expecter) SetManualModelInfo(name interface{}, version interface{}, info interface{}) *MockModelRegistry_SetManualModelInfo_Call {
+	return &MockModelRegistry_SetManualModelInfo_Call{Call: _e.mock.On("SetManualModelInfo", name, version, info)}
+}
+
+func (_c *MockModelRegistry_SetManualModelInfo_Call) Run(run func(name string, version string, info *v1.ModelInfo)) *MockModelRegistry_SetManualModelInfo_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string), args[2].(*v1.ModelInfo))
+	})
+	return _c
+}
+
+func (_c *MockModelRegistry_SetManualModelInfo_Call) Return(_a0 error) *MockModelRegistry_SetManualModelInfo_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockModelRegistry_SetManualModelInfo_Call) RunAndReturn(run func(string, string, *v1.ModelInfo) error) *MockModelRegistry_SetManualModelInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/model_registry/mocks/mock_model_registry.go
+++ b/internal/model_registry/mocks/mock_model_registry.go
@@ -496,63 +496,6 @@ func (_c *MockModelRegistry_GetNFSVersion_Call) RunAndReturn(run func() (string,
 	return _c
 }
 
-// GetReadme provides a mock function with given fields: name, version
-func (_m *MockModelRegistry) GetReadme(name string, version string) (string, error) {
-	ret := _m.Called(name, version)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetReadme")
-	}
-
-	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (string, error)); ok {
-		return rf(name, version)
-	}
-	if rf, ok := ret.Get(0).(func(string, string) string); ok {
-		r0 = rf(name, version)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(name, version)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockModelRegistry_GetReadme_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReadme'
-type MockModelRegistry_GetReadme_Call struct {
-	*mock.Call
-}
-
-// GetReadme is a helper method to define mock.On call
-//   - name string
-//   - version string
-func (_e *MockModelRegistry_Expecter) GetReadme(name interface{}, version interface{}) *MockModelRegistry_GetReadme_Call {
-	return &MockModelRegistry_GetReadme_Call{Call: _e.mock.On("GetReadme", name, version)}
-}
-
-func (_c *MockModelRegistry_GetReadme_Call) Run(run func(name string, version string)) *MockModelRegistry_GetReadme_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *MockModelRegistry_GetReadme_Call) Return(_a0 string, _a1 error) *MockModelRegistry_GetReadme_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockModelRegistry_GetReadme_Call) RunAndReturn(run func(string, string) (string, error)) *MockModelRegistry_GetReadme_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HealthyCheck provides a mock function with no fields
 func (_m *MockModelRegistry) HealthyCheck() error {
 	ret := _m.Called()

--- a/internal/model_registry/model_registry.go
+++ b/internal/model_registry/model_registry.go
@@ -31,9 +31,18 @@ type ListOption struct {
 // ModelPage is one page of a listing plus the number of models that matched the
 // search before Offset and Limit were applied, so a caller can render paging
 // without fetching everything.
+//
+// Total is nil when the registry cannot state how many matched. That is a real
+// answer, not a placeholder: reporting the page size instead would tell a client
+// it had reached the end of a listing it had barely started.
 type ModelPage struct {
 	Models []v1.GeneralModel
-	Total  int
+	Total  *int
+}
+
+// KnownTotal builds a Total for a registry that can count its own contents.
+func KnownTotal(total int) *int {
+	return &total
 }
 
 // RegistryUsage is a raw observation of what a registry's backing storage holds.

--- a/internal/model_registry/model_registry.go
+++ b/internal/model_registry/model_registry.go
@@ -71,10 +71,6 @@ type ModelRegistry interface {
 	// the checkpoint. GetModelVersion stays the cheap call for code that only
 	// needs to resolve a version or read its recorded metadata.
 	GetModelDetail(name, version string) (*v1.ModelVersion, error)
-	// GetReadme returns the model's README.md verbatim. It wraps ErrNotFound when
-	// the model has no README, and ErrNotSupported on a registry that does not
-	// serve one.
-	GetReadme(name, version string) (string, error)
 	DeleteModel(name, version string) error
 	ImportModel(reader io.Reader, name, version string, progress io.Writer) error
 	ExportModel(name, version, outputPath string) error

--- a/internal/model_registry/model_registry.go
+++ b/internal/model_registry/model_registry.go
@@ -8,25 +8,77 @@ import (
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
+var (
+	// ErrNotSupported is returned by a registry that cannot perform an operation
+	// at all, as opposed to one that tried and failed. Callers should test for it
+	// with errors.Is and translate it into a "this registry kind cannot do that"
+	// response rather than a server error.
+	ErrNotSupported = errors.New("operation not supported by this model registry")
+	// ErrNotFound is returned when the registry is reachable but the requested
+	// object is not there.
+	ErrNotFound = errors.New("not found in model registry")
+)
+
 type ListOption struct {
 	Search string
+	// Offset and Limit page the result. Offset past the end yields an empty page,
+	// not an error. Paging is only coherent because the underlying listing is
+	// ordered — see the sort in convertBentoMLModelsToGeneralModels.
+	Offset int
 	Limit  int
+}
+
+// ModelPage is one page of a listing plus the number of models that matched the
+// search before Offset and Limit were applied, so a caller can render paging
+// without fetching everything.
+type ModelPage struct {
+	Models []v1.GeneralModel
+	Total  int
+}
+
+// RegistryUsage is a raw observation of what a registry's backing storage holds.
+// It is what the registry can see; turning it into a status is the aggregator's
+// job.
+type RegistryUsage struct {
+	// ModelCount is the number of distinct model names.
+	ModelCount int
+	// StorageBytes is the on-disk size of the model tree, obtained by walking it.
+	StorageBytes int64
 }
 
 // ModelRegistry defines the interface for model registry operations
 type ModelRegistry interface {
 	// Basic registry operations
-	ListModels(option ListOption) ([]v1.GeneralModel, error)
+	ListModels(option ListOption) (*ModelPage, error)
 	Connect() error
 	Disconnect() error
 	HealthyCheck() error
 
 	// Model operations
 	GetModelVersion(name, version string) (*v1.ModelVersion, error)
+	// GetModelDetail returns everything known about one model version: what the
+	// registry records about it plus whatever its checkpoint files state. It is
+	// the read path for a model's detail view and is the expensive one — it opens
+	// the checkpoint. GetModelVersion stays the cheap call for code that only
+	// needs to resolve a version or read its recorded metadata.
+	GetModelDetail(name, version string) (*v1.ModelVersion, error)
+	// GetReadme returns the model's README.md verbatim. It wraps ErrNotFound when
+	// the model has no README, and ErrNotSupported on a registry that does not
+	// serve one.
+	GetReadme(name, version string) (string, error)
 	DeleteModel(name, version string) error
 	ImportModel(reader io.Reader, name, version string, progress io.Writer) error
 	ExportModel(name, version, outputPath string) error
 	GetModelPath(name, version string) (string, error)
+	// SetManualModelInfo records the model info fields a user filled in by hand,
+	// replacing any previously recorded set. Registries that do not carry
+	// user-supplied metadata wrap ErrNotSupported.
+	SetManualModelInfo(name, version string, info *v1.ModelInfo) error
+
+	// CollectUsage walks the registry's backing storage and reports what it
+	// currently holds. Registries whose storage is not ours to measure wrap
+	// ErrNotSupported.
+	CollectUsage() (*RegistryUsage, error)
 
 	// GetNFSVersion returns the NFS protocol version (e.g. "3", "4", "4.1")
 	// detected from the control-plane mount. Returns empty string for non-NFS registries.

--- a/internal/model_registry/modelmeta/modelmeta.go
+++ b/internal/model_registry/modelmeta/modelmeta.go
@@ -1,0 +1,249 @@
+// Package modelmeta reads what a Hugging Face style checkpoint directory states
+// about itself: the shape parameters in config.json and the exact parameter
+// count in the safetensors headers.
+//
+// It only ever reports what the files say. There is deliberately no inference
+// from a directory or repository name — a checkpoint called "qwen3-8b" is not
+// evidence of anything, and a wrong parameter count is worse than an absent one.
+// Anything the files do not establish comes back in ModelInfo.MissingFields.
+package modelmeta
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// ConfigFileName is the checkpoint config every parse is anchored on.
+const ConfigFileName = "config.json"
+
+// allFields is every field this package can establish, in the order it reports
+// them. A checkpoint with no readable config.json is unreadable as a whole, so
+// this doubles as the "nothing is known" MissingFields list.
+var allFields = []string{
+	v1.ModelInfoFieldArchitecture,
+	v1.ModelInfoFieldNumHiddenLayers,
+	v1.ModelInfoFieldNumAttentionHeads,
+	v1.ModelInfoFieldNumKeyValueHeads,
+	v1.ModelInfoFieldHeadDim,
+	v1.ModelInfoFieldMaxPositionEmbeddings,
+	v1.ModelInfoFieldContextLength,
+	v1.ModelInfoFieldParameterDtype,
+	v1.ModelInfoFieldIsMoE,
+	v1.ModelInfoFieldNumExperts,
+	v1.ModelInfoFieldNumExpertsPerToken,
+	v1.ModelInfoFieldQuantizationBits,
+	v1.ModelInfoFieldParameterCount,
+}
+
+// hfConfig is the subset of config.json this package reads. Every scalar is a
+// pointer so that a key present with value 0 is distinguishable from an absent
+// key — the difference between "the checkpoint says zero" and "we don't know".
+type hfConfig struct {
+	Architectures         []string            `json:"architectures"`
+	NumHiddenLayers       *int                `json:"num_hidden_layers"`
+	NumAttentionHeads     *int                `json:"num_attention_heads"`
+	NumKeyValueHeads      *int                `json:"num_key_value_heads"`
+	HeadDim               *int                `json:"head_dim"`
+	HiddenSize            *int                `json:"hidden_size"`
+	MaxPositionEmbeddings *int                `json:"max_position_embeddings"`
+	TorchDtype            string              `json:"torch_dtype"`
+	NumLocalExperts       *int                `json:"num_local_experts"`
+	NumExperts            *int                `json:"num_experts"`
+	NumExpertsPerTok      *int                `json:"num_experts_per_tok"`
+	QuantizationConfig    *quantizationConfig `json:"quantization_config"`
+}
+
+// quantizationConfig covers the shapes transformers writes for the quantizers
+// that carry a width: GPTQ and AWQ state it as a bit count, FP8 states only the
+// method and the width is implied by the name.
+type quantizationConfig struct {
+	Bits        *int   `json:"bits"`
+	WBit        *int   `json:"w_bit"`
+	QuantMethod string `json:"quant_method"`
+}
+
+// bits reports the weight width in bits, or nil when this config does not state
+// one in a form we recognise.
+func (q *quantizationConfig) bits() *int {
+	switch {
+	case q.Bits != nil:
+		return q.Bits
+	case q.WBit != nil:
+		return q.WBit
+	case q.QuantMethod == "fp8":
+		width := 8
+
+		return &width
+	default:
+		return nil
+	}
+}
+
+// Parse reports what the checkpoint in dir states about itself. It never fails:
+// an absent, unreadable or malformed config.json yields an empty ModelInfo whose
+// MissingFields names everything, because that file is what the rest of the
+// parse is anchored on.
+func Parse(dir string) *v1.ModelInfo {
+	info := &v1.ModelInfo{}
+
+	cfg := readConfig(dir)
+	if cfg == nil {
+		info.MissingFields = append(info.MissingFields, allFields...)
+
+		return info
+	}
+
+	applyConfig(info, cfg)
+	applyParameterCount(info, dir)
+
+	return info
+}
+
+func readConfig(dir string) *hfConfig {
+	raw, err := os.ReadFile(filepath.Join(dir, ConfigFileName))
+	if err != nil {
+		return nil
+	}
+
+	var cfg hfConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil
+	}
+
+	return &cfg
+}
+
+func applyConfig(info *v1.ModelInfo, cfg *hfConfig) {
+	if len(cfg.Architectures) > 0 && cfg.Architectures[0] != "" {
+		info.Architecture = cfg.Architectures[0]
+		info.SetFieldSource(v1.ModelInfoFieldArchitecture, v1.ModelInfoSourceAuto)
+	} else {
+		info.MarkFieldMissing(v1.ModelInfoFieldArchitecture)
+	}
+
+	info.NumHiddenLayers = cfg.NumHiddenLayers
+	recordAuto(info, v1.ModelInfoFieldNumHiddenLayers, cfg.NumHiddenLayers != nil)
+
+	info.NumAttentionHeads = cfg.NumAttentionHeads
+	recordAuto(info, v1.ModelInfoFieldNumAttentionHeads, cfg.NumAttentionHeads != nil)
+
+	// A checkpoint that omits num_key_value_heads is conventionally MHA, i.e.
+	// equal to num_attention_heads. That convention is not applied here: it would
+	// be a second derivation, and reporting the field as unknown is honest.
+	info.NumKeyValueHeads = cfg.NumKeyValueHeads
+	recordAuto(info, v1.ModelInfoFieldNumKeyValueHeads, cfg.NumKeyValueHeads != nil)
+
+	applyHeadDim(info, cfg)
+
+	info.MaxPositionEmbeddings = cfg.MaxPositionEmbeddings
+	recordAuto(info, v1.ModelInfoFieldMaxPositionEmbeddings, cfg.MaxPositionEmbeddings != nil)
+
+	if cfg.MaxPositionEmbeddings != nil {
+		info.ContextLength = strconv.Itoa(*cfg.MaxPositionEmbeddings)
+	}
+
+	recordAuto(info, v1.ModelInfoFieldContextLength, cfg.MaxPositionEmbeddings != nil)
+
+	info.ParameterDtype = cfg.TorchDtype
+	recordAuto(info, v1.ModelInfoFieldParameterDtype, cfg.TorchDtype != "")
+
+	applyExperts(info, cfg)
+	applyQuantization(info, cfg)
+}
+
+// applyHeadDim resolves the one arithmetic derivation this package allows:
+// hidden_size / num_attention_heads when head_dim is absent. That is the
+// established Hugging Face convention for the fallback, not a guess.
+func applyHeadDim(info *v1.ModelInfo, cfg *hfConfig) {
+	switch {
+	case cfg.HeadDim != nil:
+		info.HeadDim = cfg.HeadDim
+		info.SetFieldSource(v1.ModelInfoFieldHeadDim, v1.ModelInfoSourceAuto)
+	case cfg.HiddenSize != nil && cfg.NumAttentionHeads != nil && *cfg.NumAttentionHeads > 0:
+		derived := *cfg.HiddenSize / *cfg.NumAttentionHeads
+		info.HeadDim = &derived
+		info.SetFieldSource(v1.ModelInfoFieldHeadDim, v1.ModelInfoSourceDerived)
+	default:
+		info.MarkFieldMissing(v1.ModelInfoFieldHeadDim)
+	}
+}
+
+// applyExperts decides dense vs. MoE. Reading the config at all settles is_moe,
+// so it is never missing. The expert counts only apply to an MoE checkpoint; on
+// a dense one they are neither sourced nor missing, because there is nothing
+// there to know.
+func applyExperts(info *v1.ModelInfo, cfg *hfConfig) {
+	experts := cfg.NumLocalExperts
+	if experts == nil {
+		experts = cfg.NumExperts
+	}
+
+	isMoE := experts != nil && *experts > 0
+	info.IsMoE = &isMoE
+	info.SetFieldSource(v1.ModelInfoFieldIsMoE, v1.ModelInfoSourceAuto)
+
+	if !isMoE {
+		return
+	}
+
+	info.NumExperts = experts
+	info.SetFieldSource(v1.ModelInfoFieldNumExperts, v1.ModelInfoSourceAuto)
+
+	info.NumExpertsPerToken = cfg.NumExpertsPerTok
+	recordAuto(info, v1.ModelInfoFieldNumExpertsPerToken, cfg.NumExpertsPerTok != nil)
+}
+
+// applyQuantization reads the weight width. A checkpoint with no
+// quantization_config is simply not quantized, which is an answer rather than a
+// gap, so quantization_bits is left out of MissingFields in that case.
+func applyQuantization(info *v1.ModelInfo, cfg *hfConfig) {
+	if cfg.QuantizationConfig == nil {
+		return
+	}
+
+	bits := cfg.QuantizationConfig.bits()
+	info.QuantizationBits = bits
+	recordAuto(info, v1.ModelInfoFieldQuantizationBits, bits != nil)
+}
+
+// applyParameterCount sums the shapes declared in the safetensors headers. This
+// is an exact count, not an estimate: it reads the tens of kilobytes of header
+// at the front of each shard and no weight data at all.
+//
+// Only safetensors is supported. A pytorch_model.bin is a pickle — parsing it in
+// Go is impractical and executing it is a security hazard — and GGUF is a
+// different container entirely; both leave parameter_count missing.
+func applyParameterCount(info *v1.ModelInfo, dir string) {
+	total, err := sumSafetensorsElements(dir)
+	if err != nil || total == nil {
+		info.MarkFieldMissing(v1.ModelInfoFieldParameterCount)
+
+		return
+	}
+
+	// Reported as the exact decimal total so a caller can compare or reformat it.
+	// The value counts every element stored in the checkpoint, which is what the
+	// files actually contain — not strictly the trainable parameter count, since
+	// a checkpoint holds a few non-parameter tensors such as rotary embedding
+	// inverse frequencies. For an MoE checkpoint it is the total across all
+	// experts, not the per-token active count.
+	info.ParameterCount = strconv.FormatInt(*total, 10)
+	info.SetFieldSource(v1.ModelInfoFieldParameterCount, v1.ModelInfoSourceAuto)
+}
+
+// recordAuto marks a field as read straight from the checkpoint, or as missing
+// when the checkpoint did not state it. Everything this package establishes is
+// auto except head_dim's fallback, which records its own provenance.
+func recordAuto(info *v1.ModelInfo, field string, resolved bool) {
+	if resolved {
+		info.SetFieldSource(field, v1.ModelInfoSourceAuto)
+
+		return
+	}
+
+	info.MarkFieldMissing(field)
+}

--- a/internal/model_registry/modelmeta/modelmeta.go
+++ b/internal/model_registry/modelmeta/modelmeta.go
@@ -158,18 +158,30 @@ func applyConfig(info *v1.ModelInfo, cfg *hfConfig) {
 // applyHeadDim resolves the one arithmetic derivation this package allows:
 // hidden_size / num_attention_heads when head_dim is absent. That is the
 // established Hugging Face convention for the fallback, not a guess.
+//
+// The division has to come out exact. Integer division would otherwise truncate
+// a config where the two do not divide evenly and hand back a wrong head_dim
+// carrying derived provenance — worse than reporting nothing, because a value
+// that claims to come from the checkpoint gives a reader no way to notice it is
+// wrong.
 func applyHeadDim(info *v1.ModelInfo, cfg *hfConfig) {
-	switch {
-	case cfg.HeadDim != nil:
+	if cfg.HeadDim != nil {
 		info.HeadDim = cfg.HeadDim
 		info.SetFieldSource(v1.ModelInfoFieldHeadDim, v1.ModelInfoSourceAuto)
-	case cfg.HiddenSize != nil && cfg.NumAttentionHeads != nil && *cfg.NumAttentionHeads > 0:
-		derived := *cfg.HiddenSize / *cfg.NumAttentionHeads
-		info.HeadDim = &derived
-		info.SetFieldSource(v1.ModelInfoFieldHeadDim, v1.ModelInfoSourceDerived)
-	default:
-		info.MarkFieldMissing(v1.ModelInfoFieldHeadDim)
+
+		return
 	}
+
+	if cfg.HiddenSize == nil || cfg.NumAttentionHeads == nil || *cfg.NumAttentionHeads <= 0 ||
+		*cfg.HiddenSize%*cfg.NumAttentionHeads != 0 {
+		info.MarkFieldMissing(v1.ModelInfoFieldHeadDim)
+
+		return
+	}
+
+	derived := *cfg.HiddenSize / *cfg.NumAttentionHeads
+	info.HeadDim = &derived
+	info.SetFieldSource(v1.ModelInfoFieldHeadDim, v1.ModelInfoSourceDerived)
 }
 
 // applyExperts decides dense vs. MoE. Reading the config at all settles is_moe,

--- a/internal/model_registry/modelmeta/modelmeta_test.go
+++ b/internal/model_registry/modelmeta/modelmeta_test.go
@@ -64,6 +64,19 @@ func TestParse_ConfigFields(t *testing.T) {
 			missing: []string{v1.ModelInfoFieldParameterCount},
 		},
 		{
+			// Truncating 3000/32 to 93 and stamping it "derived" would be worse
+			// than saying nothing: the value would look like it came from the
+			// checkpoint, and nothing downstream could tell it was wrong.
+			name:    "head_dim that does not divide evenly is missing, not truncated",
+			fixture: "uneven-head-dim",
+			assert: func(t *testing.T, info *v1.ModelInfo) {
+				assert.Equal(t, 32, deref(t, info.NumAttentionHeads))
+				assert.Nil(t, info.HeadDim)
+				assert.NotContains(t, info.FieldSources, v1.ModelInfoFieldHeadDim)
+			},
+			missing: []string{v1.ModelInfoFieldHeadDim, v1.ModelInfoFieldParameterCount},
+		},
+		{
 			name:    "mixture-of-experts checkpoint reports its expert counts",
 			fixture: "moe",
 			assert: func(t *testing.T, info *v1.ModelInfo) {

--- a/internal/model_registry/modelmeta/modelmeta_test.go
+++ b/internal/model_registry/modelmeta/modelmeta_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -15,136 +17,93 @@ import (
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
-func TestParse_ConfigFields(t *testing.T) {
-	tests := []struct {
-		name    string
-		fixture string
-		assert  func(t *testing.T, info *v1.ModelInfo)
-		// missing is the exact MissingFields set expected for a fixture holding
-		// no weight files at all, so every case also pins parameter_count.
-		missing []string
-	}{
-		{
-			name:    "dense checkpoint states every shape parameter",
-			fixture: "dense",
-			assert: func(t *testing.T, info *v1.ModelInfo) {
-				assert.Equal(t, "LlamaForCausalLM", info.Architecture)
-				assert.Equal(t, 32, deref(t, info.NumHiddenLayers))
-				assert.Equal(t, 32, deref(t, info.NumAttentionHeads))
-				assert.Equal(t, 32, deref(t, info.NumKeyValueHeads))
-				assert.Equal(t, 128, deref(t, info.HeadDim))
-				assert.Equal(t, 8192, deref(t, info.MaxPositionEmbeddings))
-				assert.Equal(t, "8192", info.ContextLength)
-				assert.Equal(t, "float16", info.ParameterDtype)
-				assert.False(t, derefBool(t, info.IsMoE))
-				// A dense checkpoint has no experts to count, so the expert fields
-				// are absent rather than missing.
-				assert.Nil(t, info.NumExperts)
-				assert.Nil(t, info.NumExpertsPerToken)
-				// head_dim was stated outright, so it is auto and not derived.
-				assert.Equal(t, v1.ModelInfoSourceAuto, info.FieldSources[v1.ModelInfoFieldHeadDim])
-				// An unquantized checkpoint answers the question by omission.
-				assert.Nil(t, info.QuantizationBits)
-				assert.NotContains(t, info.MissingFields, v1.ModelInfoFieldQuantizationBits)
-			},
-			missing: []string{v1.ModelInfoFieldParameterCount},
-		},
-		{
-			name:    "grouped-query checkpoint derives head_dim",
-			fixture: "gqa",
-			assert: func(t *testing.T, info *v1.ModelInfo) {
-				assert.Equal(t, 28, deref(t, info.NumAttentionHeads))
-				assert.Equal(t, 4, deref(t, info.NumKeyValueHeads))
-				assert.Less(t, deref(t, info.NumKeyValueHeads), deref(t, info.NumAttentionHeads))
-				// hidden_size 3584 / 28 heads.
-				assert.Equal(t, 128, deref(t, info.HeadDim))
-				assert.Equal(t, v1.ModelInfoSourceDerived, info.FieldSources[v1.ModelInfoFieldHeadDim])
-				assert.Equal(t, "131072", info.ContextLength)
-			},
-			missing: []string{v1.ModelInfoFieldParameterCount},
-		},
-		{
-			// Truncating 3000/32 to 93 and stamping it "derived" would be worse
-			// than saying nothing: the value would look like it came from the
-			// checkpoint, and nothing downstream could tell it was wrong.
-			name:    "head_dim that does not divide evenly is missing, not truncated",
-			fixture: "uneven-head-dim",
-			assert: func(t *testing.T, info *v1.ModelInfo) {
-				assert.Equal(t, 32, deref(t, info.NumAttentionHeads))
-				assert.Nil(t, info.HeadDim)
-				assert.NotContains(t, info.FieldSources, v1.ModelInfoFieldHeadDim)
-			},
-			missing: []string{v1.ModelInfoFieldHeadDim, v1.ModelInfoFieldParameterCount},
-		},
-		{
-			name:    "mixture-of-experts checkpoint reports its expert counts",
-			fixture: "moe",
-			assert: func(t *testing.T, info *v1.ModelInfo) {
-				assert.True(t, derefBool(t, info.IsMoE))
-				assert.Equal(t, 128, deref(t, info.NumExperts))
-				assert.Equal(t, 8, deref(t, info.NumExpertsPerToken))
-				assert.Equal(t, "Qwen3MoeForCausalLM", info.Architecture)
-			},
-			missing: []string{v1.ModelInfoFieldParameterCount},
-		},
-		{
-			name:    "gptq checkpoint states its weight width",
-			fixture: "quant-gptq",
-			assert: func(t *testing.T, info *v1.ModelInfo) {
-				assert.Equal(t, 4, deref(t, info.QuantizationBits))
-				assert.Equal(t, v1.ModelInfoSourceAuto, info.FieldSources[v1.ModelInfoFieldQuantizationBits])
-			},
-			missing: []string{v1.ModelInfoFieldParameterCount},
-		},
-		{
-			name:    "awq checkpoint states its weight width under w_bit",
-			fixture: "quant-awq",
-			assert: func(t *testing.T, info *v1.ModelInfo) {
-				assert.Equal(t, 4, deref(t, info.QuantizationBits))
-			},
-			missing: []string{v1.ModelInfoFieldParameterCount},
-		},
-		{
-			name:    "fp8 checkpoint implies its weight width from the method",
-			fixture: "quant-fp8",
-			assert: func(t *testing.T, info *v1.ModelInfo) {
-				assert.Equal(t, 8, deref(t, info.QuantizationBits))
-				assert.True(t, derefBool(t, info.IsMoE))
-			},
-			missing: []string{v1.ModelInfoFieldParameterCount},
-		},
-		{
-			name:    "sparse config leaves everything it does not state missing",
-			fixture: "sparse",
-			assert: func(t *testing.T, info *v1.ModelInfo) {
-				assert.Empty(t, info.Architecture)
-				assert.Equal(t, "float32", info.ParameterDtype)
-				// Reading the config settles dense vs. MoE even when nothing else
-				// is stated.
-				assert.False(t, derefBool(t, info.IsMoE))
-			},
-			missing: []string{
-				v1.ModelInfoFieldArchitecture,
-				v1.ModelInfoFieldNumHiddenLayers,
-				v1.ModelInfoFieldNumAttentionHeads,
-				v1.ModelInfoFieldNumKeyValueHeads,
-				v1.ModelInfoFieldHeadDim,
-				v1.ModelInfoFieldMaxPositionEmbeddings,
-				v1.ModelInfoFieldContextLength,
-				v1.ModelInfoFieldParameterCount,
-			},
-		},
+// goldenFileName holds the ModelInfo its sibling config.json is expected to
+// parse into, serialized the way the API serves it. The expectation lives beside
+// the input on purpose: adding a case is adding a directory, with no Go code to
+// touch and nothing to keep in step across two files.
+const goldenFileName = "expected.json"
+
+// updateGolden rewrites every golden from what Parse currently returns:
+//
+//	go test ./internal/model_registry/modelmeta -run TestParse_MatchesGolden -update
+//
+// It is off by default, and TestMain fails any run that sets it, so a rewrite
+// can never be mistaken for a passing verification — read the resulting diff,
+// then re-run without the flag to actually check it. Pass the package path
+// rather than ./...: the flag only exists in this package's test binary.
+var updateGolden = flag.Bool("update", false, "rewrite the modelmeta golden files from the current parser output")
+
+// TestMain turns a golden rewrite into a failure. Blessing the current output
+// and reporting success in the same run is what makes golden tests rot: on CI it
+// would be a green build asserting nothing, and locally it hides the moment an
+// expectation changed.
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	code := m.Run()
+
+	if *updateGolden && code == 0 {
+		fmt.Fprintf(os.Stderr, "-update rewrote the golden files; review the diff and re-run without -update to verify them\n")
+
+		code = 1
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			info := Parse(filepath.Join("testdata", tt.fixture))
+	os.Exit(code)
+}
 
-			tt.assert(t, info)
-			assert.ElementsMatch(t, tt.missing, info.MissingFields)
-			assertNoFieldBothSetAndMissing(t, info)
+// The values every fixture parses into, pinned whole. Comparing the serialized
+// form rather than field by field also pins what a client actually receives:
+// which keys are omitted, and the order the parser reports MissingFields in.
+func TestParse_MatchesGolden(t *testing.T) {
+	for _, fixture := range fixtureDirs(t) {
+		t.Run(fixture, func(t *testing.T) {
+			golden := filepath.Join("testdata", fixture, goldenFileName)
+			got := marshalGolden(t, Parse(filepath.Join("testdata", fixture)))
+
+			if *updateGolden {
+				require.NoError(t, os.WriteFile(golden, got, 0o600))
+
+				return
+			}
+
+			want, err := os.ReadFile(golden)
+			require.NoError(t, err, "fixture %q has no %s — generate it with -update", fixture, goldenFileName)
+
+			assert.Equal(t, string(want), string(got))
 		})
 	}
+}
+
+// fixtureDirs names every checkpoint fixture. Both sweeps walk the same set, so
+// a new directory is picked up by all of them at once.
+func fixtureDirs(t *testing.T) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir("testdata")
+	require.NoError(t, err)
+
+	var dirs []string
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			dirs = append(dirs, entry.Name())
+		}
+	}
+
+	require.NotEmpty(t, dirs)
+
+	return dirs
+}
+
+// marshalGolden renders info in the one canonical form goldens are stored in, so
+// that a byte comparison is a comparison of values and not of formatting.
+func marshalGolden(t *testing.T, info *v1.ModelInfo) []byte {
+	t.Helper()
+
+	raw, err := json.MarshalIndent(info, "", "  ")
+	require.NoError(t, err)
+
+	return append(raw, '\n')
 }
 
 // A checkpoint whose config.json cannot be read tells us nothing at all — the
@@ -316,13 +275,9 @@ var backingKeys = map[string][]string{
 // key it can come from. Nothing may arrive from the directory name, and none of
 // these fixtures ship weights, so the parameter count may never be sourced.
 func TestParse_FixturesOnlyPopulateWhatTheConfigStates(t *testing.T) {
-	entries, err := os.ReadDir("testdata")
-	require.NoError(t, err)
-	require.NotEmpty(t, entries)
-
-	for _, entry := range entries {
-		t.Run(entry.Name(), func(t *testing.T) {
-			dir := filepath.Join("testdata", entry.Name())
+	for _, fixture := range fixtureDirs(t) {
+		t.Run(fixture, func(t *testing.T) {
+			dir := filepath.Join("testdata", fixture)
 			info := Parse(dir)
 
 			assertNoFieldBothSetAndMissing(t, info)
@@ -380,20 +335,6 @@ func assertNoFieldBothSetAndMissing(t *testing.T, info *v1.ModelInfo) {
 	for i := 1; i < len(sorted); i++ {
 		assert.NotEqual(t, sorted[i-1], sorted[i], "field %q listed twice in missing_fields", sorted[i])
 	}
-}
-
-func deref(t *testing.T, v *int) int {
-	t.Helper()
-	require.NotNil(t, v)
-
-	return *v
-}
-
-func derefBool(t *testing.T, v *bool) bool {
-	t.Helper()
-	require.NotNil(t, v)
-
-	return *v
 }
 
 func u64le(v uint64) []byte {

--- a/internal/model_registry/modelmeta/modelmeta_test.go
+++ b/internal/model_registry/modelmeta/modelmeta_test.go
@@ -1,0 +1,428 @@
+package modelmeta
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+func TestParse_ConfigFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		assert  func(t *testing.T, info *v1.ModelInfo)
+		// missing is the exact MissingFields set expected for a fixture holding
+		// no weight files at all, so every case also pins parameter_count.
+		missing []string
+	}{
+		{
+			name:    "dense checkpoint states every shape parameter",
+			fixture: "dense",
+			assert: func(t *testing.T, info *v1.ModelInfo) {
+				assert.Equal(t, "LlamaForCausalLM", info.Architecture)
+				assert.Equal(t, 32, deref(t, info.NumHiddenLayers))
+				assert.Equal(t, 32, deref(t, info.NumAttentionHeads))
+				assert.Equal(t, 32, deref(t, info.NumKeyValueHeads))
+				assert.Equal(t, 128, deref(t, info.HeadDim))
+				assert.Equal(t, 8192, deref(t, info.MaxPositionEmbeddings))
+				assert.Equal(t, "8192", info.ContextLength)
+				assert.Equal(t, "float16", info.ParameterDtype)
+				assert.False(t, derefBool(t, info.IsMoE))
+				// A dense checkpoint has no experts to count, so the expert fields
+				// are absent rather than missing.
+				assert.Nil(t, info.NumExperts)
+				assert.Nil(t, info.NumExpertsPerToken)
+				// head_dim was stated outright, so it is auto and not derived.
+				assert.Equal(t, v1.ModelInfoSourceAuto, info.FieldSources[v1.ModelInfoFieldHeadDim])
+				// An unquantized checkpoint answers the question by omission.
+				assert.Nil(t, info.QuantizationBits)
+				assert.NotContains(t, info.MissingFields, v1.ModelInfoFieldQuantizationBits)
+			},
+			missing: []string{v1.ModelInfoFieldParameterCount},
+		},
+		{
+			name:    "grouped-query checkpoint derives head_dim",
+			fixture: "gqa",
+			assert: func(t *testing.T, info *v1.ModelInfo) {
+				assert.Equal(t, 28, deref(t, info.NumAttentionHeads))
+				assert.Equal(t, 4, deref(t, info.NumKeyValueHeads))
+				assert.Less(t, deref(t, info.NumKeyValueHeads), deref(t, info.NumAttentionHeads))
+				// hidden_size 3584 / 28 heads.
+				assert.Equal(t, 128, deref(t, info.HeadDim))
+				assert.Equal(t, v1.ModelInfoSourceDerived, info.FieldSources[v1.ModelInfoFieldHeadDim])
+				assert.Equal(t, "131072", info.ContextLength)
+			},
+			missing: []string{v1.ModelInfoFieldParameterCount},
+		},
+		{
+			name:    "mixture-of-experts checkpoint reports its expert counts",
+			fixture: "moe",
+			assert: func(t *testing.T, info *v1.ModelInfo) {
+				assert.True(t, derefBool(t, info.IsMoE))
+				assert.Equal(t, 128, deref(t, info.NumExperts))
+				assert.Equal(t, 8, deref(t, info.NumExpertsPerToken))
+				assert.Equal(t, "Qwen3MoeForCausalLM", info.Architecture)
+			},
+			missing: []string{v1.ModelInfoFieldParameterCount},
+		},
+		{
+			name:    "gptq checkpoint states its weight width",
+			fixture: "quant-gptq",
+			assert: func(t *testing.T, info *v1.ModelInfo) {
+				assert.Equal(t, 4, deref(t, info.QuantizationBits))
+				assert.Equal(t, v1.ModelInfoSourceAuto, info.FieldSources[v1.ModelInfoFieldQuantizationBits])
+			},
+			missing: []string{v1.ModelInfoFieldParameterCount},
+		},
+		{
+			name:    "awq checkpoint states its weight width under w_bit",
+			fixture: "quant-awq",
+			assert: func(t *testing.T, info *v1.ModelInfo) {
+				assert.Equal(t, 4, deref(t, info.QuantizationBits))
+			},
+			missing: []string{v1.ModelInfoFieldParameterCount},
+		},
+		{
+			name:    "fp8 checkpoint implies its weight width from the method",
+			fixture: "quant-fp8",
+			assert: func(t *testing.T, info *v1.ModelInfo) {
+				assert.Equal(t, 8, deref(t, info.QuantizationBits))
+				assert.True(t, derefBool(t, info.IsMoE))
+			},
+			missing: []string{v1.ModelInfoFieldParameterCount},
+		},
+		{
+			name:    "sparse config leaves everything it does not state missing",
+			fixture: "sparse",
+			assert: func(t *testing.T, info *v1.ModelInfo) {
+				assert.Empty(t, info.Architecture)
+				assert.Equal(t, "float32", info.ParameterDtype)
+				// Reading the config settles dense vs. MoE even when nothing else
+				// is stated.
+				assert.False(t, derefBool(t, info.IsMoE))
+			},
+			missing: []string{
+				v1.ModelInfoFieldArchitecture,
+				v1.ModelInfoFieldNumHiddenLayers,
+				v1.ModelInfoFieldNumAttentionHeads,
+				v1.ModelInfoFieldNumKeyValueHeads,
+				v1.ModelInfoFieldHeadDim,
+				v1.ModelInfoFieldMaxPositionEmbeddings,
+				v1.ModelInfoFieldContextLength,
+				v1.ModelInfoFieldParameterCount,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := Parse(filepath.Join("testdata", tt.fixture))
+
+			tt.assert(t, info)
+			assert.ElementsMatch(t, tt.missing, info.MissingFields)
+			assertNoFieldBothSetAndMissing(t, info)
+		})
+	}
+}
+
+// A checkpoint whose config.json cannot be read tells us nothing at all — the
+// parse is anchored on that file — and it must still not be an error, because a
+// model without one is a legitimate thing to list.
+func TestParse_UnreadableConfigYieldsNothingKnown(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{name: "malformed config.json", dir: filepath.Join("testdata", "invalid")},
+		{name: "no config.json", dir: t.TempDir()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := Parse(tt.dir)
+
+			assert.Equal(t, &v1.ModelInfo{MissingFields: allFields}, info)
+		})
+	}
+}
+
+// The parameter count is read out of the safetensors headers, so it has to come
+// out exact for both the single-file and the sharded layout.
+func TestParse_ParameterCountFromSafetensors(t *testing.T) {
+	const config = `{"architectures":["LlamaForCausalLM"],"hidden_size":8,"num_attention_heads":2,` +
+		`"num_hidden_layers":1,"num_key_value_heads":2,"max_position_embeddings":128,"torch_dtype":"float16"}`
+
+	tests := []struct {
+		name   string
+		shards map[string]map[string][]int64
+		want   string
+	}{
+		{
+			name: "single file",
+			shards: map[string]map[string][]int64{
+				"model.safetensors": {
+					"model.embed_tokens.weight": {128, 8},
+					"model.layers.0.mlp.weight": {8, 16},
+					"model.norm.weight":         {8},
+				},
+			},
+			// 1024 + 128 + 8
+			want: "1160",
+		},
+		{
+			name: "sharded",
+			shards: map[string]map[string][]int64{
+				"model-00001-of-00002.safetensors": {
+					"model.embed_tokens.weight": {128, 8},
+				},
+				"model-00002-of-00002.safetensors": {
+					"model.layers.0.mlp.weight": {8, 16},
+					"model.norm.weight":         {8},
+					// A scalar tensor has an empty shape and counts as one element.
+					"model.scale": {},
+				},
+			},
+			// 1024 + 128 + 8 + 1
+			want: "1161",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, ConfigFileName), []byte(config), 0o600))
+
+			for name, tensors := range tt.shards {
+				writeSafetensors(t, filepath.Join(dir, name), tensors)
+			}
+
+			info := Parse(dir)
+
+			assert.Equal(t, tt.want, info.ParameterCount)
+			assert.Equal(t, v1.ModelInfoSourceAuto, info.FieldSources[v1.ModelInfoFieldParameterCount])
+			assert.NotContains(t, info.MissingFields, v1.ModelInfoFieldParameterCount)
+		})
+	}
+}
+
+// Only safetensors is parsed. A pickle checkpoint or a GGUF file leaves the
+// count unknown rather than estimated from the file size.
+func TestParse_UnsupportedWeightFormatsLeaveCountMissing(t *testing.T) {
+	const config = `{"architectures":["LlamaForCausalLM"],"num_hidden_layers":1}`
+
+	for _, weights := range []string{"pytorch_model.bin", "model.gguf"} {
+		t.Run(weights, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, ConfigFileName), []byte(config), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, weights), bytes.Repeat([]byte{0x42}, 4096), 0o600))
+
+			info := Parse(dir)
+
+			assert.Empty(t, info.ParameterCount)
+			assert.Contains(t, info.MissingFields, v1.ModelInfoFieldParameterCount)
+		})
+	}
+}
+
+// A truncated or corrupt shard must not be reported as a partial count: a wrong
+// parameter count is worse than an absent one.
+func TestParse_CorruptSafetensorsLeavesCountMissing(t *testing.T) {
+	const config = `{"architectures":["LlamaForCausalLM"],"num_hidden_layers":1}`
+
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{name: "truncated length prefix", content: []byte{0x01, 0x02}},
+		{name: "header longer than file", content: append(u64le(1<<20), []byte(`{}`)...)},
+		{name: "header is not json", content: append(u64le(5), []byte(`nope!`)...)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, ConfigFileName), []byte(config), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "model.safetensors"), tt.content, 0o600))
+
+			info := Parse(dir)
+
+			assert.Empty(t, info.ParameterCount)
+			assert.Contains(t, info.MissingFields, v1.ModelInfoFieldParameterCount)
+		})
+	}
+}
+
+// The one inference this package must never make. A directory named after a
+// well-advertised model, holding nothing that states any of it, has to come back
+// empty — not filled in from the name.
+func TestParse_NeverInfersFromNames(t *testing.T) {
+	for _, name := range []string{
+		"Qwen3-235B-A22B-Instruct-2507-FP8",
+		"llama-3.1-70b-instruct-awq-int4",
+		"mixtral-8x7b-v0.1",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), name)
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+
+			assert.Equal(t, &v1.ModelInfo{MissingFields: allFields}, Parse(dir))
+		})
+	}
+}
+
+// backingKeys names the config.json keys a field may legitimately be read from.
+// A nil entry means the field does not come from a config key: is_moe is settled
+// by the config being readable at all, and parameter_count comes from the weight
+// files.
+var backingKeys = map[string][]string{
+	v1.ModelInfoFieldArchitecture:          {"architectures"},
+	v1.ModelInfoFieldNumHiddenLayers:       {"num_hidden_layers"},
+	v1.ModelInfoFieldNumAttentionHeads:     {"num_attention_heads"},
+	v1.ModelInfoFieldNumKeyValueHeads:      {"num_key_value_heads"},
+	v1.ModelInfoFieldHeadDim:               {"head_dim", "hidden_size"},
+	v1.ModelInfoFieldMaxPositionEmbeddings: {"max_position_embeddings"},
+	v1.ModelInfoFieldContextLength:         {"max_position_embeddings"},
+	v1.ModelInfoFieldParameterDtype:        {"torch_dtype"},
+	v1.ModelInfoFieldNumExperts:            {"num_local_experts", "num_experts"},
+	v1.ModelInfoFieldNumExpertsPerToken:    {"num_experts_per_tok"},
+	v1.ModelInfoFieldQuantizationBits:      {"quantization_config"},
+	v1.ModelInfoFieldIsMoE:                 nil,
+	v1.ModelInfoFieldParameterCount:        nil,
+}
+
+// Sweeping every fixture: a field may only carry a value if the config states a
+// key it can come from. Nothing may arrive from the directory name, and none of
+// these fixtures ship weights, so the parameter count may never be sourced.
+func TestParse_FixturesOnlyPopulateWhatTheConfigStates(t *testing.T) {
+	entries, err := os.ReadDir("testdata")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	for _, entry := range entries {
+		t.Run(entry.Name(), func(t *testing.T) {
+			dir := filepath.Join("testdata", entry.Name())
+			info := Parse(dir)
+
+			assertNoFieldBothSetAndMissing(t, info)
+
+			raw, err := os.ReadFile(filepath.Join(dir, ConfigFileName))
+			require.NoError(t, err)
+
+			var stated map[string]any
+			if err := json.Unmarshal(raw, &stated); err != nil {
+				// The malformed fixture: nothing may be established from it.
+				assert.Equal(t, &v1.ModelInfo{MissingFields: allFields}, info)
+
+				return
+			}
+
+			assert.NotContains(t, info.FieldSources, v1.ModelInfoFieldParameterCount,
+				"parameter_count was populated for a fixture that ships no weight files")
+
+			for field := range info.FieldSources {
+				keys, known := backingKeys[field]
+				require.True(t, known, "field %q is not in backingKeys — add it there too", field)
+
+				if keys == nil {
+					continue
+				}
+
+				assert.True(t, statesAnyKey(stated, keys),
+					"field %q was populated but the config states none of %v", field, keys)
+			}
+		})
+	}
+}
+
+func statesAnyKey(stated map[string]any, keys []string) bool {
+	for _, key := range keys {
+		if _, ok := stated[key]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func assertNoFieldBothSetAndMissing(t *testing.T, info *v1.ModelInfo) {
+	t.Helper()
+
+	for _, field := range info.MissingFields {
+		assert.NotContains(t, info.FieldSources, field,
+			"field %q is reported both missing and sourced", field)
+	}
+
+	sorted := append([]string(nil), info.MissingFields...)
+	sort.Strings(sorted)
+
+	for i := 1; i < len(sorted); i++ {
+		assert.NotEqual(t, sorted[i-1], sorted[i], "field %q listed twice in missing_fields", sorted[i])
+	}
+}
+
+func deref(t *testing.T, v *int) int {
+	t.Helper()
+	require.NotNil(t, v)
+
+	return *v
+}
+
+func derefBool(t *testing.T, v *bool) bool {
+	t.Helper()
+	require.NotNil(t, v)
+
+	return *v
+}
+
+func u64le(v uint64) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, v)
+
+	return buf
+}
+
+// writeSafetensors builds a container matching the published format: an 8-byte
+// little-endian header length, that many bytes of JSON header, then the data
+// region the offsets point into.
+func writeSafetensors(t *testing.T, path string, tensors map[string][]int64) {
+	t.Helper()
+
+	header := map[string]any{"__metadata__": map[string]string{"format": "pt"}}
+
+	var offset int64
+
+	for name, shape := range tensors {
+		elements := int64(1)
+		for _, dim := range shape {
+			elements *= dim
+		}
+
+		size := elements * 2 // every fixture tensor is F16
+
+		header[name] = map[string]any{
+			"dtype":        "F16",
+			"shape":        shape,
+			"data_offsets": []int64{offset, offset + size},
+		}
+		offset += size
+	}
+
+	raw, err := json.Marshal(header)
+	require.NoError(t, err)
+
+	buf := new(bytes.Buffer)
+	buf.Write(u64le(uint64(len(raw))))
+	buf.Write(raw)
+	buf.Write(make([]byte, offset))
+
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o600))
+}

--- a/internal/model_registry/modelmeta/safetensors.go
+++ b/internal/model_registry/modelmeta/safetensors.go
@@ -1,0 +1,149 @@
+package modelmeta
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// The safetensors container is specified as: 8 bytes of unsigned little-endian
+// header length N, N bytes of UTF-8 JSON header mapping tensor name to
+// {dtype, shape, data_offsets}, then the data. Summing prod(shape) over the
+// header therefore yields the exact element count without touching the weights.
+const (
+	safetensorsExt          = ".safetensors"
+	safetensorsHeaderLenLen = 8
+	// maxSafetensorsHeaderBytes rejects a corrupt or hostile length prefix before
+	// it turns into an allocation. Real headers are tens of kilobytes; a hundred
+	// megabytes is orders of magnitude past any of them.
+	maxSafetensorsHeaderBytes = 100 << 20
+	// metadataKey is the header's one reserved, non-tensor key.
+	metadataKey = "__metadata__"
+)
+
+// safetensorsTensor is the per-tensor header entry; only the shape matters here.
+type safetensorsTensor struct {
+	Shape []int64 `json:"shape"`
+}
+
+// sumSafetensorsElements returns the total element count across every
+// *.safetensors shard directly under dir, or nil when there are none.
+//
+// Shards are enumerated by globbing rather than by reading
+// model.safetensors.index.json: that index carries only a total byte size and a
+// tensor-to-shard map, no shapes, so it cannot produce a count. Deriving a count
+// from the byte size would mean assuming a dtype, which is an estimate.
+func sumSafetensorsElements(dir string) (*int64, error) {
+	shards, err := filepath.Glob(filepath.Join(dir, "*"+safetensorsExt))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(shards) == 0 {
+		return nil, nil
+	}
+
+	var total int64
+
+	for _, shard := range shards {
+		count, err := countShardElements(shard)
+		if err != nil {
+			return nil, errors.Wrapf(err, "read safetensors header of %s", filepath.Base(shard))
+		}
+
+		if count > math.MaxInt64-total {
+			return nil, errors.Errorf("element count of %s overflows", filepath.Base(shard))
+		}
+
+		total += count
+	}
+
+	return &total, nil
+}
+
+func countShardElements(path string) (int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return 0, err
+	}
+
+	var headerLen uint64
+	if err := binary.Read(file, binary.LittleEndian, &headerLen); err != nil {
+		return 0, errors.Wrap(err, "read header length")
+	}
+
+	if headerLen == 0 || headerLen > maxSafetensorsHeaderBytes {
+		return 0, errors.Errorf("implausible header length %d", headerLen)
+	}
+
+	if int64(headerLen) > stat.Size()-safetensorsHeaderLenLen {
+		return 0, errors.Errorf("header length %d exceeds file size %d", headerLen, stat.Size())
+	}
+
+	raw := make([]byte, headerLen)
+	if _, err := io.ReadFull(file, raw); err != nil {
+		return 0, errors.Wrap(err, "read header")
+	}
+
+	var header map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return 0, errors.Wrap(err, "parse header")
+	}
+
+	var total int64
+
+	for name, entry := range header {
+		if name == metadataKey {
+			continue
+		}
+
+		var tensor safetensorsTensor
+		if err := json.Unmarshal(entry, &tensor); err != nil {
+			return 0, errors.Wrapf(err, "parse tensor %q", name)
+		}
+
+		elements, err := elementCount(tensor.Shape)
+		if err != nil {
+			return 0, errors.Wrapf(err, "tensor %q", name)
+		}
+
+		if elements > math.MaxInt64-total {
+			return 0, errors.New("element count overflows")
+		}
+
+		total += elements
+	}
+
+	return total, nil
+}
+
+// elementCount is prod(shape). An empty shape is a scalar, so the product starts
+// at one.
+func elementCount(shape []int64) (int64, error) {
+	count := int64(1)
+
+	for _, dim := range shape {
+		if dim < 0 {
+			return 0, errors.Errorf("negative dimension %d", dim)
+		}
+
+		if dim != 0 && count > math.MaxInt64/dim {
+			return 0, errors.New("shape product overflows")
+		}
+
+		count *= dim
+	}
+
+	return count, nil
+}

--- a/internal/model_registry/modelmeta/testdata/dense/config.json
+++ b/internal/model_registry/modelmeta/testdata/dense/config.json
@@ -1,0 +1,12 @@
+{
+  "architectures": ["LlamaForCausalLM"],
+  "hidden_size": 4096,
+  "head_dim": 128,
+  "intermediate_size": 11008,
+  "max_position_embeddings": 8192,
+  "num_attention_heads": 32,
+  "num_hidden_layers": 32,
+  "num_key_value_heads": 32,
+  "torch_dtype": "float16",
+  "vocab_size": 32000
+}

--- a/internal/model_registry/modelmeta/testdata/dense/expected.json
+++ b/internal/model_registry/modelmeta/testdata/dense/expected.json
@@ -1,0 +1,25 @@
+{
+  "context_length": "8192",
+  "architecture": "LlamaForCausalLM",
+  "num_hidden_layers": 32,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 32,
+  "head_dim": 128,
+  "max_position_embeddings": 8192,
+  "is_moe": false,
+  "parameter_dtype": "float16",
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "auto",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/gqa/config.json
+++ b/internal/model_registry/modelmeta/testdata/gqa/config.json
@@ -1,0 +1,11 @@
+{
+  "architectures": ["Qwen2ForCausalLM"],
+  "hidden_size": 3584,
+  "intermediate_size": 18944,
+  "max_position_embeddings": 131072,
+  "num_attention_heads": 28,
+  "num_hidden_layers": 28,
+  "num_key_value_heads": 4,
+  "torch_dtype": "bfloat16",
+  "vocab_size": 152064
+}

--- a/internal/model_registry/modelmeta/testdata/gqa/expected.json
+++ b/internal/model_registry/modelmeta/testdata/gqa/expected.json
@@ -1,0 +1,25 @@
+{
+  "context_length": "131072",
+  "architecture": "Qwen2ForCausalLM",
+  "num_hidden_layers": 28,
+  "num_attention_heads": 28,
+  "num_key_value_heads": 4,
+  "head_dim": 128,
+  "max_position_embeddings": 131072,
+  "is_moe": false,
+  "parameter_dtype": "bfloat16",
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "derived",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/invalid/config.json
+++ b/internal/model_registry/modelmeta/testdata/invalid/config.json
@@ -1,0 +1,1 @@
+{ "architectures": ["LlamaForCausalLM",

--- a/internal/model_registry/modelmeta/testdata/invalid/expected.json
+++ b/internal/model_registry/modelmeta/testdata/invalid/expected.json
@@ -1,0 +1,17 @@
+{
+  "missing_fields": [
+    "architecture",
+    "num_hidden_layers",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "head_dim",
+    "max_position_embeddings",
+    "context_length",
+    "parameter_dtype",
+    "is_moe",
+    "num_experts",
+    "num_experts_per_token",
+    "quantization_bits",
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/moe/config.json
+++ b/internal/model_registry/modelmeta/testdata/moe/config.json
@@ -1,0 +1,13 @@
+{
+  "architectures": ["Qwen3MoeForCausalLM"],
+  "head_dim": 128,
+  "hidden_size": 4096,
+  "max_position_embeddings": 40960,
+  "num_attention_heads": 64,
+  "num_experts_per_tok": 8,
+  "num_hidden_layers": 94,
+  "num_key_value_heads": 4,
+  "num_local_experts": 128,
+  "torch_dtype": "bfloat16",
+  "vocab_size": 151936
+}

--- a/internal/model_registry/modelmeta/testdata/moe/expected.json
+++ b/internal/model_registry/modelmeta/testdata/moe/expected.json
@@ -1,0 +1,29 @@
+{
+  "context_length": "40960",
+  "architecture": "Qwen3MoeForCausalLM",
+  "num_hidden_layers": 94,
+  "num_attention_heads": 64,
+  "num_key_value_heads": 4,
+  "head_dim": 128,
+  "max_position_embeddings": 40960,
+  "is_moe": true,
+  "num_experts": 128,
+  "num_experts_per_token": 8,
+  "parameter_dtype": "bfloat16",
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "auto",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_experts": "auto",
+    "num_experts_per_token": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/quant-awq/config.json
+++ b/internal/model_registry/modelmeta/testdata/quant-awq/config.json
@@ -1,0 +1,15 @@
+{
+  "architectures": ["LlamaForCausalLM"],
+  "hidden_size": 4096,
+  "max_position_embeddings": 8192,
+  "num_attention_heads": 32,
+  "num_hidden_layers": 32,
+  "num_key_value_heads": 8,
+  "quantization_config": {
+    "q_group_size": 128,
+    "quant_method": "awq",
+    "version": "gemm",
+    "w_bit": 4
+  },
+  "torch_dtype": "float16"
+}

--- a/internal/model_registry/modelmeta/testdata/quant-awq/expected.json
+++ b/internal/model_registry/modelmeta/testdata/quant-awq/expected.json
@@ -1,0 +1,27 @@
+{
+  "context_length": "8192",
+  "architecture": "LlamaForCausalLM",
+  "num_hidden_layers": 32,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 8,
+  "head_dim": 128,
+  "max_position_embeddings": 8192,
+  "is_moe": false,
+  "parameter_dtype": "float16",
+  "quantization_bits": 4,
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "derived",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto",
+    "quantization_bits": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/quant-fp8/config.json
+++ b/internal/model_registry/modelmeta/testdata/quant-fp8/config.json
@@ -1,0 +1,16 @@
+{
+  "architectures": ["Qwen3MoeForCausalLM"],
+  "head_dim": 128,
+  "hidden_size": 4096,
+  "max_position_embeddings": 40960,
+  "num_attention_heads": 64,
+  "num_experts_per_tok": 8,
+  "num_hidden_layers": 94,
+  "num_key_value_heads": 4,
+  "num_local_experts": 128,
+  "quantization_config": {
+    "activation_scheme": "dynamic",
+    "quant_method": "fp8"
+  },
+  "torch_dtype": "bfloat16"
+}

--- a/internal/model_registry/modelmeta/testdata/quant-fp8/expected.json
+++ b/internal/model_registry/modelmeta/testdata/quant-fp8/expected.json
@@ -1,0 +1,31 @@
+{
+  "context_length": "40960",
+  "architecture": "Qwen3MoeForCausalLM",
+  "num_hidden_layers": 94,
+  "num_attention_heads": 64,
+  "num_key_value_heads": 4,
+  "head_dim": 128,
+  "max_position_embeddings": 40960,
+  "is_moe": true,
+  "num_experts": 128,
+  "num_experts_per_token": 8,
+  "parameter_dtype": "bfloat16",
+  "quantization_bits": 8,
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "auto",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_experts": "auto",
+    "num_experts_per_token": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto",
+    "quantization_bits": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/quant-gptq/config.json
+++ b/internal/model_registry/modelmeta/testdata/quant-gptq/config.json
@@ -1,0 +1,15 @@
+{
+  "architectures": ["Qwen2ForCausalLM"],
+  "hidden_size": 3584,
+  "max_position_embeddings": 32768,
+  "num_attention_heads": 28,
+  "num_hidden_layers": 28,
+  "num_key_value_heads": 4,
+  "quantization_config": {
+    "bits": 4,
+    "group_size": 128,
+    "quant_method": "gptq",
+    "sym": true
+  },
+  "torch_dtype": "float16"
+}

--- a/internal/model_registry/modelmeta/testdata/quant-gptq/expected.json
+++ b/internal/model_registry/modelmeta/testdata/quant-gptq/expected.json
@@ -1,0 +1,27 @@
+{
+  "context_length": "32768",
+  "architecture": "Qwen2ForCausalLM",
+  "num_hidden_layers": 28,
+  "num_attention_heads": 28,
+  "num_key_value_heads": 4,
+  "head_dim": 128,
+  "max_position_embeddings": 32768,
+  "is_moe": false,
+  "parameter_dtype": "float16",
+  "quantization_bits": 4,
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "derived",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto",
+    "quantization_bits": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/sparse/config.json
+++ b/internal/model_registry/modelmeta/testdata/sparse/config.json
@@ -1,0 +1,4 @@
+{
+  "model_type": "custom",
+  "torch_dtype": "float32"
+}

--- a/internal/model_registry/modelmeta/testdata/sparse/expected.json
+++ b/internal/model_registry/modelmeta/testdata/sparse/expected.json
@@ -1,0 +1,18 @@
+{
+  "is_moe": false,
+  "parameter_dtype": "float32",
+  "field_sources": {
+    "is_moe": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "architecture",
+    "num_hidden_layers",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "head_dim",
+    "max_position_embeddings",
+    "context_length",
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/uneven-head-dim/config.json
+++ b/internal/model_registry/modelmeta/testdata/uneven-head-dim/config.json
@@ -1,0 +1,9 @@
+{
+  "architectures": ["CustomForCausalLM"],
+  "hidden_size": 3000,
+  "max_position_embeddings": 8192,
+  "num_attention_heads": 32,
+  "num_hidden_layers": 24,
+  "num_key_value_heads": 8,
+  "torch_dtype": "bfloat16"
+}

--- a/internal/model_registry/modelmeta/testdata/uneven-head-dim/expected.json
+++ b/internal/model_registry/modelmeta/testdata/uneven-head-dim/expected.json
@@ -1,0 +1,24 @@
+{
+  "context_length": "8192",
+  "architecture": "CustomForCausalLM",
+  "num_hidden_layers": 24,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 8,
+  "max_position_embeddings": 8192,
+  "is_moe": false,
+  "parameter_dtype": "bfloat16",
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "head_dim",
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/stats.go
+++ b/internal/model_registry/stats.go
@@ -1,0 +1,105 @@
+package model_registry
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// DefaultStatsStaleAfter is how long a registry's counters stay usable before
+// they are worth recomputing.
+//
+// It has to be far above the reconcile interval. Measuring a registry means
+// walking its whole model tree, which for a networked store is minutes of I/O;
+// doing that on every reconcile would keep the control plane permanently busy
+// re-measuring something that changes only when someone pushes a model.
+const DefaultStatsStaleAfter = 10 * time.Minute
+
+// StatsAggregator turns an observation of a registry into the stats block on its
+// status. It keeps no state between calls: everything it needs comes in as an
+// argument, so the same instance is safe to share and trivial to test.
+type StatsAggregator struct {
+	// StaleAfter overrides DefaultStatsStaleAfter. Zero means the default.
+	StaleAfter time.Duration
+	// Now overrides the clock. Nil means time.Now.
+	Now func() time.Time
+}
+
+func (a StatsAggregator) now() time.Time {
+	if a.Now == nil {
+		return time.Now()
+	}
+
+	return a.Now()
+}
+
+func (a StatsAggregator) staleAfter() time.Duration {
+	if a.StaleAfter <= 0 {
+		return DefaultStatsStaleAfter
+	}
+
+	return a.StaleAfter
+}
+
+// NeedsRefresh reports whether previous is stale enough to be worth recomputing.
+// Counters that have never been computed, or whose timestamp is missing or
+// unparseable, always are.
+func (a StatsAggregator) NeedsRefresh(previous *v1.ModelRegistryStats) bool {
+	if previous == nil || previous.StatsUpdatedAt == "" {
+		return true
+	}
+
+	updatedAt, err := time.Parse(time.RFC3339Nano, previous.StatsUpdatedAt)
+	if err != nil {
+		return true
+	}
+
+	return a.now().Sub(updatedAt) >= a.staleAfter()
+}
+
+// Aggregate builds the stats block from a fresh observation.
+func (a StatsAggregator) Aggregate(observed *RegistryUsage) *v1.ModelRegistryStats {
+	if observed == nil {
+		return nil
+	}
+
+	return &v1.ModelRegistryStats{
+		ModelCount:     observed.ModelCount,
+		StorageBytes:   observed.StorageBytes,
+		StatsUpdatedAt: a.now().Format(time.RFC3339Nano),
+	}
+}
+
+// Refresh returns the stats to persist for a registry, measuring it only when
+// the cached counters have gone stale. The second result says whether it
+// measured; the caller needs it because a recomputation must be written back
+// even when the counters came out identical — the stored timestamp is what
+// stops the next reconcile from walking the tree again.
+//
+// It is best effort: a registry that cannot be measured — a public one, or a
+// private one whose storage is unreachable — keeps whatever it last reported.
+// Reporting zero instead would turn a transient mount failure into a registry
+// that looks empty.
+func (a StatsAggregator) Refresh(
+	registry ModelRegistry,
+	previous *v1.ModelRegistryStats,
+	name string,
+) (*v1.ModelRegistryStats, bool) {
+	if !a.NeedsRefresh(previous) {
+		return previous, false
+	}
+
+	observed, err := registry.CollectUsage()
+	if err != nil {
+		if !errors.Is(err, ErrNotSupported) {
+			klog.Warningf("failed to collect usage of model registry %s: %v", name, err)
+		}
+
+		return previous, false
+	}
+
+	return a.Aggregate(observed), true
+}

--- a/internal/model_registry/stats_test.go
+++ b/internal/model_registry/stats_test.go
@@ -1,0 +1,173 @@
+package model_registry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+	"github.com/neutree-ai/neutree/internal/model_registry/mocks"
+)
+
+func fixedClock(at string) func() time.Time {
+	return func() time.Time {
+		parsed, err := time.Parse(time.RFC3339Nano, at)
+		if err != nil {
+			panic(err)
+		}
+
+		return parsed
+	}
+}
+
+func TestStatsAggregator_NeedsRefresh(t *testing.T) {
+	aggregator := model_registry.StatsAggregator{
+		StaleAfter: time.Hour,
+		Now:        fixedClock("2026-01-01T12:00:00Z"),
+	}
+
+	tests := []struct {
+		name     string
+		previous *v1.ModelRegistryStats
+		want     bool
+	}{
+		{name: "never measured", previous: nil, want: true},
+		{
+			name:     "measured but undated",
+			previous: &v1.ModelRegistryStats{ModelCount: 1},
+			want:     true,
+		},
+		{
+			name:     "timestamp unparseable",
+			previous: &v1.ModelRegistryStats{StatsUpdatedAt: "yesterday"},
+			want:     true,
+		},
+		{
+			name:     "fresh",
+			previous: &v1.ModelRegistryStats{StatsUpdatedAt: "2026-01-01T11:30:00Z"},
+			want:     false,
+		},
+		{
+			name:     "exactly at the threshold",
+			previous: &v1.ModelRegistryStats{StatsUpdatedAt: "2026-01-01T11:00:00Z"},
+			want:     true,
+		},
+		{
+			name:     "stale",
+			previous: &v1.ModelRegistryStats{StatsUpdatedAt: "2026-01-01T09:00:00Z"},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, aggregator.NeedsRefresh(tt.previous))
+		})
+	}
+}
+
+// The whole point of the staleness check: the reconcile loop runs every ten
+// seconds and walking a networked model tree cannot.
+func TestStatsAggregator_ThrottlesTheWalk(t *testing.T) {
+	registry := &mocks.MockModelRegistry{}
+	registry.On("CollectUsage").Return(&model_registry.RegistryUsage{ModelCount: 2, StorageBytes: 4096}, nil)
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	aggregator := model_registry.StatsAggregator{
+		StaleAfter: time.Hour,
+		Now:        func() time.Time { return now },
+	}
+
+	var (
+		stats     *v1.ModelRegistryStats
+		refreshed bool
+		writes    int
+	)
+
+	// Twenty reconciles a minute apart: one measurement, at the first.
+	for i := 0; i < 20; i++ {
+		stats, refreshed = aggregator.Refresh(registry, stats, "default/models")
+		if refreshed {
+			writes++
+		}
+
+		now = now.Add(time.Minute)
+	}
+
+	registry.AssertNumberOfCalls(t, "CollectUsage", 1)
+	assert.Equal(t, 1, writes)
+	require.NotNil(t, stats)
+	assert.Equal(t, 2, stats.ModelCount)
+	assert.Equal(t, int64(4096), stats.StorageBytes)
+
+	// Once the counters age past the threshold it measures again.
+	now = now.Add(2 * time.Hour)
+	_, refreshed = aggregator.Refresh(registry, stats, "default/models")
+	assert.True(t, refreshed)
+	registry.AssertNumberOfCalls(t, "CollectUsage", 2)
+}
+
+// A registry that cannot be measured — unreachable, or public and not ours to
+// measure — must keep the counters it last reported. Zeroing them would present
+// a mount failure as an empty registry.
+func TestStatsAggregator_KeepsPreviousWhenMeasurementFails(t *testing.T) {
+	previous := &v1.ModelRegistryStats{
+		ModelCount:     7,
+		StorageBytes:   123456,
+		StatsUpdatedAt: "2026-01-01T00:00:00Z",
+	}
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "storage unreachable", err: errors.New("mount gone")},
+		{name: "registry does not support it", err: errors.Wrap(model_registry.ErrNotSupported, "public registry")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := &mocks.MockModelRegistry{}
+			registry.On("CollectUsage").Return(nil, tt.err)
+
+			aggregator := model_registry.StatsAggregator{Now: fixedClock("2026-06-01T00:00:00Z")}
+
+			stats, refreshed := aggregator.Refresh(registry, previous, "default/models")
+
+			assert.False(t, refreshed)
+			assert.Equal(t, previous, stats)
+		})
+	}
+}
+
+func TestStatsAggregator_Aggregate(t *testing.T) {
+	aggregator := model_registry.StatsAggregator{Now: fixedClock("2026-01-01T12:00:00Z")}
+
+	stats := aggregator.Aggregate(&model_registry.RegistryUsage{ModelCount: 3, StorageBytes: 900})
+	require.NotNil(t, stats)
+	assert.Equal(t, 3, stats.ModelCount)
+	assert.Equal(t, int64(900), stats.StorageBytes)
+	assert.Equal(t, "2026-01-01T12:00:00Z", stats.StatsUpdatedAt)
+
+	assert.Nil(t, aggregator.Aggregate(nil))
+}
+
+func TestStatsAggregator_DefaultStaleAfter(t *testing.T) {
+	aggregator := model_registry.StatsAggregator{Now: fixedClock("2026-01-01T12:00:00Z")}
+
+	justInside := &v1.ModelRegistryStats{
+		StatsUpdatedAt: fixedClock("2026-01-01T12:00:00Z")().
+			Add(-model_registry.DefaultStatsStaleAfter + time.Second).Format(time.RFC3339Nano),
+	}
+	assert.False(t, aggregator.NeedsRefresh(justInside))
+
+	justOutside := &v1.ModelRegistryStats{
+		StatsUpdatedAt: fixedClock("2026-01-01T12:00:00Z")().
+			Add(-model_registry.DefaultStatsStaleAfter - time.Second).Format(time.RFC3339Nano),
+	}
+	assert.True(t, aggregator.NeedsRefresh(justOutside))
+}

--- a/internal/routes/models/alias.go
+++ b/internal/routes/models/alias.go
@@ -1,0 +1,315 @@
+package models
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// uniqueViolationCode is the Postgres SQLSTATE for a unique constraint failure.
+// PostgREST puts it in the error body and the client hands that body back as the
+// error text, so this is how a lost race for an alias arrives.
+const uniqueViolationCode = "23505"
+
+// aliasConflictError is the body of a 409. It names the model already holding
+// the alias so the caller can say which one it is, rather than only that the
+// name is taken.
+type aliasConflictError struct {
+	Message  string        `json:"message"`
+	Conflict aliasConflict `json:"conflict"`
+}
+
+// aliasConflict identifies the object holding the alias. Physical name and
+// version, never the alias: the point is to tell the user which real model they
+// have collided with.
+type aliasConflict struct {
+	// Kind is "Model" for another model version, or "ModelName" when the alias
+	// would shadow a physical model name.
+	Kind    string `json:"kind"`
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+const (
+	aliasConflictKindModel     = "Model"
+	aliasConflictKindModelName = "ModelName"
+)
+
+// aliasKey identifies a model version inside one registry. Physical coordinates
+// are lowercase on disk, so they are compared lowercase.
+func aliasKey(modelName, version string) string {
+	return strings.ToLower(modelName) + ":" + strings.ToLower(version)
+}
+
+// listRegistryAliases returns every alias row recorded for a registry, keyed by
+// the model version it names. Rows whose model no longer exists are still in
+// here; callers that render aliases must look them up by a live model, which is
+// what keeps an orphan invisible.
+func listRegistryAliases(deps *Dependencies, registryID int) (map[string]v1.ModelAlias, error) {
+	rows, err := listAliasRows(deps, registryID)
+	if err != nil {
+		return nil, err
+	}
+
+	aliases := make(map[string]v1.ModelAlias, len(rows))
+	for _, row := range rows {
+		aliases[aliasKey(row.ModelName, row.ModelVersion)] = row
+	}
+
+	return aliases, nil
+}
+
+// attachAliases fills in the alias of every version in a listing. A registry
+// with no aliases costs one query and no further work.
+func attachAliases(models []v1.GeneralModel, aliases map[string]v1.ModelAlias) {
+	if len(aliases) == 0 {
+		return
+	}
+
+	for i := range models {
+		for j := range models[i].Versions {
+			row, ok := aliases[aliasKey(models[i].Name, models[i].Versions[j].Name)]
+			if ok {
+				models[i].Versions[j].Alias = row.Alias
+			}
+		}
+	}
+}
+
+// setModelAlias records alias for one model version, enforcing that it is unique
+// within the registry and does not shadow a physical model name.
+//
+// It returns the HTTP status to answer with and, for a conflict, the body
+// describing what the alias collided with.
+func setModelAlias(deps *Dependencies, handle *registryHandle,
+	modelName, version, alias string) (int, any, error) {
+	rows, err := listAliasRows(deps, handle.registry.ID)
+	if err != nil {
+		return http.StatusInternalServerError, nil, err
+	}
+
+	existing := findAliasRow(rows, func(row v1.ModelAlias) bool {
+		return aliasKey(row.ModelName, row.ModelVersion) == aliasKey(modelName, version)
+	})
+
+	if strings.TrimSpace(alias) == "" {
+		return clearModelAlias(deps, existing)
+	}
+
+	if err := v1.ValidateModelAlias(alias); err != nil {
+		return http.StatusBadRequest, gin.H{"message": err.Error()}, nil
+	}
+
+	normalized := v1.NormalizeModelAlias(alias)
+
+	page, err := handle.client.ListModels(model_registry.ListOption{})
+	if err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to list models: %w", err)
+	}
+
+	// An alias that equals a physical model name makes the model selector
+	// ambiguous: two different entries would offer the same name.
+	for _, model := range page.Models {
+		if v1.NormalizeModelAlias(model.Name) == normalized {
+			return http.StatusConflict, aliasConflictError{
+				Message:  fmt.Sprintf("alias %q is already the name of a model in this registry", alias),
+				Conflict: aliasConflict{Kind: aliasConflictKindModelName, Name: model.Name},
+			}, nil
+		}
+	}
+
+	status, body, err := resolveAliasHolder(deps, rows, page, normalized, existing, alias)
+	if err != nil || status != 0 {
+		return status, body, err
+	}
+
+	return writeModelAlias(deps, handle.registry, existing, modelName, version, alias, normalized)
+}
+
+// resolveAliasHolder deals with a row that already holds the normalized alias.
+// A live model keeps it; a row whose model has since disappeared does not
+// reserve anything and is cleared out of the way.
+//
+// A zero status means "nothing in the way, carry on".
+func resolveAliasHolder(deps *Dependencies, rows []v1.ModelAlias, page *model_registry.ModelPage,
+	normalized string, existing *v1.ModelAlias, alias string) (int, any, error) {
+	holder := findAliasRow(rows, func(row v1.ModelAlias) bool {
+		return row.AliasNormalized == normalized
+	})
+
+	if holder == nil || (existing != nil && holder.ID == existing.ID) {
+		return 0, nil, nil
+	}
+
+	if modelVersionExists(page, holder.ModelName, holder.ModelVersion) {
+		return http.StatusConflict, aliasConflictError{
+			Message: fmt.Sprintf("alias %q is already used in this registry", alias),
+			Conflict: aliasConflict{
+				Kind:    aliasConflictKindModel,
+				Name:    holder.ModelName,
+				Version: holder.ModelVersion,
+			},
+		}, nil
+	}
+
+	// The holder is an orphan: the alias table is a projection of the registry
+	// filesystem, and the filesystem no longer has that model.
+	if err := deps.Storage.DeleteModelAlias(strconv.Itoa(holder.ID)); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to release orphaned alias: %w", err)
+	}
+
+	return 0, nil, nil
+}
+
+func clearModelAlias(deps *Dependencies, existing *v1.ModelAlias) (int, any, error) {
+	if existing == nil {
+		return 0, nil, nil
+	}
+
+	if err := deps.Storage.DeleteModelAlias(strconv.Itoa(existing.ID)); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to delete model alias: %w", err)
+	}
+
+	return 0, nil, nil
+}
+
+func writeModelAlias(deps *Dependencies, registry *v1.ModelRegistry, existing *v1.ModelAlias,
+	modelName, version, alias, normalized string) (int, any, error) {
+	row := &v1.ModelAlias{
+		ModelRegistryID: registry.ID,
+		ModelName:       strings.ToLower(modelName),
+		ModelVersion:    strings.ToLower(version),
+		Alias:           alias,
+		AliasNormalized: normalized,
+	}
+
+	var err error
+	if existing != nil {
+		err = deps.Storage.UpdateModelAlias(strconv.Itoa(existing.ID), row)
+	} else {
+		err = deps.Storage.CreateModelAlias(row)
+	}
+
+	if err != nil {
+		// The checks above ran against a snapshot; the unique index is what
+		// actually arbitrates, and losing that race is a conflict, not a failure.
+		if isUniqueViolation(err) {
+			return http.StatusConflict, aliasConflictError{
+				Message:  fmt.Sprintf("alias %q is already used in this registry", alias),
+				Conflict: aliasHolderAfterRace(deps, registry.ID, normalized),
+			}, nil
+		}
+
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to save model alias: %w", err)
+	}
+
+	return 0, nil, nil
+}
+
+// aliasHolderAfterRace re-reads who ended up with the alias, so a caller that
+// lost the race is told which model it collided with rather than only that it
+// collided. A failed re-read still yields a conflict — just a less specific one.
+func aliasHolderAfterRace(deps *Dependencies, registryID int, normalized string) aliasConflict {
+	conflict := aliasConflict{Kind: aliasConflictKindModel}
+
+	rows, err := listAliasRows(deps, registryID)
+	if err != nil {
+		klog.Warningf("failed to identify the holder of alias %q: %v", normalized, err)
+
+		return conflict
+	}
+
+	holder := findAliasRow(rows, func(row v1.ModelAlias) bool {
+		return row.AliasNormalized == normalized
+	})
+	if holder == nil {
+		return conflict
+	}
+
+	conflict.Name = holder.ModelName
+	conflict.Version = holder.ModelVersion
+
+	return conflict
+}
+
+// deleteModelAliases drops the alias rows attached to a model version. It is
+// best effort by design: a model that is gone from disk must not stay
+// undeletable because its alias row would not go away, and a leftover row is
+// already invisible to every read path.
+func deleteModelAliases(deps *Dependencies, registryID int, modelName, version string) {
+	rows, err := listAliasRows(deps, registryID)
+	if err != nil {
+		klog.Warningf("failed to look up aliases of deleted model %s:%s: %v", modelName, version, err)
+
+		return
+	}
+
+	row := findAliasRow(rows, func(candidate v1.ModelAlias) bool {
+		return aliasKey(candidate.ModelName, candidate.ModelVersion) == aliasKey(modelName, version)
+	})
+	if row == nil {
+		return
+	}
+
+	if err := deps.Storage.DeleteModelAlias(strconv.Itoa(row.ID)); err != nil {
+		klog.Warningf("failed to delete alias of deleted model %s:%s: %v", modelName, version, err)
+	}
+}
+
+// listAliasRows reads every alias row recorded for one registry. Uniqueness and
+// orphan questions are both answered against the same snapshot, so they are
+// answered from one read.
+func listAliasRows(deps *Dependencies, registryID int) ([]v1.ModelAlias, error) {
+	rows, err := deps.Storage.ListModelAlias(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "model_registry_id",
+				Operator: "eq",
+				Value:    strconv.Itoa(registryID),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list model aliases: %w", err)
+	}
+
+	return rows, nil
+}
+
+func findAliasRow(rows []v1.ModelAlias, match func(v1.ModelAlias) bool) *v1.ModelAlias {
+	for i := range rows {
+		if match(rows[i]) {
+			return &rows[i]
+		}
+	}
+
+	return nil
+}
+
+func modelVersionExists(page *model_registry.ModelPage, modelName, version string) bool {
+	for _, model := range page.Models {
+		if !strings.EqualFold(model.Name, modelName) {
+			continue
+		}
+
+		for _, candidate := range model.Versions {
+			if strings.EqualFold(candidate.Name, version) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func isUniqueViolation(err error) bool {
+	return err != nil && strings.Contains(err.Error(), uniqueViolationCode)
+}

--- a/internal/routes/models/alias_test.go
+++ b/internal/routes/models/alias_test.go
@@ -161,7 +161,7 @@ func aliasTestRegistry(t *testing.T, models ...v1.GeneralModel) (
 	mockRegistry.On("Connect").Return(nil)
 	mockRegistry.On("Disconnect").Return(nil)
 	mockRegistry.On("ListModels", mock.Anything).
-		Return(&model_registry.ModelPage{Models: models, Total: len(models)}, nil).Maybe()
+		Return(&model_registry.ModelPage{Models: models, Total: model_registry.KnownTotal(len(models))}, nil).Maybe()
 
 	return &Dependencies{Storage: mockStorage}, mockStorage, mockRegistry, table
 }

--- a/internal/routes/models/alias_test.go
+++ b/internal/routes/models/alias_test.go
@@ -1,0 +1,475 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+	model_registry_mocks "github.com/neutree-ai/neutree/internal/model_registry/mocks"
+	"github.com/neutree-ai/neutree/pkg/storage"
+	"github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+// aliasTable is an in-memory stand-in for api.model_aliases, unique index and
+// all. The uniqueness rule is the database's to enforce, so a test of the
+// handler's behaviour under contention is only meaningful against something that
+// actually enforces it.
+type aliasTable struct {
+	mu     sync.Mutex
+	nextID int
+	rows   []v1.ModelAlias
+}
+
+func (a *aliasTable) list(_ storage.ListOption) []v1.ModelAlias {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return append([]v1.ModelAlias(nil), a.rows...)
+}
+
+func (a *aliasTable) create(row *v1.ModelAlias) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for _, existing := range a.rows {
+		if existing.ModelRegistryID == row.ModelRegistryID && existing.AliasNormalized == row.AliasNormalized {
+			return errors.New(`{"code":"23505","message":"duplicate key value violates unique constraint"}`)
+		}
+	}
+
+	a.nextID++
+	stored := *row
+	stored.ID = a.nextID
+	a.rows = append(a.rows, stored)
+
+	return nil
+}
+
+func (a *aliasTable) update(id string, row *v1.ModelAlias) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for i := range a.rows {
+		if a.rows[i].ModelRegistryID == row.ModelRegistryID &&
+			a.rows[i].AliasNormalized == row.AliasNormalized &&
+			idOf(a.rows[i]) != id {
+			return errors.New(`{"code":"23505","message":"duplicate key value violates unique constraint"}`)
+		}
+	}
+
+	for i := range a.rows {
+		if idOf(a.rows[i]) == id {
+			stored := *row
+			stored.ID = a.rows[i].ID
+			a.rows[i] = stored
+
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func (a *aliasTable) delete(id string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	remaining := a.rows[:0]
+
+	for _, row := range a.rows {
+		if idOf(row) != id {
+			remaining = append(remaining, row)
+		}
+	}
+
+	a.rows = remaining
+
+	return nil
+}
+
+func idOf(row v1.ModelAlias) string {
+	return strconv.Itoa(row.ID)
+}
+
+// bindAliasTable wires the in-memory table into a mock storage.
+func bindAliasTable(t *testing.T, mockStorage *mocks.MockStorage) *aliasTable {
+	t.Helper()
+
+	table := &aliasTable{}
+
+	// Which of these a given test exercises depends on what the handler decides
+	// to do, so none of them is required to be called.
+	mockStorage.On("ListModelAlias", mock.Anything).
+		Return(table.list, func(storage.ListOption) error { return nil }).Maybe()
+	mockStorage.On("CreateModelAlias", mock.Anything).Return(table.create).Maybe()
+	mockStorage.On("UpdateModelAlias", mock.Anything, mock.Anything).Return(table.update).Maybe()
+	mockStorage.On("DeleteModelAlias", mock.Anything).Return(table.delete).Maybe()
+
+	return table
+}
+
+func newPatchContext(t *testing.T, workspace, registryName, modelName, version, body string) (
+	*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	url := "/api/v1/workspaces/" + workspace + "/model_registries/" + registryName + "/models/" + modelName
+	if version != "" {
+		url += "?version=" + version
+	}
+
+	c.Request = httptest.NewRequest(http.MethodPatch, url, strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = []gin.Param{
+		{Key: "workspace", Value: workspace},
+		{Key: "registry", Value: registryName},
+		{Key: "model", Value: modelName},
+	}
+
+	return c, w
+}
+
+// aliasTestRegistry stands up a private registry holding the given models, and
+// returns dependencies wired to an alias table that enforces uniqueness.
+func aliasTestRegistry(t *testing.T, models ...v1.GeneralModel) (
+	*Dependencies, *mocks.MockStorage, *model_registry_mocks.MockModelRegistry, *aliasTable) {
+	t.Helper()
+
+	mockStorage, mockRegistry := setupMocks(t)
+	table := bindAliasTable(t, mockStorage)
+
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("ListModels", mock.Anything).
+		Return(&model_registry.ModelPage{Models: models, Total: len(models)}, nil).Maybe()
+
+	return &Dependencies{Storage: mockStorage}, mockStorage, mockRegistry, table
+}
+
+func storedModel(name string, versions ...string) v1.GeneralModel {
+	model := v1.GeneralModel{Name: name}
+	for _, version := range versions {
+		model.Versions = append(model.Versions, v1.ModelVersion{Name: version})
+	}
+
+	return model
+}
+
+func TestPatchModel_SetsAlias(t *testing.T) {
+	deps, mockStorage, mockRegistry, table := aliasTestRegistry(t, storedModel("qwen3", "v1"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1", `{"alias":"Qwen3 Chat"}`)
+	patchModel(deps)(c)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	rows := table.list(storage.ListOption{})
+	require.Len(t, rows, 1)
+	// The verbatim spelling is the display name; the normalized form is only for
+	// comparison.
+	assert.Equal(t, "Qwen3 Chat", rows[0].Alias)
+	assert.Equal(t, "qwen3 chat", rows[0].AliasNormalized)
+	assert.Equal(t, 7, rows[0].ModelRegistryID)
+	assert.Equal(t, "qwen3", rows[0].ModelName)
+	assert.Equal(t, "v1", rows[0].ModelVersion)
+
+	var response v1.ModelVersion
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "Qwen3 Chat", response.Alias)
+
+	// An alias is a label in the database and nothing else. The registry is not
+	// written to at all, so the physical name, version and stored path a running
+	// deployment resolves against cannot have moved.
+	mockRegistry.AssertNotCalled(t, "SetManualModelInfo", mock.Anything, mock.Anything, mock.Anything)
+	mockRegistry.AssertNotCalled(t, "ImportModel", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockRegistry.AssertNotCalled(t, "DeleteModel", mock.Anything, mock.Anything)
+	mockRegistry.AssertNotCalled(t, "GetModelPath", mock.Anything, mock.Anything)
+
+	mockStorage.AssertExpectations(t)
+}
+
+// Uniqueness is per registry and spans versions: the alias is what a user picks
+// a model by, so two versions offering the same one is exactly the ambiguity the
+// rule exists to prevent.
+func TestPatchModel_AliasConflictsAcrossVersions(t *testing.T) {
+	deps, _, mockRegistry, _ := aliasTestRegistry(t, storedModel("qwen3", "v1", "v2"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+	mockRegistry.On("GetModelDetail", "qwen3", "v2").Return(&v1.ModelVersion{Name: "v2"}, nil)
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1", `{"alias":"Chat"}`)
+	patchModel(deps)(c)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Same alias, different version, and normalization must catch the variants.
+	for _, alias := range []string{"Chat", "chat", "  CHAT  "} {
+		c, w = newPatchContext(t, "default", "test-registry", "qwen3", "v2", `{"alias":"`+alias+`"}`)
+		patchModel(deps)(c)
+
+		require.Equal(t, http.StatusConflict, w.Code, "alias %q should have collided", alias)
+
+		var body aliasConflictError
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, aliasConflictKindModel, body.Conflict.Kind)
+		assert.Equal(t, "qwen3", body.Conflict.Name)
+		assert.Equal(t, "v1", body.Conflict.Version)
+	}
+}
+
+func TestPatchModel_SameAliasInAnotherRegistryIsAllowed(t *testing.T) {
+	deps, mockStorage, mockRegistry, table := aliasTestRegistry(t, storedModel("qwen3", "v1"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+
+	// A row belonging to a different registry holds the same normalized alias.
+	require.NoError(t, table.create(&v1.ModelAlias{
+		ModelRegistryID: 99,
+		ModelName:       "other",
+		ModelVersion:    "v1",
+		Alias:           "Chat",
+		AliasNormalized: "chat",
+	}))
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1", `{"alias":"Chat"}`)
+	patchModel(deps)(c)
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	mockStorage.AssertExpectations(t)
+}
+
+// An alias that shadows a physical model name would make the model selector
+// offer the same name twice.
+func TestPatchModel_AliasCannotShadowAModelName(t *testing.T) {
+	deps, _, mockRegistry, _ := aliasTestRegistry(t,
+		storedModel("qwen3", "v1"), storedModel("llama", "v1"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1", `{"alias":"Llama"}`)
+	patchModel(deps)(c)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+
+	var body aliasConflictError
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, aliasConflictKindModelName, body.Conflict.Kind)
+	assert.Equal(t, "llama", body.Conflict.Name)
+}
+
+// The alias table is a projection of the registry filesystem. A row whose model
+// has since been removed out of band reserves nothing.
+func TestPatchModel_OrphanedAliasDoesNotReserveTheName(t *testing.T) {
+	deps, _, mockRegistry, table := aliasTestRegistry(t, storedModel("qwen3", "v1"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+
+	require.NoError(t, table.create(&v1.ModelAlias{
+		ModelRegistryID: 7,
+		ModelName:       "deleted-behind-our-back",
+		ModelVersion:    "v9",
+		Alias:           "Chat",
+		AliasNormalized: "chat",
+	}))
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1", `{"alias":"Chat"}`)
+	patchModel(deps)(c)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	rows := table.list(storage.ListOption{})
+	require.Len(t, rows, 1)
+	assert.Equal(t, "qwen3", rows[0].ModelName)
+}
+
+func TestPatchModel_ClearsAlias(t *testing.T) {
+	deps, _, mockRegistry, table := aliasTestRegistry(t, storedModel("qwen3", "v1"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1", `{"alias":"Chat"}`)
+	patchModel(deps)(c)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	c, w = newPatchContext(t, "default", "test-registry", "qwen3", "v1", `{"alias":""}`)
+	patchModel(deps)(c)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Empty(t, table.list(storage.ListOption{}))
+}
+
+func TestPatchModel_RejectsUnusableAlias(t *testing.T) {
+	deps, _, mockRegistry, _ := aliasTestRegistry(t, storedModel("qwen3", "v1"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1",
+		`{"alias":"`+strings.Repeat("x", 129)+`"}`)
+	patchModel(deps)(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// Two writers racing for the same alias: the checks upstream both pass against
+// their own snapshot, and the unique index is what settles it. Exactly one must
+// win and the loser must be told it is a conflict, not a server error.
+func TestPatchModel_ConcurrentAliasWritesLeaveExactlyOneWinner(t *testing.T) {
+	deps, _, mockRegistry, table := aliasTestRegistry(t, storedModel("qwen3", "v1", "v2"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+	mockRegistry.On("GetModelDetail", "qwen3", "v2").Return(&v1.ModelVersion{Name: "v2"}, nil)
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		results []int
+	)
+
+	// Both requests are built up front: gin.SetMode writes package state, which is
+	// the test harness racing with itself rather than anything under test.
+	requests := make([]*gin.Context, 0, 2)
+	recorders := make([]*httptest.ResponseRecorder, 0, 2)
+
+	for _, version := range []string{"v1", "v2"} {
+		c, w := newPatchContext(t, "default", "test-registry", "qwen3", version, `{"alias":"Chat"}`)
+		requests = append(requests, c)
+		recorders = append(recorders, w)
+	}
+
+	// A gate so both requests start together and can interleave.
+	start := make(chan struct{})
+
+	for i := range requests {
+		wg.Add(1)
+
+		go func(c *gin.Context, w *httptest.ResponseRecorder) {
+			defer wg.Done()
+
+			<-start
+			patchModel(deps)(c)
+
+			mu.Lock()
+			results = append(results, w.Code)
+			mu.Unlock()
+		}(requests[i], recorders[i])
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.ElementsMatch(t, []int{http.StatusOK, http.StatusConflict}, results)
+
+	rows := table.list(storage.ListOption{})
+	assert.Len(t, rows, 1)
+	assert.Equal(t, "chat", rows[0].AliasNormalized)
+}
+
+// The loser of a race is told which model took the alias, not merely that
+// something did.
+func TestPatchModel_LostRaceNamesTheHolder(t *testing.T) {
+	deps, mockStorage, mockRegistry, table := aliasTestRegistry(t, storedModel("qwen3", "v1", "v2"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+
+	// Slip a row in between the pre-checks and the write, the way a concurrent
+	// request would.
+	mockStorage.ExpectedCalls = filterOutCall(mockStorage.ExpectedCalls, "CreateModelAlias")
+	mockStorage.On("CreateModelAlias", mock.Anything).Return(func(row *v1.ModelAlias) error {
+		_ = table.create(&v1.ModelAlias{
+			ModelRegistryID: row.ModelRegistryID,
+			ModelName:       "qwen3",
+			ModelVersion:    "v2",
+			Alias:           row.Alias,
+			AliasNormalized: row.AliasNormalized,
+		})
+
+		return table.create(row)
+	})
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1", `{"alias":"Chat"}`)
+	patchModel(deps)(c)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+
+	var body aliasConflictError
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, aliasConflictKindModel, body.Conflict.Kind)
+	assert.Equal(t, "qwen3", body.Conflict.Name)
+	assert.Equal(t, "v2", body.Conflict.Version)
+}
+
+func filterOutCall(calls []*mock.Call, method string) []*mock.Call {
+	remaining := calls[:0]
+
+	for _, call := range calls {
+		if call.Method != method {
+			remaining = append(remaining, call)
+		}
+	}
+
+	return remaining
+}
+
+// A public registry has nothing to write to, and says so plainly rather than
+// failing somewhere deeper.
+func TestPatchModel_UnsupportedOnPublicRegistry(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       8,
+		Metadata: &v1.Metadata{Name: "hf", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
+	}}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("GetModelDetail", "qwen3", v1.LatestVersion).
+		Return(nil, errors.Wrap(model_registry.ErrNotSupported, "hugging face"))
+
+	c, w := newPatchContext(t, "default", "hf", "qwen3", "", `{"alias":"Chat"}`)
+	patchModel(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "does not support")
+}
+
+// Hand-filled values are recorded as the user's, whatever the request claimed
+// about their provenance.
+func TestPatchModel_RecordsManualModelInfo(t *testing.T) {
+	deps, _, mockRegistry, _ := aliasTestRegistry(t, storedModel("qwen3", "v1"))
+	mockRegistry.On("GetModelDetail", "qwen3", "v1").Return(&v1.ModelVersion{Name: "v1"}, nil)
+
+	var recorded *v1.ModelInfo
+
+	mockRegistry.On("SetManualModelInfo", "qwen3", "v1", mock.Anything).Run(func(args mock.Arguments) {
+		recorded = args.Get(2).(*v1.ModelInfo) //nolint:errcheck
+	}).Return(nil)
+
+	c, w := newPatchContext(t, "default", "test-registry", "qwen3", "v1",
+		`{"info":{"quantization":"fp8","num_hidden_layers":36,"field_sources":{"quantization":"auto"}}}`)
+	patchModel(deps)(c)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotNil(t, recorded)
+	assert.Equal(t, "fp8", recorded.Quantization)
+	require.NotNil(t, recorded.NumHiddenLayers)
+	assert.Equal(t, 36, *recorded.NumHiddenLayers)
+	assert.Equal(t, v1.ModelInfoSourceManual, recorded.FieldSources[v1.ModelInfoFieldQuantization])
+	assert.Equal(t, v1.ModelInfoSourceManual, recorded.FieldSources[v1.ModelInfoFieldNumHiddenLayers])
+}
+
+func TestIsUniqueViolation(t *testing.T) {
+	assert.True(t, isUniqueViolation(errors.New(`{"code":"23505","message":"duplicate key"}`)))
+	assert.False(t, isUniqueViolation(errors.New(`{"code":"42501","message":"permission denied"}`)))
+	assert.False(t, isUniqueViolation(nil))
+}

--- a/internal/routes/models/e2e_disk_test.go
+++ b/internal/routes/models/e2e_disk_test.go
@@ -1,0 +1,190 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+// diskRegistryDeps points a real file-based registry at a temporary BentoML
+// store. Nothing between the checkpoint on disk and the HTTP response is
+// stubbed, so these tests pin the whole read path rather than the handler alone.
+func diskRegistryDeps(t *testing.T, homePath string) *Dependencies {
+	t.Helper()
+
+	mockStorage := &mocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "file://" + homePath,
+		},
+	}}, nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil).Maybe()
+
+	return &Dependencies{Storage: mockStorage}
+}
+
+// writeCheckpoint lays down a model version with an optional config.json.
+func writeCheckpoint(t *testing.T, homePath, name, version, config string, labels map[string]string) {
+	t.Helper()
+
+	dir := filepath.Join(homePath, "models", name, version)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	descriptor := fmt.Sprintf("name: %s\nversion: %s\nmodule: transformers\nsize: 1.0 kB\n"+
+		"creation_time: 2026-01-01T00:00:00.000000+00:00\n", name, version)
+	for key, value := range labels {
+		descriptor += fmt.Sprintf("labels:\n  %s: %q\n", key, value)
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "model.yaml"), []byte(descriptor), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(homePath, "models", name, v1.LatestVersion),
+		[]byte(version), 0o600))
+
+	if config != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(config), 0o600))
+	}
+}
+
+func getModelFromDisk(t *testing.T, homePath, modelName string) *v1.ModelVersion {
+	t.Helper()
+
+	c, w := createMockContext("default", "test-registry", modelName, "")
+	getModel(diskRegistryDeps(t, homePath))(c)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var response v1.ModelVersion
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+
+	return &response
+}
+
+func TestGetModel_DenseCheckpointReachesTheResponse(t *testing.T) {
+	home := t.TempDir()
+	writeCheckpoint(t, home, "qwen3", "v1", `{
+		"architectures": ["Qwen3ForCausalLM"],
+		"hidden_size": 4096,
+		"num_attention_heads": 32,
+		"num_hidden_layers": 36,
+		"num_key_value_heads": 8,
+		"max_position_embeddings": 40960,
+		"torch_dtype": "bfloat16"
+	}`, nil)
+
+	response := getModelFromDisk(t, home, "qwen3")
+
+	require.NotNil(t, response.Info)
+	assert.Equal(t, "Qwen3ForCausalLM", response.Info.Architecture)
+	assert.Equal(t, "40960", response.Info.ContextLength)
+	require.NotNil(t, response.Info.NumKeyValueHeads)
+	assert.Equal(t, 8, *response.Info.NumKeyValueHeads)
+	require.NotNil(t, response.Info.IsMoE)
+	assert.False(t, *response.Info.IsMoE)
+	assert.Equal(t, v1.ModelInfoSourceDerived, response.Info.FieldSources[v1.ModelInfoFieldHeadDim])
+	assert.Contains(t, response.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+}
+
+func TestGetModel_MoECheckpointReachesTheResponse(t *testing.T) {
+	home := t.TempDir()
+	writeCheckpoint(t, home, "qwen3-moe", "v1", `{
+		"architectures": ["Qwen3MoeForCausalLM"],
+		"head_dim": 128,
+		"hidden_size": 4096,
+		"num_attention_heads": 64,
+		"num_hidden_layers": 94,
+		"num_key_value_heads": 4,
+		"num_local_experts": 128,
+		"num_experts_per_tok": 8,
+		"max_position_embeddings": 40960,
+		"torch_dtype": "bfloat16"
+	}`, nil)
+
+	response := getModelFromDisk(t, home, "qwen3-moe")
+
+	require.NotNil(t, response.Info)
+	require.NotNil(t, response.Info.IsMoE)
+	assert.True(t, *response.Info.IsMoE)
+	require.NotNil(t, response.Info.NumExperts)
+	assert.Equal(t, 128, *response.Info.NumExperts)
+	require.NotNil(t, response.Info.NumExpertsPerToken)
+	assert.Equal(t, 8, *response.Info.NumExpertsPerToken)
+	assert.Equal(t, v1.ModelInfoSourceAuto, response.Info.FieldSources[v1.ModelInfoFieldHeadDim])
+}
+
+// A model with no checkpoint config is still a model. The response says so
+// explicitly rather than omitting the block or filling it from the name.
+func TestGetModel_CheckpointWithoutConfigReportsEverythingMissing(t *testing.T) {
+	home := t.TempDir()
+	writeCheckpoint(t, home, "qwen3-235b-a22b-fp8", "v1", "", nil)
+
+	response := getModelFromDisk(t, home, "qwen3-235b-a22b-fp8")
+
+	require.NotNil(t, response.Info)
+	assert.Empty(t, response.Info.Architecture)
+	assert.Empty(t, response.Info.ParameterCount)
+	assert.Empty(t, response.Info.FieldSources)
+	assert.Contains(t, response.Info.MissingFields, v1.ModelInfoFieldArchitecture)
+	assert.Contains(t, response.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+	assert.Contains(t, response.Info.MissingFields, v1.ModelInfoFieldQuantizationBits)
+}
+
+// The labels written into model.yaml were decoded into a struct that did not
+// carry them, so nothing could read them back. This is the end of that path.
+func TestGetModel_LabelsWrittenToModelYAMLAreReadableOverTheAPI(t *testing.T) {
+	home := t.TempDir()
+	writeCheckpoint(t, home, "qwen3", "v1", "", map[string]string{"team": "search"})
+
+	response := getModelFromDisk(t, home, "qwen3")
+
+	assert.Equal(t, map[string]string{"team": "search"}, response.Labels)
+}
+
+// Two identical listings of the same store must come back in the same order,
+// through the HTTP layer as much as below it.
+func TestListModels_ResponseOrderIsStableFromDisk(t *testing.T) {
+	home := t.TempDir()
+	for _, name := range []string{"zeta", "alpha", "mu", "beta", "omega", "gamma"} {
+		writeCheckpoint(t, home, name, "v1", "", nil)
+	}
+
+	var first []string
+
+	for i := 0; i < 10; i++ {
+		c, w := newListContext(t, "")
+		listModels(diskRegistryDeps(t, home))(c)
+
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var body []v1.GeneralModel
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+		names := make([]string, 0, len(body))
+		for _, model := range body {
+			names = append(names, model.Name)
+		}
+
+		if first == nil {
+			first = names
+			assert.Equal(t, "0-5/6", w.Header().Get("Content-Range"))
+
+			continue
+		}
+
+		require.Equal(t, first, names, "listing order changed between identical requests")
+	}
+
+	assert.Equal(t, []string{"alpha", "beta", "gamma", "mu", "omega", "zeta"}, first)
+}

--- a/internal/routes/models/list_test.go
+++ b/internal/routes/models/list_test.go
@@ -1,0 +1,166 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+func newListContext(t *testing.T, rawQuery string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	url := "/api/v1/workspaces/default/model_registries/test-registry/models"
+	if rawQuery != "" {
+		url += "?" + rawQuery
+	}
+
+	c.Request = httptest.NewRequest(http.MethodGet, url, nil)
+	c.Params = []gin.Param{
+		{Key: "workspace", Value: "default"},
+		{Key: "registry", Value: "test-registry"},
+	}
+
+	return c, w
+}
+
+// The total travels in a header and the body stays a bare array: two existing
+// callers consume the response as an array, and an envelope would break them
+// across repositories for the sake of one number.
+func TestListModels_ReportsTotalInContentRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		returned   []v1.GeneralModel
+		total      int
+		wantOffset int
+		wantLimit  int
+		wantHeader string
+	}{
+		{
+			name:       "whole listing",
+			returned:   []v1.GeneralModel{storedModel("a", "v1"), storedModel("b", "v1")},
+			total:      2,
+			wantHeader: "0-1/2",
+		},
+		{
+			name:       "second page",
+			query:      "offset=2&limit=2",
+			returned:   []v1.GeneralModel{storedModel("c", "v1")},
+			total:      5,
+			wantOffset: 2,
+			wantLimit:  2,
+			wantHeader: "2-2/5",
+		},
+		{
+			name:       "offset past the end",
+			query:      "offset=50",
+			returned:   []v1.GeneralModel{},
+			total:      5,
+			wantOffset: 50,
+			wantHeader: "*/5",
+		},
+		{
+			name:       "empty registry",
+			returned:   []v1.GeneralModel{},
+			total:      0,
+			wantHeader: "*/0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage, mockRegistry := setupMocks(t)
+			mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+				ID:       7,
+				Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+				Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+			}}, nil)
+			mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
+			mockRegistry.On("Connect").Return(nil)
+			mockRegistry.On("Disconnect").Return(nil)
+			mockRegistry.On("ListModels", mock.MatchedBy(func(option model_registry.ListOption) bool {
+				return option.Offset == tt.wantOffset && option.Limit == tt.wantLimit
+			})).Return(&model_registry.ModelPage{Models: tt.returned, Total: tt.total}, nil)
+
+			c, w := newListContext(t, tt.query)
+			listModels(&Dependencies{Storage: mockStorage})(c)
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			assert.Equal(t, tt.wantHeader, w.Header().Get("Content-Range"))
+
+			var body []v1.GeneralModel
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			assert.Len(t, body, len(tt.returned))
+
+			mockStorage.AssertExpectations(t)
+			mockRegistry.AssertExpectations(t)
+		})
+	}
+}
+
+func TestListModels_RejectsUnusablePaging(t *testing.T) {
+	for _, query := range []string{"limit=abc", "offset=-1", "offset=x"} {
+		t.Run(query, func(t *testing.T) {
+			mockStorage, _ := setupMocks(t)
+
+			c, w := newListContext(t, query)
+			listModels(&Dependencies{Storage: mockStorage})(c)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+// A listing surfaces the alias next to the version it belongs to, and an alias
+// whose model is no longer in the registry stays invisible.
+func TestListModels_AttachesAliases(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}}, nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{
+		{ID: 1, ModelRegistryID: 7, ModelName: "qwen3", ModelVersion: "v1", Alias: "Qwen3 Chat"},
+		{ID: 2, ModelRegistryID: 7, ModelName: "removed-out-of-band", ModelVersion: "v1", Alias: "Ghost"},
+	}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("ListModels", mock.Anything).Return(&model_registry.ModelPage{
+		Models: []v1.GeneralModel{storedModel("qwen3", "v1", "v2")},
+		Total:  1,
+	}, nil)
+
+	c, w := newListContext(t, "")
+	listModels(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body []v1.GeneralModel
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Len(t, body, 1)
+	require.Len(t, body[0].Versions, 2)
+	assert.Equal(t, "Qwen3 Chat", body[0].Versions[0].Alias)
+	assert.Empty(t, body[0].Versions[1].Alias)
+	assert.NotContains(t, w.Body.String(), "Ghost")
+}
+
+func TestContentRange(t *testing.T) {
+	assert.Equal(t, "0-9/100", contentRange(0, 10, 100))
+	assert.Equal(t, "10-19/100", contentRange(10, 10, 100))
+	assert.Equal(t, "*/100", contentRange(200, 0, 100))
+	assert.Equal(t, "*/0", contentRange(0, 0, 0))
+}

--- a/internal/routes/models/list_test.go
+++ b/internal/routes/models/list_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -44,7 +45,7 @@ func TestListModels_ReportsTotalInContentRange(t *testing.T) {
 		name       string
 		query      string
 		returned   []v1.GeneralModel
-		total      int
+		total      *int
 		wantOffset int
 		wantLimit  int
 		wantHeader string
@@ -52,14 +53,14 @@ func TestListModels_ReportsTotalInContentRange(t *testing.T) {
 		{
 			name:       "whole listing",
 			returned:   []v1.GeneralModel{storedModel("a", "v1"), storedModel("b", "v1")},
-			total:      2,
+			total:      model_registry.KnownTotal(2),
 			wantHeader: "0-1/2",
 		},
 		{
 			name:       "second page",
 			query:      "offset=2&limit=2",
 			returned:   []v1.GeneralModel{storedModel("c", "v1")},
-			total:      5,
+			total:      model_registry.KnownTotal(5),
 			wantOffset: 2,
 			wantLimit:  2,
 			wantHeader: "2-2/5",
@@ -68,15 +69,23 @@ func TestListModels_ReportsTotalInContentRange(t *testing.T) {
 			name:       "offset past the end",
 			query:      "offset=50",
 			returned:   []v1.GeneralModel{},
-			total:      5,
+			total:      model_registry.KnownTotal(5),
 			wantOffset: 50,
 			wantHeader: "*/5",
 		},
 		{
 			name:       "empty registry",
 			returned:   []v1.GeneralModel{},
-			total:      0,
+			total:      model_registry.KnownTotal(0),
 			wantHeader: "*/0",
+		},
+		{
+			// A registry that cannot count what matched says so, rather than
+			// passing off the page size as the total.
+			name:       "registry cannot count its contents",
+			returned:   []v1.GeneralModel{storedModel("a", "v1"), storedModel("b", "v1")},
+			total:      nil,
+			wantHeader: "0-1/*",
 		},
 	}
 
@@ -141,7 +150,7 @@ func TestListModels_AttachesAliases(t *testing.T) {
 	mockRegistry.On("Disconnect").Return(nil)
 	mockRegistry.On("ListModels", mock.Anything).Return(&model_registry.ModelPage{
 		Models: []v1.GeneralModel{storedModel("qwen3", "v1", "v2")},
-		Total:  1,
+		Total:  model_registry.KnownTotal(1),
 	}, nil)
 
 	c, w := newListContext(t, "")
@@ -159,8 +168,33 @@ func TestListModels_AttachesAliases(t *testing.T) {
 }
 
 func TestContentRange(t *testing.T) {
-	assert.Equal(t, "0-9/100", contentRange(0, 10, 100))
-	assert.Equal(t, "10-19/100", contentRange(10, 10, 100))
-	assert.Equal(t, "*/100", contentRange(200, 0, 100))
-	assert.Equal(t, "*/0", contentRange(0, 0, 0))
+	assert.Equal(t, "0-9/100", contentRange(0, 10, model_registry.KnownTotal(100)))
+	assert.Equal(t, "10-19/100", contentRange(10, 10, model_registry.KnownTotal(100)))
+	assert.Equal(t, "*/100", contentRange(200, 0, model_registry.KnownTotal(100)))
+	assert.Equal(t, "*/0", contentRange(0, 0, model_registry.KnownTotal(0)))
+	// An unknown total is reported as unknown, not as zero.
+	assert.Equal(t, "0-9/*", contentRange(0, 10, nil))
+	assert.Equal(t, "*/*", contentRange(0, 0, nil))
+}
+
+// A registry that refuses to page from an offset gets a plain refusal, not a
+// server error and not a silent first page.
+func TestListModels_OffsetRefusedByRegistry(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       8,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
+	}}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("ListModels", mock.Anything).
+		Return(nil, errors.Wrap(model_registry.ErrNotSupported, "cannot list from an offset"))
+
+	c, w := newListContext(t, "offset=10&limit=5")
+	listModels(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "cannot list models this way")
+	assert.Empty(t, w.Header().Get("Content-Range"))
 }

--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -322,6 +323,14 @@ func listModels(deps *Dependencies) gin.HandlerFunc {
 			Limit:  limit,
 		})
 		if err != nil {
+			if errors.Is(err, model_registry.ErrNotSupported) {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"message": fmt.Sprintf("This model registry cannot list models this way: %v", err),
+				})
+
+				return
+			}
+
 			klog.Errorf("Failed to list models: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"message": fmt.Sprintf("Failed to list models: %v", err),
@@ -370,14 +379,20 @@ func intQuery(c *gin.Context, name string) (int, bool) {
 	return value, true
 }
 
-// contentRange formats the PostgREST-style range header: "first-last/total", or
-// "*/total" for an empty page.
-func contentRange(offset, returned, total int) string {
-	if returned == 0 {
-		return fmt.Sprintf("*/%d", total)
+// contentRange formats the PostgREST-style range header: "first-last/total",
+// with "*" in place of the range for an empty page and in place of the total
+// when the registry cannot count what matched.
+func contentRange(offset, returned int, total *int) string {
+	size := "*"
+	if total != nil {
+		size = strconv.Itoa(*total)
 	}
 
-	return fmt.Sprintf("%d-%d/%d", offset, offset+returned-1, total)
+	if returned == 0 {
+		return "*/" + size
+	}
+
+	return fmt.Sprintf("%d-%d/%s", offset, offset+returned-1, size)
 }
 
 // getModel handles retrieving a specific model

--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -114,6 +114,14 @@ func RegisterModelsRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 					middleware.RequireWorkspacePermission("model:read", permissionDeps),
 					getModel(deps))
 
+				// Update a model's display metadata: its alias and the model info
+				// fields a user fills in by hand. Both are annotations on an
+				// existing model, so they reuse model:push rather than introducing
+				// a permission action of their own.
+				models.PATCH("/:model",
+					middleware.RequireWorkspacePermission("model:push", permissionDeps),
+					patchModel(deps))
+
 				// Upload a new model
 				models.POST("",
 					middleware.RequirePermission("model:push", permissionDeps),
@@ -176,7 +184,7 @@ func finalizeModel(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		modelRegistry, err := getModelRegistry(c, deps)
+		handle, err := getModelRegistry(c, deps)
 		if err != nil {
 			klog.Errorf("Failed to get model registry: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -185,9 +193,9 @@ func finalizeModel(deps *Dependencies) gin.HandlerFunc {
 
 			return
 		}
-		defer (*modelRegistry).Disconnect() //nolint:errcheck
+		defer handle.client.Disconnect() //nolint:errcheck
 
-		modelVersion, err := (*modelRegistry).GetModelVersion(modelName, version)
+		modelVersion, err := handle.client.GetModelVersion(modelName, version)
 		if err != nil {
 			klog.Errorf("Failed to finalize model %s:%s: %v", modelName, version, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -230,8 +238,16 @@ func validateFinalizedModelVersion(req finalizeModelRequest, modelVersion *v1.Mo
 	return nil
 }
 
+// registryHandle is a connected registry client together with the stored object
+// it was built from. Handlers need both: the client to reach the backing store,
+// and the object for its row id, which is what the alias table keys on.
+type registryHandle struct {
+	registry *v1.ModelRegistry
+	client   model_registry.ModelRegistry
+}
+
 // getModelRegistry retrieves and connects to a model registry
-func getModelRegistry(c *gin.Context, deps *Dependencies) (*model_registry.ModelRegistry, error) {
+func getModelRegistry(c *gin.Context, deps *Dependencies) (*registryHandle, error) {
 	workspace := c.Param("workspace")
 	registryName := c.Param("registry")
 
@@ -269,30 +285,26 @@ func getModelRegistry(c *gin.Context, deps *Dependencies) (*model_registry.Model
 		return nil, fmt.Errorf("failed to connect to model registry: %w", err)
 	}
 
-	return &modelRegistry, nil
+	return &registryHandle{registry: &modelRegistries[0], client: modelRegistry}, nil
 }
 
 // listModels handles listing all models in a registry
 func listModels(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		search := c.Query("search")
-		limit := 0
 
-		if limitStr := c.Query("limit"); limitStr != "" {
-			var err error
+		limit, ok := intQuery(c, "limit")
+		if !ok {
+			return
+		}
 
-			limit, err = strconv.Atoi(limitStr)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{
-					"message": "Invalid limit parameter",
-				})
-
-				return
-			}
+		offset, ok := intQuery(c, "offset")
+		if !ok {
+			return
 		}
 
 		// Get and connect to the model registry
-		modelRegistry, err := getModelRegistry(c, deps)
+		handle, err := getModelRegistry(c, deps)
 		if err != nil {
 			klog.Errorf("Failed to get model registry: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -301,11 +313,12 @@ func listModels(deps *Dependencies) gin.HandlerFunc {
 
 			return
 		}
-		defer (*modelRegistry).Disconnect() //nolint:errcheck
+		defer handle.client.Disconnect() //nolint:errcheck
 
 		// List models
-		models, err := (*modelRegistry).ListModels(model_registry.ListOption{
+		page, err := handle.client.ListModels(model_registry.ListOption{
 			Search: search,
+			Offset: offset,
 			Limit:  limit,
 		})
 		if err != nil {
@@ -317,8 +330,54 @@ func listModels(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		c.JSON(http.StatusOK, models)
+		aliases, err := listRegistryAliases(deps, handle.registry.ID)
+		if err != nil {
+			klog.Errorf("Failed to list model aliases: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": err.Error(),
+			})
+
+			return
+		}
+
+		attachAliases(page.Models, aliases)
+
+		// The total goes in a header, PostgREST style, and the body stays a bare
+		// array. Wrapping the body in an envelope would break every existing
+		// caller for the sake of one number.
+		c.Header("Content-Range", contentRange(offset, len(page.Models), page.Total))
+		c.JSON(http.StatusOK, page.Models)
 	}
+}
+
+// intQuery reads a non-negative integer query parameter, answering 400 and
+// reporting false when it is present but not a number.
+func intQuery(c *gin.Context, name string) (int, bool) {
+	raw := c.Query(name)
+	if raw == "" {
+		return 0, true
+	}
+
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": fmt.Sprintf("Invalid %s parameter", name),
+		})
+
+		return 0, false
+	}
+
+	return value, true
+}
+
+// contentRange formats the PostgREST-style range header: "first-last/total", or
+// "*/total" for an empty page.
+func contentRange(offset, returned, total int) string {
+	if returned == 0 {
+		return fmt.Sprintf("*/%d", total)
+	}
+
+	return fmt.Sprintf("%d-%d/%d", offset, offset+returned-1, total)
 }
 
 // getModel handles retrieving a specific model
@@ -332,7 +391,7 @@ func getModel(deps *Dependencies) gin.HandlerFunc {
 		}
 
 		// Get and connect to the model registry
-		modelRegistry, err := getModelRegistry(c, deps)
+		handle, err := getModelRegistry(c, deps)
 		if err != nil {
 			klog.Errorf("Failed to get model registry: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -341,10 +400,11 @@ func getModel(deps *Dependencies) gin.HandlerFunc {
 
 			return
 		}
-		defer (*modelRegistry).Disconnect() //nolint:errcheck
+		defer handle.client.Disconnect() //nolint:errcheck
 
-		// Get model version details
-		modelVersion, err := (*modelRegistry).GetModelVersion(modelName, version)
+		// Get model version details, including whatever the checkpoint states
+		// about itself.
+		modelVersion, err := handle.client.GetModelDetail(modelName, version)
 		if err != nil {
 			klog.Errorf("Failed to get model %s:%s: %v", modelName, version, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -354,8 +414,34 @@ func getModel(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
+		if err := attachModelAlias(deps, handle, modelName, modelVersion); err != nil {
+			klog.Errorf("Failed to read alias of model %s:%s: %v", modelName, version, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": err.Error(),
+			})
+
+			return
+		}
+
 		c.JSON(http.StatusOK, modelVersion)
 	}
+}
+
+// attachModelAlias fills in the alias of a single resolved version. The lookup
+// keys off the version the registry resolved, not the one the caller asked for,
+// so "latest" lands on the alias of the version it currently points at.
+func attachModelAlias(deps *Dependencies, handle *registryHandle,
+	modelName string, modelVersion *v1.ModelVersion) error {
+	aliases, err := listRegistryAliases(deps, handle.registry.ID)
+	if err != nil {
+		return err
+	}
+
+	if row, ok := aliases[aliasKey(modelName, modelVersion.Name)]; ok {
+		modelVersion.Alias = row.Alias
+	}
+
+	return nil
 }
 
 // uploadModel handles uploading a new model
@@ -459,7 +545,7 @@ func uploadModel(deps *Dependencies) gin.HandlerFunc {
 		defer modelPart.Close()
 
 		// Get and connect to the model registry
-		modelRegistry, err := getModelRegistry(c, deps)
+		handle, err := getModelRegistry(c, deps)
 		if err != nil {
 			klog.Errorf("Failed to get model registry: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -468,7 +554,7 @@ func uploadModel(deps *Dependencies) gin.HandlerFunc {
 
 			return
 		}
-		defer (*modelRegistry).Disconnect() //nolint:errcheck
+		defer handle.client.Disconnect() //nolint:errcheck
 
 		// Use chunked encoding for progress reporting
 		c.Header("Transfer-Encoding", "chunked")
@@ -485,7 +571,7 @@ func uploadModel(deps *Dependencies) gin.HandlerFunc {
 		// Import directly from uploaded file reader with progress
 		klog.V(4).Infof("Importing model %s:%s", name, version)
 
-		if err := (*modelRegistry).ImportModel(modelPart, name, version, progressWriter); err != nil {
+		if err := handle.client.ImportModel(modelPart, name, version, progressWriter); err != nil {
 			klog.Errorf("Failed to import model: %v", err)
 			fmt.Fprintf(c.Writer, "Error: Failed to import model: %v\n", err)
 
@@ -521,7 +607,7 @@ func downloadModel(deps *Dependencies) gin.HandlerFunc {
 		}
 
 		// Get and connect to the model registry
-		modelRegistry, err := getModelRegistry(c, deps)
+		handle, err := getModelRegistry(c, deps)
 		if err != nil {
 			klog.Errorf("Failed to get model registry: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -530,14 +616,14 @@ func downloadModel(deps *Dependencies) gin.HandlerFunc {
 
 			return
 		}
-		defer (*modelRegistry).Disconnect() //nolint:errcheck
+		defer handle.client.Disconnect() //nolint:errcheck
 
 		// Create temporary file for export
 		tempFile := filepath.Join(tempDir, fmt.Sprintf("%s-%s.bentomodel", modelName, version))
 		defer os.Remove(tempFile) // Clean up when done
 
 		// Export model to temporary file
-		if err := (*modelRegistry).ExportModel(modelName, version, tempFile); err != nil {
+		if err := handle.client.ExportModel(modelName, version, tempFile); err != nil {
 			klog.Errorf("Failed to export model %s:%s: %v", modelName, version, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"message": fmt.Sprintf("Failed to export model: %v", err),
@@ -555,50 +641,6 @@ func downloadModel(deps *Dependencies) gin.HandlerFunc {
 	}
 }
 
-func validateModelDeletion(deps *Dependencies, workspace, registryName, modelName, version string) (int, error) {
-	endpoints, err := deps.Storage.ListEndpoint(storage.ListOption{
-		Filters: []storage.Filter{
-			{
-				Column:   "metadata->workspace",
-				Operator: "eq",
-				Value:    strconv.Quote(workspace),
-			},
-			{
-				Column:   "spec->model->>registry",
-				Operator: "eq",
-				Value:    registryName,
-			},
-			{
-				Column:   "spec->model->>name",
-				Operator: "eq",
-				Value:    modelName,
-			},
-		},
-	})
-	if err != nil {
-		return 0, fmt.Errorf("failed to list endpoints: %w", err)
-	}
-
-	references := 0
-
-	for _, endpoint := range endpoints {
-		if endpoint.Spec == nil || endpoint.Spec.Model == nil {
-			continue
-		}
-
-		endpointVersion := endpoint.Spec.Model.Version
-		if endpointVersion == "" {
-			endpointVersion = v1.LatestVersion
-		}
-
-		if version == v1.LatestVersion || endpointVersion == v1.LatestVersion || endpointVersion == version {
-			references++
-		}
-	}
-
-	return references, nil
-}
-
 // deleteModel handles deleting a model
 func deleteModel(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -611,7 +653,7 @@ func deleteModel(deps *Dependencies) gin.HandlerFunc {
 			version = v1.LatestVersion
 		}
 
-		references, err := validateModelDeletion(deps, workspace, registryName, modelName, version)
+		references, err := collectModelReferences(deps, workspace, registryName, modelName, version)
 		if err != nil {
 			klog.Errorf("Failed to validate model deletion %s/%s/%s:%s: %v", workspace, registryName, modelName, version, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -621,18 +663,19 @@ func deleteModel(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		if references > 0 {
+		if len(references) > 0 {
 			c.JSON(http.StatusBadRequest, gin.H{
-				"code":    modelReferencedByEndpointCode,
-				"message": fmt.Sprintf("cannot delete model '%s/%s/%s:%s'", workspace, registryName, modelName, version),
-				"hint":    fmt.Sprintf("%d endpoint(s) still reference this model", references),
+				"code":       modelReferencedByEndpointCode,
+				"message":    fmt.Sprintf("cannot delete model '%s/%s/%s:%s'", workspace, registryName, modelName, version),
+				"hint":       referenceHint(references),
+				"references": references,
 			})
 
 			return
 		}
 
 		// Get and connect to the model registry
-		modelRegistry, err := getModelRegistry(c, deps)
+		handle, err := getModelRegistry(c, deps)
 		if err != nil {
 			klog.Errorf("Failed to get model registry: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{
@@ -641,10 +684,15 @@ func deleteModel(deps *Dependencies) gin.HandlerFunc {
 
 			return
 		}
-		defer (*modelRegistry).Disconnect() //nolint:errcheck
+		defer handle.client.Disconnect() //nolint:errcheck
+
+		// Resolve the version before deleting: afterwards there is nothing left to
+		// resolve "latest" against, and the alias rows are keyed on the concrete
+		// version.
+		deletedVersion := resolveConcreteVersion(handle, modelName, version)
 
 		// Delete the model
-		if err := (*modelRegistry).DeleteModel(modelName, version); err != nil {
+		if err := handle.client.DeleteModel(modelName, version); err != nil {
 			klog.Errorf("Failed to delete model %s:%s: %v", modelName, version, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"message": fmt.Sprintf("Failed to delete model: %v", err),
@@ -653,6 +701,25 @@ func deleteModel(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
+		if deletedVersion != "" {
+			deleteModelAliases(deps, handle.registry.ID, modelName, deletedVersion)
+		}
+
 		c.Status(http.StatusNoContent)
 	}
+}
+
+// resolveConcreteVersion turns "latest" into the version it points at, or
+// returns an empty string when it cannot. Failing to resolve only costs an alias
+// row that is left behind, and an alias whose model no longer exists is already
+// invisible to every read path.
+func resolveConcreteVersion(handle *registryHandle, modelName, version string) string {
+	modelVersion, err := handle.client.GetModelVersion(modelName, version)
+	if err != nil {
+		klog.Warningf("Failed to resolve version of model %s:%s before deletion: %v", modelName, version, err)
+
+		return ""
+	}
+
+	return modelVersion.Name
 }

--- a/internal/routes/models/models_test.go
+++ b/internal/routes/models/models_test.go
@@ -215,7 +215,7 @@ func TestListModels_Success(t *testing.T) {
 	mockModelRegistry.On("Disconnect").Return(nil)
 	mockModelRegistry.On("ListModels", mock.MatchedBy(func(option model_registry.ListOption) bool {
 		return option.Search == "test"
-	})).Return(&model_registry.ModelPage{Models: mockModels, Total: len(mockModels)}, nil)
+	})).Return(&model_registry.ModelPage{Models: mockModels, Total: model_registry.KnownTotal(len(mockModels))}, nil)
 	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
 
 	// Call the handler function directly

--- a/internal/routes/models/models_test.go
+++ b/internal/routes/models/models_test.go
@@ -7,6 +7,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -104,28 +105,40 @@ func setupMocks(t *testing.T) (*mocks.MockStorage, *model_registry_mocks.MockMod
 
 func endpointModelReferenceFilterMatcher(workspace, registryName, modelName string) interface{} {
 	return mock.MatchedBy(func(option storage.ListOption) bool {
-		expected := map[string]string{
-			"metadata->workspace":    strconvQuote(workspace),
-			"spec->model->>registry": registryName,
-			"spec->model->>name":     modelName,
+		expected := []storage.Filter{
+			{Column: "metadata->workspace", Operator: "eq", Value: strconvQuote(workspace)},
+			{Column: "spec->model->>registry", Operator: "eq", Value: registryName},
+			{Column: "spec->model->>name", Operator: "eq", Value: modelName},
+			// Endpoints on their way out must not hold the model hostage.
+			{Column: "metadata->>deletion_timestamp", Operator: "is", Value: "null"},
 		}
 
 		if len(option.Filters) != len(expected) {
 			return false
 		}
 
-		for _, filter := range option.Filters {
-			if filter.Operator != "eq" {
-				return false
-			}
-
-			value, ok := expected[filter.Column]
-			if !ok || filter.Value != value {
+		for _, want := range expected {
+			if !slices.Contains(option.Filters, want) {
 				return false
 			}
 		}
 
 		return true
+	})
+}
+
+// catalogReferenceFilterMatcher matches the workspace-scoped, not-yet-deleted
+// model catalog listing the deletion check sweeps in Go.
+func catalogReferenceFilterMatcher(workspace string) interface{} {
+	return mock.MatchedBy(func(option storage.ListOption) bool {
+		expected := []storage.Filter{
+			{Column: "metadata->workspace", Operator: "eq", Value: strconvQuote(workspace)},
+			{Column: "metadata->>deletion_timestamp", Operator: "is", Value: "null"},
+		}
+
+		return len(option.Filters) == len(expected) &&
+			slices.Contains(option.Filters, expected[0]) &&
+			slices.Contains(option.Filters, expected[1])
 	})
 }
 
@@ -202,7 +215,8 @@ func TestListModels_Success(t *testing.T) {
 	mockModelRegistry.On("Disconnect").Return(nil)
 	mockModelRegistry.On("ListModels", mock.MatchedBy(func(option model_registry.ListOption) bool {
 		return option.Search == "test"
-	})).Return(mockModels, nil)
+	})).Return(&model_registry.ModelPage{Models: mockModels, Total: len(mockModels)}, nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
 
 	// Call the handler function directly
 	handlerFunc := listModels(deps)
@@ -247,7 +261,7 @@ func TestListModels_RegistryNotFound(t *testing.T) {
 	// Verify the results
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
-	var response map[string]string
+	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Contains(t, response["message"], "model registry not found")
@@ -281,7 +295,7 @@ func TestListModels_StorageError(t *testing.T) {
 	// Verify the results
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
-	var response map[string]string
+	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Contains(t, response["message"], "failed to find model registry")
@@ -327,7 +341,7 @@ func TestListModels_ListModelsError(t *testing.T) {
 	// Verify the results
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
-	var response map[string]string
+	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Contains(t, response["message"], "Failed to list models")
@@ -369,7 +383,8 @@ func TestGetModel_Success(t *testing.T) {
 	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{modelRegistry}, nil)
 	mockModelRegistry.On("Connect").Return(nil)
 	mockModelRegistry.On("Disconnect").Return(nil)
-	mockModelRegistry.On("GetModelVersion", "test-model", v1.LatestVersion).Return(mockModelVersion, nil)
+	mockModelRegistry.On("GetModelDetail", "test-model", v1.LatestVersion).Return(mockModelVersion, nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
 
 	// Call the handler function directly
 	handlerFunc := getModel(deps)
@@ -410,7 +425,7 @@ func TestGetModel_NotFound(t *testing.T) {
 	mockModelRegistry.On("Connect").Return(nil)
 	mockModelRegistry.On("Disconnect").Return(nil)
 	mockError := errors.New("model not found")
-	mockModelRegistry.On("GetModelVersion", "non-existent-model", v1.LatestVersion).Return(nil, mockError)
+	mockModelRegistry.On("GetModelDetail", "non-existent-model", v1.LatestVersion).Return(nil, mockError)
 
 	// Call the handler function directly
 	handlerFunc := getModel(deps)
@@ -419,7 +434,7 @@ func TestGetModel_NotFound(t *testing.T) {
 	// Verify the results
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
-	var response map[string]string
+	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Contains(t, response["message"], "Failed to get model")
@@ -455,9 +470,14 @@ func TestDeleteModel_Success(t *testing.T) {
 	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{modelRegistry}, nil)
 	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
 		Return([]v1.Endpoint{}, nil)
+	mockStorage.On("ListModelCatalog", catalogReferenceFilterMatcher("default")).
+		Return([]v1.ModelCatalog{}, nil).Maybe()
 	mockModelRegistry.On("Connect").Return(nil)
 	mockModelRegistry.On("Disconnect").Return(nil)
 	mockModelRegistry.On("DeleteModel", "test-model", v1.LatestVersion).Return(nil)
+	mockModelRegistry.On("GetModelVersion", "test-model", v1.LatestVersion).
+		Return(&v1.ModelVersion{Name: "v1.0.0"}, nil).Maybe()
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil).Maybe()
 
 	// Call the handler function directly
 	handlerFunc := deleteModel(deps)
@@ -486,6 +506,8 @@ func TestDeleteModel_BlockedWhenEndpointReferencesExactVersion(t *testing.T) {
 
 	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
 		Return([]v1.Endpoint{endpointWithModel("test-registry", "test-model", "v1.0.0")}, nil)
+	mockStorage.On("ListModelCatalog", catalogReferenceFilterMatcher("default")).
+		Return([]v1.ModelCatalog{}, nil).Maybe()
 	mockModelRegistry.On("DeleteModel", "test-model", "v1.0.0").Return(nil).Maybe()
 
 	handlerFunc := deleteModel(deps)
@@ -493,7 +515,7 @@ func TestDeleteModel_BlockedWhenEndpointReferencesExactVersion(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 
-	var response map[string]string
+	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, "10131", response["code"])
@@ -536,6 +558,8 @@ func TestDeleteModel_BlockedWhenEndpointReferencesLatestVersion(t *testing.T) {
 
 			mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
 				Return([]v1.Endpoint{endpointWithModel("test-registry", "test-model", tc.endpointVersion)}, nil)
+			mockStorage.On("ListModelCatalog", catalogReferenceFilterMatcher("default")).
+				Return([]v1.ModelCatalog{}, nil).Maybe()
 			mockModelRegistry.On("DeleteModel", "test-model", "v1.0.0").Return(nil).Maybe()
 
 			handlerFunc := deleteModel(deps)
@@ -543,7 +567,7 @@ func TestDeleteModel_BlockedWhenEndpointReferencesLatestVersion(t *testing.T) {
 
 			assert.Equal(t, http.StatusBadRequest, w.Code)
 
-			var response map[string]string
+			var response map[string]any
 			err := json.Unmarshal(w.Body.Bytes(), &response)
 			assert.NoError(t, err)
 			assert.Equal(t, "10131", response["code"])
@@ -570,6 +594,8 @@ func TestDeleteModel_BlockedWhenDeletingLatestAndEndpointReferencesConcreteVersi
 
 	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
 		Return([]v1.Endpoint{endpointWithModel("test-registry", "test-model", "v1.0.0")}, nil)
+	mockStorage.On("ListModelCatalog", catalogReferenceFilterMatcher("default")).
+		Return([]v1.ModelCatalog{}, nil).Maybe()
 	mockModelRegistry.On("DeleteModel", "test-model", v1.LatestVersion).Return(nil).Maybe()
 
 	handlerFunc := deleteModel(deps)
@@ -577,7 +603,7 @@ func TestDeleteModel_BlockedWhenDeletingLatestAndEndpointReferencesConcreteVersi
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 
-	var response map[string]string
+	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, "10131", response["code"])
@@ -611,9 +637,14 @@ func TestDeleteModel_AllowsUnrelatedEndpointVersion(t *testing.T) {
 	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{modelRegistry}, nil)
 	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
 		Return([]v1.Endpoint{endpointWithModel("test-registry", "test-model", "v2.0.0")}, nil)
+	mockStorage.On("ListModelCatalog", catalogReferenceFilterMatcher("default")).
+		Return([]v1.ModelCatalog{}, nil).Maybe()
 	mockModelRegistry.On("Connect").Return(nil)
 	mockModelRegistry.On("Disconnect").Return(nil)
 	mockModelRegistry.On("DeleteModel", "test-model", "v1.0.0").Return(nil)
+	mockModelRegistry.On("GetModelVersion", "test-model", "v1.0.0").
+		Return(&v1.ModelVersion{Name: "v1.0.0"}, nil).Maybe()
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil).Maybe()
 
 	handlerFunc := deleteModel(deps)
 	handlerFunc(c)
@@ -645,7 +676,7 @@ func TestDeleteModel_ValidationErrorSkipsRegistryDelete(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
-	var response map[string]string
+	var response map[string]any
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Contains(t, response["message"], "Failed to validate model deletion")
@@ -712,7 +743,7 @@ func TestUploadModel_InvalidName(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 
-	var response map[string]string
+	var response map[string]any
 	err = json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Contains(t, response["message"], "Invalid model name")

--- a/internal/routes/models/patch.go
+++ b/internal/routes/models/patch.go
@@ -1,0 +1,164 @@
+package models
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+// patchModelRequest is the editable surface of a model. Everything here is a
+// label on top of the model; the physical name, version and storage path are not
+// editable and are not represented.
+type patchModelRequest struct {
+	// Alias is the display name. A nil value leaves the current alias alone; an
+	// empty string removes it.
+	Alias *string `json:"alias,omitempty"`
+	// Info is the complete set of hand-filled model info fields. It replaces any
+	// previously recorded set wholesale — nil leaves it alone, an empty object
+	// clears it — because per-field patching would have no way to express
+	// "remove this one value".
+	Info *v1.ModelInfo `json:"info,omitempty"`
+}
+
+// patchModel updates a model's alias and hand-filled metadata.
+func patchModel(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		modelName := c.Param("model")
+
+		version := c.Query("version")
+		if version == "" {
+			version = v1.LatestVersion
+		}
+
+		var req patchModelRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"message": "Invalid model update request",
+			})
+
+			return
+		}
+
+		handle, err := getModelRegistry(c, deps)
+		if err != nil {
+			klog.Errorf("Failed to get model registry: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": err.Error(),
+			})
+
+			return
+		}
+		defer handle.client.Disconnect() //nolint:errcheck
+
+		// Resolve the model first: it validates that the model is there, turns
+		// "latest" into the version the alias row has to name, and tells us
+		// straight away whether this registry supports being written to at all.
+		detail, err := handle.client.GetModelDetail(modelName, version)
+		if err != nil {
+			respondModelLookupError(c, modelName, version, err)
+
+			return
+		}
+
+		if !applyModelPatch(c, deps, handle, modelName, detail.Name, req) {
+			return
+		}
+
+		// Read back rather than patching the copy in hand, so the response is what
+		// the next GET will return.
+		updated, err := handle.client.GetModelDetail(modelName, detail.Name)
+		if err != nil {
+			respondModelLookupError(c, modelName, detail.Name, err)
+
+			return
+		}
+
+		if err := attachModelAlias(deps, handle, modelName, updated); err != nil {
+			klog.Errorf("Failed to read alias of model %s:%s: %v", modelName, detail.Name, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": err.Error(),
+			})
+
+			return
+		}
+
+		c.JSON(http.StatusOK, updated)
+	}
+}
+
+// applyModelPatch performs the requested writes, answering the request itself on
+// any failure. It reports whether the caller should carry on and respond.
+func applyModelPatch(c *gin.Context, deps *Dependencies, handle *registryHandle,
+	modelName, version string, req patchModelRequest) bool {
+	if req.Info != nil {
+		// Provenance is the server's to state, not the client's: whatever arrives
+		// here was typed by a person, so it is recorded as manual regardless of
+		// what the request claimed.
+		manual := &v1.ModelInfo{}
+		manual.MergeManual(req.Info)
+
+		if err := handle.client.SetManualModelInfo(modelName, version, manual); err != nil {
+			respondModelWriteError(c, modelName, version, err)
+
+			return false
+		}
+	}
+
+	if req.Alias == nil {
+		return true
+	}
+
+	status, body, err := setModelAlias(deps, handle, modelName, version, *req.Alias)
+	if err != nil {
+		klog.Errorf("Failed to set alias of model %s:%s: %v", modelName, version, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"message": err.Error(),
+		})
+
+		return false
+	}
+
+	if status != 0 {
+		c.JSON(status, body)
+
+		return false
+	}
+
+	return true
+}
+
+func respondModelLookupError(c *gin.Context, modelName, version string, err error) {
+	if errors.Is(err, model_registry.ErrNotSupported) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "This model registry does not support editing model metadata",
+		})
+
+		return
+	}
+
+	klog.Errorf("Failed to get model %s:%s: %v", modelName, version, err)
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"message": fmt.Sprintf("Failed to get model %s:%s: %v", modelName, version, err),
+	})
+}
+
+func respondModelWriteError(c *gin.Context, modelName, version string, err error) {
+	if errors.Is(err, model_registry.ErrNotSupported) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "This model registry does not support editing model metadata",
+		})
+
+		return
+	}
+
+	klog.Errorf("Failed to update model %s:%s: %v", modelName, version, err)
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"message": fmt.Sprintf("Failed to update model %s:%s: %v", modelName, version, err),
+	})
+}

--- a/internal/routes/models/references.go
+++ b/internal/routes/models/references.go
@@ -1,0 +1,242 @@
+package models
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// Kinds a model reference can name. They match the resource kinds the scheme
+// registers, so a client can route from a reference back to the object.
+const (
+	endpointKind     = "Endpoint"
+	modelCatalogKind = "ModelCatalog"
+)
+
+// ModelReference is one object standing in the way of deleting a model. It
+// carries enough for a user to go and change that object: what kind it is, where
+// it lives, and — for a recipe catalog — which variant inside it points at the
+// model.
+type ModelReference struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Workspace string `json:"workspace"`
+	// Phase is the referring endpoint's phase. A deployment that is still coming
+	// up (Deploying, ModelDownloading) is a reference just as much as a running
+	// one; it is not a separate kind of object, so the phase is what lets a
+	// client tell them apart.
+	Phase string `json:"phase,omitempty"`
+	// Variant is the recipe variant key inside a model catalog. Without it a user
+	// facing a catalog with a dozen variants does not know which one to edit.
+	Variant string `json:"variant,omitempty"`
+}
+
+// collectModelReferences finds everything that still points at a model version.
+func collectModelReferences(deps *Dependencies, workspace, registryName, modelName, version string) ([]ModelReference, error) {
+	references, err := endpointReferences(deps, workspace, registryName, modelName, version)
+	if err != nil {
+		return nil, err
+	}
+
+	catalogReferences, err := modelCatalogReferences(deps, workspace, registryName, modelName, version)
+	if err != nil {
+		return nil, err
+	}
+
+	references = append(references, catalogReferences...)
+
+	sort.Slice(references, func(i, j int) bool {
+		if references[i].Kind != references[j].Kind {
+			return references[i].Kind < references[j].Kind
+		}
+
+		if references[i].Name != references[j].Name {
+			return references[i].Name < references[j].Name
+		}
+
+		return references[i].Variant < references[j].Variant
+	})
+
+	return references, nil
+}
+
+func endpointReferences(deps *Dependencies, workspace, registryName, modelName, version string) ([]ModelReference, error) {
+	endpoints, err := deps.Storage.ListEndpoint(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->workspace",
+				Operator: "eq",
+				Value:    strconv.Quote(workspace),
+			},
+			{
+				Column:   "spec->model->>registry",
+				Operator: "eq",
+				Value:    registryName,
+			},
+			{
+				Column:   "spec->model->>name",
+				Operator: "eq",
+				Value:    modelName,
+			},
+			{
+				// An endpoint marked for deletion is on its way out and must not
+				// hold a model hostage: without this the user deletes the endpoint,
+				// still cannot delete the model, and has no way to break the
+				// deadlock.
+				Column:   "metadata->>deletion_timestamp",
+				Operator: "is",
+				Value:    "null",
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list endpoints: %w", err)
+	}
+
+	var references []ModelReference
+
+	for i := range endpoints {
+		endpoint := endpoints[i]
+		if endpoint.Spec == nil || endpoint.Spec.Model == nil {
+			continue
+		}
+
+		if !versionsOverlap(endpoint.Spec.Model.Version, version) {
+			continue
+		}
+
+		reference := ModelReference{
+			Kind:      endpointKind,
+			Name:      endpoint.GetName(),
+			Workspace: endpoint.GetWorkspace(),
+		}
+
+		if endpoint.Status != nil {
+			reference.Phase = string(endpoint.Status.Phase)
+		}
+
+		references = append(references, reference)
+	}
+
+	return references, nil
+}
+
+// modelCatalogReferences scans the workspace's model catalogs in Go rather than
+// filtering in the database. A recipe catalog keeps its variants in a JSON object
+// with arbitrary keys, so "any variant points at this model" is not expressible
+// as a filter on one column, and inventing a SQL function for it would put the
+// matching rules in two places.
+func modelCatalogReferences(deps *Dependencies, workspace, registryName, modelName, version string) ([]ModelReference, error) {
+	catalogs, err := deps.Storage.ListModelCatalog(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->workspace",
+				Operator: "eq",
+				Value:    strconv.Quote(workspace),
+			},
+			{
+				Column:   "metadata->>deletion_timestamp",
+				Operator: "is",
+				Value:    "null",
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list model catalogs: %w", err)
+	}
+
+	var references []ModelReference
+
+	for i := range catalogs {
+		catalog := catalogs[i]
+		if catalog.Spec == nil {
+			continue
+		}
+
+		if modelSpecReferences(catalog.Spec.Model, registryName, modelName, version) {
+			references = append(references, ModelReference{
+				Kind:      modelCatalogKind,
+				Name:      catalog.GetName(),
+				Workspace: catalog.GetWorkspace(),
+			})
+		}
+
+		for variantKey := range catalog.Spec.Variants {
+			variant := catalog.Spec.Variants[variantKey]
+			if !modelSpecReferences(variant.Model, registryName, modelName, version) {
+				continue
+			}
+
+			references = append(references, ModelReference{
+				Kind:      modelCatalogKind,
+				Name:      catalog.GetName(),
+				Workspace: catalog.GetWorkspace(),
+				Variant:   variantKey,
+			})
+		}
+	}
+
+	return references, nil
+}
+
+// modelSpecReferences reports whether a model spec points at the model.
+//
+// A spec that names no registry matches any of them. Catalog validation does not
+// require the field — a recipe variant only has to name a model — so treating an
+// empty registry as "no opinion" is what keeps a real reference from slipping
+// past the check. It can over-match, which costs the user an explanation; the
+// other way round costs them a model deleted out from under a catalog.
+func modelSpecReferences(spec *v1.ModelSpec, registryName, modelName, version string) bool {
+	if spec == nil || spec.Name != modelName {
+		return false
+	}
+
+	if spec.Registry != "" && spec.Registry != registryName {
+		return false
+	}
+
+	return versionsOverlap(spec.Version, version)
+}
+
+// versionsOverlap applies the wildcard rule for model versions: "latest" is not
+// a version but a pointer to one, so it matches whatever the other side names,
+// in either direction. An unset version means "latest".
+func versionsOverlap(referencedVersion, version string) bool {
+	if referencedVersion == "" {
+		referencedVersion = v1.LatestVersion
+	}
+
+	if version == "" {
+		version = v1.LatestVersion
+	}
+
+	return version == v1.LatestVersion || referencedVersion == v1.LatestVersion || referencedVersion == version
+}
+
+// referenceHint describes the blockers in the terms the caller will recognise.
+// The endpoint-only wording is the long-standing one and is asserted by the
+// existing tests, so it is reproduced exactly.
+func referenceHint(references []ModelReference) string {
+	var endpoints, catalogs int
+
+	for _, reference := range references {
+		switch reference.Kind {
+		case endpointKind:
+			endpoints++
+		case modelCatalogKind:
+			catalogs++
+		}
+	}
+
+	switch {
+	case catalogs == 0:
+		return fmt.Sprintf("%d endpoint(s) still reference this model", endpoints)
+	case endpoints == 0:
+		return fmt.Sprintf("%d model catalog(s) still reference this model", catalogs)
+	default:
+		return fmt.Sprintf("%d endpoint(s) and %d model catalog(s) still reference this model", endpoints, catalogs)
+	}
+}

--- a/internal/routes/models/references_test.go
+++ b/internal/routes/models/references_test.go
@@ -1,0 +1,362 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+func catalogWithModel(name string, model *v1.ModelSpec) v1.ModelCatalog {
+	return v1.ModelCatalog{
+		Metadata: &v1.Metadata{Name: name, Workspace: "default"},
+		Spec:     &v1.ModelCatalogSpec{Model: model},
+	}
+}
+
+func recipeCatalog(name string, variants map[string]v1.RecipeVariant) v1.ModelCatalog {
+	return v1.ModelCatalog{
+		Metadata: &v1.Metadata{Name: name, Workspace: "default"},
+		Spec:     &v1.ModelCatalogSpec{Variants: variants},
+	}
+}
+
+// deletionTestDeps wires a deletion check against fixed endpoint and catalog
+// listings.
+func deletionTestDeps(t *testing.T, endpoints []v1.Endpoint, catalogs []v1.ModelCatalog) *Dependencies {
+	t.Helper()
+
+	mockStorage, mockRegistry := setupMocks(t)
+
+	mockStorage.On("ListEndpoint", endpointModelReferenceFilterMatcher("default", "test-registry", "test-model")).
+		Return(endpoints, nil)
+	mockStorage.On("ListModelCatalog", catalogReferenceFilterMatcher("default")).Return(catalogs, nil)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}}, nil).Maybe()
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil).Maybe()
+	mockStorage.On("DeleteModelAlias", mock.Anything).Return(nil).Maybe()
+	mockRegistry.On("Connect").Return(nil).Maybe()
+	mockRegistry.On("Disconnect").Return(nil).Maybe()
+	mockRegistry.On("GetModelVersion", "test-model", mock.Anything).
+		Return(&v1.ModelVersion{Name: "v1.0.0"}, nil).Maybe()
+	mockRegistry.On("DeleteModel", "test-model", mock.Anything).Return(nil).Maybe()
+
+	return &Dependencies{Storage: mockStorage}
+}
+
+// decodeReferences pulls the references array out of a 10131 body.
+func decodeReferences(t *testing.T, body []byte) []ModelReference {
+	t.Helper()
+
+	var response struct {
+		Code       string           `json:"code"`
+		Hint       string           `json:"hint"`
+		References []ModelReference `json:"references"`
+	}
+
+	require.NoError(t, json.Unmarshal(body, &response))
+	assert.Equal(t, "10131", response.Code)
+	assert.Contains(t, response.Hint, "still reference this model")
+
+	return response.References
+}
+
+// An endpoint marked for deletion is on its way out. Counting it left the user
+// with a model they could not delete and no way to break the deadlock: the
+// endpoint was already gone as far as they could see.
+func TestDeleteModel_SoftDeletedEndpointDoesNotBlock(t *testing.T) {
+	softDeleted := endpointWithModel("test-registry", "test-model", "v1.0.0")
+	softDeleted.Metadata = &v1.Metadata{
+		Name:              "going-away",
+		Workspace:         "default",
+		DeletionTimestamp: time.Now().Format(time.RFC3339Nano),
+	}
+
+	// The query filters soft-deleted endpoints out at the database, so a correct
+	// implementation never sees this row. The listing returns nothing precisely
+	// because the filter the matcher asserts on is in the query.
+	deps := deletionTestDeps(t, []v1.Endpoint{}, []v1.ModelCatalog{})
+
+	c, w := createMockContext("default", "test-registry", "test-model", "")
+	setVersionQuery(c, "v1.0.0")
+	deleteModel(deps)(c)
+
+	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
+	assert.Empty(t, w.Body.String())
+}
+
+func TestDeleteModel_BlockedByPlainCatalog(t *testing.T) {
+	deps := deletionTestDeps(t, []v1.Endpoint{}, []v1.ModelCatalog{
+		catalogWithModel("qwen-card", &v1.ModelSpec{
+			Registry: "test-registry",
+			Name:     "test-model",
+			Version:  "v1.0.0",
+		}),
+	})
+
+	c, w := createMockContext("default", "test-registry", "test-model", "")
+	setVersionQuery(c, "v1.0.0")
+	deleteModel(deps)(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	references := decodeReferences(t, w.Body.Bytes())
+	require.Len(t, references, 1)
+	assert.Equal(t, modelCatalogKind, references[0].Kind)
+	assert.Equal(t, "qwen-card", references[0].Name)
+	assert.Equal(t, "default", references[0].Workspace)
+	assert.Empty(t, references[0].Variant)
+}
+
+// A recipe catalog keeps its variants under arbitrary JSON keys, so the check
+// has to walk them — and name the one that matched, or the user has no idea
+// which entry to edit.
+func TestDeleteModel_BlockedByRecipeVariant(t *testing.T) {
+	deps := deletionTestDeps(t, []v1.Endpoint{}, []v1.ModelCatalog{
+		recipeCatalog("qwen-recipe", map[string]v1.RecipeVariant{
+			"fp8": {Model: &v1.ModelSpec{Registry: "test-registry", Name: "other-model"}},
+			"bf16-high-throughput": {
+				Model: &v1.ModelSpec{Registry: "test-registry", Name: "test-model", Version: "v1.0.0"},
+			},
+		}),
+	})
+
+	c, w := createMockContext("default", "test-registry", "test-model", "")
+	setVersionQuery(c, "v1.0.0")
+	deleteModel(deps)(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	references := decodeReferences(t, w.Body.Bytes())
+	require.Len(t, references, 1)
+	assert.Equal(t, modelCatalogKind, references[0].Kind)
+	assert.Equal(t, "qwen-recipe", references[0].Name)
+	assert.Equal(t, "bf16-high-throughput", references[0].Variant)
+}
+
+// Catalog validation does not require a variant to name a registry, so a variant
+// that omits it still points at the model as far as anyone deploying it is
+// concerned.
+func TestDeleteModel_BlockedByVariantWithoutRegistry(t *testing.T) {
+	deps := deletionTestDeps(t, []v1.Endpoint{}, []v1.ModelCatalog{
+		recipeCatalog("registry-less", map[string]v1.RecipeVariant{
+			"default": {Model: &v1.ModelSpec{Name: "test-model"}},
+		}),
+	})
+
+	c, w := createMockContext("default", "test-registry", "test-model", "")
+	setVersionQuery(c, "v1.0.0")
+	deleteModel(deps)(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	references := decodeReferences(t, w.Body.Bytes())
+	require.Len(t, references, 1)
+	assert.Equal(t, "default", references[0].Variant)
+}
+
+func TestDeleteModel_UnrelatedCatalogsDoNotBlock(t *testing.T) {
+	deps := deletionTestDeps(t, []v1.Endpoint{}, []v1.ModelCatalog{
+		catalogWithModel("other-model-card", &v1.ModelSpec{
+			Registry: "test-registry",
+			Name:     "some-other-model",
+			Version:  "v1.0.0",
+		}),
+		catalogWithModel("other-registry-card", &v1.ModelSpec{
+			Registry: "another-registry",
+			Name:     "test-model",
+			Version:  "v1.0.0",
+		}),
+		catalogWithModel("other-version-card", &v1.ModelSpec{
+			Registry: "test-registry",
+			Name:     "test-model",
+			Version:  "v2.0.0",
+		}),
+		recipeCatalog("empty-recipe", map[string]v1.RecipeVariant{"a": {}}),
+		{Metadata: &v1.Metadata{Name: "spec-less", Workspace: "default"}},
+	})
+
+	c, _ := createMockContext("default", "test-registry", "test-model", "")
+	setVersionQuery(c, "v1.0.0")
+	deleteModel(deps)(c)
+
+	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
+}
+
+// The body has to carry enough for a user to act on: what kind of object, where
+// it lives, and — for an endpoint still coming up — which stage it is at.
+func TestDeleteModel_ReferenceBodyIdentifiesEveryBlocker(t *testing.T) {
+	deploying := endpointWithModel("test-registry", "test-model", "v1.0.0")
+	deploying.Metadata = &v1.Metadata{Name: "coming-up", Workspace: "default"}
+	deploying.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseDEPLOYING}
+
+	running := endpointWithModel("test-registry", "test-model", v1.LatestVersion)
+	running.Metadata = &v1.Metadata{Name: "serving", Workspace: "default"}
+	running.Status = &v1.EndpointStatus{Phase: v1.EndpointPhaseRUNNING}
+
+	deps := deletionTestDeps(t, []v1.Endpoint{deploying, running}, []v1.ModelCatalog{
+		catalogWithModel("qwen-card", &v1.ModelSpec{Registry: "test-registry", Name: "test-model"}),
+	})
+
+	c, w := createMockContext("default", "test-registry", "test-model", "")
+	setVersionQuery(c, "v1.0.0")
+	deleteModel(deps)(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	references := decodeReferences(t, w.Body.Bytes())
+	require.Len(t, references, 3)
+
+	assert.Contains(t, references, ModelReference{
+		Kind:      endpointKind,
+		Name:      "coming-up",
+		Workspace: "default",
+		Phase:     string(v1.EndpointPhaseDEPLOYING),
+	})
+	assert.Contains(t, references, ModelReference{
+		Kind:      endpointKind,
+		Name:      "serving",
+		Workspace: "default",
+		Phase:     string(v1.EndpointPhaseRUNNING),
+	})
+	assert.Contains(t, references, ModelReference{
+		Kind:      modelCatalogKind,
+		Name:      "qwen-card",
+		Workspace: "default",
+	})
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Contains(t, response["hint"], "2 endpoint(s) and 1 model catalog(s) still reference this model")
+}
+
+// The endpoint-only wording predates catalog checking and is asserted elsewhere,
+// including by an e2e test, so it has to come out unchanged.
+func TestReferenceHint(t *testing.T) {
+	endpoint := ModelReference{Kind: endpointKind, Name: "a"}
+	catalog := ModelReference{Kind: modelCatalogKind, Name: "b"}
+
+	assert.Equal(t, "1 endpoint(s) still reference this model",
+		referenceHint([]ModelReference{endpoint}))
+	assert.Equal(t, "2 model catalog(s) still reference this model",
+		referenceHint([]ModelReference{catalog, catalog}))
+	assert.Equal(t, "1 endpoint(s) and 1 model catalog(s) still reference this model",
+		referenceHint([]ModelReference{endpoint, catalog}))
+}
+
+func TestVersionsOverlap(t *testing.T) {
+	tests := []struct {
+		referenced string
+		requested  string
+		want       bool
+	}{
+		{referenced: "v1", requested: "v1", want: true},
+		{referenced: "v1", requested: "v2", want: false},
+		{referenced: "", requested: "v1", want: true},
+		{referenced: v1.LatestVersion, requested: "v1", want: true},
+		{referenced: "v1", requested: v1.LatestVersion, want: true},
+		{referenced: "v1", requested: "", want: true},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, versionsOverlap(tt.referenced, tt.requested),
+			"referenced=%q requested=%q", tt.referenced, tt.requested)
+	}
+}
+
+// The deletion handler drops the alias rows of the model it just removed, so a
+// later model reusing those coordinates does not inherit a stale display name.
+func TestDeleteModel_RemovesAliasRows(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+
+	mockStorage.On("ListEndpoint", mock.Anything).Return([]v1.Endpoint{}, nil)
+	mockStorage.On("ListModelCatalog", mock.Anything).Return([]v1.ModelCatalog{}, nil)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}}, nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{{
+		ID:              3,
+		ModelRegistryID: 7,
+		ModelName:       "test-model",
+		ModelVersion:    "v1.0.0",
+		Alias:           "Chat",
+	}}, nil)
+	mockStorage.On("DeleteModelAlias", "3").Return(nil)
+
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	// The version has to be resolved before the model goes away; afterwards
+	// "latest" points at nothing.
+	mockRegistry.On("GetModelVersion", "test-model", v1.LatestVersion).
+		Return(&v1.ModelVersion{Name: "v1.0.0"}, nil)
+	mockRegistry.On("DeleteModel", "test-model", v1.LatestVersion).Return(nil)
+
+	c, _ := createMockContext("default", "test-registry", "test-model", "")
+	deleteModel(&Dependencies{Storage: mockStorage})(c)
+
+	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
+	mockStorage.AssertExpectations(t)
+	mockRegistry.AssertExpectations(t)
+}
+
+// A failure to clean up an alias must not fail the deletion: the model is gone,
+// and a row pointing at a model that no longer exists is invisible to every read
+// path anyway.
+func TestDeleteModel_AliasCleanupIsBestEffort(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+
+	mockStorage.On("ListEndpoint", mock.Anything).Return([]v1.Endpoint{}, nil)
+	mockStorage.On("ListModelCatalog", mock.Anything).Return([]v1.ModelCatalog{}, nil)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}}, nil)
+	mockStorage.On("ListModelAlias", mock.Anything).
+		Return([]v1.ModelAlias(nil), assert.AnError)
+
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("GetModelVersion", "test-model", v1.LatestVersion).
+		Return(&v1.ModelVersion{Name: "v1.0.0"}, nil)
+	mockRegistry.On("DeleteModel", "test-model", v1.LatestVersion).Return(nil)
+
+	c, _ := createMockContext("default", "test-registry", "test-model", "")
+	deleteModel(&Dependencies{Storage: mockStorage})(c)
+
+	assert.Equal(t, http.StatusNoContent, c.Writer.Status())
+}
+
+// The endpoint query must ask the database for the soft-delete filter rather
+// than sorting it out in Go, so the filter set itself is the assertion.
+func TestEndpointReferences_QueryFiltersSoftDeleted(t *testing.T) {
+	mockStorage, _ := setupMocks(t)
+
+	var captured storage.ListOption
+
+	mockStorage.On("ListEndpoint", mock.Anything).Run(func(args mock.Arguments) {
+		captured = args.Get(0).(storage.ListOption) //nolint:errcheck
+	}).Return([]v1.Endpoint{}, nil)
+
+	_, err := endpointReferences(&Dependencies{Storage: mockStorage},
+		"default", "test-registry", "test-model", "v1.0.0")
+	require.NoError(t, err)
+
+	assert.Contains(t, captured.Filters, storage.Filter{
+		Column:   "metadata->>deletion_timestamp",
+		Operator: "is",
+		Value:    "null",
+	})
+}


### PR DESCRIPTION
## What

Phase-one server work for private model registry asset management (NEU-620), on top of the database groundwork in the base branch: a structured model information type, repository interface extensions with paging, a checkpoint metadata parser, display aliases and hand-filled metadata, registry statistics, and deletion protection that names what still references a model.

The database groundwork it builds on (NEU-619) has since landed, and this branch was rebased onto `main` with those commits dropped — they arrived there as a squash. The rebase did not change the diff: the same 40 files and the same `+5153/-331` it showed against the old base.

### 1. `ModelInfo` — structured, with per-field provenance

`ModelInfo` moves to `api/v1/model_info_types.go` (a test file of that name already existed with no source beside it) and gains the shape parameters a model card and a resource estimate need: layer/head counts, head dimension, position embeddings, MoE expert counts, parameter dtype and quantization width. The four existing display fields keep their exact JSON shape, and every new field is optional, so a spec written before they existed serializes byte for byte as it did — asserted directly.

Provenance is recorded **per field** (`field_sources`: `auto` / `derived` / `manual`) rather than once per record. A record-level enum could not answer "which of these values did a person type", which is what the UI has to mark, nor "where did `num_key_value_heads` come from", which is what a confidence rating for a resource estimate depends on. `missing_fields` is the convenience complement: the fields that were looked for and not established.

### 2. Repository interface: paging and a detail read

`ListOption` gains `Offset`; `ListModels` now returns a page plus the total. New `GetModelDetail` (the expensive read that opens the checkpoint) sits beside the existing cheap `GetModelVersion`, which orchestration and the direct-push finalize path keep using.

A `GetReadme` was declared and implemented here in an earlier revision and has been dropped: nothing outside its own tests called it and no route reached it, so a reviewer had no call site to judge it against. It lands together with the route that serves it in NEU-624 (#535), which replaces this signature wholesale anyway.

**The total travels in a `Content-Range` header and the body stays a bare array.** Two existing callers in the UI consume the listing as an array; an `{items, total}` envelope would break them across repositories for the sake of one number. The header form matches the PostgREST convention already in use elsewhere in the API.

Hugging Face stays read-only: the new operations return an error wrapping a typed `ErrNotSupported`, so a handler can answer "this registry kind cannot do that" instead of a server error. The existing message text is unchanged.

**Paging a public registry is refused, not faked.** The Hub's supported pagination is an opaque, server-generated cursor carried in a `Link` header, which cannot express "start at row N"; its `skip` parameter, which could, is documented by the Hub itself as deprecated — measured against the live API, it is honoured up to somewhere between 3000 and 4000 and returns `The 'skip' query parameter is deprecated and only still supported temporarily in a limited number of use cases` beyond that. Building paging on it would work in a dev registry and break silently in a real one. So `ListModels` refuses a non-zero `Offset` with a typed error, which the route turns into a `400`, rather than serving the first page for every request while the client believes it is advancing.

For the same reason `ModelPage.Total` is `*int`, and a nil total renders as `Content-Range: 0-1/*`. The Hub does not report how many models matched; reporting the size of the page that came back would tell a client it had reached the end of a listing it had barely started. Private registries always know their total and always report it.

### 3. Checkpoint metadata parser (`internal/model_registry/modelmeta`)

Nothing in this repository parsed a checkpoint before; this is new. Pure functions plus testdata fixtures, no I/O beyond reading the files it is asked about.

Each fixture directory holds its own `config.json` and an `expected.json` golden of the `ModelInfo` it parses into, and the tests walk the directory rather than naming fixtures in a Go table, so adding a case is adding a directory. `-update` regenerates the goldens, is off by default, and `TestMain` fails any run that sets it — a rewrite can never be reported as a passing verification. Fixtures carry no binary weights: safetensors are built in `t.TempDir()` by the tests that need them.

`config.json` supplies the shape fields directly. **`parameter_count` is read exactly from the safetensors headers**, not estimated: the format puts an 8-byte little-endian length in front of a JSON header describing every tensor's shape, so summing `prod(shape)` over a few tens of kilobytes per shard gives the exact element total without touching a byte of weight data. `model.safetensors.index.json` is deliberately not used — it carries a total byte size and a tensor-to-shard map but no shapes, and deriving a count from bytes would mean assuming a dtype. Only safetensors is supported: a `pytorch_model.bin` is a pickle and GGUF is a different container, so both leave the count missing.

The value is reported as the exact decimal total of **stored tensor elements**. That is what the files contain — not strictly the trainable parameter count, since a checkpoint holds a few non-parameter tensors — and for an MoE checkpoint it is the total across all experts, not the per-token active count.

Exactly one arithmetic derivation is allowed, marked `derived`: `head_dim` = `hidden_size / num_attention_heads` when the config omits it, which is the established convention rather than a guess. **Nothing is ever inferred from a model or directory name**; there is a test that sweeps directories named after well-advertised models and asserts nothing comes out. An absent or malformed `config.json` yields an empty result with everything in `missing_fields` and no error.

### 4. Parsing wired into the private registry read path

`GetModelDetail` fills `ModelInfo` from the checkpoint and exposes it, together with `field_sources` and `missing_fields`, on `GET /workspaces/:ws/model_registries/:reg/models/:model`. Listings deliberately do not pay for the parse.

Two fields that were declared but never written anywhere get their meaning fixed here: `ModelVersion.Labels` carries the labels from the model's own descriptor; `Description` stays unused.

### 5. Aliases and hand-filled metadata

New `PATCH /workspaces/:ws/model_registries/:reg/models/:model`, reusing the `model:push` permission — no new permission action.

An alias is unique within a registry and **across versions**, because it is what a user picks a model by; two versions offering the same display name is exactly the ambiguity the rule prevents. It also may not shadow a physical model name in the same registry. Both are checked, and a conflict is a `409` whose body names the physical model and version it collided with. The application-side check runs against a snapshot, so the unique index is the real arbiter: a lost race comes back as a `409` naming the winner, not as a server error.

An alias row whose model is no longer in the registry is an orphan — the filesystem, not the table, decides what exists. It is hidden from reads and it does not reserve its name; a colliding write takes it over. Model deletion drops the alias rows of what it deleted, best effort.

Hand-filled `ModelInfo` values live in the model's own descriptor, so they travel with the model through export/import. The block is replaced wholesale by a `PATCH`, which is what makes a value removable. Provenance is the server's to state: whatever arrives is recorded as `manual` regardless of what the request claimed. The descriptor is edited as a generic document and written through a rename, so keys this codebase does not model survive and no reader sees a half-written file.

**Changing an alias cannot move a running deployment.** Nothing in orchestration reads aliases — every path is built from `endpoint.spec.model.name` and the resolved real version — and the alias never reaches `spec.model.name`, so the name a model is served under, and therefore the API key `allowed_models` matching that name, are untouched. The handler test asserts the registry receives no write at all when only the alias changes.

Public registries answer `PATCH` with a plain "not supported".

### 6. Registry statistics

A stateless aggregator turns an observation of a registry into the `stats` block on its status. Storage is a real byte traversal: the `size` string in a descriptor is human-readable, frozen at push time, never recomputed, and measured over a different file set than the archive contains.

**Throttled by `stats_updated_at`.** The reconcile interval is ten seconds and walking a model tree on networked storage is not a ten-second operation, so the tree is measured only once the stored counters have aged past a threshold. A recomputation is written back even when the counters came out identical — the stored timestamp is what holds off the next reconcile. There is a test that runs twenty reconciles and asserts exactly one walk.

Best effort throughout: measurement happens only on a registry that just passed its health check, and a failure leaves the previous counters in place. Zeroing them would present a transient storage failure as an empty registry. A public registry is not measured at all, so it carries no stats block.

### 7. Deletion protection

The `10131` response gains a `references[]` array — `kind` / `name` / `workspace`, plus `phase` for an endpoint and the variant key for a recipe catalog. The code and the existing message and hint wording are unchanged for the endpoint-only case, which is every case that existed before.

Model catalogs are now checked, in both shapes. A recipe catalog keeps its variants under arbitrary JSON keys, so "any variant points at this model" is not expressible as a filter on one column; the workspace's catalogs are listed and swept in Go rather than growing a SQL function that would put the matching rules in two places. A variant that names no registry is treated as matching any — catalog validation does not require the field, and over-matching costs a user an explanation while under-matching costs them a model deleted out from under a catalog.

A deployment that is still coming up is not a separate kind of reference; it is an endpoint whose phase says so, and the phase is in the body so a client can distinguish them.

API key `allowed_models` is deliberately **not** checked. That field holds an externally visible model name with no registry and no version, so it cannot be resolved to a model in a particular registry. Matching on the bare name would produce blocks a user cannot clear — a model in one registry undeletable because an unrelated API key lists the same name — and routing it through the endpoints that serve the model is what the endpoint check already does.

## Bundled defect fixes

**This PR bundles three pre-existing defect fixes. Each is independent of the feature work; please review them separately.**

### Defect A — a truncated listing returned a random subset

`convertBentoMLModelsToGeneralModels` built a `map[string]*GeneralModel`, converted it to a slice, and then applied `Limit`. Go randomises map iteration, so the truncated subset differed on every request. Adding `Offset` on that foundation would have produced pages that overlap and drop entries.

Fixed by sorting by name before paging.

**Regression cases:** `TestListModels_OrderIsStable` (twenty identical listings must match), `TestListModels_PagesCoverTheListingExactlyOnce`, and `TestListModels_ResponseOrderIsStableFromDisk` end to end through the handler. All fail without the sort.

### Defect B — both read paths discarded labels and metadata

The descriptor carries `labels` and `metadata`, and the export/import round trip preserves them faithfully, but both read paths decoded into a narrower struct holding only name / version / module / size / creation time. Everything written there was silently unreadable — nowhere in the repository could get it back.

Fixed by decoding the whole descriptor on both paths. This is also what makes hand-filled metadata work at all: without it the data is writable and not readable.

**Regression cases:** `TestModelLabelsSurviveBothReadPaths` (both the listing and the detail path) and `TestGetModel_LabelsWrittenToModelYAMLAreReadableOverTheAPI` end to end through the handler.

### Defect C — a soft-deleted endpoint still blocked deletion

`validateModelDeletion` queried endpoints without a `deletion_timestamp is null` condition, so an endpoint already marked for deletion kept holding the model. The user deleted the endpoint, still could not delete the model, and had no way to break the deadlock. The comparable query in `api.get_workspace_models` has always had the filter.

**Regression cases:** `TestDeleteModel_SoftDeletedEndpointDoesNotBlock` and `TestEndpointReferences_QueryFiltersSoftDeleted`, which pins the filter in the query rather than in Go.

The three existing `10131` assertions in `internal/routes/models/models_test.go` pass unchanged, as does e2e C2723579.

## Test Plan

- [x] Unit: `api/v1`, `internal/model_registry/...`, `internal/routes/models`, `controllers`, `internal/cli/model` — all pass. New coverage: `modelmeta` 90.8%, `internal/model_registry` 70.8%, `internal/routes/models` 63.2%.
- [x] `go build ./...`, `gofmt`, `golangci-lint run` — clean.
- [x] `go test -race -count=3` over `internal/routes/models` and `internal/model_registry`, which is what the concurrent-alias case is worth running under.
- [x] **Manual verification, not an automated test.** The acceptance item that needs a live environment — renaming the alias of a model an actually-running endpoint is serving — was driven by hand against a real control plane running this branch, with a private NFS-backed registry and a single-node cluster serving the model. Four alias changes left the orchestration path byte-identical across ten fields, including the registry path, the cache path, the serve name and the whole engine container spec with its NFS mount. The endpoint stayed `Running` across 31 samples spanning a rename, with exactly one container set observed — same IDs, same `StartedAt` — and an unchanged `last_deployed_time_s`, so the Serve app was never redeployed. The three conflict shapes each answered `409` naming what they collided with: alias against alias returns `{"kind":"Model","name":...,"version":...}`, alias against a physical model name returns `{"kind":"ModelName","name":...}`, and a rejected write left the target's alias unset.
- [ ] E2E suite: not run, and **this PR touches no file under `tests/e2e/`**. C2723579 covers the deletion path and its assertions are untouched. The alias-vs-running-endpoint result above is prose evidence from a hand-driven session — nothing in CI guards it. **NEU-652** tracks the automated e2e for it (SSH endpoint + NFS, following `endpoint_model_cache_test.go`); it is deliberately not bundled here.
- [ ] DB integration (`make db-test`): not affected — no migration in this PR. The schema this builds on ships with NEU-619 and is tested there.

## Risk & Rollback

No schema change. The response body grows in three places and shrinks nowhere: `info` and `alias` on a model version, `references` on a `10131`, and a `Content-Range` header on the listing. Existing clients ignore all of them, and the listing body stays the array they already parse. `PATCH` is a new method on an existing path. Rollback is reverting the commit.



