### PR TITLE
fix: clean imported local image refs

### DIFF
--- a/cmd/neutree-cli/app/cmd/packageimport/cluster.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/cluster.go
@@ -71,8 +71,9 @@ func runClusterImport(opts *ClusterImportOptions) error {
 
 	// Prepare import options
 	importOpts := &packageimport.ImportOptions{
-		PackagePath: opts.packagePath,
-		ExtractPath: opts.extractPath,
+		PackagePath:      opts.packagePath,
+		ExtractPath:      opts.extractPath,
+		SkipImageCleanup: noCleanupImage,
 	}
 
 	// if not importLocal, set registry info

--- a/cmd/neutree-cli/app/cmd/packageimport/controlplane.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/controlplane.go
@@ -74,9 +74,10 @@ func runControlPlaneImport(opts *ControlPlaneImportOptions) error {
 
 	// Prepare import options
 	importOpts := &packageimport.ImportOptions{
-		PackagePath: opts.packagePath,
-		Workspace:   workspace,
-		ExtractPath: opts.extractPath,
+		PackagePath:      opts.packagePath,
+		Workspace:        workspace,
+		ExtractPath:      opts.extractPath,
+		SkipImageCleanup: noCleanupImage,
 	}
 
 	// if not importLocal, set registry info

--- a/cmd/neutree-cli/app/cmd/packageimport/engine.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/engine.go
@@ -94,6 +94,7 @@ func runEngineImport(opts *EngineImportOptions) error {
 		Workspace:        workspace,
 		SkipImagePush:    opts.skipImagePush,
 		SkipImageLoad:    opts.skipImagePush,
+		SkipImageCleanup: noCleanupImage,
 		Force:            opts.force,
 		ExtractPath:      opts.extractPath,
 	}

--- a/cmd/neutree-cli/app/cmd/packageimport/import.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/import.go
@@ -9,6 +9,7 @@ var (
 	registryUsername string
 	registryPassword string
 	workspace        string
+	noCleanupImage   bool
 )
 
 func NewImportCmd() *cobra.Command {
@@ -35,6 +36,8 @@ Use the appropriate subcommand based on the package type you want to import.
 	importCmd.PersistentFlags().StringVar(&registryProject, "registry-project", "", "Project/namespace in the registry to push images to (e.g., 'neutree-ai')")
 	importCmd.PersistentFlags().StringVar(&registryUsername, "registry-username", "", "Username for the container image registry (if required)")
 	importCmd.PersistentFlags().StringVar(&registryPassword, "registry-password", "", "Password for the container image registry (if required)")
+	importCmd.PersistentFlags().BoolVar(&noCleanupImage, "no-cleanup-image", false,
+		"Keep locally loaded image references after a successful registry push")
 
 	importCmd.AddCommand(NewClusterImportCmd())
 	importCmd.AddCommand(NewEngineImportCmd())

--- a/cmd/neutree-cli/app/cmd/packageimport/import_test.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/import_test.go
@@ -1,0 +1,37 @@
+package packageimport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportCmdNoCleanupImageFlagIsInheritedByImageImportCommands(t *testing.T) {
+	importCmd := NewImportCmd()
+
+	flag := importCmd.PersistentFlags().Lookup("no-cleanup-image")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+
+	for _, commandName := range []string{"engine", "cluster", "controlplane"} {
+		t.Run(commandName, func(t *testing.T) {
+			command, _, err := importCmd.Find([]string{commandName})
+			require.NoError(t, err)
+			require.NotNil(t, command)
+			assert.NotNil(t, command.InheritedFlags().Lookup("no-cleanup-image"))
+		})
+	}
+}
+
+func TestImportCmdParsesNoCleanupImageFlagForChildCommand(t *testing.T) {
+	previousValue := noCleanupImage
+	noCleanupImage = false
+	t.Cleanup(func() { noCleanupImage = previousValue })
+
+	importCmd := NewImportCmd()
+	importCmd.SetArgs([]string{"cluster", "--no-cleanup-image", "--help"})
+
+	require.NoError(t, importCmd.Execute())
+	assert.True(t, noCleanupImage)
+}

--- a/internal/cli/packageimport/image_pusher.go
+++ b/internal/cli/packageimport/image_pusher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/docker/docker/api/types/image"
@@ -12,6 +13,11 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
+
+type imageSnapshot struct {
+	ids  map[string]struct{}
+	refs map[string]string
+}
 
 // ImagePusher handles pushing container images to registries
 type ImagePusher struct {
@@ -26,9 +32,107 @@ func NewImagePusher() (*ImagePusher, error) {
 		return nil, errors.Wrap(err, "failed to create Docker client")
 	}
 
-	return &ImagePusher{
-		dockerClient: dockerClient,
-	}, nil
+	return &ImagePusher{dockerClient: dockerClient}, nil
+}
+
+// SnapshotLocalImages captures local image IDs and tags before package import.
+func (p *ImagePusher) SnapshotLocalImages(ctx context.Context) (*imageSnapshot, error) {
+	images, err := p.dockerClient.ImageList(ctx, image.ListOptions{All: true})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list local images")
+	}
+
+	snapshot := &imageSnapshot{
+		ids:  make(map[string]struct{}),
+		refs: make(map[string]string),
+	}
+
+	for _, imageSummary := range images {
+		if imageSummary.ID != "" {
+			snapshot.ids[imageSummary.ID] = struct{}{}
+		}
+
+		for _, ref := range imageSummary.RepoTags {
+			if ref == "" || ref == "<none>:<none>" {
+				continue
+			}
+
+			snapshot.refs[ref] = imageSummary.ID
+		}
+	}
+
+	return snapshot, nil
+}
+
+// CleanupImages removes newly introduced image references after all pushes succeed.
+func (p *ImagePusher) CleanupImages(ctx context.Context, before *imageSnapshot, mirrorRegistry string, manifest *PackageManifest) error {
+	after, err := p.SnapshotLocalImages(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to snapshot local images for cleanup")
+	}
+
+	targetRefs := make(map[string]struct{})
+	sourceRefs := make(map[string]struct{})
+
+	for _, imageSpec := range manifest.Images {
+		sourceRef := fmt.Sprintf("%s:%s", imageSpec.ImageName, imageSpec.Tag)
+		targetRef := p.buildTargetImage(mirrorRegistry, imageSpec)
+
+		if isCleanupCandidate(before, after, targetRef) {
+			targetRefs[targetRef] = struct{}{}
+		}
+
+		if isCleanupCandidate(before, after, sourceRef) {
+			sourceRefs[sourceRef] = struct{}{}
+		}
+	}
+
+	var cleanupErrors []string
+	cleanupRefs := func(refs map[string]struct{}) {
+		for _, ref := range sortedImageRefs(refs) {
+			if _, err := p.dockerClient.ImageRemove(ctx, ref, image.RemoveOptions{}); err != nil {
+				cleanupErrors = append(cleanupErrors, fmt.Sprintf("%s: %v", ref, err))
+			}
+		}
+	}
+	cleanupRefs(targetRefs)
+	cleanupRefs(sourceRefs)
+
+	if len(cleanupErrors) > 0 {
+		return errors.Errorf("failed to clean local image references: %s", strings.Join(cleanupErrors, "; "))
+	}
+
+	return nil
+}
+
+func isCleanupCandidate(before, after *imageSnapshot, ref string) bool {
+	if before == nil || after == nil {
+		return false
+	}
+
+	if _, existed := before.refs[ref]; existed {
+		return false
+	}
+
+	imageID, exists := after.refs[ref]
+	if !exists || imageID == "" {
+		return false
+	}
+
+	_, existed := before.ids[imageID]
+
+	return !existed
+}
+
+func sortedImageRefs(refs map[string]struct{}) []string {
+	result := make([]string, 0, len(refs))
+	for ref := range refs {
+		result = append(result, ref)
+	}
+
+	sort.Strings(result)
+
+	return result
 }
 
 func (p *ImagePusher) LoadImages(ctx context.Context, manifest *PackageManifest, extractedPath string) error {

--- a/internal/cli/packageimport/image_pusher_test.go
+++ b/internal/cli/packageimport/image_pusher_test.go
@@ -7,6 +7,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsCleanupCandidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		before *imageSnapshot
+		after  *imageSnapshot
+		want   bool
+	}{
+		{
+			name:  "nil snapshot is never eligible",
+			after: &imageSnapshot{refs: map[string]string{"example/image:v1": "sha256:new"}},
+			want:  false,
+		},
+		{
+			name:   "missing post-push ref is not eligible",
+			before: &imageSnapshot{ids: map[string]struct{}{}, refs: map[string]string{}},
+			after:  &imageSnapshot{refs: map[string]string{}},
+			want:   false,
+		},
+		{
+			name:   "empty post-push ID is not eligible",
+			before: &imageSnapshot{ids: map[string]struct{}{}, refs: map[string]string{}},
+			after:  &imageSnapshot{refs: map[string]string{"example/image:v1": ""}},
+			want:   false,
+		},
+		{
+			name:   "pre-existing ref is not eligible",
+			before: &imageSnapshot{ids: map[string]struct{}{}, refs: map[string]string{"example/image:v1": "sha256:old"}},
+			after:  &imageSnapshot{refs: map[string]string{"example/image:v1": "sha256:new"}},
+			want:   false,
+		},
+		{
+			name:   "pre-existing ID is not eligible",
+			before: &imageSnapshot{ids: map[string]struct{}{"sha256:existing": {}}, refs: map[string]string{}},
+			after:  &imageSnapshot{refs: map[string]string{"example/image:v1": "sha256:existing"}},
+			want:   false,
+		},
+		{
+			name:   "new ref on a new ID is eligible",
+			before: &imageSnapshot{ids: map[string]struct{}{}, refs: map[string]string{}},
+			after:  &imageSnapshot{refs: map[string]string{"example/image:v1": "sha256:new"}},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isCleanupCandidate(tt.before, tt.after, "example/image:v1"))
+		})
+	}
+}
+
 func TestImagePusherBuildTargetImage(t *testing.T) {
 	pusher, err := NewImagePusher() // No API client needed for testing buildTargetImage
 	require.NoError(t, err, "Failed to create ImagePusher")

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -221,6 +221,14 @@ func (i *Importer) pushImages(ctx context.Context, opts *ImportOptions, manifest
 		return nil, errors.Wrap(err, "failed to create image pusher")
 	}
 
+	var snapshot *imageSnapshot
+	if !opts.SkipImagePush && !opts.SkipImageCleanup {
+		snapshot, err = imagePusher.SnapshotLocalImages(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to snapshot local images")
+		}
+	}
+
 	err = imagePusher.LoadImages(ctx, manifest, opts.ExtractPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load images")
@@ -254,6 +262,15 @@ func (i *Importer) pushImages(ctx context.Context, opts *ImportOptions, manifest
 	pushedImages, err := imagePusher.PushImagesToMirrorRegistry(ctx, imagePrefix, registryAuth, manifest)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to push images to mirror registry")
+	}
+
+	if opts.SkipImageCleanup {
+		klog.Info("Skipping local image cleanup as per configuration")
+		return pushedImages, nil
+	}
+
+	if err := imagePusher.CleanupImages(ctx, snapshot, imagePrefix, manifest); err != nil {
+		return nil, errors.Wrap(err, "failed to clean local images")
 	}
 
 	return pushedImages, nil

--- a/internal/cli/packageimport/types.go
+++ b/internal/cli/packageimport/types.go
@@ -95,6 +95,9 @@ type ImportOptions struct {
 	// SkipImageLoad skips loading images from files
 	SkipImageLoad bool
 
+	// SkipImageCleanup retains local image references after a successful remote push.
+	SkipImageCleanup bool
+
 	// Force forces the import even if the engine version already exists
 	Force bool
 


### PR DESCRIPTION
## Summary
- snapshot local Docker refs before remote package image imports and remove only newly introduced target/source refs after every push succeeds
- retain refs on load, tag, or push failures; never force-delete, prune, or remove by image ID
- add inherited `neutree-cli import --no-cleanup-image` for engine, cluster, and controlplane imports

## Test Plan

### Unit test
- [x] `go test -race ./internal/cli/packageimport/... ./cmd/neutree-cli/app/cmd/packageimport`
- [x] `go vet ./internal/cli/packageimport/... ./cmd/neutree-cli/app/cmd/packageimport`
- [x] covered pure cleanup-candidate rules and CLI flag inheritance/parsing without test-only production interfaces

### DB test
- [x] N/A: the CLI import path makes no database changes for cluster/controlplane; engine registration is unchanged.

### E2E test
- [ ] Manual E2E is required because the repository E2E environment cannot provide the package archives, Docker daemon, and mirror registry needed to validate Docker API cleanup. Planned TestRail coverage: C2744124-C2744130.

## Notes
- `go test ./cmd/neutree-cli/app/...` is blocked in this checkout by a pre-existing missing embedded artifact: `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`.