### PR TITLE
fix: prevent endpoint cluster changes

### DIFF
--- a/internal/routes/proxies/endpoint_proxy.go
+++ b/internal/routes/proxies/endpoint_proxy.go
@@ -19,11 +19,10 @@ func RegisterEndpointRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFun
 	proxyGroup.Use(middlewares...)
 
 	handler := CreateStructProxyHandler[v1.Endpoint](deps, storage.ENDPOINT_TABLE)
-	clusterValidation := validateEndpointClusterImmutable(deps.Storage)
-	vgpuValidation := validateEndpointVGPU(deps.Storage)
+	endpointValidation := validateEndpoint(deps.Storage)
 
 	// Only register allowed methods
 	proxyGroup.GET("", handler)
-	proxyGroup.POST("", vgpuValidation, handler)
-	proxyGroup.PATCH("", clusterValidation, vgpuValidation, handler)
+	proxyGroup.POST("", endpointValidation, handler)
+	proxyGroup.PATCH("", endpointValidation, handler)
 }

--- a/internal/routes/proxies/endpoint_proxy.go
+++ b/internal/routes/proxies/endpoint_proxy.go
@@ -19,10 +19,11 @@ func RegisterEndpointRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFun
 	proxyGroup.Use(middlewares...)
 
 	handler := CreateStructProxyHandler[v1.Endpoint](deps, storage.ENDPOINT_TABLE)
+	clusterValidation := validateEndpointClusterImmutable(deps.Storage)
 	vgpuValidation := validateEndpointVGPU(deps.Storage)
 
 	// Only register allowed methods
 	proxyGroup.GET("", handler)
 	proxyGroup.POST("", vgpuValidation, handler)
-	proxyGroup.PATCH("", vgpuValidation, handler)
+	proxyGroup.PATCH("", clusterValidation, vgpuValidation, handler)
 }

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -69,7 +69,53 @@ func validateEndpointVGPURequest(
 		return validationErr
 	}
 
