### PR TITLE
fix: bind static runtime resolution to owner plugin

### DIFF
--- a/internal/accelerator/manager.go
+++ b/internal/accelerator/manager.go
@@ -122,6 +122,7 @@ func (a *manager) addInternalPlugin(p publicaccelerator.Plugin) error {
 		plugin:           p,
 		lastRegisterTime: time.Now(),
 	})
+	klog.Infof("Register internal accelerator plugin: %s", p.Resource())
 
 	return nil
 }
@@ -272,7 +273,7 @@ func (a *manager) DetectAccelerator(
 			return false
 		}
 
-		if staticErr != nil && p.plugin.Type() == publicaccelerator.InternalPluginType {
+		if staticErr != nil {
 			klog.Warningf("detect static node accelerator from plugin %s failed: %s", p.resource, staticErr.Error())
 
 			if detectErr == nil {
@@ -280,28 +281,6 @@ func (a *manager) DetectAccelerator(
 			}
 
 			return true
-		}
-
-		response, err := p.plugin.Handle().GetNodeAccelerator(ctx, &v1.GetNodeAcceleratorRequest{
-			NodeIp:  nodeIP,
-			SSHAuth: sshAuth,
-		})
-		if err != nil {
-			klog.Warningf("detect static node accelerator from plugin %s failed: %s", p.resource, err.Error())
-
-			if detectErr == nil {
-				detectErr = errors.Wrapf(err, "detect static node accelerator from plugin %s failed", p.resource)
-			}
-
-			return true
-		}
-
-		if response != nil && len(response.Accelerators) > 0 {
-			detected = &v1.StaticNodeAcceleratorStatus{
-				Type: p.resource,
-			}
-
-			return false
 		}
 
 		return true
@@ -419,88 +398,43 @@ func (a *manager) GetStaticNodeRuntimeConfig(
 		return nil, nil
 	}
 
-	fallbackAllowed := false
-
-	if value, ok := a.acceleratorsMap.Load(acceleratorStatus.Type); ok {
-		if registered, registeredOK := value.(registerPlugin); registeredOK {
-			if _, resolverOK := registered.plugin.Handle().(publicaccelerator.StaticNodeRuntimeConfigResolver); resolverOK {
-				config, matched, err := resolveStaticNodeRuntimeConfig(ctx, acceleratorStatus, registered)
-				if err != nil {
-					return nil, err
-				}
-
-				if !matched {
-					return nil, errors.Errorf(
-						"static runtime resolver for accelerator type %s from owner plugin %s did not match",
-						acceleratorStatus.Type,
-						registered.resource,
-					)
-				}
-
-				return config, nil
-			}
-
-			fallbackAllowed = true
-		}
+	owner, found := a.GetPlugin(acceleratorStatus.Type)
+	if !found {
+		return nil, errors.Errorf("accelerator plugin %s not found", acceleratorStatus.Type)
 	}
 
-	if !fallbackAllowed {
-		return nil, nil
-	}
-
-	registeredPlugins := []registerPlugin{}
-
-	a.acceleratorsMap.Range(func(_, value any) bool {
-		registered, registeredOK := value.(registerPlugin)
-		if registeredOK && registered.resource != acceleratorStatus.Type {
-			registeredPlugins = append(registeredPlugins, registered)
-		}
-
-		return true
-	})
-	sort.Slice(registeredPlugins, func(i, j int) bool {
-		return registeredPlugins[i].resource < registeredPlugins[j].resource
-	})
-
-	for _, registered := range registeredPlugins {
-		config, matched, err := resolveStaticNodeRuntimeConfig(ctx, acceleratorStatus, registered)
-		if err != nil || matched {
-			return config, err
-		}
-	}
-
-	return nil, nil
-}
-
-func resolveStaticNodeRuntimeConfig(
-	ctx context.Context,
-	acceleratorStatus *v1.StaticNodeAcceleratorStatus,
-	registered registerPlugin,
-) (*v1.RuntimeConfig, bool, error) {
-	resolver, resolverOK := registered.plugin.Handle().(publicaccelerator.StaticNodeRuntimeConfigResolver)
+	resolver, resolverOK := owner.Handle().(publicaccelerator.StaticNodeRuntimeConfigResolver)
 	if !resolverOK {
-		return nil, false, nil
+		return nil, nil
 	}
 
 	config, matched, err := resolver.GetStaticNodeRuntimeConfig(ctx, acceleratorStatus)
 	if err != nil {
-		return nil, false, errors.Wrapf(
+		return nil, errors.Wrapf(
 			err,
 			"get static node runtime config for accelerator type %s from plugin %s",
 			acceleratorStatus.Type,
-			registered.resource,
+			owner.Resource(),
 		)
 	}
 
 	if matched && config == nil {
-		return nil, false, errors.Errorf(
+		return nil, errors.Errorf(
 			"static runtime resolver for accelerator type %s from plugin %s returned nil config for a matched status",
 			acceleratorStatus.Type,
-			registered.resource,
+			owner.Resource(),
 		)
 	}
 
-	return config, matched, nil
+	if !matched {
+		return nil, errors.Errorf(
+			"static runtime resolver for accelerator type %s from owner plugin %s did not match",
+			acceleratorStatus.Type,
+			owner.Resource(),
+		)
+	}
+
+	return config, nil
 }
 
 func (a *manager) GetAllConverters() map[string]plugin.ResourceConverter {

--- a/internal/accelerator/manager_test.go
+++ b/internal/accelerator/manager_test.go
@@ -97,7 +97,7 @@ func TestManagerGetStaticNodeRuntimeConfig(t *testing.T) {
 	}
 }
 
-func TestManagerGetStaticNodeRuntimeConfigDoesNotUseFallbackWithoutOwningPlugin(t *testing.T) {
+func TestManagerGetStaticNodeRuntimeConfigRequiresOwningPlugin(t *testing.T) {
 	fallback := &fakeStaticNodeAcceleratorPlugin{
 		resourceSet:          true,
 		resource:             "fallback_gpu",
@@ -113,12 +113,13 @@ func TestManagerGetStaticNodeRuntimeConfigDoesNotUseFallbackWithoutOwningPlugin(
 
 	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "legacy_gpu"})
 
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accelerator plugin legacy_gpu not found")
 	assert.Nil(t, config)
 	assert.Zero(t, fallback.staticRuntimeCalls)
 }
 
-func TestManagerGetStaticNodeRuntimeConfigUsesFallbackWhenOwnerHasNoResolver(t *testing.T) {
+func TestManagerGetStaticNodeRuntimeConfigDoesNotUseFallbackWhenOwnerHasNoResolver(t *testing.T) {
 	fallback := &fakeStaticNodeAcceleratorPlugin{
 		resourceSet:          true,
 		resource:             "fallback_gpu",
@@ -140,51 +141,15 @@ func TestManagerGetStaticNodeRuntimeConfigUsesFallbackWhenOwnerHasNoResolver(t *
 	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "owner_gpu"})
 
 	require.NoError(t, err)
-	require.NotNil(t, config)
-	assert.Equal(t, "true", config.Env["FALLBACK"])
-	assert.Equal(t, 1, fallback.staticRuntimeCalls)
-}
-
-func TestManagerGetStaticNodeRuntimeConfigStopsAtFirstFallbackError(t *testing.T) {
-	failing := &fakeStaticNodeAcceleratorPlugin{
-		resourceSet:      true,
-		resource:         "a_fallback_gpu",
-		staticRuntimeErr: errors.New("unsafe static runtime"),
-	}
-	laterMatch := &fakeStaticNodeAcceleratorPlugin{
-		resourceSet:          true,
-		resource:             "z_fallback_gpu",
-		staticRuntimeConfig:  &v1.RuntimeConfig{Env: map[string]string{"LATER": "true"}},
-		staticRuntimeMatched: true,
-	}
-	m := &manager{}
-	m.acceleratorsMap.Store("owner_gpu", registerPlugin{
-		resource:         "owner_gpu",
-		plugin:           &plugin.GPUAcceleratorPlugin{},
-		lastRegisterTime: time.Now(),
-	})
-	m.acceleratorsMap.Store(failing.Resource(), registerPlugin{
-		resource:         failing.Resource(),
-		plugin:           failing,
-		lastRegisterTime: time.Now(),
-	})
-	m.acceleratorsMap.Store(laterMatch.Resource(), registerPlugin{
-		resource:         laterMatch.Resource(),
-		plugin:           laterMatch,
-		lastRegisterTime: time.Now(),
-	})
-
-	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "owner_gpu"})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "a_fallback_gpu")
 	assert.Nil(t, config)
+	assert.Zero(t, fallback.staticRuntimeCalls)
 }
 
-func TestManagerGetStaticNodeRuntimeConfigRejectsNilFallbackConfig(t *testing.T) {
-	fallback := &fakeStaticNodeAcceleratorPlugin{
+func TestManagerGetStaticNodeRuntimeConfigDoesNotCallUnrelatedResolver(t *testing.T) {
+	unrelated := &fakeStaticNodeAcceleratorPlugin{
 		resourceSet:          true,
-		resource:             "fallback_gpu",
+		resource:             "unrelated_gpu",
+		staticRuntimeConfig:  &v1.RuntimeConfig{Env: map[string]string{"UNRELATED": "true"}},
 		staticRuntimeMatched: true,
 	}
 	m := &manager{}
@@ -193,16 +158,36 @@ func TestManagerGetStaticNodeRuntimeConfigRejectsNilFallbackConfig(t *testing.T)
 		plugin:           &plugin.GPUAcceleratorPlugin{},
 		lastRegisterTime: time.Now(),
 	})
-	m.acceleratorsMap.Store(fallback.Resource(), registerPlugin{
-		resource:         fallback.Resource(),
-		plugin:           fallback,
+	m.acceleratorsMap.Store(unrelated.Resource(), registerPlugin{
+		resource:         unrelated.Resource(),
+		plugin:           unrelated,
+		lastRegisterTime: time.Now(),
+	})
+
+	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "owner_gpu"})
+
+	require.NoError(t, err)
+	assert.Nil(t, config)
+	assert.Zero(t, unrelated.staticRuntimeCalls)
+}
+
+func TestManagerGetStaticNodeRuntimeConfigRejectsNilOwnerConfig(t *testing.T) {
+	owner := &fakeStaticNodeAcceleratorPlugin{
+		resourceSet:          true,
+		resource:             "owner_gpu",
+		staticRuntimeMatched: true,
+	}
+	m := &manager{}
+	m.acceleratorsMap.Store(owner.Resource(), registerPlugin{
+		resource:         owner.Resource(),
+		plugin:           owner,
 		lastRegisterTime: time.Now(),
 	})
 
 	config, err := m.GetStaticNodeRuntimeConfig(context.Background(), &v1.StaticNodeAcceleratorStatus{Type: "owner_gpu"})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "fallback_gpu returned nil config for a matched status")
+	assert.Contains(t, err.Error(), "owner_gpu returned nil config for a matched status")
 	assert.Nil(t, config)
 }
 
@@ -342,13 +327,13 @@ func TestManagerDetectAcceleratorPreservesStaticNodeAcceleratorStatus(t *testing
 	detector := &fakeStaticNodeAcceleratorPlugin{staticResponse: &v1.DetectStaticNodeAcceleratorResponse{
 		Matched: true,
 		Accelerator: &v1.StaticNodeAcceleratorStatus{
-			Type:    "npu",
-			Devices: []v1.StaticNodeAcceleratorDeviceStatus{{ID: "0", ProductModel: "HUAWEI_Ascend910B"}},
+			Type:    "custom_gpu",
+			Devices: []v1.StaticNodeAcceleratorDeviceStatus{{ID: "0", ProductModel: "custom-model"}},
 		},
 	}}
 	m := &manager{}
-	m.acceleratorsMap.Store("npu", registerPlugin{
-		resource:         "npu",
+	m.acceleratorsMap.Store("custom_gpu", registerPlugin{
+		resource:         "custom_gpu",
 		plugin:           detector,
 		lastRegisterTime: time.Now(),
 	})
@@ -360,26 +345,20 @@ func TestManagerDetectAcceleratorPreservesStaticNodeAcceleratorStatus(t *testing
 
 	require.NoError(t, err)
 	require.NotNil(t, status)
-	assert.Equal(t, "npu", status.Type)
+	assert.Equal(t, "custom_gpu", status.Type)
 	require.Len(t, status.Devices, 1)
-	assert.Equal(t, "HUAWEI_Ascend910B", status.Devices[0].ProductModel)
+	assert.Equal(t, "custom-model", status.Devices[0].ProductModel)
 	assert.Zero(t, detector.getCalls)
 }
 
-func TestManagerDetectAcceleratorSupportsExternalPluginWithoutStaticDetectEndpoint(t *testing.T) {
+func TestManagerDetectAcceleratorRequiresStaticDetectEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == v1.DetectStaticNodeAcceleratorPath {
 			http.NotFound(w, r)
 			return
 		}
 
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, v1.GetNodeAcceleratorPath, r.URL.Path)
-
-		err := json.NewEncoder(w).Encode(v1.GetNodeAcceleratorResponse{
-			Accelerators: []v1.Accelerator{{ID: "0"}},
-		})
-		require.NoError(t, err)
+		t.Fatalf("unexpected legacy detection request: %s", r.URL.Path)
 	}))
 	defer server.Close()
 
@@ -395,9 +374,9 @@ func TestManagerDetectAcceleratorSupportsExternalPluginWithoutStaticDetectEndpoi
 		SSHPrivateKey: "key",
 	})
 
