### PR TITLE
feat: support internal accelerator plugins

### DIFF
--- a/cmd/neutree-core/app/builder.go
+++ b/cmd/neutree-core/app/builder.go
@@ -7,12 +7,15 @@ import (
 
 	"github.com/neutree-ai/neutree/cmd/neutree-core/app/config"
 	"github.com/neutree-ai/neutree/controllers"
+	"github.com/neutree-ai/neutree/internal/accelerator"
+	publicaccelerator "github.com/neutree-ai/neutree/pkg/accelerator"
 )
 
 // Builder is the application builder
 type Builder struct {
-	controllerInits map[string]ControllerFactory
-	config          *config.CoreConfig
+	controllerInits    map[string]ControllerFactory
+	config             *config.CoreConfig
+	acceleratorPlugins []publicaccelerator.Plugin
 
 	beforeHooks       map[string][]controllers.HookFunc
 	afterHooks        map[string][]controllers.HookFunc
@@ -56,6 +59,11 @@ func NewBuilder() *Builder {
 
 func (b *Builder) WithConfig(c *config.CoreConfig) *Builder {
 	b.config = c
+	return b
+}
+
+func (b *Builder) WithAcceleratorPlugins(plugins ...publicaccelerator.Plugin) *Builder {
+	b.acceleratorPlugins = append(b.acceleratorPlugins, append([]publicaccelerator.Plugin(nil), plugins...)...)
 	return b
 }
 
@@ -105,6 +113,13 @@ func (b *Builder) Build() (*App, error) {
 	if b.config == nil {
 		return nil, fmt.Errorf("configuration is required to build the application")
 	}
+
+	acceleratorManager, err := accelerator.NewManagerWithPlugins(b.config.GinEngine, b.acceleratorPlugins...)
+	if err != nil {
+		return nil, fmt.Errorf("create accelerator manager: %w", err)
+	}
+
+	b.config.AcceleratorManager = acceleratorManager
 
 	registerControllers := make(map[string]controllers.Controller)
 	// Initialize controllers

--- a/cmd/neutree-core/app/builder.go
+++ b/cmd/neutree-core/app/builder.go
@@ -114,12 +114,14 @@ func (b *Builder) Build() (*App, error) {
 		return nil, fmt.Errorf("configuration is required to build the application")
 	}
 
-	acceleratorManager, err := accelerator.NewManagerWithPlugins(b.config.GinEngine, b.acceleratorPlugins...)
-	if err != nil {
-		return nil, fmt.Errorf("create accelerator manager: %w", err)
-	}
+	if b.config.AcceleratorManager == nil || len(b.acceleratorPlugins) > 0 {
+		acceleratorManager, err := accelerator.NewManagerWithPlugins(b.config.GinEngine, b.acceleratorPlugins...)
+		if err != nil {
+			return nil, fmt.Errorf("create accelerator manager: %w", err)
+		}
 
-	b.config.AcceleratorManager = acceleratorManager
+		b.config.AcceleratorManager = acceleratorManager
+	}
 
 	registerControllers := make(map[string]controllers.Controller)
 	// Initialize controllers

--- a/cmd/neutree-core/app/builder.go
+++ b/cmd/neutree-core/app/builder.go
@@ -113,6 +113,9 @@ func (b *Builder) Build() (*App, error) {
 	if b.config == nil {
 		return nil, fmt.Errorf("configuration is required to build the application")
 	}
+	if b.config.GinEngine == nil {
+		return nil, fmt.Errorf("gin engine is required")
+	}
 
 	if b.config.AcceleratorManager == nil || len(b.acceleratorPlugins) > 0 {
 		acceleratorManager, err := accelerator.NewManagerWithPlugins(b.config.GinEngine, b.acceleratorPlugins...)

--- a/cmd/neutree-core/app/builder.go
+++ b/cmd/neutree-core/app/builder.go
@@ -113,6 +113,7 @@ func (b *Builder) Build() (*App, error) {
 	if b.config == nil {
 		return nil, fmt.Errorf("configuration is required to build the application")
 	}
+
 	if b.config.GinEngine == nil {
 		return nil, fmt.Errorf("gin engine is required")
 	}

--- a/cmd/neutree-core/app/builder_test.go
+++ b/cmd/neutree-core/app/builder_test.go
@@ -68,7 +68,7 @@ func TestBuilderBuildRequiresGinEngine(t *testing.T) {
 
 func TestBuilderBuildPreservesConfiguredAcceleratorManagerWithoutInjectedPlugins(t *testing.T) {
 	manager := &acceleratormocks.MockManager{}
-	config := &config.CoreConfig{AcceleratorManager: manager}
+	config := &config.CoreConfig{GinEngine: gin.New(), AcceleratorManager: manager}
 	builder := NewBuilder().WithConfig(config)
 	builder.controllerInits = map[string]ControllerFactory{}
 
@@ -79,6 +79,17 @@ func TestBuilderBuildPreservesConfiguredAcceleratorManagerWithoutInjectedPlugins
 	}
 	if config.AcceleratorManager != manager {
 		t.Fatal("Build() replaced the configured AcceleratorManager without injected plugins")
+	}
+}
+
+func TestBuilderBuildRequiresGinEngineWithConfiguredAcceleratorManager(t *testing.T) {
+	builder := NewBuilder().WithConfig(&config.CoreConfig{AcceleratorManager: &acceleratormocks.MockManager{}})
+	builder.controllerInits = map[string]ControllerFactory{}
+
+	_, err := builder.Build()
+
+	if err == nil {
+		t.Fatal("Build() error = nil, want GinEngine validation error")
 	}
 }
 

--- a/cmd/neutree-core/app/builder_test.go
+++ b/cmd/neutree-core/app/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/neutree-ai/neutree/cmd/neutree-core/app/config"
+	acceleratormocks "github.com/neutree-ai/neutree/internal/accelerator/mocks"
 	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
 )
 
@@ -62,6 +63,22 @@ func TestBuilderBuildRequiresGinEngine(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("Build() error = nil, want GinEngine validation error")
+	}
+}
+
+func TestBuilderBuildPreservesConfiguredAcceleratorManagerWithoutInjectedPlugins(t *testing.T) {
+	manager := &acceleratormocks.MockManager{}
+	config := &config.CoreConfig{AcceleratorManager: manager}
+	builder := NewBuilder().WithConfig(config)
+	builder.controllerInits = map[string]ControllerFactory{}
+
+	_, err := builder.Build()
+
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if config.AcceleratorManager != manager {
+		t.Fatal("Build() replaced the configured AcceleratorManager without injected plugins")
 	}
 }
 

--- a/cmd/neutree-core/app/builder_test.go
+++ b/cmd/neutree-core/app/builder_test.go
@@ -3,7 +3,9 @@ package app
 import (
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/neutree-ai/neutree/cmd/neutree-core/app/config"
+	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
 )
 
 func TestNewBuilder(t *testing.T) {
@@ -31,6 +33,44 @@ func TestBuilderWithConfig(t *testing.T) {
 	if builder.config != config {
 		t.Errorf("Expected config to be set in builder, got %v", builder.config)
 	}
+}
+
+func TestBuilderBuildInjectsAcceleratorPlugins(t *testing.T) {
+	config := &config.CoreConfig{GinEngine: gin.New()}
+	injected := internalTestPlugin{AcceleratorPlugin: plugin.NewAcceleratorRestPlugin("injected-test", "http://plugin.example")}
+	builder := NewBuilder().WithConfig(config).WithAcceleratorPlugins(injected)
+	builder.controllerInits = map[string]ControllerFactory{}
+
+	_, err := builder.Build()
+
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if config.AcceleratorManager == nil {
+		t.Fatal("Build() did not initialize AcceleratorManager")
+	}
+	if _, ok := config.AcceleratorManager.GetPlugin("injected-test"); !ok {
+		t.Fatal("Build() did not register the injected accelerator plugin")
+	}
+}
+
+func TestBuilderBuildRequiresGinEngine(t *testing.T) {
+	builder := NewBuilder().WithConfig(&config.CoreConfig{})
+	builder.controllerInits = map[string]ControllerFactory{}
+
+	_, err := builder.Build()
+
+	if err == nil {
+		t.Fatal("Build() error = nil, want GinEngine validation error")
+	}
+}
+
+type internalTestPlugin struct {
+	plugin.AcceleratorPlugin
+}
+
+func (internalTestPlugin) Type() string {
+	return plugin.InternalPluginType
 }
 
 func TestBuilderWithController(t *testing.T) {

--- a/cmd/neutree-core/app/options/options.go
+++ b/cmd/neutree-core/app/options/options.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/klog"
 
 	"github.com/neutree-ai/neutree/cmd/neutree-core/app/config"
-	"github.com/neutree-ai/neutree/internal/accelerator"
 	"github.com/neutree-ai/neutree/internal/engine"
 	"github.com/neutree-ai/neutree/internal/gateway"
 	"github.com/neutree-ai/neutree/internal/observability/manager"
@@ -87,9 +86,6 @@ func (o *NeutreeCoreOptions) Config(scheme *scheme.Scheme) (*config.CoreConfig, 
 	}
 
 	klog.Infof("Transformed metrics remote write url: %s", o.Observability.MetricsRemoteWriteURL)
-
-	acceleratorManager := accelerator.NewManager(e)
-	c.AcceleratorManager = acceleratorManager
 
 	engineRegistry, err := engine.NewRegistry(e)
 	if err != nil {

--- a/internal/accelerator/manager.go
+++ b/internal/accelerator/manager.go
@@ -26,6 +26,7 @@ type Manager interface {
 	Start(ctx context.Context)
 	DetectAccelerator(ctx context.Context, nodeIP string, sshAuth v1.Auth) (*v1.StaticNodeAcceleratorStatus, error)
 	GetAcceleratorProfile(ctx context.Context, acceleratorType string) (*v1.AcceleratorProfile, error)
+	GetStaticNodeRuntimeConfig(ctx context.Context, accelerator *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, error)
 	GetNodeAcceleratorType(ctx context.Context, nodeIp string, sshAuth v1.Auth) (string, error)
 	GetNodeRuntimeConfig(ctx context.Context, acceleratorType string, nodeIp string, sshAuth v1.Auth) (v1.RuntimeConfig, error)
 
@@ -388,6 +389,98 @@ func (a *manager) GetAcceleratorProfile(
 	}
 
 	return profile, nil
+}
+
+func (a *manager) GetStaticNodeRuntimeConfig(
+	ctx context.Context,
+	acceleratorStatus *v1.StaticNodeAcceleratorStatus,
+) (*v1.RuntimeConfig, error) {
+	if acceleratorStatus == nil || acceleratorStatus.Type == "" {
+		return nil, nil
+	}
+
+	fallbackAllowed := false
+
+	if value, ok := a.acceleratorsMap.Load(acceleratorStatus.Type); ok {
+		if registered, registeredOK := value.(registerPlugin); registeredOK {
+			if _, resolverOK := registered.plugin.Handle().(publicaccelerator.StaticNodeRuntimeConfigResolver); resolverOK {
+				config, matched, err := resolveStaticNodeRuntimeConfig(ctx, acceleratorStatus, registered)
+				if err != nil {
+					return nil, err
+				}
+
+				if !matched {
+					return nil, errors.Errorf(
+						"static runtime resolver for accelerator type %s from owner plugin %s did not match",
+						acceleratorStatus.Type,
+						registered.resource,
+					)
+				}
+
+				return config, nil
+			}
+
+			fallbackAllowed = true
+		}
+	}
+
+	if !fallbackAllowed {
+		return nil, nil
+	}
+
+	registeredPlugins := []registerPlugin{}
+
+	a.acceleratorsMap.Range(func(_, value any) bool {
+		registered, registeredOK := value.(registerPlugin)
+		if registeredOK && registered.resource != acceleratorStatus.Type {
+			registeredPlugins = append(registeredPlugins, registered)
+		}
+
+		return true
+	})
+	sort.Slice(registeredPlugins, func(i, j int) bool {
+		return registeredPlugins[i].resource < registeredPlugins[j].resource
+	})
+
+	for _, registered := range registeredPlugins {
+		config, matched, err := resolveStaticNodeRuntimeConfig(ctx, acceleratorStatus, registered)
+		if err != nil || matched {
+			return config, err
+		}
+	}
+
+	return nil, nil
+}
+
+func resolveStaticNodeRuntimeConfig(
+	ctx context.Context,
+	acceleratorStatus *v1.StaticNodeAcceleratorStatus,
+	registered registerPlugin,
+) (*v1.RuntimeConfig, bool, error) {
+	resolver, resolverOK := registered.plugin.Handle().(publicaccelerator.StaticNodeRuntimeConfigResolver)
+	if !resolverOK {
+		return nil, false, nil
+	}
+
+	config, matched, err := resolver.GetStaticNodeRuntimeConfig(ctx, acceleratorStatus)
+	if err != nil {
+		return nil, false, errors.Wrapf(
+			err,
+			"get static node runtime config for accelerator type %s from plugin %s",
+			acceleratorStatus.Type,
+			registered.resource,
+		)
+	}
+
+	if matched && config == nil {
+		return nil, false, errors.Errorf(
+			"static runtime resolver for accelerator type %s from plugin %s returned nil config for a matched status",
+			acceleratorStatus.Type,
+			registered.resource,
+		)
+	}
+
+	return config, matched, nil
 }
 
 func (a *manager) GetAllConverters() map[string]plugin.ResourceConverter {

--- a/internal/accelerator/manager.go
+++ b/internal/accelerator/manager.go
@@ -2,7 +2,9 @@ package accelerator
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -15,6 +17,7 @@ import (
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
 	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
+	publicaccelerator "github.com/neutree-ai/neutree/pkg/accelerator"
 )
 
 type Manager interface {
@@ -60,6 +63,19 @@ type manager struct {
 }
 
 func NewManager(e *gin.Engine) *manager {
+	manager, err := NewManagerWithPlugins(e)
+	if err != nil {
+		panic(err)
+	}
+
+	return manager
+}
+
+func NewManagerWithPlugins(e *gin.Engine, injectedPlugins ...publicaccelerator.Plugin) (*manager, error) {
+	if e == nil {
+		return nil, fmt.Errorf("gin engine is required")
+	}
+
 	manager := &manager{
 		acceleratorsMap: sync.Map{},
 	}
@@ -74,11 +90,53 @@ func NewManager(e *gin.Engine) *manager {
 		klog.Infof("Register local accelerator plugin: %s", p.Resource())
 	}
 
+	for _, p := range injectedPlugins {
+		if err := manager.addInternalPlugin(p); err != nil {
+			return nil, err
+		}
+	}
+
 	// register plugin register handler
 	pluginGroup := e.Group(v1.PluginAPIGroupPath)
 	pluginGroup.POST("/register", manager.registerHandler)
 
-	return manager
+	return manager, nil
+}
+
+func (a *manager) addInternalPlugin(p publicaccelerator.Plugin) error {
+	if isNilPlugin(p) {
+		return fmt.Errorf("accelerator plugin is nil")
+	}
+
+	if p.Resource() == "" {
+		return fmt.Errorf("accelerator plugin resource is required")
+	}
+
+	if _, exists := a.acceleratorsMap.Load(p.Resource()); exists {
+		return fmt.Errorf("accelerator plugin resource %q is already registered", p.Resource())
+	}
+
+	a.acceleratorsMap.Store(p.Resource(), registerPlugin{
+		resource:         p.Resource(),
+		plugin:           p,
+		lastRegisterTime: time.Now(),
+	})
+
+	return nil
+}
+
+func isNilPlugin(p publicaccelerator.Plugin) bool {
+	if p == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(p)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 func (a *manager) registerHandler(c *gin.Context) {

--- a/internal/accelerator/manager.go
+++ b/internal/accelerator/manager.go
@@ -262,6 +262,26 @@ func (a *manager) DetectAccelerator(
 			return true
 		}
 
+		staticResponse, staticErr := p.plugin.Handle().DetectStaticNodeAccelerator(ctx, &v1.DetectStaticNodeAcceleratorRequest{
+			NodeIp:  nodeIP,
+			SSHAuth: sshAuth,
+		})
+		if staticErr == nil && staticResponse != nil && staticResponse.Matched && staticResponse.Accelerator != nil {
+			detected = staticResponse.Accelerator
+
+			return false
+		}
+
+		if staticErr != nil && p.plugin.Type() == publicaccelerator.InternalPluginType {
+			klog.Warningf("detect static node accelerator from plugin %s failed: %s", p.resource, staticErr.Error())
+
+			if detectErr == nil {
+				detectErr = errors.Wrapf(staticErr, "detect static node accelerator from plugin %s failed", p.resource)
+			}
+
+			return true
+		}
+
 		response, err := p.plugin.Handle().GetNodeAccelerator(ctx, &v1.GetNodeAcceleratorRequest{
 			NodeIp:  nodeIP,
 			SSHAuth: sshAuth,

--- a/internal/accelerator/manager_test.go
+++ b/internal/accelerator/manager_test.go
@@ -34,6 +34,201 @@ func TestManagerGetAcceleratorProfile(t *testing.T) {
 	assert.Equal(t, "dcgm-exporter", profile.MetricsExporter.Name)
 }
 
+func TestManagerGetStaticNodeRuntimeConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		plugin  *fakeStaticNodeAcceleratorPlugin
+		wantNil bool
+		wantErr string
+	}{
+		{
+			name: "matching resolver",
+			plugin: &fakeStaticNodeAcceleratorPlugin{
+				staticRuntimeConfig:  &v1.RuntimeConfig{Env: map[string]string{"VISIBLE_DEVICES": "0,1"}},
+				staticRuntimeMatched: true,
+			},
+		},
+		{
+			name:    "owner resolver does not match",
+			plugin:  &fakeStaticNodeAcceleratorPlugin{},
+			wantNil: true,
+			wantErr: "static runtime resolver for accelerator type custom_gpu from owner plugin custom_gpu did not match",
+		},
+		{
+			name: "owner resolver returns nil config",
+			plugin: &fakeStaticNodeAcceleratorPlugin{
+				staticRuntimeMatched: true,
+			},
+			wantNil: true,
+			wantErr: "static runtime resolver for accelerator type custom_gpu from plugin custom_gpu returned nil config for a matched status",
+		},
+		{
+			name:    "resolver error",
+			plugin:  &fakeStaticNodeAcceleratorPlugin{staticRuntimeErr: errors.New("unsupported static runtime")},
+			wantNil: true,
+			wantErr: "get static node runtime config for accelerator type custom_gpu from plugin custom_gpu",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &manager{}
+			m.acceleratorsMap.Store(tt.plugin.Resource(), registerPlugin{
+				resource:         tt.plugin.Resource(),
+				plugin:           tt.plugin,
+				lastRegisterTime: time.Now(),
+			})
+
+			config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "custom_gpu"})
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.wantNil {
+				assert.Nil(t, config)
+				return
+			}
+			require.NotNil(t, config)
+			assert.Equal(t, "0,1", config.Env["VISIBLE_DEVICES"])
+		})
+	}
+}
+
+func TestManagerGetStaticNodeRuntimeConfigDoesNotUseFallbackWithoutOwningPlugin(t *testing.T) {
+	fallback := &fakeStaticNodeAcceleratorPlugin{
+		resourceSet:          true,
+		resource:             "fallback_gpu",
+		staticRuntimeConfig:  &v1.RuntimeConfig{Env: map[string]string{"FALLBACK": "true"}},
+		staticRuntimeMatched: true,
+	}
+	m := &manager{}
+	m.acceleratorsMap.Store(fallback.Resource(), registerPlugin{
+		resource:         fallback.Resource(),
+		plugin:           fallback,
+		lastRegisterTime: time.Now(),
+	})
+
+	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "legacy_gpu"})
+
+	require.NoError(t, err)
+	assert.Nil(t, config)
+	assert.Zero(t, fallback.staticRuntimeCalls)
+}
+
+func TestManagerGetStaticNodeRuntimeConfigUsesFallbackWhenOwnerHasNoResolver(t *testing.T) {
+	fallback := &fakeStaticNodeAcceleratorPlugin{
+		resourceSet:          true,
+		resource:             "fallback_gpu",
+		staticRuntimeConfig:  &v1.RuntimeConfig{Env: map[string]string{"FALLBACK": "true"}},
+		staticRuntimeMatched: true,
+	}
+	m := &manager{}
+	m.acceleratorsMap.Store("owner_gpu", registerPlugin{
+		resource:         "owner_gpu",
+		plugin:           &plugin.GPUAcceleratorPlugin{},
+		lastRegisterTime: time.Now(),
+	})
+	m.acceleratorsMap.Store(fallback.Resource(), registerPlugin{
+		resource:         fallback.Resource(),
+		plugin:           fallback,
+		lastRegisterTime: time.Now(),
+	})
+
+	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "owner_gpu"})
+
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	assert.Equal(t, "true", config.Env["FALLBACK"])
+	assert.Equal(t, 1, fallback.staticRuntimeCalls)
+}
+
+func TestManagerGetStaticNodeRuntimeConfigStopsAtFirstFallbackError(t *testing.T) {
+	failing := &fakeStaticNodeAcceleratorPlugin{
+		resourceSet:      true,
+		resource:         "a_fallback_gpu",
+		staticRuntimeErr: errors.New("unsafe static runtime"),
+	}
+	laterMatch := &fakeStaticNodeAcceleratorPlugin{
+		resourceSet:          true,
+		resource:             "z_fallback_gpu",
+		staticRuntimeConfig:  &v1.RuntimeConfig{Env: map[string]string{"LATER": "true"}},
+		staticRuntimeMatched: true,
+	}
+	m := &manager{}
+	m.acceleratorsMap.Store("owner_gpu", registerPlugin{
+		resource:         "owner_gpu",
+		plugin:           &plugin.GPUAcceleratorPlugin{},
+		lastRegisterTime: time.Now(),
+	})
+	m.acceleratorsMap.Store(failing.Resource(), registerPlugin{
+		resource:         failing.Resource(),
+		plugin:           failing,
+		lastRegisterTime: time.Now(),
+	})
+	m.acceleratorsMap.Store(laterMatch.Resource(), registerPlugin{
+		resource:         laterMatch.Resource(),
+		plugin:           laterMatch,
+		lastRegisterTime: time.Now(),
+	})
+
+	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "owner_gpu"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a_fallback_gpu")
+	assert.Nil(t, config)
+}
+
+func TestManagerGetStaticNodeRuntimeConfigRejectsNilFallbackConfig(t *testing.T) {
+	fallback := &fakeStaticNodeAcceleratorPlugin{
+		resourceSet:          true,
+		resource:             "fallback_gpu",
+		staticRuntimeMatched: true,
+	}
+	m := &manager{}
+	m.acceleratorsMap.Store("owner_gpu", registerPlugin{
+		resource:         "owner_gpu",
+		plugin:           &plugin.GPUAcceleratorPlugin{},
+		lastRegisterTime: time.Now(),
+	})
+	m.acceleratorsMap.Store(fallback.Resource(), registerPlugin{
+		resource:         fallback.Resource(),
+		plugin:           fallback,
+		lastRegisterTime: time.Now(),
+	})
+
+	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "owner_gpu"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fallback_gpu returned nil config for a matched status")
+	assert.Nil(t, config)
+}
+
+func TestManagerGetStaticNodeRuntimeConfigPrioritizesOwningPlugin(t *testing.T) {
+	owner := &fakeStaticNodeAcceleratorPlugin{
+		resourceSet:          true,
+		resource:             "owner_gpu",
+		staticRuntimeConfig:  &v1.RuntimeConfig{Env: map[string]string{"OWNER": "true"}},
+		staticRuntimeMatched: true,
+	}
+	unrelated := &fakeStaticNodeAcceleratorPlugin{
+		resourceSet:      true,
+		resource:         "unrelated_gpu",
+		staticRuntimeErr: errors.New("must not resolve unrelated accelerator"),
+	}
+	m := &manager{}
+	m.acceleratorsMap.Store(owner.Resource(), registerPlugin{resource: owner.Resource(), plugin: owner, lastRegisterTime: time.Now()})
+	m.acceleratorsMap.Store(unrelated.Resource(), registerPlugin{resource: unrelated.Resource(), plugin: unrelated, lastRegisterTime: time.Now()})
+
+	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: owner.Resource()})
+
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	assert.Equal(t, "true", config.Env["OWNER"])
+}
+
 func TestNewManagerWithPluginsRegistersInjectedPlugin(t *testing.T) {
 	injected := &fakeStaticNodeAcceleratorPlugin{}
 
@@ -245,6 +440,11 @@ type fakeStaticNodeAcceleratorPlugin struct {
 	getRequest   *v1.GetNodeAcceleratorRequest
 
 	acceleratorProfile *v1.AcceleratorProfile
+
+	staticRuntimeConfig  *v1.RuntimeConfig
+	staticRuntimeMatched bool
+	staticRuntimeErr     error
+	staticRuntimeCalls   int
 }
 
 func (p *fakeStaticNodeAcceleratorPlugin) Resource() string {
@@ -307,4 +507,10 @@ func (p *fakeStaticNodeAcceleratorPlugin) GetContainerRuntimeConfig() (v1.Runtim
 
 func (p *fakeStaticNodeAcceleratorPlugin) GetAcceleratorProfile(ctx context.Context) (*v1.AcceleratorProfile, error) {
 	return p.acceleratorProfile, nil
+}
+
+func (p *fakeStaticNodeAcceleratorPlugin) GetStaticNodeRuntimeConfig(context.Context, *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, bool, error) {
+	p.staticRuntimeCalls++
+
+	return p.staticRuntimeConfig, p.staticRuntimeMatched, p.staticRuntimeErr
 }

--- a/internal/accelerator/manager_test.go
+++ b/internal/accelerator/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
 	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
@@ -31,6 +32,49 @@ func TestManagerGetAcceleratorProfile(t *testing.T) {
 	assert.Equal(t, v1.AcceleratorTypeNVIDIAGPU.String(), profile.AcceleratorType)
 	require.NotNil(t, profile.MetricsExporter)
 	assert.Equal(t, "dcgm-exporter", profile.MetricsExporter.Name)
+}
+
+func TestNewManagerWithPluginsRegistersInjectedPlugin(t *testing.T) {
+	injected := &fakeStaticNodeAcceleratorPlugin{}
+
+	manager, err := NewManagerWithPlugins(gin.New(), injected)
+
+	require.NoError(t, err)
+	assert.Contains(t, manager.SupportPlugins(), injected.Resource())
+	assert.Contains(t, manager.SupportPlugins(), v1.AcceleratorTypeNVIDIAGPU.String())
+}
+
+func TestNewManagerWithPluginsRequiresGinEngine(t *testing.T) {
+	_, err := NewManagerWithPlugins(nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gin engine is required")
+}
+
+func TestNewManagerWithPluginsRejectsInvalidPlugins(t *testing.T) {
+	var typedNil *fakeStaticNodeAcceleratorPlugin
+	emptyResource := &fakeStaticNodeAcceleratorPlugin{resourceSet: true}
+	injected := &fakeStaticNodeAcceleratorPlugin{}
+
+	tests := []struct {
+		name    string
+		plugins []plugin.AcceleratorPlugin
+		message string
+	}{
+		{name: "nil plugin", plugins: []plugin.AcceleratorPlugin{nil}, message: "accelerator plugin is nil"},
+		{name: "typed nil plugin", plugins: []plugin.AcceleratorPlugin{typedNil}, message: "accelerator plugin is nil"},
+		{name: "empty resource", plugins: []plugin.AcceleratorPlugin{emptyResource}, message: "resource is required"},
+		{name: "duplicate resource", plugins: []plugin.AcceleratorPlugin{injected, injected}, message: "already registered"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewManagerWithPlugins(gin.New(), tt.plugins...)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.message)
+		})
+	}
 }
 
 func TestManagerGetAcceleratorProfileFromExternalPlugin(t *testing.T) {
@@ -192,6 +236,9 @@ func TestManagerDetectAcceleratorReturnsDetectorErrorWhenNothingMatches(t *testi
 }
 
 type fakeStaticNodeAcceleratorPlugin struct {
+	resourceSet bool
+	resource    string
+
 	accelerators []v1.Accelerator
 	getErr       error
 	getCalls     int
@@ -201,6 +248,10 @@ type fakeStaticNodeAcceleratorPlugin struct {
 }
 
 func (p *fakeStaticNodeAcceleratorPlugin) Resource() string {
+	if p.resourceSet {
+		return p.resource
+	}
+
 	return "custom_gpu"
 }
 

--- a/internal/accelerator/manager_test.go
+++ b/internal/accelerator/manager_test.go
@@ -338,11 +338,17 @@ func TestManagerGetAcceleratorProfileMissingPlugin(t *testing.T) {
 	assert.Contains(t, err.Error(), "accelerator plugin missing not found")
 }
 
-func TestManagerDetectAcceleratorUsesNodeAcceleratorProbe(t *testing.T) {
-	detector := &fakeStaticNodeAcceleratorPlugin{accelerators: []v1.Accelerator{{ID: "0"}}}
+func TestManagerDetectAcceleratorPreservesStaticNodeAcceleratorStatus(t *testing.T) {
+	detector := &fakeStaticNodeAcceleratorPlugin{staticResponse: &v1.DetectStaticNodeAcceleratorResponse{
+		Matched: true,
+		Accelerator: &v1.StaticNodeAcceleratorStatus{
+			Type:    "npu",
+			Devices: []v1.StaticNodeAcceleratorDeviceStatus{{ID: "0", ProductModel: "HUAWEI_Ascend910B"}},
+		},
+	}}
 	m := &manager{}
-	m.acceleratorsMap.Store("custom_gpu", registerPlugin{
-		resource:         "custom_gpu",
+	m.acceleratorsMap.Store("npu", registerPlugin{
+		resource:         "npu",
 		plugin:           detector,
 		lastRegisterTime: time.Now(),
 	})
@@ -354,15 +360,19 @@ func TestManagerDetectAcceleratorUsesNodeAcceleratorProbe(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, status)
-	assert.Equal(t, "custom_gpu", status.Type)
-	assert.Empty(t, status.Devices, "type discovery must not report detailed device data")
-	assert.Equal(t, 1, detector.getCalls)
-	assert.Equal(t, "10.0.0.10", detector.getRequest.NodeIp)
-	assert.Equal(t, "root", detector.getRequest.SSHAuth.SSHUser)
+	assert.Equal(t, "npu", status.Type)
+	require.Len(t, status.Devices, 1)
+	assert.Equal(t, "HUAWEI_Ascend910B", status.Devices[0].ProductModel)
+	assert.Zero(t, detector.getCalls)
 }
 
 func TestManagerDetectAcceleratorSupportsExternalPluginWithoutStaticDetectEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == v1.DetectStaticNodeAcceleratorPath {
+			http.NotFound(w, r)
+			return
+		}
+
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, v1.GetNodeAcceleratorPath, r.URL.Path)
 
@@ -445,6 +455,7 @@ type fakeStaticNodeAcceleratorPlugin struct {
 	staticRuntimeMatched bool
 	staticRuntimeErr     error
 	staticRuntimeCalls   int
+	staticResponse       *v1.DetectStaticNodeAcceleratorResponse
 }
 
 func (p *fakeStaticNodeAcceleratorPlugin) Resource() string {
@@ -467,6 +478,10 @@ func (p *fakeStaticNodeAcceleratorPlugin) DetectStaticNodeAccelerator(
 	ctx context.Context,
 	request *v1.DetectStaticNodeAcceleratorRequest,
 ) (*v1.DetectStaticNodeAcceleratorResponse, error) {
+	if p.staticResponse != nil {
+		return p.staticResponse, nil
+	}
+
 	return &v1.DetectStaticNodeAcceleratorResponse{}, nil
 }
 

--- a/internal/accelerator/mocks/mock_manager.go
+++ b/internal/accelerator/mocks/mock_manager.go
@@ -5,10 +5,8 @@ package mocks
 import (
 	context "context"
 
-	plugin "github.com/neutree-ai/neutree/internal/accelerator/plugin"
+	pkgaccelerator "github.com/neutree-ai/neutree/pkg/accelerator"
 	mock "github.com/stretchr/testify/mock"
-
-	resourceparser "github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
@@ -86,100 +84,6 @@ func (_c *MockManager_DetectAccelerator_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// GetAllConverters provides a mock function with no fields
-func (_m *MockManager) GetAllConverters() map[string]plugin.ResourceConverter {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAllConverters")
-	}
-
-	var r0 map[string]plugin.ResourceConverter
-	if rf, ok := ret.Get(0).(func() map[string]plugin.ResourceConverter); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]plugin.ResourceConverter)
-		}
-	}
-
-	return r0
-}
-
-// MockManager_GetAllConverters_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllConverters'
-type MockManager_GetAllConverters_Call struct {
-	*mock.Call
-}
-
-// GetAllConverters is a helper method to define mock.On call
-func (_e *MockManager_Expecter) GetAllConverters() *MockManager_GetAllConverters_Call {
-	return &MockManager_GetAllConverters_Call{Call: _e.mock.On("GetAllConverters")}
-}
-
-func (_c *MockManager_GetAllConverters_Call) Run(run func()) *MockManager_GetAllConverters_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockManager_GetAllConverters_Call) Return(_a0 map[string]plugin.ResourceConverter) *MockManager_GetAllConverters_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockManager_GetAllConverters_Call) RunAndReturn(run func() map[string]plugin.ResourceConverter) *MockManager_GetAllConverters_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetAllParsers provides a mock function with no fields
-func (_m *MockManager) GetAllParsers() map[string]resourceparser.ResourceParser {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAllParsers")
-	}
-
-	var r0 map[string]resourceparser.ResourceParser
-	if rf, ok := ret.Get(0).(func() map[string]resourceparser.ResourceParser); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]resourceparser.ResourceParser)
-		}
-	}
-
-	return r0
-}
-
-// MockManager_GetAllParsers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllParsers'
-type MockManager_GetAllParsers_Call struct {
-	*mock.Call
-}
-
-// GetAllParsers is a helper method to define mock.On call
-func (_e *MockManager_Expecter) GetAllParsers() *MockManager_GetAllParsers_Call {
-	return &MockManager_GetAllParsers_Call{Call: _e.mock.On("GetAllParsers")}
-}
-
-func (_c *MockManager_GetAllParsers_Call) Run(run func()) *MockManager_GetAllParsers_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockManager_GetAllParsers_Call) Return(_a0 map[string]resourceparser.ResourceParser) *MockManager_GetAllParsers_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockManager_GetAllParsers_Call) RunAndReturn(run func() map[string]resourceparser.ResourceParser) *MockManager_GetAllParsers_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetAcceleratorProfile provides a mock function with given fields: ctx, acceleratorType
 func (_m *MockManager) GetAcceleratorProfile(ctx context.Context, acceleratorType string) (*v1.AcceleratorProfile, error) {
 	ret := _m.Called(ctx, acceleratorType)
@@ -190,6 +94,9 @@ func (_m *MockManager) GetAcceleratorProfile(ctx context.Context, acceleratorTyp
 
 	var r0 *v1.AcceleratorProfile
 	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*v1.AcceleratorProfile, error)); ok {
+		return rf(ctx, acceleratorType)
+	}
 	if rf, ok := ret.Get(0).(func(context.Context, string) *v1.AcceleratorProfile); ok {
 		r0 = rf(ctx, acceleratorType)
 	} else {
@@ -236,24 +143,118 @@ func (_c *MockManager_GetAcceleratorProfile_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// GetAllConverters provides a mock function with no fields
+func (_m *MockManager) GetAllConverters() map[string]pkgaccelerator.ResourceConverter {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllConverters")
+	}
+
+	var r0 map[string]pkgaccelerator.ResourceConverter
+	if rf, ok := ret.Get(0).(func() map[string]pkgaccelerator.ResourceConverter); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]pkgaccelerator.ResourceConverter)
+		}
+	}
+
+	return r0
+}
+
+// MockManager_GetAllConverters_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllConverters'
+type MockManager_GetAllConverters_Call struct {
+	*mock.Call
+}
+
+// GetAllConverters is a helper method to define mock.On call
+func (_e *MockManager_Expecter) GetAllConverters() *MockManager_GetAllConverters_Call {
+	return &MockManager_GetAllConverters_Call{Call: _e.mock.On("GetAllConverters")}
+}
+
+func (_c *MockManager_GetAllConverters_Call) Run(run func()) *MockManager_GetAllConverters_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockManager_GetAllConverters_Call) Return(_a0 map[string]pkgaccelerator.ResourceConverter) *MockManager_GetAllConverters_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockManager_GetAllConverters_Call) RunAndReturn(run func() map[string]pkgaccelerator.ResourceConverter) *MockManager_GetAllConverters_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAllParsers provides a mock function with no fields
+func (_m *MockManager) GetAllParsers() map[string]pkgaccelerator.ResourceParser {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllParsers")
+	}
+
+	var r0 map[string]pkgaccelerator.ResourceParser
+	if rf, ok := ret.Get(0).(func() map[string]pkgaccelerator.ResourceParser); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]pkgaccelerator.ResourceParser)
+		}
+	}
+
+	return r0
+}
+
+// MockManager_GetAllParsers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllParsers'
+type MockManager_GetAllParsers_Call struct {
+	*mock.Call
+}
+
+// GetAllParsers is a helper method to define mock.On call
+func (_e *MockManager_Expecter) GetAllParsers() *MockManager_GetAllParsers_Call {
+	return &MockManager_GetAllParsers_Call{Call: _e.mock.On("GetAllParsers")}
+}
+
+func (_c *MockManager_GetAllParsers_Call) Run(run func()) *MockManager_GetAllParsers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockManager_GetAllParsers_Call) Return(_a0 map[string]pkgaccelerator.ResourceParser) *MockManager_GetAllParsers_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockManager_GetAllParsers_Call) RunAndReturn(run func() map[string]pkgaccelerator.ResourceParser) *MockManager_GetAllParsers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetConverter provides a mock function with given fields: acceleratorType
-func (_m *MockManager) GetConverter(acceleratorType string) (plugin.ResourceConverter, bool) {
+func (_m *MockManager) GetConverter(acceleratorType string) (pkgaccelerator.ResourceConverter, bool) {
 	ret := _m.Called(acceleratorType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConverter")
 	}
 
-	var r0 plugin.ResourceConverter
+	var r0 pkgaccelerator.ResourceConverter
 	var r1 bool
-	if rf, ok := ret.Get(0).(func(string) (plugin.ResourceConverter, bool)); ok {
+	if rf, ok := ret.Get(0).(func(string) (pkgaccelerator.ResourceConverter, bool)); ok {
 		return rf(acceleratorType)
 	}
-	if rf, ok := ret.Get(0).(func(string) plugin.ResourceConverter); ok {
+	if rf, ok := ret.Get(0).(func(string) pkgaccelerator.ResourceConverter); ok {
 		r0 = rf(acceleratorType)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(plugin.ResourceConverter)
+			r0 = ret.Get(0).(pkgaccelerator.ResourceConverter)
 		}
 	}
 
@@ -284,12 +285,12 @@ func (_c *MockManager_GetConverter_Call) Run(run func(acceleratorType string)) *
 	return _c
 }
 
-func (_c *MockManager_GetConverter_Call) Return(_a0 plugin.ResourceConverter, _a1 bool) *MockManager_GetConverter_Call {
+func (_c *MockManager_GetConverter_Call) Return(_a0 pkgaccelerator.ResourceConverter, _a1 bool) *MockManager_GetConverter_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockManager_GetConverter_Call) RunAndReturn(run func(string) (plugin.ResourceConverter, bool)) *MockManager_GetConverter_Call {
+func (_c *MockManager_GetConverter_Call) RunAndReturn(run func(string) (pkgaccelerator.ResourceConverter, bool)) *MockManager_GetConverter_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -516,23 +517,23 @@ func (_c *MockManager_GetNodeRuntimeConfig_Call) RunAndReturn(run func(context.C
 }
 
 // GetParser provides a mock function with given fields: acceleratorType
-func (_m *MockManager) GetParser(acceleratorType string) (resourceparser.ResourceParser, bool) {
+func (_m *MockManager) GetParser(acceleratorType string) (pkgaccelerator.ResourceParser, bool) {
 	ret := _m.Called(acceleratorType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetParser")
 	}
 
-	var r0 resourceparser.ResourceParser
+	var r0 pkgaccelerator.ResourceParser
 	var r1 bool
-	if rf, ok := ret.Get(0).(func(string) (resourceparser.ResourceParser, bool)); ok {
+	if rf, ok := ret.Get(0).(func(string) (pkgaccelerator.ResourceParser, bool)); ok {
 		return rf(acceleratorType)
 	}
-	if rf, ok := ret.Get(0).(func(string) resourceparser.ResourceParser); ok {
+	if rf, ok := ret.Get(0).(func(string) pkgaccelerator.ResourceParser); ok {
 		r0 = rf(acceleratorType)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(resourceparser.ResourceParser)
+			r0 = ret.Get(0).(pkgaccelerator.ResourceParser)
 		}
 	}
 
@@ -563,34 +564,34 @@ func (_c *MockManager_GetParser_Call) Run(run func(acceleratorType string)) *Moc
 	return _c
 }
 
-func (_c *MockManager_GetParser_Call) Return(_a0 resourceparser.ResourceParser, _a1 bool) *MockManager_GetParser_Call {
+func (_c *MockManager_GetParser_Call) Return(_a0 pkgaccelerator.ResourceParser, _a1 bool) *MockManager_GetParser_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockManager_GetParser_Call) RunAndReturn(run func(string) (resourceparser.ResourceParser, bool)) *MockManager_GetParser_Call {
+func (_c *MockManager_GetParser_Call) RunAndReturn(run func(string) (pkgaccelerator.ResourceParser, bool)) *MockManager_GetParser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetPlugin provides a mock function with given fields: acceleratorType
-func (_m *MockManager) GetPlugin(acceleratorType string) (plugin.AcceleratorPlugin, bool) {
+func (_m *MockManager) GetPlugin(acceleratorType string) (pkgaccelerator.Plugin, bool) {
 	ret := _m.Called(acceleratorType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPlugin")
 	}
 
-	var r0 plugin.AcceleratorPlugin
+	var r0 pkgaccelerator.Plugin
 	var r1 bool
-	if rf, ok := ret.Get(0).(func(string) (plugin.AcceleratorPlugin, bool)); ok {
+	if rf, ok := ret.Get(0).(func(string) (pkgaccelerator.Plugin, bool)); ok {
 		return rf(acceleratorType)
 	}
-	if rf, ok := ret.Get(0).(func(string) plugin.AcceleratorPlugin); ok {
+	if rf, ok := ret.Get(0).(func(string) pkgaccelerator.Plugin); ok {
 		r0 = rf(acceleratorType)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(plugin.AcceleratorPlugin)
+			r0 = ret.Get(0).(pkgaccelerator.Plugin)
 		}
 	}
 
@@ -621,12 +622,12 @@ func (_c *MockManager_GetPlugin_Call) Run(run func(acceleratorType string)) *Moc
 	return _c
 }
 
-func (_c *MockManager_GetPlugin_Call) Return(_a0 plugin.AcceleratorPlugin, _a1 bool) *MockManager_GetPlugin_Call {
+func (_c *MockManager_GetPlugin_Call) Return(_a0 pkgaccelerator.Plugin, _a1 bool) *MockManager_GetPlugin_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockManager_GetPlugin_Call) RunAndReturn(run func(string) (plugin.AcceleratorPlugin, bool)) *MockManager_GetPlugin_Call {
+func (_c *MockManager_GetPlugin_Call) RunAndReturn(run func(string) (pkgaccelerator.Plugin, bool)) *MockManager_GetPlugin_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/accelerator/mocks/mock_manager.go
+++ b/internal/accelerator/mocks/mock_manager.go
@@ -632,6 +632,65 @@ func (_c *MockManager_GetPlugin_Call) RunAndReturn(run func(string) (pkgaccelera
 	return _c
 }
 
+// GetStaticNodeRuntimeConfig provides a mock function with given fields: ctx, _a1
+func (_m *MockManager) GetStaticNodeRuntimeConfig(ctx context.Context, _a1 *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, error) {
+	ret := _m.Called(ctx, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetStaticNodeRuntimeConfig")
+	}
+
+	var r0 *v1.RuntimeConfig
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, error)); ok {
+		return rf(ctx, _a1)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *v1.StaticNodeAcceleratorStatus) *v1.RuntimeConfig); ok {
+		r0 = rf(ctx, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.RuntimeConfig)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *v1.StaticNodeAcceleratorStatus) error); ok {
+		r1 = rf(ctx, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockManager_GetStaticNodeRuntimeConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStaticNodeRuntimeConfig'
+type MockManager_GetStaticNodeRuntimeConfig_Call struct {
+	*mock.Call
+}
+
+// GetStaticNodeRuntimeConfig is a helper method to define mock.On call
+//   - ctx context.Context
+//   - _a1 *v1.StaticNodeAcceleratorStatus
+func (_e *MockManager_Expecter) GetStaticNodeRuntimeConfig(ctx interface{}, _a1 interface{}) *MockManager_GetStaticNodeRuntimeConfig_Call {
+	return &MockManager_GetStaticNodeRuntimeConfig_Call{Call: _e.mock.On("GetStaticNodeRuntimeConfig", ctx, _a1)}
+}
+
+func (_c *MockManager_GetStaticNodeRuntimeConfig_Call) Run(run func(ctx context.Context, _a1 *v1.StaticNodeAcceleratorStatus)) *MockManager_GetStaticNodeRuntimeConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*v1.StaticNodeAcceleratorStatus))
+	})
+	return _c
+}
+
+func (_c *MockManager_GetStaticNodeRuntimeConfig_Call) Return(_a0 *v1.RuntimeConfig, _a1 error) *MockManager_GetStaticNodeRuntimeConfig_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockManager_GetStaticNodeRuntimeConfig_Call) RunAndReturn(run func(context.Context, *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, error)) *MockManager_GetStaticNodeRuntimeConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Start provides a mock function with given fields: ctx
 func (_m *MockManager) Start(ctx context.Context) {
 	_m.Called(ctx)

--- a/internal/accelerator/plugin/plugin.go
+++ b/internal/accelerator/plugin/plugin.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
-	"github.com/neutree-ai/neutree/internal/accelerator/resourceparser"
+	"github.com/neutree-ai/neutree/pkg/accelerator"
 )
 
 const (
@@ -13,19 +13,11 @@ const (
 )
 
 const (
-	ExternalPluginType = "external"
-	InternalPluginType = "internal"
+	ExternalPluginType = accelerator.ExternalPluginType
+	InternalPluginType = accelerator.InternalPluginType
 )
 
-type AcceleratorPlugin interface {
-	Handle() AcceleratorPluginHandle
-	// Resource returns the accelerator resource type identifier (e.g., "nvidia_gpu", "amd_gpu")
-	// This identifier is used for:
-	// - Plugin registration and lookup
-	// - Resource converter registration (maps to accelerator.type in user configuration)
-	Resource() string
-	Type() string
-}
+type AcceleratorPlugin = accelerator.Plugin
 
 type AcceleratorPluginProvider interface {
 	SupportPlugins() []string
@@ -36,36 +28,11 @@ type ClusterVirtualizationConfigProvider interface {
 	ResolveClusterVirtualizationConfig(ctx context.Context, cluster *v1.Cluster) (*VirtualizationConfig, error)
 }
 
-type AcceleratorPluginHandle interface {
-	GetNodeAccelerator(ctx context.Context, request *v1.GetNodeAcceleratorRequest) (*v1.GetNodeAcceleratorResponse, error)
-	GetNodeRuntimeConfig(ctx context.Context, request *v1.GetNodeRuntimeConfigRequest) (*v1.GetNodeRuntimeConfigResponse, error)
-	DetectStaticNodeAccelerator(
-		ctx context.Context,
-		request *v1.DetectStaticNodeAcceleratorRequest,
-	) (*v1.DetectStaticNodeAcceleratorResponse, error)
-	Ping(ctx context.Context) error
-	GetAcceleratorProfile(ctx context.Context) (*v1.AcceleratorProfile, error)
-	// GetResourceConverter returns the resource converter
-	GetResourceConverter() ResourceConverter
-
-	// GetResourceParser returns the resource parser
-	GetResourceParser() resourceparser.ResourceParser
-
-	// GetContainerRuntimeConfig returns the static RuntimeConfig for engine containers.
-	// Unlike GetNodeRuntimeConfig, this does NOT require SSH access to a node.
-	// Used to generate Docker run_options for engine containers (runtime_env.container).
-	GetContainerRuntimeConfig() (v1.RuntimeConfig, error)
-}
+type AcceleratorPluginHandle = accelerator.PluginHandle
 
 // ResourceConverter is the interface for resource converters
 // Converts Neutree's unified resource specifications to resource configurations for different cluster types (Ray, Kubernetes)
-type ResourceConverter interface {
-	// ConvertToRay converts to Ray resource configuration
-	ConvertToRay(spec *v1.ResourceSpec) (*v1.RayResourceSpec, error)
-
-	// ConvertToKubernetes converts to Kubernetes resource configuration
-	ConvertToKubernetes(spec *v1.ResourceSpec) (*v1.KubernetesResourceSpec, error)
-}
+type ResourceConverter = accelerator.ResourceConverter
 
 type RegisterHandle func(plugin AcceleratorPlugin)
 

--- a/internal/accelerator/resourceparser/types.go
+++ b/internal/accelerator/resourceparser/types.go
@@ -4,7 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 
-	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/accelerator"
 )
 
 const (
@@ -14,10 +14,7 @@ const (
 
 // ResourceParser handles standard accelerator resource semantics. Kubernetes
 // Neutree node/pod annotation aggregation lives in internal/resource.
-type ResourceParser interface {
-	ParseFromRay(resource map[string]float64) (*v1.ResourceInfo, error)
-	ParseFromKubernetes(resource map[corev1.ResourceName]k8sresource.Quantity, labels map[string]string) (*v1.ResourceInfo, error)
-}
+type ResourceParser = accelerator.ResourceParser
 
 type KubernetesNodeResourceContext struct {
 	NodeName             string

--- a/internal/cluster/staticcluster/helpers.go
+++ b/internal/cluster/staticcluster/helpers.go
@@ -2,6 +2,7 @@ package staticcluster
 
 import (
 	"context"
+	"maps"
 
 	"github.com/pkg/errors"
 
@@ -127,23 +128,10 @@ func copyRuntimeConfig(config *v1.RuntimeConfig) *v1.RuntimeConfig {
 	}
 
 	result := *config
-	result.Env = copyStringMap(config.Env)
+	result.Env = maps.Clone(config.Env)
 	result.Options = append([]string(nil), config.Options...)
 
 	return &result
-}
-
-func copyStringMap(source map[string]string) map[string]string {
-	if source == nil {
-		return nil
-	}
-
-	result := make(map[string]string, len(source))
-	for key, value := range source {
-		result[key] = value
-	}
-
-	return result
 }
 
 func staticComponentImage(cluster *v1.StaticNodeCluster, image string) string {

--- a/internal/cluster/staticcluster/helpers.go
+++ b/internal/cluster/staticcluster/helpers.go
@@ -66,11 +66,80 @@ func (r *Planner) runtimeProfile(
 	}
 
 	profile, err := r.AcceleratorProfileProvider.GetAcceleratorProfile(ctx, accelerator.Type)
-	if err != nil {
+	if err != nil || profile == nil {
 		return nil, err
 	}
 
-	return profile, nil
+	provider, ok := r.AcceleratorProfileProvider.(staticNodeRuntimeConfigProvider)
+	if !ok {
+		return profile, nil
+	}
+
+	runtimeConfig, err := provider.GetStaticNodeRuntimeConfig(ctx, &accelerator)
+	if err != nil || runtimeConfig == nil {
+		return profile, err
+	}
+
+	resolvedProfile := *profile
+	resolvedProfile.ClusterRuntime = mergeRuntimeConfig(profile.ClusterRuntime, runtimeConfig)
+
+	return &resolvedProfile, nil
+}
+
+func mergeRuntimeConfig(base, override *v1.RuntimeConfig) *v1.RuntimeConfig {
+	if base == nil {
+		return copyRuntimeConfig(override)
+	}
+
+	result := copyRuntimeConfig(base)
+	if override.ImageSuffix != "" {
+		result.ImageSuffix = override.ImageSuffix
+	}
+
+	if override.Runtime != "" {
+		result.Runtime = override.Runtime
+	}
+
+	if override.Env != nil {
+		if result.Env == nil {
+			result.Env = map[string]string{}
+		}
+
+		for key, value := range override.Env {
+			result.Env[key] = value
+		}
+	}
+
+	if len(override.Options) > 0 {
+		result.Options = append([]string(nil), override.Options...)
+	}
+
+	return result
+}
+
+func copyRuntimeConfig(config *v1.RuntimeConfig) *v1.RuntimeConfig {
+	if config == nil {
+		return nil
+	}
+
+	result := *config
+	result.Env = copyStringMap(config.Env)
+	result.Options = append([]string(nil), config.Options...)
+
+	return &result
+}
+
+func copyStringMap(source map[string]string) map[string]string {
+	if source == nil {
+		return nil
+	}
+
+	result := make(map[string]string, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+
+	return result
 }
 
 func staticComponentImage(cluster *v1.StaticNodeCluster, image string) string {

--- a/internal/cluster/staticcluster/helpers.go
+++ b/internal/cluster/staticcluster/helpers.go
@@ -106,6 +106,10 @@ func mergeRuntimeConfig(base, override *v1.RuntimeConfig) *v1.RuntimeConfig {
 		}
 
 		for key, value := range override.Env {
+			if value == "" {
+				continue
+			}
+
 			result.Env[key] = value
 		}
 	}

--- a/internal/cluster/staticcluster/planner.go
+++ b/internal/cluster/staticcluster/planner.go
@@ -19,6 +19,10 @@ type AcceleratorProfileProvider interface {
 	GetAcceleratorProfile(ctx context.Context, acceleratorType string) (*v1.AcceleratorProfile, error)
 }
 
+type staticNodeRuntimeConfigProvider interface {
+	GetStaticNodeRuntimeConfig(context.Context, *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, error)
+}
+
 type DesiredNodePlan struct {
 	Node             *v1.StaticNode
 	Accelerator      *v1.StaticNodeAcceleratorStatus

--- a/internal/cluster/staticcluster/planner_test.go
+++ b/internal/cluster/staticcluster/planner_test.go
@@ -1518,6 +1518,62 @@ type fakeAcceleratorProfileProvider struct {
 	profiles map[string]*v1.AcceleratorProfile
 }
 
+func TestPlannerRuntimeProfileOverridesStaticNodeRuntimeConfigOnCopy(t *testing.T) {
+	profileConfig := &v1.RuntimeConfig{
+		ImageSuffix: "base-image",
+		Runtime:     "base-runtime",
+		Env:         map[string]string{"PROFILE_ONLY": "true", "CONFLICT": "profile"},
+		Options:     []string{"--profile"},
+	}
+	resolvedConfig := &v1.RuntimeConfig{
+		Env: map[string]string{"VISIBLE_DEVICES": "0,1", "CONFLICT": "resolver"},
+	}
+	planner := &Planner{AcceleratorProfileProvider: staticNodeRuntimeConfigProfileProvider{
+		fakeAcceleratorProfileProvider: fakeAcceleratorProfileProvider{profiles: map[string]*v1.AcceleratorProfile{
+			"custom_accelerator": {AcceleratorType: "custom_accelerator", ClusterRuntime: profileConfig},
+		}},
+		runtimeConfig: resolvedConfig,
+	}}
+
+	profile, err := planner.runtimeProfile(context.Background(), v1.StaticNodeAcceleratorStatus{
+		Type:    "custom_accelerator",
+		Devices: []v1.StaticNodeAcceleratorDeviceStatus{{ID: "0"}, {ID: "1"}},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+	require.NotNil(t, profile.ClusterRuntime)
+	assert.Equal(t, "0,1", profile.ClusterRuntime.Env["VISIBLE_DEVICES"])
+	assert.Equal(t, "resolver", profile.ClusterRuntime.Env["CONFLICT"])
+	assert.Equal(t, "base-image", profile.ClusterRuntime.ImageSuffix)
+	assert.Equal(t, "base-runtime", profile.ClusterRuntime.Runtime)
+	assert.Equal(t, []string{"--profile"}, profile.ClusterRuntime.Options)
+	assert.NotSame(t, resolvedConfig, profile.ClusterRuntime)
+	assert.Equal(t, "true", profileConfig.Env["PROFILE_ONLY"])
+	assert.Equal(t, "profile", profileConfig.Env["CONFLICT"])
+	profile.ClusterRuntime.Env["VISIBLE_DEVICES"] = "changed"
+	assert.Equal(t, "0,1", resolvedConfig.Env["VISIBLE_DEVICES"])
+}
+
+func TestMergeRuntimeConfigDoesNotClearBaseOptions(t *testing.T) {
+	merged := mergeRuntimeConfig(
+		&v1.RuntimeConfig{Options: []string{"--profile"}},
+		&v1.RuntimeConfig{Options: []string{}},
+	)
+
+	require.NotNil(t, merged)
+	assert.Equal(t, []string{"--profile"}, merged.Options)
+}
+
+type staticNodeRuntimeConfigProfileProvider struct {
+	fakeAcceleratorProfileProvider
+	runtimeConfig *v1.RuntimeConfig
+}
+
+func (p staticNodeRuntimeConfigProfileProvider) GetStaticNodeRuntimeConfig(context.Context, *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, error) {
+	return p.runtimeConfig, nil
+}
+
 func (f fakeAcceleratorProfileProvider) GetAcceleratorProfile(
 	_ context.Context,
 	acceleratorType string,

--- a/internal/cluster/staticcluster/planner_test.go
+++ b/internal/cluster/staticcluster/planner_test.go
@@ -1565,6 +1565,16 @@ func TestMergeRuntimeConfigDoesNotClearBaseOptions(t *testing.T) {
 	assert.Equal(t, []string{"--profile"}, merged.Options)
 }
 
+func TestMergeRuntimeConfigDoesNotClearBaseEnvValue(t *testing.T) {
+	merged := mergeRuntimeConfig(
+		&v1.RuntimeConfig{Env: map[string]string{"PROFILE_ONLY": "true"}},
+		&v1.RuntimeConfig{Env: map[string]string{"PROFILE_ONLY": ""}},
+	)
+
+	require.NotNil(t, merged)
+	assert.Equal(t, "true", merged.Env["PROFILE_ONLY"])
+}
+
 type staticNodeRuntimeConfigProfileProvider struct {
 	fakeAcceleratorProfileProvider
 	runtimeConfig *v1.RuntimeConfig

--- a/pkg/accelerator/types.go
+++ b/pkg/accelerator/types.go
@@ -1,0 +1,43 @@
+// Package accelerator defines the public extension contract for accelerator plugins.
+package accelerator
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+const (
+	ExternalPluginType = "external"
+	InternalPluginType = "internal"
+)
+
+type Plugin interface {
+	Resource() string
+	Type() string
+	Handle() PluginHandle
+}
+
+type PluginHandle interface {
+	GetNodeAccelerator(context.Context, *v1.GetNodeAcceleratorRequest) (*v1.GetNodeAcceleratorResponse, error)
+	GetNodeRuntimeConfig(context.Context, *v1.GetNodeRuntimeConfigRequest) (*v1.GetNodeRuntimeConfigResponse, error)
+	DetectStaticNodeAccelerator(context.Context, *v1.DetectStaticNodeAcceleratorRequest) (*v1.DetectStaticNodeAcceleratorResponse, error)
+	GetContainerRuntimeConfig() (v1.RuntimeConfig, error)
+	GetAcceleratorProfile(context.Context) (*v1.AcceleratorProfile, error)
+	GetResourceConverter() ResourceConverter
+	GetResourceParser() ResourceParser
+	Ping(context.Context) error
+}
+
+type ResourceConverter interface {
+	ConvertToRay(*v1.ResourceSpec) (*v1.RayResourceSpec, error)
+	ConvertToKubernetes(*v1.ResourceSpec) (*v1.KubernetesResourceSpec, error)
+}
+
+type ResourceParser interface {
+	ParseFromRay(map[string]float64) (*v1.ResourceInfo, error)
+	ParseFromKubernetes(map[corev1.ResourceName]resource.Quantity, map[string]string) (*v1.ResourceInfo, error)
+}

--- a/pkg/accelerator/types.go
+++ b/pkg/accelerator/types.go
@@ -32,6 +32,14 @@ type PluginHandle interface {
 	Ping(context.Context) error
 }
 
+// StaticNodeRuntimeConfigResolver optionally resolves a cluster runtime
+// configuration from a previously detected static-node accelerator status.
+// This stays in-process so vendor-specific runtime details are not exposed by
+// the public plugin REST API.
+type StaticNodeRuntimeConfigResolver interface {
+	GetStaticNodeRuntimeConfig(context.Context, *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, bool, error)
+}
+
 type ResourceConverter interface {
 	ConvertToRay(*v1.ResourceSpec) (*v1.RayResourceSpec, error)
 	ConvertToKubernetes(*v1.ResourceSpec) (*v1.KubernetesResourceSpec, error)

--- a/pkg/accelerator/types_test.go
+++ b/pkg/accelerator/types_test.go
@@ -1,0 +1,56 @@
+package accelerator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+func TestPluginImplementsPublicContract(t *testing.T) {
+	var _ Plugin = contractPlugin{}
+	var _ PluginHandle = contractPlugin{}
+	var _ ResourceConverter = contractPlugin{}
+	var _ ResourceParser = contractPlugin{}
+}
+
+type contractPlugin struct{}
+
+func (contractPlugin) Resource() string { return "contract-test" }
+func (contractPlugin) Type() string     { return InternalPluginType }
+func (p contractPlugin) Handle() PluginHandle {
+	return p
+}
+func (contractPlugin) GetNodeAccelerator(context.Context, *v1.GetNodeAcceleratorRequest) (*v1.GetNodeAcceleratorResponse, error) {
+	return nil, nil
+}
+func (contractPlugin) GetNodeRuntimeConfig(context.Context, *v1.GetNodeRuntimeConfigRequest) (*v1.GetNodeRuntimeConfigResponse, error) {
+	return nil, nil
+}
+func (contractPlugin) DetectStaticNodeAccelerator(context.Context, *v1.DetectStaticNodeAcceleratorRequest) (*v1.DetectStaticNodeAcceleratorResponse, error) {
+	return nil, nil
+}
+func (contractPlugin) GetContainerRuntimeConfig() (v1.RuntimeConfig, error) {
+	return v1.RuntimeConfig{}, nil
+}
+func (contractPlugin) GetAcceleratorProfile(context.Context) (*v1.AcceleratorProfile, error) {
+	return nil, nil
+}
+func (p contractPlugin) GetResourceConverter() ResourceConverter { return p }
+func (p contractPlugin) GetResourceParser() ResourceParser       { return p }
+func (contractPlugin) Ping(context.Context) error                { return nil }
+func (contractPlugin) ConvertToRay(*v1.ResourceSpec) (*v1.RayResourceSpec, error) {
+	return nil, nil
+}
+func (contractPlugin) ConvertToKubernetes(*v1.ResourceSpec) (*v1.KubernetesResourceSpec, error) {
+	return nil, nil
+}
+func (contractPlugin) ParseFromRay(map[string]float64) (*v1.ResourceInfo, error) {
+	return nil, nil
+}
+func (contractPlugin) ParseFromKubernetes(map[corev1.ResourceName]resource.Quantity, map[string]string) (*v1.ResourceInfo, error) {
+	return nil, nil
+}

--- a/pkg/accelerator/types_test.go
+++ b/pkg/accelerator/types_test.go
@@ -15,6 +15,7 @@ func TestPluginImplementsPublicContract(t *testing.T) {
 	var _ PluginHandle = contractPlugin{}
 	var _ ResourceConverter = contractPlugin{}
 	var _ ResourceParser = contractPlugin{}
+	var _ StaticNodeRuntimeConfigResolver = contractPlugin{}
 }
 
 type contractPlugin struct{}
@@ -38,6 +39,9 @@ func (contractPlugin) GetContainerRuntimeConfig() (v1.RuntimeConfig, error) {
 }
 func (contractPlugin) GetAcceleratorProfile(context.Context) (*v1.AcceleratorProfile, error) {
 	return nil, nil
+}
+func (contractPlugin) GetStaticNodeRuntimeConfig(context.Context, *v1.StaticNodeAcceleratorStatus) (*v1.RuntimeConfig, bool, error) {
+	return nil, false, nil
 }
 func (p contractPlugin) GetResourceConverter() ResourceConverter { return p }
 func (p contractPlugin) GetResourceParser() ResourceParser       { return p }


### PR DESCRIPTION
## Summary
- add the vendor-neutral public accelerator plugin contract
- allow neutree-core builders to inject plugins before controller construction
- resolve static-node runtime configuration from full accelerator status through an optional in-process plugin capability
- preserve generic runtime profiles with fail-closed owner resolution and deterministic compatibility fallback
- retain complete static accelerator status for runtime selection, preserve explicitly configured managers, and prevent empty overrides from clearing inherited environment values
- keep `Build()` configuration validation intact when reusing an explicitly configured accelerator manager
- use the standard-library map clone for isolated static runtime profile copies

## Issues
- NEU-562

## Test Plan

### Unit test
- `go test ./pkg/accelerator ./internal/accelerator ./internal/accelerator/plugin ./internal/accelerator/resourceparser ./internal/cluster/... ./controllers/... ./cmd/neutree-core/app -count=1`
- `go test ./cmd/neutree-core/app ./internal/accelerator ./internal/cluster/staticcluster -count=1`
- `go test ./internal/cluster/staticcluster -count=1`
- `go vet ./pkg/accelerator ./internal/accelerator ./internal/cluster/staticcluster ./cmd/neutree-core/app`
- `bin/golangci-lint run -v --fast=false`
- `make mockgen`; retained only the required manager mock update

### DB test
- No DB code changes. `go test ./... -count=1` passed all observed non-DB packages and reaches `db/dbtest`, which requires PostgreSQL at `127.0.0.1:5432`; that service is unavailable in this workspace.

### E2E test
- N/A: this is a build-time library extension with no OSS end-user workflow or test-only production injection path. Manual testing is not required.
- The TestRail contract case update was skipped for this iteration by user direction.