-	return validateEndpointVGPUPreflight(store, method, queryParams, endpoint)
+	var resolvedPatch *v1.Endpoint
+
+	if method == http.MethodPatch {
+		clusterPresent, validationErr := endpointPatchIncludesCluster(body)
+		if validationErr != nil {
+			return validationErr
+		}
+
+		if clusterPresent {
+			resolvedPatch, validationErr = resolveEndpointPatch(store, queryParams)
+			if validationErr != nil {
+				return validationErr
+			}
+
+			if endpointClusterChanged(resolvedPatch, endpoint) {
+				return endpointClusterImmutableError()
+			}
+		}
+	}
+
+	return validateEndpointVGPUPreflightWithResolvedPatch(store, method, queryParams, endpoint, resolvedPatch)
+}
+
+func endpointPatchIncludesCluster(body []byte) (bool, *validationError) {
+	var payload struct {
+		Spec map[string]json.RawMessage `json:"spec"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false, invalidEndpointPayloadError(err)
+	}
+
+	_, ok := payload.Spec["cluster"]
+
+	return ok, nil
+}
+
+func endpointClusterChanged(existing *v1.Endpoint, patch *v1.Endpoint) bool {
+	if existing == nil || existing.Spec == nil {
+		return false
+	}
+
+	if patch == nil || patch.Spec == nil {
+		return existing.Spec.Cluster != ""
+	}
+
+	return existing.Spec.Cluster != patch.Spec.Cluster
 }
 
 func parseEndpointBody(body []byte) (*v1.Endpoint, *validationError) {
@@ -87,6 +133,16 @@ func validateEndpointVGPUPreflight(
 	queryParams url.Values,
 	endpoint *v1.Endpoint,
 ) *validationError {
+	return validateEndpointVGPUPreflightWithResolvedPatch(store, method, queryParams, endpoint, nil)
+}
+
+func validateEndpointVGPUPreflightWithResolvedPatch(
+	store storage.Storage,
+	method string,
+	queryParams url.Values,
+	endpoint *v1.Endpoint,
+	resolvedPatch *v1.Endpoint,
+) *validationError {
 	if endpoint == nil || endpoint.GetDeletionTimestamp() != "" {
 		return nil
 	}
@@ -101,7 +157,7 @@ func validateEndpointVGPUPreflight(
 		}
 	}
 
-	targetEndpoint, validationErr := endpointVGPUValidationTarget(store, method, queryParams, endpoint)
+	targetEndpoint, validationErr := endpointVGPUValidationTarget(store, method, queryParams, endpoint, resolvedPatch)
 	if validationErr != nil {
 		return validationErr
 	}
@@ -149,17 +205,22 @@ func endpointVGPUValidationTarget(
 	method string,
 	queryParams url.Values,
 	endpoint *v1.Endpoint,
+	resolvedPatch *v1.Endpoint,
 ) (*v1.Endpoint, *validationError) {
 	if method != http.MethodPatch {
 		return endpoint, nil
 	}
 
-	resolved, validationErr := resolveEndpointPatch(store, queryParams)
-	if validationErr != nil {
-		return nil, validationErr
+	if resolvedPatch == nil {
+		var validationErr *validationError
+		resolvedPatch, validationErr = resolveEndpointPatch(store, queryParams)
+
+		if validationErr != nil {
+			return nil, validationErr
+		}
 	}
 
-	merged := mergeEndpointPatch(resolved, endpoint)
+	merged := mergeEndpointPatch(resolvedPatch, endpoint)
 
 	return &merged, nil
 }
@@ -649,5 +710,13 @@ func endpointVGPUNotReadyError(cluster *v1.Cluster, hint string) *validationErro
 		Code:    "10222",
 		Message: "cluster accelerator virtualization is not ready",
 		Hint:    hint,
+	}
+}
+
+func endpointClusterImmutableError() *validationError {
+	return &validationError{
+		Code:    "10225",
+		Message: "endpoint cluster is immutable",
+		Hint:    "spec.cluster cannot be changed after endpoint creation",
 	}
 }

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -3,10 +3,12 @@ package proxies
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -186,20 +188,19 @@ func prepareEndpointValidationInput(
 		return validationErr
 	}
 
-	merged := mergeEndpointPatch(current, &input.Patch)
+	newEndpoint, err := buildPostgrestEndpointPatchValidationNew(current, input.Body)
+	if err != nil {
+		return invalidEndpointPayloadError(err)
+	}
+
 	input.Current = current
-	input.New = &merged
+	input.New = newEndpoint
 
 	return nil
 }
 
 func endpointPatchRequiresCurrent(input *endpointValidationInput) (bool, *validationError) {
-	clusterPresent, validationErr := endpointPatchIncludesCluster(input.RawPayload)
-	if validationErr != nil {
-		return false, validationErr
-	}
-
-	return clusterPresent || endpointPatchMayAffectVGPUValidation(&input.Patch), nil
+	return endpointPatchIncludesSpec(input.RawPayload), nil
 }
 
 func endpointPatchIsSoftDelete(payload map[string]json.RawMessage) (bool, error) {
@@ -237,40 +238,21 @@ func validateEndpointPatchVGPU(store storage.Storage, input *endpointValidationI
 }
 
 func validateEndpointClusterImmutable(input *endpointValidationInput) *validationError {
-	clusterPresent, validationErr := endpointPatchIncludesCluster(input.RawPayload)
-	if validationErr != nil {
-		return validationErr
-	}
-
-	if !clusterPresent {
+	if !endpointPatchIncludesSpec(input.RawPayload) {
 		return nil
 	}
 
-	if endpointClusterChanged(input.Current, &input.Patch) {
+	if endpointClusterChanged(input.Current, input.New) {
 		return endpointClusterImmutableError()
 	}
 
 	return nil
 }
 
-func endpointPatchIncludesCluster(payload map[string]json.RawMessage) (bool, *validationError) {
-	specRaw, ok := payload["spec"]
-	if !ok {
-		return false, nil
-	}
+func endpointPatchIncludesSpec(payload map[string]json.RawMessage) bool {
+	_, ok := payload["spec"]
 
-	if bytes.Equal(bytes.TrimSpace(specRaw), []byte("null")) {
-		return true, nil
-	}
-
-	var spec map[string]json.RawMessage
-	if err := json.Unmarshal(specRaw, &spec); err != nil {
-		return false, invalidEndpointPayloadError(err)
-	}
-
-	_, ok = spec["cluster"]
-
-	return ok, nil
+	return ok
 }
 
 func endpointClusterChanged(existing *v1.Endpoint, patch *v1.Endpoint) bool {
@@ -294,42 +276,60 @@ func parseEndpointBody(body []byte) (*v1.Endpoint, *validationError) {
 	return &endpoint, nil
 }
 
-func validateEndpointVGPUPreflight(
-	store storage.Storage,
-	method string,
-	queryParams url.Values,
-	endpoint *v1.Endpoint,
-) *validationError {
-	return validateEndpointVGPUPreflightWithResolvedPatch(store, method, queryParams, endpoint, nil)
-}
-
-func validateEndpointVGPUPreflightWithResolvedPatch(
-	store storage.Storage,
-	method string,
-	queryParams url.Values,
-	endpoint *v1.Endpoint,
-	resolvedPatch *v1.Endpoint,
-) *validationError {
-	if endpoint == nil || endpoint.GetDeletionTimestamp() != "" {
-		return nil
+// buildPostgrestEndpointPatchValidationNew mirrors the resource proxy before
+// it forwards a PATCH: supplied top-level columns replace their current
+// values. A supplied spec therefore replaces the complete PostgreSQL
+// composite rather than recursively merging its attributes.
+func buildPostgrestEndpointPatchValidationNew(current *v1.Endpoint, body []byte) (*v1.Endpoint, error) {
+	if current == nil {
+		return nil, errors.New("current endpoint is required")
 	}
 
-	if endpoint.Spec == nil {
-		return nil
+	currentBody, err := json.Marshal(current)
+	if err != nil {
+		return nil, fmt.Errorf("marshal current endpoint: %w", err)
 	}
 
-	if method == http.MethodPatch {
-		if !endpointPatchMayAffectVGPUValidation(endpoint) {
-			return nil
-		}
+	var currentPayload map[string]interface{}
+	if err := json.Unmarshal(currentBody, &currentPayload); err != nil {
+		return nil, fmt.Errorf("decode current endpoint: %w", err)
 	}
 
-	targetEndpoint, validationErr := endpointVGPUValidationTarget(store, method, queryParams, endpoint, resolvedPatch)
-	if validationErr != nil {
-		return validationErr
+	if len(bytes.TrimSpace(body)) == 0 {
+		body = []byte(`{}`)
 	}
 
-	return validateEndpointVGPUEffective(store, targetEndpoint)
+	filteredBody, err := filterPayloadToTopLevelFields(
+		body,
+		extractTopLevelJSONFields(reflect.TypeOf(v1.Endpoint{})),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("filter endpoint patch payload: %w", err)
+	}
+
+	var patchPayload map[string]interface{}
+	if err := json.Unmarshal(filteredBody, &patchPayload); err != nil {
+		return nil, fmt.Errorf("decode endpoint patch payload: %w", err)
+	}
+
+	tagConfig := extractStructTagConfig(reflect.TypeOf(v1.Endpoint{}))
+	mergeExcludedFields(patchPayload, currentPayload, tagConfig.excludeFields, tagConfig.arrayMergeKeys)
+
+	for field, value := range patchPayload {
+		currentPayload[field] = value
+	}
+
+	nextBody, err := json.Marshal(currentPayload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal patched endpoint: %w", err)
+	}
+
+	var next v1.Endpoint
+	if err := json.Unmarshal(nextBody, &next); err != nil {
+		return nil, fmt.Errorf("decode patched endpoint: %w", err)
+	}
+
+	return &next, nil
 }
 
 func validateEndpointVGPUEffective(store storage.Storage, endpoint *v1.Endpoint) *validationError {
@@ -369,31 +369,6 @@ func validateEndpointVGPUEffective(store storage.Storage, endpoint *v1.Endpoint)
 	// Capacity is intentionally left to scheduling/runtime status. Cluster
 	// resource snapshots can be stale and should not be used as admission gates.
 	return nil
-}
-
-func endpointVGPUValidationTarget(
-	store storage.Storage,
-	method string,
-	queryParams url.Values,
-	endpoint *v1.Endpoint,
-	resolvedPatch *v1.Endpoint,
-) (*v1.Endpoint, *validationError) {
-	if method != http.MethodPatch {
-		return endpoint, nil
-	}
-
-	if resolvedPatch == nil {
-		var validationErr *validationError
-		resolvedPatch, validationErr = resolveEndpointPatch(store, queryParams)
-
-		if validationErr != nil {
-			return nil, validationErr
-		}
-	}
-
-	merged := mergeEndpointPatch(resolvedPatch, endpoint)
-
-	return &merged, nil
 }
 
 func resolveEndpointPatch(
@@ -456,149 +431,6 @@ func resolveEndpointVGPUCluster(store storage.Storage, endpoint *v1.Endpoint) (*
 	}
 
 	return &clusters[0], nil
-}
-
-func mergeEndpointPatch(existing *v1.Endpoint, patch *v1.Endpoint) v1.Endpoint {
-	if existing == nil {
-		if patch == nil {
-			return v1.Endpoint{}
-		}
-
-		return *patch
-	}
-
-	merged := *existing
-
-	if existing.Metadata != nil {
-		metadata := *existing.Metadata
-		merged.Metadata = &metadata
-	}
-
-	if existing.Spec != nil {
-		spec := *existing.Spec
-		if existing.Spec.Resources != nil {
-			spec.Resources = copyEndpointResourceSpec(existing.Spec.Resources)
-		}
-
-		merged.Spec = &spec
-	}
-
-	if patch == nil {
-		return merged
-	}
-
-	if patch.Metadata != nil {
-		if merged.Metadata == nil {
-			merged.Metadata = &v1.Metadata{}
-		}
-
-		if patch.Metadata.Name != "" {
-			merged.Metadata.Name = patch.Metadata.Name
-		}
-
-		if patch.Metadata.Workspace != "" {
-			merged.Metadata.Workspace = patch.Metadata.Workspace
-		}
-	}
-
-	if patch.Spec != nil {
-		if merged.Spec == nil {
-			merged.Spec = &v1.EndpointSpec{}
-		}
-
-		if patch.Spec.Cluster != "" {
-			merged.Spec.Cluster = patch.Spec.Cluster
-		}
-
-		if patch.Spec.Replicas.Num != nil {
-			merged.Spec.Replicas.Num = patch.Spec.Replicas.Num
-		}
-
-		if patch.Spec.Resources != nil {
-			merged.Spec.Resources = mergeEndpointResourceSpec(merged.Spec.Resources, patch.Spec.Resources)
-		}
-	}
-
-	return merged
-}
-
-func mergeEndpointResourceSpec(existing *v1.ResourceSpec, patch *v1.ResourceSpec) *v1.ResourceSpec {
-	if existing == nil {
-		return copyEndpointResourceSpec(patch)
-	}
-
-	merged := copyEndpointResourceSpec(existing)
-
-	if patch.CPU != nil {
-		merged.CPU = patch.CPU
-	}
-
-	if patch.GPU != nil {
-		merged.GPU = patch.GPU
-	}
-
-	if patch.Memory != nil {
-		merged.Memory = patch.Memory
-	}
-
-	if patch.Accelerator != nil {
-		if merged.Accelerator == nil {
-			merged.Accelerator = make(map[string]string, len(patch.Accelerator))
-		}
-
-		for key, value := range patch.Accelerator {
-			merged.Accelerator[key] = value
-		}
-
-		if acceleratorPatchClearsVirtualization(patch.Accelerator) {
-			clearAcceleratorVirtualization(merged.Accelerator)
-		}
-	}
-
-	return merged
-}
-
-func acceleratorPatchClearsVirtualization(accelerator map[string]string) bool {
-	if accelerator == nil {
-		return false
-	}
-
-	_, hasType := accelerator[v1.AcceleratorTypeKey]
-	_, hasProduct := accelerator[v1.AcceleratorProductKey]
-
-	return hasType && hasProduct && !acceleratorHasVirtualization(accelerator)
-}
-
-func clearAcceleratorVirtualization(accelerator map[string]string) {
-	delete(accelerator, v1.AcceleratorVirtualizationMemoryMiBKey)
-	delete(accelerator, v1.AcceleratorVirtualizationMemoryPercentKey)
-	delete(accelerator, v1.AcceleratorVirtualizationCorePercentKey)
-}
-
-func acceleratorHasVirtualization(accelerator map[string]string) bool {
-	for key := range accelerator {
-		if v1.IsAcceleratorVirtualizationKey(key) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func copyEndpointResourceSpec(resources *v1.ResourceSpec) *v1.ResourceSpec {
-	if resources == nil {
-		return nil
-	}
-
-	copied := *resources
-	if resources.Accelerator != nil {
-		copied.Accelerator = make(map[string]string, len(resources.Accelerator))
-		for key, value := range resources.Accelerator {
-			copied.Accelerator[key] = value
-		}
-	}
-
-	return &copied
 }
 
 func endpointPatchMayAffectVGPUValidation(endpoint *v1.Endpoint) bool {

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -15,7 +15,34 @@ import (
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
+const endpointResolvedPatchContextKey = "endpoint.resolvedPatch"
+
+type endpointRequestValidator func(*gin.Context, string, url.Values, []byte) *validationError
+
+func validateEndpointClusterImmutable(store storage.Storage) gin.HandlerFunc {
+	return validateEndpointRequest(func(c *gin.Context, method string, queryParams url.Values, body []byte) *validationError {
+		resolvedPatch, validationErr := validateEndpointClusterImmutableRequest(store, method, queryParams, body)
+		if resolvedPatch != nil {
+			c.Set(endpointResolvedPatchContextKey, resolvedPatch)
+		}
+
+		return validationErr
+	})
+}
+
 func validateEndpointVGPU(store storage.Storage) gin.HandlerFunc {
+	return validateEndpointRequest(func(c *gin.Context, method string, queryParams url.Values, body []byte) *validationError {
+		return validateEndpointVGPURequest(
+			store,
+			method,
+			queryParams,
+			body,
+			endpointResolvedPatch(c),
+		)
+	})
+}
+
+func validateEndpointRequest(validator endpointRequestValidator) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -41,8 +68,8 @@ func validateEndpointVGPU(store storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		validationErr := validateEndpointVGPURequest(
-			store,
+		validationErr := validator(
+			c,
 			c.Request.Method,
 			c.Request.URL.Query(),
 			body,
@@ -58,38 +85,69 @@ func validateEndpointVGPU(store storage.Storage) gin.HandlerFunc {
 	}
 }
 
+func validateEndpointClusterImmutableRequest(
+	store storage.Storage,
+	method string,
+	queryParams url.Values,
+	body []byte,
+) (*v1.Endpoint, *validationError) {
+	if method != http.MethodPatch {
+		return nil, nil
+	}
+
+	clusterPresent, validationErr := endpointPatchIncludesCluster(body)
+	if validationErr != nil {
+		return nil, validationErr
+	}
+
+	if !clusterPresent {
+		return nil, nil
+	}
+
+	endpoint, validationErr := parseEndpointBody(body)
+	if validationErr != nil {
+		return nil, validationErr
+	}
+
+	resolvedPatch, validationErr := resolveEndpointPatch(store, queryParams)
+	if validationErr != nil {
+		return nil, validationErr
+	}
+
+	if endpointClusterChanged(resolvedPatch, endpoint) {
+		return nil, endpointClusterImmutableError()
+	}
+
+	return resolvedPatch, nil
+}
+
 func validateEndpointVGPURequest(
 	store storage.Storage,
 	method string,
 	queryParams url.Values,
 	body []byte,
+	resolvedPatch *v1.Endpoint,
 ) *validationError {
 	endpoint, validationErr := parseEndpointBody(body)
 	if validationErr != nil {
 		return validationErr
 	}
 
-	var resolvedPatch *v1.Endpoint
+	return validateEndpointVGPUPreflightWithResolvedPatch(store, method, queryParams, endpoint, resolvedPatch)
+}
 
-	if method == http.MethodPatch {
-		clusterPresent, validationErr := endpointPatchIncludesCluster(body)
-		if validationErr != nil {
-			return validationErr
-		}
-
-		if clusterPresent {
-			resolvedPatch, validationErr = resolveEndpointPatch(store, queryParams)
-			if validationErr != nil {
-				return validationErr
-			}
-
-			if endpointClusterChanged(resolvedPatch, endpoint) {
-				return endpointClusterImmutableError()
-			}
-		}
+func endpointResolvedPatch(c *gin.Context) *v1.Endpoint {
+	resolvedPatch, ok := c.Get(endpointResolvedPatchContextKey)
+	if !ok {
+		return nil
 	}
 
-	return validateEndpointVGPUPreflightWithResolvedPatch(store, method, queryParams, endpoint, resolvedPatch)
+	endpoint, ok := resolvedPatch.(*v1.Endpoint)
+	if !ok {
+		return nil
+	}
+
+	return endpoint
 }
 
 func endpointPatchIncludesCluster(body []byte) (bool, *validationError) {

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -37,11 +37,9 @@ type endpointValidationInput struct {
 }
 
 type endpointValidator func(storage.Storage, *endpointValidationInput) *validationError
-type endpointPreparationRequirement func(*endpointValidationInput) (bool, *validationError)
 
 type endpointValidationConfig struct {
-	RequiresCurrent endpointPreparationRequirement
-	Validators      []endpointValidator
+	Validators []endpointValidator
 }
 
 var endpointValidationConfigs = map[endpointValidationOperation]endpointValidationConfig{
@@ -51,7 +49,6 @@ var endpointValidationConfigs = map[endpointValidationOperation]endpointValidati
 		},
 	},
 	endpointValidationPatch: {
-		RequiresCurrent: endpointPatchRequiresCurrent,
 		Validators: []endpointValidator{
 			validateEndpointPatchClusterImmutable,
 			validateEndpointPatchVGPU,
@@ -76,7 +73,8 @@ func validateEndpoint(store storage.Storage) gin.HandlerFunc {
 		}
 
 		config := endpointValidationConfigs[input.Operation]
-		if validationErr := prepareEndpointValidationInput(store, input, config); validationErr != nil {
+
+		if validationErr := prepareEndpointValidationInput(store, input); validationErr != nil {
 			c.JSON(validationErrStatus(validationErr), validationErr)
 			c.Abort()
 
@@ -163,23 +161,13 @@ func readEndpointValidationInput(c *gin.Context) (*endpointValidationInput, *val
 func prepareEndpointValidationInput(
 	store storage.Storage,
 	input *endpointValidationInput,
-	config endpointValidationConfig,
 ) *validationError {
 	if input.Operation == endpointValidationSoftDelete {
 		return nil
 	}
 
 	input.New = &input.Patch
-	if input.Operation != endpointValidationPatch || config.RequiresCurrent == nil {
-		return nil
-	}
-
-	requiresCurrent, validationErr := config.RequiresCurrent(input)
-	if validationErr != nil {
-		return validationErr
-	}
-
-	if !requiresCurrent {
+	if input.Operation != endpointValidationPatch {
 		return nil
 	}
 
@@ -197,10 +185,6 @@ func prepareEndpointValidationInput(
 	input.New = newEndpoint
 
 	return nil
-}
-
-func endpointPatchRequiresCurrent(input *endpointValidationInput) (bool, *validationError) {
-	return endpointPatchIncludesSpec(input.RawPayload), nil
 }
 
 func endpointPatchIsSoftDelete(payload map[string]json.RawMessage) (bool, error) {
@@ -376,25 +360,25 @@ func resolveEndpointPatch(
 	queryParams url.Values,
 ) (*v1.Endpoint, *validationError) {
 	if store == nil {
-		return nil, endpointVGPULookupError("storage is required to validate endpoint accelerator virtualization")
+		return nil, endpointPatchLookupError("storage is required to resolve endpoint PATCH target")
 	}
 
 	filters := queryParamsToFilters(queryParams)
 	if len(filters) == 0 {
-		return nil, endpointVGPUTargetError("endpoint lookup filters are required for vGPU resource PATCH")
+		return nil, endpointPatchTargetError("endpoint lookup filters are required for endpoint PATCH")
 	}
 
 	endpoints, err := store.ListEndpoint(storage.ListOption{Filters: filters})
 	if err != nil {
-		return nil, endpointVGPULookupError("failed to look up endpoint for vGPU resource PATCH")
+		return nil, endpointPatchLookupError("failed to look up endpoint for endpoint PATCH")
 	}
 
 	if len(endpoints) == 0 {
-		return nil, endpointVGPUTargetError("endpoint not found for vGPU resource PATCH")
+		return nil, endpointPatchTargetError("endpoint not found for endpoint PATCH")
 	}
 
 	if len(endpoints) > 1 {
-		return nil, endpointVGPUTargetError("multiple endpoints matched vGPU resource PATCH filters")
+		return nil, endpointPatchTargetError("multiple endpoints matched endpoint PATCH filters")
 	}
 
 	return &endpoints[0], nil
@@ -689,8 +673,23 @@ func endpointVGPUTargetError(hint string) *validationError {
 	}
 }
 
+func endpointPatchTargetError(hint string) *validationError {
+	return &validationError{
+		Code:    "10221",
+		Message: "invalid endpoint patch target",
+		Hint:    hint,
+	}
+}
+
 func endpointVGPULookupError(hint string) *validationError {
 	err := endpointVGPUTargetError(hint)
+	err.HTTPStatus = http.StatusServiceUnavailable
+
+	return err
+}
+
+func endpointPatchLookupError(hint string) *validationError {
+	err := endpointPatchTargetError(hint)
 	err.HTTPStatus = http.StatusServiceUnavailable
 
 	return err

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -15,6 +15,46 @@ import (
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
+type endpointValidationOperation string
+
+const (
+	endpointValidationCreate     endpointValidationOperation = "create"
+	endpointValidationPatch      endpointValidationOperation = "patch"
+	endpointValidationSoftDelete endpointValidationOperation = "soft-delete"
+)
+
+type endpointValidationInput struct {
+	Body              []byte
+	QueryParams       url.Values
+	Patch             *v1.Endpoint
+	ResolvedPatch     *v1.Endpoint
+	EffectiveEndpoint *v1.Endpoint
+}
+
+type endpointValidator func(storage.Storage, endpointValidationInput) *validationError
+type endpointResolvedPatchRequirement func(endpointValidationInput) (bool, *validationError)
+
+type endpointValidationConfig struct {
+	RequiresResolvedPatch endpointResolvedPatchRequirement
+	Validators            []endpointValidator
+}
+
+var endpointValidationConfigs = map[endpointValidationOperation]endpointValidationConfig{
+	endpointValidationCreate: {
+		Validators: []endpointValidator{
+			validateEndpointCreateVGPU,
+		},
+	},
+	endpointValidationPatch: {
+		RequiresResolvedPatch: endpointPatchRequiresResolvedPatch,
+		Validators: []endpointValidator{
+			validateEndpointPatchClusterImmutable,
+			validateEndpointPatchVGPU,
+		},
+	},
+	endpointValidationSoftDelete: {},
+}
+
 func validateEndpoint(store storage.Storage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
@@ -64,32 +104,85 @@ func validateEndpointRequest(
 	queryParams url.Values,
 	body []byte,
 ) *validationError {
-	endpoint, validationErr := parseEndpointBody(body)
+	patch, validationErr := parseEndpointBody(body)
 	if validationErr != nil {
 		return validationErr
 	}
 
-	var resolvedPatch *v1.Endpoint
+	operation := endpointValidationOperationFor(method, patch)
+	config := endpointValidationConfigs[operation]
+	input := endpointValidationInput{
+		Body:              body,
+		QueryParams:       queryParams,
+		Patch:             patch,
+		EffectiveEndpoint: patch,
+	}
 
-	if method == http.MethodPatch {
-		clusterPresent, validationErr := endpointPatchIncludesCluster(body)
+	if config.RequiresResolvedPatch != nil {
+		needsResolvedPatch, validationErr := config.RequiresResolvedPatch(input)
 		if validationErr != nil {
 			return validationErr
 		}
 
-		if clusterPresent || endpointPatchMayAffectVGPUValidation(endpoint) {
-			resolvedPatch, validationErr = resolveEndpointPatch(store, queryParams)
+		if needsResolvedPatch {
+			input.ResolvedPatch, validationErr = resolveEndpointPatch(store, queryParams)
 			if validationErr != nil {
 				return validationErr
 			}
-		}
 
-		if validationErr := validateEndpointClusterImmutable(body, endpoint, resolvedPatch); validationErr != nil {
+			merged := mergeEndpointPatch(input.ResolvedPatch, input.Patch)
+			input.EffectiveEndpoint = &merged
+		}
+	}
+
+	for _, validator := range config.Validators {
+		if validationErr := validator(store, input); validationErr != nil {
 			return validationErr
 		}
 	}
 
-	return validateEndpointVGPUPreflightWithResolvedPatch(store, method, queryParams, endpoint, resolvedPatch)
+	return nil
+}
+
+func endpointValidationOperationFor(method string, endpoint *v1.Endpoint) endpointValidationOperation {
+	if method == http.MethodPatch && endpoint.GetDeletionTimestamp() != "" {
+		return endpointValidationSoftDelete
+	}
+
+	if method == http.MethodPatch {
+		return endpointValidationPatch
+	}
+
+	return endpointValidationCreate
+}
+
+func endpointPatchRequiresResolvedPatch(input endpointValidationInput) (bool, *validationError) {
+	clusterPresent, validationErr := endpointPatchIncludesCluster(input.Body)
+	if validationErr != nil {
+		return false, validationErr
+	}
+
+	return clusterPresent || endpointPatchMayAffectVGPUValidation(input.Patch), nil
+}
+
+func validateEndpointCreateVGPU(store storage.Storage, input endpointValidationInput) *validationError {
+	if input.Patch.GetDeletionTimestamp() != "" {
+		return nil
+	}
+
+	return validateEndpointVGPUEffective(store, input.EffectiveEndpoint)
+}
+
+func validateEndpointPatchClusterImmutable(_ storage.Storage, input endpointValidationInput) *validationError {
+	return validateEndpointClusterImmutable(input.Body, input.Patch, input.ResolvedPatch)
+}
+
+func validateEndpointPatchVGPU(store storage.Storage, input endpointValidationInput) *validationError {
+	if !endpointPatchMayAffectVGPUValidation(input.Patch) {
+		return nil
+	}
+
+	return validateEndpointVGPUEffective(store, input.EffectiveEndpoint)
 }
 
 func validateEndpointClusterImmutable(
@@ -196,23 +289,27 @@ func validateEndpointVGPUPreflightWithResolvedPatch(
 		return validationErr
 	}
 
-	if targetEndpoint == nil || targetEndpoint.Spec == nil {
+	return validateEndpointVGPUEffective(store, targetEndpoint)
+}
+
+func validateEndpointVGPUEffective(store storage.Storage, endpoint *v1.Endpoint) *validationError {
+	if endpoint == nil || endpoint.Spec == nil {
 		return nil
 	}
 
-	if validationErr := validateEndpointReplicaCount(targetEndpoint.Spec); validationErr != nil {
+	if validationErr := validateEndpointReplicaCount(endpoint.Spec); validationErr != nil {
 		return validationErr
 	}
 
-	if targetEndpoint.Spec.Resources == nil || !targetEndpoint.Spec.Resources.HasAcceleratorVirtualization() {
+	if endpoint.Spec.Resources == nil || !endpoint.Spec.Resources.HasAcceleratorVirtualization() {
 		return nil
 	}
 
-	if endpointReplicaCount(targetEndpoint.Spec) == 0 {
+	if endpointReplicaCount(endpoint.Spec) == 0 {
 		return nil
 	}
 
-	cluster, validationErr := resolveEndpointVGPUCluster(store, targetEndpoint)
+	cluster, validationErr := resolveEndpointVGPUCluster(store, endpoint)
 	if validationErr != nil {
 		return validationErr
 	}
@@ -221,11 +318,11 @@ func validateEndpointVGPUPreflightWithResolvedPatch(
 		return validationErr
 	}
 
-	if validationErr := validateEndpointVGPUResourceShape(targetEndpoint.Spec.Resources); validationErr != nil {
+	if validationErr := validateEndpointVGPUResourceShape(endpoint.Spec.Resources); validationErr != nil {
 		return validationErr
 	}
 
-	if validationErr := validateEndpointVGPUMemorySpec(targetEndpoint.Spec.Resources, cluster); validationErr != nil {
+	if validationErr := validateEndpointVGPUMemorySpec(endpoint.Spec.Resources, cluster); validationErr != nil {
 		return validationErr
 	}
 

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -24,19 +24,22 @@ const (
 )
 
 type endpointValidationInput struct {
-	Body              []byte
-	QueryParams       url.Values
-	Patch             *v1.Endpoint
-	ResolvedPatch     *v1.Endpoint
-	EffectiveEndpoint *v1.Endpoint
+	Method      string
+	Body        []byte
+	RawPayload  map[string]json.RawMessage
+	Patch       v1.Endpoint
+	Current     *v1.Endpoint
+	New         *v1.Endpoint
+	QueryParams url.Values
+	Operation   endpointValidationOperation
 }
 
-type endpointValidator func(storage.Storage, endpointValidationInput) *validationError
-type endpointResolvedPatchRequirement func(endpointValidationInput) (bool, *validationError)
+type endpointValidator func(storage.Storage, *endpointValidationInput) *validationError
+type endpointPreparationRequirement func(*endpointValidationInput) (bool, *validationError)
 
 type endpointValidationConfig struct {
-	RequiresResolvedPatch endpointResolvedPatchRequirement
-	Validators            []endpointValidator
+	RequiresCurrent endpointPreparationRequirement
+	Validators      []endpointValidator
 }
 
 var endpointValidationConfigs = map[endpointValidationOperation]endpointValidationConfig{
@@ -46,7 +49,7 @@ var endpointValidationConfigs = map[endpointValidationOperation]endpointValidati
 		},
 	},
 	endpointValidationPatch: {
-		RequiresResolvedPatch: endpointPatchRequiresResolvedPatch,
+		RequiresCurrent: endpointPatchRequiresCurrent,
 		Validators: []endpointValidator{
 			validateEndpointPatchClusterImmutable,
 			validateEndpointPatchVGPU,
@@ -62,31 +65,7 @@ func validateEndpoint(store storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		body, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, &validationError{
-				Code:    "10214",
-				Message: "invalid endpoint payload",
-				Hint:    err.Error(),
-			})
-			c.Abort()
-
-			return
-		}
-
-		c.Request.Body = io.NopCloser(bytes.NewReader(body))
-
-		if len(bytes.TrimSpace(body)) == 0 {
-			c.Next()
-			return
-		}
-
-		validationErr := validateEndpointRequest(
-			store,
-			c.Request.Method,
-			c.Request.URL.Query(),
-			body,
-		)
+		input, validationErr := readEndpointValidationInput(c)
 		if validationErr != nil {
 			c.JSON(validationErrStatus(validationErr), validationErr)
 			c.Abort()
@@ -94,61 +73,28 @@ func validateEndpoint(store storage.Storage) gin.HandlerFunc {
 			return
 		}
 
+		config := endpointValidationConfigs[input.Operation]
+		if validationErr := prepareEndpointValidationInput(store, input, config); validationErr != nil {
+			c.JSON(validationErrStatus(validationErr), validationErr)
+			c.Abort()
+
+			return
+		}
+
+		for _, validator := range config.Validators {
+			if validationErr := validator(store, input); validationErr != nil {
+				c.JSON(validationErrStatus(validationErr), validationErr)
+				c.Abort()
+
+				return
+			}
+		}
+
 		c.Next()
 	}
 }
 
-func validateEndpointRequest(
-	store storage.Storage,
-	method string,
-	queryParams url.Values,
-	body []byte,
-) *validationError {
-	patch, validationErr := parseEndpointBody(body)
-	if validationErr != nil {
-		return validationErr
-	}
-
-	operation := endpointValidationOperationFor(method, patch)
-	config := endpointValidationConfigs[operation]
-	input := endpointValidationInput{
-		Body:              body,
-		QueryParams:       queryParams,
-		Patch:             patch,
-		EffectiveEndpoint: patch,
-	}
-
-	if config.RequiresResolvedPatch != nil {
-		needsResolvedPatch, validationErr := config.RequiresResolvedPatch(input)
-		if validationErr != nil {
-			return validationErr
-		}
-
-		if needsResolvedPatch {
-			input.ResolvedPatch, validationErr = resolveEndpointPatch(store, queryParams)
-			if validationErr != nil {
-				return validationErr
-			}
-
-			merged := mergeEndpointPatch(input.ResolvedPatch, input.Patch)
-			input.EffectiveEndpoint = &merged
-		}
-	}
-
-	for _, validator := range config.Validators {
-		if validationErr := validator(store, input); validationErr != nil {
-			return validationErr
-		}
-	}
-
-	return nil
-}
-
-func endpointValidationOperationFor(method string, endpoint *v1.Endpoint) endpointValidationOperation {
-	if method == http.MethodPatch && endpoint.GetDeletionTimestamp() != "" {
-		return endpointValidationSoftDelete
-	}
-
+func endpointValidationOperationFor(method string) endpointValidationOperation {
 	if method == http.MethodPatch {
 		return endpointValidationPatch
 	}
@@ -156,41 +102,142 @@ func endpointValidationOperationFor(method string, endpoint *v1.Endpoint) endpoi
 	return endpointValidationCreate
 }
 
-func endpointPatchRequiresResolvedPatch(input endpointValidationInput) (bool, *validationError) {
-	clusterPresent, validationErr := endpointPatchIncludesCluster(input.Body)
+func readEndpointValidationInput(c *gin.Context) (*endpointValidationInput, *validationError) {
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return nil, invalidEndpointPayloadError(err)
+	}
+
+	if err := c.Request.Body.Close(); err != nil {
+		return nil, invalidEndpointPayloadError(err)
+	}
+
+	c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	c.Request.ContentLength = int64(len(body))
+	c.Request.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	input := &endpointValidationInput{
+		Method:      c.Request.Method,
+		Body:        body,
+		QueryParams: c.Request.URL.Query(),
+		Operation:   endpointValidationOperationFor(c.Request.Method),
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return input, nil
+	}
+
+	if err := json.Unmarshal(body, &input.RawPayload); err != nil {
+		return nil, invalidEndpointPayloadError(err)
+	}
+
+	if input.Operation == endpointValidationPatch {
+		isSoftDelete, err := endpointPatchIsSoftDelete(input.RawPayload)
+		if err != nil {
+			return nil, invalidEndpointPayloadError(err)
+		}
+
+		if isSoftDelete {
+			input.Operation = endpointValidationSoftDelete
+			if metadataRaw, ok := input.RawPayload["metadata"]; ok {
+				if err := json.Unmarshal(metadataRaw, &input.Patch.Metadata); err != nil {
+					return nil, invalidEndpointPayloadError(err)
+				}
+			}
+
+			return input, nil
+		}
+	}
+
+	patch, validationErr := parseEndpointBody(body)
+	if validationErr != nil {
+		return nil, validationErr
+	}
+
+	input.Patch = *patch
+
+	return input, nil
+}
+
+func prepareEndpointValidationInput(
+	store storage.Storage,
+	input *endpointValidationInput,
+	config endpointValidationConfig,
+) *validationError {
+	if input.Operation == endpointValidationSoftDelete {
+		return nil
+	}
+
+	input.New = &input.Patch
+	if input.Operation != endpointValidationPatch || config.RequiresCurrent == nil {
+		return nil
+	}
+
+	requiresCurrent, validationErr := config.RequiresCurrent(input)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	if !requiresCurrent {
+		return nil
+	}
+
+	current, validationErr := resolveEndpointPatch(store, input.QueryParams)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	merged := mergeEndpointPatch(current, &input.Patch)
+	input.Current = current
+	input.New = &merged
+
+	return nil
+}
+
+func endpointPatchRequiresCurrent(input *endpointValidationInput) (bool, *validationError) {
+	clusterPresent, validationErr := endpointPatchIncludesCluster(input.RawPayload)
 	if validationErr != nil {
 		return false, validationErr
 	}
 
-	return clusterPresent || endpointPatchMayAffectVGPUValidation(input.Patch), nil
+	return clusterPresent || endpointPatchMayAffectVGPUValidation(&input.Patch), nil
 }
 
-func validateEndpointCreateVGPU(store storage.Storage, input endpointValidationInput) *validationError {
+func endpointPatchIsSoftDelete(payload map[string]json.RawMessage) (bool, error) {
+	metadataRaw, ok := payload["metadata"]
+	if !ok {
+		return false, nil
+	}
+
+	var metadata v1.Metadata
+	if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
+		return false, err
+	}
+
+	return metadata.DeletionTimestamp != "", nil
+}
+
+func validateEndpointCreateVGPU(store storage.Storage, input *endpointValidationInput) *validationError {
 	if input.Patch.GetDeletionTimestamp() != "" {
 		return nil
 	}
 
-	return validateEndpointVGPUEffective(store, input.EffectiveEndpoint)
+	return validateEndpointVGPUEffective(store, input.New)
 }
 
-func validateEndpointPatchClusterImmutable(_ storage.Storage, input endpointValidationInput) *validationError {
-	return validateEndpointClusterImmutable(input.Body, input.Patch, input.ResolvedPatch)
+func validateEndpointPatchClusterImmutable(_ storage.Storage, input *endpointValidationInput) *validationError {
+	return validateEndpointClusterImmutable(input)
 }
 
-func validateEndpointPatchVGPU(store storage.Storage, input endpointValidationInput) *validationError {
-	if !endpointPatchMayAffectVGPUValidation(input.Patch) {
+func validateEndpointPatchVGPU(store storage.Storage, input *endpointValidationInput) *validationError {
+	if !endpointPatchMayAffectVGPUValidation(&input.Patch) {
 		return nil
 	}
 
-	return validateEndpointVGPUEffective(store, input.EffectiveEndpoint)
+	return validateEndpointVGPUEffective(store, input.New)
 }
 
-func validateEndpointClusterImmutable(
-	body []byte,
-	endpoint *v1.Endpoint,
-	resolvedPatch *v1.Endpoint,
-) *validationError {
-	clusterPresent, validationErr := endpointPatchIncludesCluster(body)
+func validateEndpointClusterImmutable(input *endpointValidationInput) *validationError {
+	clusterPresent, validationErr := endpointPatchIncludesCluster(input.RawPayload)
 	if validationErr != nil {
 		return validationErr
 	}
@@ -199,36 +246,29 @@ func validateEndpointClusterImmutable(
 		return nil
 	}
 
-	if endpointClusterChanged(resolvedPatch, endpoint) {
+	if endpointClusterChanged(input.Current, &input.Patch) {
 		return endpointClusterImmutableError()
 	}
 
 	return nil
 }
 
-func endpointPatchIncludesCluster(body []byte) (bool, *validationError) {
-	var payload struct {
-		Spec json.RawMessage `json:"spec"`
-	}
-
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return false, invalidEndpointPayloadError(err)
-	}
-
-	if len(payload.Spec) == 0 {
+func endpointPatchIncludesCluster(payload map[string]json.RawMessage) (bool, *validationError) {
+	specRaw, ok := payload["spec"]
+	if !ok {
 		return false, nil
 	}
 
-	if bytes.Equal(bytes.TrimSpace(payload.Spec), []byte("null")) {
+	if bytes.Equal(bytes.TrimSpace(specRaw), []byte("null")) {
 		return true, nil
 	}
 
 	var spec map[string]json.RawMessage
-	if err := json.Unmarshal(payload.Spec, &spec); err != nil {
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
 		return false, invalidEndpointPayloadError(err)
 	}
 
-	_, ok := spec["cluster"]
+	_, ok = spec["cluster"]
 
 	return ok, nil
 }

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -15,34 +15,7 @@ import (
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
-const endpointResolvedPatchContextKey = "endpoint.resolvedPatch"
-
-type endpointRequestValidator func(*gin.Context, string, url.Values, []byte) *validationError
-
-func validateEndpointClusterImmutable(store storage.Storage) gin.HandlerFunc {
-	return validateEndpointRequest(func(c *gin.Context, method string, queryParams url.Values, body []byte) *validationError {
-		resolvedPatch, validationErr := validateEndpointClusterImmutableRequest(store, method, queryParams, body)
-		if resolvedPatch != nil {
-			c.Set(endpointResolvedPatchContextKey, resolvedPatch)
-		}
-
-		return validationErr
-	})
-}
-
-func validateEndpointVGPU(store storage.Storage) gin.HandlerFunc {
-	return validateEndpointRequest(func(c *gin.Context, method string, queryParams url.Values, body []byte) *validationError {
-		return validateEndpointVGPURequest(
-			store,
-			method,
-			queryParams,
-			body,
-			endpointResolvedPatch(c),
-		)
-	})
-}
-
-func validateEndpointRequest(validator endpointRequestValidator) gin.HandlerFunc {
+func validateEndpoint(store storage.Storage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
 			c.Next()
@@ -68,8 +41,8 @@ func validateEndpointRequest(validator endpointRequestValidator) gin.HandlerFunc
 			return
 		}
 
-		validationErr := validator(
-			c,
+		validationErr := validateEndpointRequest(
+			store,
 			c.Request.Method,
 			c.Request.URL.Query(),
 			body,
@@ -85,69 +58,59 @@ func validateEndpointRequest(validator endpointRequestValidator) gin.HandlerFunc
 	}
 }
 
-func validateEndpointClusterImmutableRequest(
+func validateEndpointRequest(
 	store storage.Storage,
 	method string,
 	queryParams url.Values,
 	body []byte,
-) (*v1.Endpoint, *validationError) {
-	if method != http.MethodPatch {
-		return nil, nil
-	}
-
-	clusterPresent, validationErr := endpointPatchIncludesCluster(body)
-	if validationErr != nil {
-		return nil, validationErr
-	}
-
-	if !clusterPresent {
-		return nil, nil
-	}
-
-	endpoint, validationErr := parseEndpointBody(body)
-	if validationErr != nil {
-		return nil, validationErr
-	}
-
-	resolvedPatch, validationErr := resolveEndpointPatch(store, queryParams)
-	if validationErr != nil {
-		return nil, validationErr
-	}
-
-	if endpointClusterChanged(resolvedPatch, endpoint) {
-		return nil, endpointClusterImmutableError()
-	}
-
-	return resolvedPatch, nil
-}
-
-func validateEndpointVGPURequest(
-	store storage.Storage,
-	method string,
-	queryParams url.Values,
-	body []byte,
-	resolvedPatch *v1.Endpoint,
 ) *validationError {
 	endpoint, validationErr := parseEndpointBody(body)
 	if validationErr != nil {
 		return validationErr
 	}
 
+	var resolvedPatch *v1.Endpoint
+
+	if method == http.MethodPatch {
+		clusterPresent, validationErr := endpointPatchIncludesCluster(body)
+		if validationErr != nil {
+			return validationErr
+		}
+
+		if clusterPresent || endpointPatchMayAffectVGPUValidation(endpoint) {
+			resolvedPatch, validationErr = resolveEndpointPatch(store, queryParams)
+			if validationErr != nil {
+				return validationErr
+			}
+		}
+
+		if validationErr := validateEndpointClusterImmutable(body, endpoint, resolvedPatch); validationErr != nil {
+			return validationErr
+		}
+	}
+
 	return validateEndpointVGPUPreflightWithResolvedPatch(store, method, queryParams, endpoint, resolvedPatch)
 }
 
-func endpointResolvedPatch(c *gin.Context) *v1.Endpoint {
-	resolvedPatch, ok := c.Get(endpointResolvedPatchContextKey)
-	if !ok {
+func validateEndpointClusterImmutable(
+	body []byte,
+	endpoint *v1.Endpoint,
+	resolvedPatch *v1.Endpoint,
+) *validationError {
+	clusterPresent, validationErr := endpointPatchIncludesCluster(body)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	if !clusterPresent {
 		return nil
 	}
 
-	endpoint, ok := resolvedPatch.(*v1.Endpoint)
-	if !ok {
-		return nil
+	if endpointClusterChanged(resolvedPatch, endpoint) {
+		return endpointClusterImmutableError()
 	}
 
-	return endpoint
+	return nil
 }
 
 func endpointPatchIncludesCluster(body []byte) (bool, *validationError) {

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -94,14 +94,27 @@ func validateEndpointVGPURequest(
 
 func endpointPatchIncludesCluster(body []byte) (bool, *validationError) {
 	var payload struct {
-		Spec map[string]json.RawMessage `json:"spec"`
+		Spec json.RawMessage `json:"spec"`
 	}
 
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return false, invalidEndpointPayloadError(err)
 	}
 
-	_, ok := payload.Spec["cluster"]
+	if len(payload.Spec) == 0 {
+		return false, nil
+	}
+
+	if bytes.Equal(bytes.TrimSpace(payload.Spec), []byte("null")) {
+		return true, nil
+	}
+
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(payload.Spec, &spec); err != nil {
+		return false, invalidEndpointPayloadError(err)
+	}
+
+	_, ok := spec["cluster"]
 
 	return ok, nil
 }

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -1059,6 +1059,52 @@ func TestEndpointVGPUValidationAllowsPatchWithoutClusterChange(t *testing.T) {
 	}
 }
 
+func TestEndpointValidationSkipsPatchValidatorsForSoftDelete(t *testing.T) {
+	existing := v1.Endpoint{
+		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
+		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
+	}
+	clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{existing}}
+	body := `{
+		"metadata": {"deletion_timestamp": "2026-08-10T08:30:00Z"},
+		"spec": {"cluster": "cluster-b"}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+	assert.Zero(t, clusterStorage.endpointListCalls)
+}
+
+func TestEndpointValidationSkipsVGPUValidationForDeletedPost(t *testing.T) {
+	body := `{
+		"metadata": {"name": "endpoint", "workspace": "team-a", "deletion_timestamp": "2026-08-10T08:30:00Z"},
+		"spec": {
+			"cluster": "cluster-a",
+			"resources": {
+				"gpu": "1",
+				"accelerator": {
+					"type": "nvidia_gpu",
+					"product": "Tesla-T4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
+				}
+			}
+		}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, nil)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+}
+
 func endpointWithVGPU(cluster string, workspace string) *v1.Endpoint {
 	return &v1.Endpoint{
 		Metadata: &v1.Metadata{

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -568,7 +568,7 @@ func TestEndpointVGPUValidationAllowsPausePatchWhenVirtualizationNotReady(t *tes
 	assert.True(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationAllowsPausePatchWithMissingCluster(t *testing.T) {
+func TestEndpointVGPUValidationRejectsPausePatchThatChangesCluster(t *testing.T) {
 	clusterStorage := &fakeClusterStorage{
 		endpoints: []v1.Endpoint{
 			*endpointWithVGPU("cluster-a", "team-a"),
@@ -588,8 +588,11 @@ func TestEndpointVGPUValidationAllowsPausePatchWithMissingCluster(t *testing.T) 
 		clusterStorage,
 	)
 
-	assert.Equal(t, http.StatusNoContent, recorder.Code)
-	assert.True(t, handlerCalled)
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10225", response.Code)
+	assert.False(t, handlerCalled)
 }
 
 func TestEndpointVGPUValidationAllowsPausePatchWithInvalidVGPUResourceShape(t *testing.T) {
@@ -910,8 +913,106 @@ func TestEndpointVGPUValidationAllowsPatchWhenTargetDeviceCannotPhysicallyFitVGP
 		clusterStorage,
 	)
 
-	assert.Equal(t, http.StatusNoContent, recorder.Code)
-	assert.True(t, handlerCalled)
+	var response validationError
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "10225", response.Code)
+	assert.False(t, handlerCalled)
+}
+
+func TestEndpointVGPUValidationRejectsPatchThatChangesCluster(t *testing.T) {
+	existing := &v1.Endpoint{
+		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
+		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
+	}
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "different cluster",
+			body: `{"spec":{"cluster":"cluster-b"}}`,
+		},
+		{
+			name: "empty cluster",
+			body: `{"spec":{"cluster":""}}`,
+		},
+		{
+			name: "null cluster",
+			body: `{"spec":{"cluster":null}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{*existing}}
+
+			recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+				http.MethodPatch,
+				"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+				tt.body,
+				clusterStorage,
+			)
+
+			var response validationError
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			assert.Equal(t, "10225", response.Code)
+			assert.False(t, handlerCalled)
+			assert.Equal(t, 1, clusterStorage.endpointListCalls)
+		})
+	}
+}
+
+func TestEndpointVGPUValidationAllowsPatchWithoutClusterChange(t *testing.T) {
+	existing := v1.Endpoint{
+		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
+		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
+	}
+
+	tests := []struct {
+		name              string
+		method            string
+		body              string
+		expectedListCalls int
+	}{
+		{
+			name:              "same cluster patch",
+			method:            http.MethodPatch,
+			body:              `{"spec":{"cluster":"cluster-a"}}`,
+			expectedListCalls: 1,
+		},
+		{
+			name:              "patch without cluster",
+			method:            http.MethodPatch,
+			body:              `{"spec":{"variables":{"foo":"bar"}}}`,
+			expectedListCalls: 0,
+		},
+		{
+			name:              "post remains allowed",
+			method:            http.MethodPost,
+			body:              `{"metadata":{"name":"new","workspace":"team-a"},"spec":{"cluster":"cluster-b"}}`,
+			expectedListCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{existing}}
+
+			recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+				tt.method,
+				"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+				tt.body,
+				clusterStorage,
+			)
+
+			assert.Equal(t, http.StatusNoContent, recorder.Code)
+			assert.True(t, handlerCalled)
+			assert.Equal(t, tt.expectedListCalls, clusterStorage.endpointListCalls)
+		})
+	}
 }
 
 func endpointWithVGPU(cluster string, workspace string) *v1.Endpoint {

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -409,8 +409,79 @@ func TestEndpointVGPUValidationRejectsPatchWithoutEndpointFilters(t *testing.T) 
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
 	assert.Equal(t, "10221", response.Code)
+	assert.Equal(t, "invalid endpoint patch target", response.Message)
 	assert.Contains(t, response.Hint, "endpoint lookup filters")
+	assert.NotContains(t, response.Hint, "vGPU")
 	assert.False(t, handlerCalled)
+}
+
+func TestEndpointValidationRejectsPatchWithInvalidTarget(t *testing.T) {
+	tests := []struct {
+		name              string
+		path              string
+		clusterStorage    *fakeClusterStorage
+		expectedStatus    int
+		expectedHint      string
+		expectedListCalls int
+	}{
+		{
+			name:              "without endpoint filters",
+			path:              "/endpoints",
+			clusterStorage:    &fakeClusterStorage{},
+			expectedStatus:    http.StatusBadRequest,
+			expectedHint:      "endpoint lookup filters",
+			expectedListCalls: 0,
+		},
+		{
+			name:              "when endpoint is not found",
+			path:              "/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+			clusterStorage:    &fakeClusterStorage{},
+			expectedStatus:    http.StatusBadRequest,
+			expectedHint:      "endpoint not found",
+			expectedListCalls: 1,
+		},
+		{
+			name: "when endpoint lookup fails",
+			path: "/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+			clusterStorage: &fakeClusterStorage{
+				endpointListError: errors.New("database is down"),
+			},
+			expectedStatus:    http.StatusServiceUnavailable,
+			expectedHint:      "failed to look up endpoint",
+			expectedListCalls: 1,
+		},
+		{
+			name: "when multiple endpoints match",
+			path: "/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+			clusterStorage: &fakeClusterStorage{
+				endpoints: []v1.Endpoint{{}, {}},
+			},
+			expectedStatus:    http.StatusBadRequest,
+			expectedHint:      "multiple endpoints matched",
+			expectedListCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+				http.MethodPatch,
+				tt.path,
+				`{}`,
+				tt.clusterStorage,
+			)
+
+			var response validationError
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+			assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			assert.Equal(t, "10221", response.Code)
+			assert.Equal(t, "invalid endpoint patch target", response.Message)
+			assert.Contains(t, response.Hint, tt.expectedHint)
+			assert.NotContains(t, response.Hint, "vGPU")
+			assert.False(t, handlerCalled)
+			assert.Equal(t, tt.expectedListCalls, tt.clusterStorage.endpointListCalls)
+		})
+	}
 }
 
 func TestEndpointVGPUValidationResolvesEndpointAndAllowsPatchWithoutCapacityPrecheck(t *testing.T) {
@@ -1019,6 +1090,14 @@ func TestEndpointVGPUValidationAllowsPatchWithoutClusterChange(t *testing.T) {
 			name:              "same cluster patch",
 			method:            http.MethodPatch,
 			body:              `{"spec":{"cluster":"cluster-a"}}`,
+			expectedStatus:    http.StatusNoContent,
+			expectedHandler:   true,
+			expectedListCalls: 1,
+		},
+		{
+			name:              "patch without spec resolves current endpoint",
+			method:            http.MethodPatch,
+			body:              `{}`,
 			expectedStatus:    http.StatusNoContent,
 			expectedHandler:   true,
 			expectedListCalls: 1,

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -3,8 +3,10 @@ package proxies
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -152,39 +154,6 @@ func TestValidateEndpointVGPUResourceShape(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("skips patch that does not touch resources", func(t *testing.T) {
-		endpoint, err := parseEndpointBody([]byte(`{
-			"spec": {
-				"variables": {"foo": "bar"}
-			}
-		}`))
-
-		assert.Nil(t, err)
-		assert.NotNil(t, endpoint)
-		assert.Nil(t, validateEndpointVGPUPreflight(nil, http.MethodPatch, nil, endpoint))
-	})
-}
-
-func TestMergeEndpointResourceSpec(t *testing.T) {
-	t.Run("clears virtualization keys and preserves custom keys when switching to whole GPU", func(t *testing.T) {
-		existing := vgpuResources("1", "Tesla-T4", map[string]string{
-			v1.AcceleratorVirtualizationMemoryMiBKey:   "4096",
-			v1.AcceleratorVirtualizationCorePercentKey: "50",
-			"nvidia.com/gpucores":                      "50",
-		})
-		patch := &v1.ResourceSpec{
-			Accelerator: map[string]string{
-				v1.AcceleratorTypeKey:    string(v1.AcceleratorTypeNVIDIAGPU),
-				v1.AcceleratorProductKey: "Tesla-T4",
-			},
-		}
-
-		merged := mergeEndpointResourceSpec(existing, patch)
-
-		assert.Equal(t, "50", merged.Accelerator["nvidia.com/gpucores"])
-		assert.Empty(t, merged.Accelerator[v1.AcceleratorVirtualizationMemoryMiBKey])
-		assert.Empty(t, merged.Accelerator[v1.AcceleratorVirtualizationCorePercentKey])
-	})
 }
 
 func TestEndpointVGPUValidationAllowsPostWithoutCapacityPrecheck(t *testing.T) {
@@ -457,6 +426,7 @@ func TestEndpointVGPUValidationResolvesEndpointAndAllowsPatchWithoutCapacityPrec
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"resources": {
 				"gpu": "1",
 				"accelerator": {
@@ -494,6 +464,7 @@ func TestEndpointVGPUValidationAllowsMergedPatchWhenOnlyGPUChanges(t *testing.T)
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"resources": {
 				"gpu": "2"
 			}
@@ -525,6 +496,7 @@ func TestEndpointVGPUValidationAllowsMergedPatchWhenOnlyReplicasChange(t *testin
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"replicas": {"num": 3}
 		}
 	}`
@@ -553,6 +525,7 @@ func TestEndpointVGPUValidationAllowsPausePatchWhenVirtualizationNotReady(t *tes
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"replicas": {"num": 0}
 		}
 	}`
@@ -603,6 +576,7 @@ func TestEndpointVGPUValidationAllowsPausePatchWithInvalidVGPUResourceShape(t *t
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"replicas": {"num": 0},
 			"resources": {
 				"accelerator": {
@@ -632,6 +606,7 @@ func TestEndpointVGPUValidationRejectsNegativeReplicaPatch(t *testing.T) {
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"replicas": {"num": -1}
 		}
 	}`
@@ -666,6 +641,7 @@ func TestEndpointVGPUValidationAllowsNonVGPUPatchWhenReplicasChange(t *testing.T
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"replicas": {"num": 3}
 		}
 	}`
@@ -689,6 +665,7 @@ func TestEndpointVGPUValidationAllowsPatchFromVGPUToWholeGPU(t *testing.T) {
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"resources": {
 				"gpu": "1",
 				"accelerator": {
@@ -725,9 +702,14 @@ func TestEndpointVGPUValidationRejectsMergedPatchWhenOnlyProductChangesToMissing
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"resources": {
+				"gpu": "1",
 				"accelerator": {
-					"product": "L4"
+					"type": "nvidia_gpu",
+					"product": "L4",
+					"virtualization.memory_mib": "4096",
+					"virtualization.core_percent": "50"
 				}
 			}
 		}
@@ -779,6 +761,7 @@ func TestEndpointVGPUValidationAllowsPatchWhenCurrentAvailableCapacityIsZero(t *
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"resources": {
 				"gpu": "1",
 				"accelerator": {
@@ -840,6 +823,7 @@ func TestEndpointVGPUValidationAllowsWholeGPUToVGPUPatchWhenCurrentAvailableCapa
 	}
 	body := `{
 		"spec": {
+			"cluster": "cluster-a",
 			"resources": {
 				"gpu": "1",
 				"accelerator": {
@@ -969,48 +953,49 @@ func TestEndpointValidationRejectsPatchThatChangesCluster(t *testing.T) {
 	}
 }
 
-func TestEndpointClusterValidationRejectsPatchThatChangesCluster(t *testing.T) {
-	existing := &v1.Endpoint{
-		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
-		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
-	}
-
+func TestBuildPostgrestEndpointPatchValidationNew(t *testing.T) {
 	tests := []struct {
-		name string
-		body string
+		name    string
+		body    string
+		wantErr bool
+		assert  func(*testing.T, *v1.Endpoint, *v1.Endpoint)
 	}{
 		{
-			name: "different cluster",
-			body: `{"spec":{"cluster":"cluster-b"}}`,
+			name: "replaces a supplied spec composite without mutating Current",
+			body: `{"spec":{"replicas":{"num":0}}}`,
+			assert: func(t *testing.T, current, next *v1.Endpoint) {
+				assert.NotSame(t, current, next)
+				assert.Equal(t, "cluster-a", current.Spec.Cluster)
+				assert.Equal(t, "1", *current.Spec.Resources.GPU)
+				assert.Empty(t, next.Spec.Cluster)
+				assert.Empty(t, next.Spec.Resources)
+				assert.Equal(t, 0, *next.Spec.Replicas.Num)
+			},
 		},
 		{
-			name: "empty cluster",
-			body: `{"spec":{"cluster":""}}`,
-		},
-		{
-			name: "null cluster",
-			body: `{"spec":{"cluster":null}}`,
-		},
-		{
-			name: "null spec",
-			body: `{"spec":null}`,
+			name:    "rejects malformed patch payloads",
+			body:    `[`,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			endpoint, validationErr := parseEndpointBody([]byte(tt.body))
-			var rawPayload map[string]json.RawMessage
+			gpu := "1"
+			current := &v1.Endpoint{Spec: &v1.EndpointSpec{
+				Cluster:   "cluster-a",
+				Resources: &v1.ResourceSpec{GPU: &gpu},
+			}}
 
-			assert.Nil(t, validationErr)
-			assert.NoError(t, json.Unmarshal([]byte(tt.body), &rawPayload))
-			validationErr = validateEndpointClusterImmutable(&endpointValidationInput{
-				RawPayload: rawPayload,
-				Patch:      *endpoint,
-				Current:    existing,
-			})
-			assert.NotNil(t, validationErr)
-			assert.Equal(t, "10225", validationErr.Code)
+			next, err := buildPostgrestEndpointPatchValidationNew(current, []byte(tt.body))
+			if tt.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			assert.NoError(t, err)
+			tt.assert(t, current, next)
 		})
 	}
 }
@@ -1025,24 +1010,33 @@ func TestEndpointVGPUValidationAllowsPatchWithoutClusterChange(t *testing.T) {
 		name              string
 		method            string
 		body              string
+		expectedStatus    int
+		expectedCode      string
+		expectedHandler   bool
 		expectedListCalls int
 	}{
 		{
 			name:              "same cluster patch",
 			method:            http.MethodPatch,
 			body:              `{"spec":{"cluster":"cluster-a"}}`,
+			expectedStatus:    http.StatusNoContent,
+			expectedHandler:   true,
 			expectedListCalls: 1,
 		},
 		{
-			name:              "patch without cluster",
+			name:              "patch spec without cluster clears persisted cluster",
 			method:            http.MethodPatch,
 			body:              `{"spec":{"variables":{"foo":"bar"}}}`,
-			expectedListCalls: 0,
+			expectedStatus:    http.StatusBadRequest,
+			expectedCode:      "10225",
+			expectedListCalls: 1,
 		},
 		{
 			name:              "post remains allowed",
 			method:            http.MethodPost,
 			body:              `{"metadata":{"name":"new","workspace":"team-a"},"spec":{"cluster":"cluster-b"}}`,
+			expectedStatus:    http.StatusNoContent,
+			expectedHandler:   true,
 			expectedListCalls: 0,
 		},
 	}
@@ -1058,57 +1052,84 @@ func TestEndpointVGPUValidationAllowsPatchWithoutClusterChange(t *testing.T) {
 				clusterStorage,
 			)
 
-			assert.Equal(t, http.StatusNoContent, recorder.Code)
-			assert.True(t, handlerCalled)
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+			assert.Equal(t, tt.expectedHandler, handlerCalled)
 			assert.Equal(t, tt.expectedListCalls, clusterStorage.endpointListCalls)
+			if tt.expectedCode != "" {
+				var response validationError
+				assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+				assert.Equal(t, tt.expectedCode, response.Code)
+			}
 		})
 	}
 }
 
-func TestEndpointValidationSkipsPatchValidatorsForSoftDelete(t *testing.T) {
-	existing := v1.Endpoint{
-		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
-		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
+func TestValidateEndpointSoftDelete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "skips ordinary patch validators",
+			body: `{
+				"metadata": {"deletion_timestamp": "2026-08-10T08:30:00Z"},
+				"spec": {"cluster": "cluster-b"}
+			}`,
+		},
+		{
+			name: "bypasses malformed patch payload",
+			body: `{
+				"metadata": {"deletion_timestamp": "2026-08-10T08:30:00Z"},
+				"spec": {"resources": []}
+			}`,
+		},
 	}
-	clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{existing}}
-	body := `{
-		"metadata": {"deletion_timestamp": "2026-08-10T08:30:00Z"},
-		"spec": {"cluster": "cluster-b"}
-	}`
 
-	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
-		http.MethodPatch,
-		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
-		body,
-		clusterStorage,
-	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := v1.Endpoint{
+				Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
+				Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
+			}
+			clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{existing}}
+			originalBody := &trackingReadCloser{Reader: strings.NewReader(tt.body)}
+			handlerCalled := false
+			router := gin.New()
+			router.PATCH(
+				"/endpoints",
+				validateEndpoint(clusterStorage),
+				func(c *gin.Context) {
+					handlerCalled = true
 
-	assert.Equal(t, http.StatusNoContent, recorder.Code)
-	assert.True(t, handlerCalled)
-	assert.Zero(t, clusterStorage.endpointListCalls)
-}
+					forwardedBody, err := io.ReadAll(c.Request.Body)
+					assert.NoError(t, err)
+					assert.Equal(t, tt.body, string(forwardedBody))
+					assert.Equal(t, int64(len(tt.body)), c.Request.ContentLength)
+					assert.Equal(t, strconv.Itoa(len(tt.body)), c.Request.Header.Get("Content-Length"))
+					c.Status(http.StatusNoContent)
+				},
+			)
 
-func TestEndpointValidationSoftDeleteBypassesMalformedPatchPayload(t *testing.T) {
-	existing := v1.Endpoint{
-		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
-		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
+			req := httptest.NewRequest(
+				http.MethodPatch,
+				"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+				nil,
+			)
+			req.Body = originalBody
+			req.ContentLength = 0
+			req.Header.Set("Content-Length", "0")
+			recorder := httptest.NewRecorder()
+
+			router.ServeHTTP(recorder, req)
+
+			assert.True(t, handlerCalled)
+			assert.True(t, originalBody.closed)
+			assert.Equal(t, http.StatusNoContent, recorder.Code)
+			assert.Zero(t, clusterStorage.endpointListCalls)
+		})
 	}
-	clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{existing}}
-	body := `{
-		"metadata": {"deletion_timestamp": "2026-08-10T08:30:00Z"},
-		"spec": {"resources": []}
-	}`
-
-	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
-		http.MethodPatch,
-		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
-		body,
-		clusterStorage,
-	)
-
-	assert.Equal(t, http.StatusNoContent, recorder.Code)
-	assert.True(t, handlerCalled)
-	assert.Zero(t, clusterStorage.endpointListCalls)
 }
 
 func TestEndpointValidationSkipsVGPUValidationForDeletedPost(t *testing.T) {

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -920,7 +920,7 @@ func TestEndpointVGPUValidationAllowsPatchWhenTargetDeviceCannotPhysicallyFitVGP
 	assert.False(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationRejectsPatchThatChangesCluster(t *testing.T) {
+func TestEndpointValidationRejectsPatchThatChangesCluster(t *testing.T) {
 	existing := &v1.Endpoint{
 		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
 		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
@@ -958,6 +958,63 @@ func TestEndpointVGPUValidationRejectsPatchThatChangesCluster(t *testing.T) {
 				tt.body,
 				clusterStorage,
 			)
+
+			var response validationError
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			assert.Equal(t, "10225", response.Code)
+			assert.False(t, handlerCalled)
+			assert.Equal(t, 1, clusterStorage.endpointListCalls)
+		})
+	}
+}
+
+func TestEndpointClusterValidationRejectsPatchThatChangesCluster(t *testing.T) {
+	existing := &v1.Endpoint{
+		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
+		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
+	}
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "different cluster",
+			body: `{"spec":{"cluster":"cluster-b"}}`,
+		},
+		{
+			name: "empty cluster",
+			body: `{"spec":{"cluster":""}}`,
+		},
+		{
+			name: "null cluster",
+			body: `{"spec":{"cluster":null}}`,
+		},
+		{
+			name: "null spec",
+			body: `{"spec":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{*existing}}
+			router := gin.New()
+			handlerCalled := false
+			router.PATCH("/endpoints", validateEndpointClusterImmutable(clusterStorage), func(c *gin.Context) {
+				handlerCalled = true
+				c.Status(http.StatusNoContent)
+			})
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(
+				http.MethodPatch,
+				"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+				strings.NewReader(tt.body),
+			)
+			request.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(recorder, request)
 
 			var response validationError
 			assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -1062,10 +1119,16 @@ func runEndpointVGPUValidationWithHandlerAndPath(
 
 	router := gin.New()
 	handlerCalled := false
-	router.Handle(method, "/endpoints", validateEndpointVGPU(clusterStorage), func(c *gin.Context) {
-		handlerCalled = true
-		c.Status(http.StatusNoContent)
-	})
+	router.Handle(
+		method,
+		"/endpoints",
+		validateEndpointClusterImmutable(clusterStorage),
+		validateEndpointVGPU(clusterStorage),
+		func(c *gin.Context) {
+			handlerCalled = true
+			c.Status(http.StatusNoContent)
+		},
+	)
 
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(method, path, strings.NewReader(body))

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -1000,9 +1000,15 @@ func TestEndpointClusterValidationRejectsPatchThatChangesCluster(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			endpoint, validationErr := parseEndpointBody([]byte(tt.body))
+			var rawPayload map[string]json.RawMessage
 
 			assert.Nil(t, validationErr)
-			validationErr = validateEndpointClusterImmutable([]byte(tt.body), endpoint, existing)
+			assert.NoError(t, json.Unmarshal([]byte(tt.body), &rawPayload))
+			validationErr = validateEndpointClusterImmutable(&endpointValidationInput{
+				RawPayload: rawPayload,
+				Patch:      *endpoint,
+				Current:    existing,
+			})
 			assert.NotNil(t, validationErr)
 			assert.Equal(t, "10225", validationErr.Code)
 		})
@@ -1068,6 +1074,29 @@ func TestEndpointValidationSkipsPatchValidatorsForSoftDelete(t *testing.T) {
 	body := `{
 		"metadata": {"deletion_timestamp": "2026-08-10T08:30:00Z"},
 		"spec": {"cluster": "cluster-b"}
+	}`
+
+	recorder, handlerCalled := runEndpointVGPUValidationWithPath(
+		http.MethodPatch,
+		"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
+		body,
+		clusterStorage,
+	)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.True(t, handlerCalled)
+	assert.Zero(t, clusterStorage.endpointListCalls)
+}
+
+func TestEndpointValidationSoftDeleteBypassesMalformedPatchPayload(t *testing.T) {
+	existing := v1.Endpoint{
+		Metadata: &v1.Metadata{Name: "endpoint", Workspace: "team-a"},
+		Spec:     &v1.EndpointSpec{Cluster: "cluster-a"},
+	}
+	clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{existing}}
+	body := `{
+		"metadata": {"deletion_timestamp": "2026-08-10T08:30:00Z"},
+		"spec": {"resources": []}
 	}`
 
 	recorder, handlerCalled := runEndpointVGPUValidationWithPath(

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -999,29 +999,12 @@ func TestEndpointClusterValidationRejectsPatchThatChangesCluster(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clusterStorage := &fakeClusterStorage{endpoints: []v1.Endpoint{*existing}}
-			router := gin.New()
-			handlerCalled := false
-			router.PATCH("/endpoints", validateEndpointClusterImmutable(clusterStorage), func(c *gin.Context) {
-				handlerCalled = true
-				c.Status(http.StatusNoContent)
-			})
+			endpoint, validationErr := parseEndpointBody([]byte(tt.body))
 
-			recorder := httptest.NewRecorder()
-			request := httptest.NewRequest(
-				http.MethodPatch,
-				"/endpoints?metadata->>name=eq.endpoint&metadata->>workspace=eq.team-a",
-				strings.NewReader(tt.body),
-			)
-			request.Header.Set("Content-Type", "application/json")
-			router.ServeHTTP(recorder, request)
-
-			var response validationError
-			assert.Equal(t, http.StatusBadRequest, recorder.Code)
-			assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-			assert.Equal(t, "10225", response.Code)
-			assert.False(t, handlerCalled)
-			assert.Equal(t, 1, clusterStorage.endpointListCalls)
+			assert.Nil(t, validationErr)
+			validationErr = validateEndpointClusterImmutable([]byte(tt.body), endpoint, existing)
+			assert.NotNil(t, validationErr)
+			assert.Equal(t, "10225", validationErr.Code)
 		})
 	}
 }
@@ -1122,8 +1105,7 @@ func runEndpointVGPUValidationWithHandlerAndPath(
 	router.Handle(
 		method,
 		"/endpoints",
-		validateEndpointClusterImmutable(clusterStorage),
-		validateEndpointVGPU(clusterStorage),
+		validateEndpoint(clusterStorage),
 		func(c *gin.Context) {
 			handlerCalled = true
 			c.Status(http.StatusNoContent)

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -942,6 +942,10 @@ func TestEndpointVGPUValidationRejectsPatchThatChangesCluster(t *testing.T) {
 			name: "null cluster",
 			body: `{"spec":{"cluster":null}}`,
 		},
+		{
+			name: "null spec",
+			body: `{"spec":null}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue

NEU-635

## Summary

Prevent an existing endpoint from being reassigned to another cluster, and validate every ordinary PATCH against the effective PostgREST object before it is forwarded.

## Changes

- Use one Endpoint validation entry point for create, ordinary PATCH, and soft delete.
- Resolve the current Endpoint and construct the effective `New` object for every ordinary PATCH.
- Model PostgREST composite replacement: a supplied `spec` replaces the stored composite, so a partial `spec` that clears the bound cluster is rejected.
- Keep cluster immutability and vGPU validation as independent validators over the same prepared input.
- Preserve raw soft-delete classification and request-body restoration.
- Return generic Endpoint PATCH target errors when all PATCH requests require a current row.

## Test Plan

### Unit test

- `go test ./internal/routes/proxies -count=1` passed.
- Targeted operation, target-resolution, effective-patch, cluster-immutable, vGPU, and soft-delete cases passed.
- `go vet ./...` and `./bin/golangci-lint run ./internal/routes/proxies/...` passed.

### DB test

- No schema or migration change.
- API E2E exercised the deployed PostgREST composite semantics, required model/metadata fields, and the database soft-delete guard.

### E2E test

- Deployed exact commit `5325ffc12b8708576ede9706ca242102e67c62ed` to community control plane `10.255.1.54`.
- API E2E covered ordinary PATCH target lookup, existing empty PATCH, partial-spec and changed-cluster rejection (`10225`), vGPU success and excess-memory rejection (`10216`), create, deletion-marked create, soft-delete classification, and ordinary versus soft-delete malformed payload handling.
- The soft-delete DB/PostgREST guards returned their own errors after the Endpoint validator bypassed them; the equivalent ordinary malformed PATCH returned `10214`.
- All `neu635-` fixtures and temporary credentials were removed; core/API were restored healthy. No browser UI E2E is required because UI code is unchanged.