-	require.NoError(t, err)
-	require.NotNil(t, status)
-	assert.Equal(t, "external_gpu", status.Type)
+	require.Error(t, err)
+	assert.Nil(t, status)
+	assert.Contains(t, err.Error(), "detect static node accelerator from plugin external_gpu failed")
 }
 
 func TestManagerDetectAcceleratorFallsBackToCPUWhenDetectorDoesNotMatch(t *testing.T) {
@@ -417,11 +396,11 @@ func TestManagerDetectAcceleratorFallsBackToCPUWhenDetectorDoesNotMatch(t *testi
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	assert.Equal(t, v1.StaticNodeAcceleratorTypeCPU, status.Type)
-	assert.Equal(t, 1, detector.getCalls)
+	assert.Zero(t, detector.getCalls)
 }
 
 func TestManagerDetectAcceleratorReturnsDetectorErrorWhenNothingMatches(t *testing.T) {
-	detector := &fakeStaticNodeAcceleratorPlugin{getErr: errors.New("lspci unavailable")}
+	detector := &fakeStaticNodeAcceleratorPlugin{staticDetectErr: errors.New("lspci unavailable")}
 	m := &manager{}
 	m.acceleratorsMap.Store("custom_gpu", registerPlugin{
 		resource:         "custom_gpu",
@@ -437,7 +416,7 @@ func TestManagerDetectAcceleratorReturnsDetectorErrorWhenNothingMatches(t *testi
 	require.Error(t, err)
 	require.Nil(t, status)
 	assert.Contains(t, err.Error(), "detect static node accelerator from plugin custom_gpu failed")
-	assert.Equal(t, 1, detector.getCalls)
+	assert.Zero(t, detector.getCalls)
 }
 
 type fakeStaticNodeAcceleratorPlugin struct {
@@ -456,6 +435,7 @@ type fakeStaticNodeAcceleratorPlugin struct {
 	staticRuntimeErr     error
 	staticRuntimeCalls   int
 	staticResponse       *v1.DetectStaticNodeAcceleratorResponse
+	staticDetectErr      error
 }
 
 func (p *fakeStaticNodeAcceleratorPlugin) Resource() string {
@@ -478,6 +458,10 @@ func (p *fakeStaticNodeAcceleratorPlugin) DetectStaticNodeAccelerator(
 	ctx context.Context,
 	request *v1.DetectStaticNodeAcceleratorRequest,
 ) (*v1.DetectStaticNodeAcceleratorResponse, error) {
+	if p.staticDetectErr != nil {
+		return nil, p.staticDetectErr
+	}
+
 	if p.staticResponse != nil {
 		return p.staticResponse, nil
 	}


### PR DESCRIPTION
## Summary
- retain the vendor-neutral static runtime resolver extension without community NPU or Ascend references
- bind runtime resolution strictly to the plugin selected by `StaticNodeAcceleratorStatus.Type`
- preserve the generic runtime profile when the owner plugin does not implement the optional resolver
- require `DetectStaticNodeAccelerator` for static-node discovery and remove the legacy `GetNodeAccelerator` fallback
- log successful internal accelerator plugin registrations by resource

## Issues
- NEU-562

## Test Plan

### Unit test
- `go test ./pkg/accelerator ./internal/accelerator ./internal/cluster/staticcluster ./cmd/neutree-core/app -count=1`
- `go test ./internal/accelerator -run "TestManagerGetStaticNodeRuntimeConfig|TestManagerDetectAccelerator" -count=1`
- `go test ./internal/accelerator -count=1`
- `go vet ./pkg/accelerator ./internal/accelerator ./internal/cluster/staticcluster ./cmd/neutree-core/app`
- `bin/golangci-lint run ./internal/accelerator/...`

### DB test
- No DB code changes.

### E2E test
- N/A: this changes in-process static-node resolver dispatch and detector contract only; no OSS end-user workflow is added. Manual testing is not required.