### PR TITLE
feat(cli): show aliases and field provenance in model list/get (NEU-621)

### DIFF
--- a/cmd/neutree-cli/app/cmd/model/get.go
+++ b/cmd/neutree-cli/app/cmd/model/get.go
@@ -90,7 +90,7 @@ func runGet(opts *getOptions, modelTag string) error {
 	// Get model details
 	detail, err := c.Models.Get(workspace, registry, modelName, version)
 	if err != nil {
-		return fmt.Errorf("failed to get model %s: %w", modelTag, err)
+		return fmt.Errorf("failed to get model %s in registry %q: %w", modelTag, registry, err)
 	}
 
 	printed, err := printPayload(os.Stdout, opts.output, detail.Raw)

--- a/cmd/neutree-cli/app/cmd/model/get.go
+++ b/cmd/neutree-cli/app/cmd/model/get.go
@@ -82,6 +82,7 @@ func runGet(opts *getOptions, modelTag string) error {
 
 	// Create client
 	c := client.NewClient(global.ServerURL, clientOptions...)
+
 	_, err = c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
 	if err != nil {
 		return fmt.Errorf("failed to get model registry %s: %w", registry, err)

--- a/cmd/neutree-cli/app/cmd/model/get.go
+++ b/cmd/neutree-cli/app/cmd/model/get.go
@@ -2,76 +2,224 @@ package model
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"sort"
+	"strconv"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
 	"github.com/neutree-ai/neutree/pkg/client"
 )
 
+// infoField binds a ModelInfo field's API name to the way its value is read.
+// The names are the constants the API declares, so a field renamed there stops
+// compiling here instead of quietly drifting out of step with the payload.
+type infoField struct {
+	name string
+	read func(*v1.ModelInfo) string
+}
+
+// infoFields lists the checkpoint metadata in the order ModelInfo declares it:
+// the four display fields a catalog can carry by hand, then the structured shape
+// read out of the checkpoint.
+var infoFields = []infoField{
+	{v1.ModelInfoFieldParameterCount, func(i *v1.ModelInfo) string { return i.ParameterCount }},
+	{v1.ModelInfoFieldQuantization, func(i *v1.ModelInfo) string { return i.Quantization }},
+	{v1.ModelInfoFieldContextLength, func(i *v1.ModelInfo) string { return i.ContextLength }},
+	{v1.ModelInfoFieldArchitecture, func(i *v1.ModelInfo) string { return i.Architecture }},
+	{v1.ModelInfoFieldNumHiddenLayers, func(i *v1.ModelInfo) string { return formatInt(i.NumHiddenLayers) }},
+	{v1.ModelInfoFieldNumAttentionHeads, func(i *v1.ModelInfo) string { return formatInt(i.NumAttentionHeads) }},
+	{v1.ModelInfoFieldNumKeyValueHeads, func(i *v1.ModelInfo) string { return formatInt(i.NumKeyValueHeads) }},
+	{v1.ModelInfoFieldHeadDim, func(i *v1.ModelInfo) string { return formatInt(i.HeadDim) }},
+	{v1.ModelInfoFieldMaxPositionEmbeddings, func(i *v1.ModelInfo) string { return formatInt(i.MaxPositionEmbeddings) }},
+	{v1.ModelInfoFieldIsMoE, func(i *v1.ModelInfo) string { return formatBool(i.IsMoE) }},
+	{v1.ModelInfoFieldNumExperts, func(i *v1.ModelInfo) string { return formatInt(i.NumExperts) }},
+	{v1.ModelInfoFieldNumExpertsPerToken, func(i *v1.ModelInfo) string { return formatInt(i.NumExpertsPerToken) }},
+	{v1.ModelInfoFieldParameterDtype, func(i *v1.ModelInfo) string { return i.ParameterDtype }},
+	{v1.ModelInfoFieldQuantizationBits, func(i *v1.ModelInfo) string { return formatInt(i.QuantizationBits) }},
+}
+
+type getOptions struct {
+	output string
+}
+
 func NewGetCmd() *cobra.Command {
+	opts := &getOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "get [model_name:version]",
 		Short: "Get detailed information about a model",
 		Long:  `Get detailed information about a specific model in the registry`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			modelTag := args[0]
-
-			// Parse model tag
-			modelName, version, err := client.ParseModelTag(modelTag)
-			if err != nil {
-				return err
-			}
-
-			clientOptions := []client.ClientOption{
-				client.WithAPIKey(global.APIKey),
-			}
-
-			if global.Insecure {
-				clientOptions = append(clientOptions, client.WithInsecureSkipVerify())
-			}
-
-			// Create client
-			c := client.NewClient(global.ServerURL, clientOptions...)
-			_, err = c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
-			if err != nil {
-				return fmt.Errorf("failed to get model registry %s: %w", registry, err)
-			}
-
-			// Get model details
-			modelVersion, err := c.Models.Get(workspace, registry, modelName, version)
-			if err != nil {
-				return fmt.Errorf("failed to get model %s: %w", modelTag, err)
-			}
-
-			// Use tabwriter for formatted output
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintf(w, "Name:\t%s\n", modelName)
-			fmt.Fprintf(w, "Version:\t%s\n", modelVersion.Name)
-			fmt.Fprintf(w, "Size:\t%s\n", modelVersion.Size)
-			fmt.Fprintf(w, "Creation Time:\t%s\n", modelVersion.CreationTime)
-			if modelVersion.Module != "" {
-				fmt.Fprintf(w, "Module:\t%s\n", modelVersion.Module)
-			}
-
-			if len(modelVersion.Labels) > 0 {
-				fmt.Fprintln(w, "Labels:")
-				for k, v := range modelVersion.Labels {
-					fmt.Fprintf(w, "  %s:\t%s\n", k, v)
-				}
-			}
-
-			if modelVersion.Description != "" {
-				fmt.Fprintf(w, "Description:\t%s\n", modelVersion.Description)
-			}
-
-			w.Flush()
-			return nil
+			return runGet(opts, args[0])
 		},
 	}
 
+	addOutputFlag(cmd, &opts.output)
+
 	return cmd
+}
+
+func runGet(opts *getOptions, modelTag string) error {
+	// Parse model tag
+	modelName, version, err := client.ParseModelTag(modelTag)
+	if err != nil {
+		return err
+	}
+
+	clientOptions := []client.ClientOption{
+		client.WithAPIKey(global.APIKey),
+	}
+
+	if global.Insecure {
+		clientOptions = append(clientOptions, client.WithInsecureSkipVerify())
+	}
+
+	// Create client
+	c := client.NewClient(global.ServerURL, clientOptions...)
+	_, err = c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
+	if err != nil {
+		return fmt.Errorf("failed to get model registry %s: %w", registry, err)
+	}
+
+	// Get model details
+	detail, err := c.Models.Get(workspace, registry, modelName, version)
+	if err != nil {
+		return fmt.Errorf("failed to get model %s: %w", modelTag, err)
+	}
+
+	printed, err := printPayload(os.Stdout, opts.output, detail.Raw)
+	if err != nil || printed {
+		return err
+	}
+
+	return renderModelDetail(os.Stdout, modelName, detail.Version)
+}
+
+// renderModelDetail writes one model version as label/value lines.
+//
+// Labels are the API's own names for what they show. Two of them come from the
+// request rather than the body: the body is a version, so its "name" field is
+// the version and it carries no model name at all — the two are labelled with
+// the path and query parameters that selected them, "model" and "version".
+func renderModelDetail(out io.Writer, modelName string, modelVersion *v1.ModelVersion) error {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "model:\t%s\n", modelName)
+	fmt.Fprintf(w, "version:\t%s\n", orUnknown(modelVersion.Name))
+	// An unset alias is not a gap in what the registry knows: this version was
+	// never given a display name, and it still answers to its physical name.
+	fmt.Fprintf(w, "alias:\t%s\n", orUnset(modelVersion.Alias))
+	fmt.Fprintf(w, "size:\t%s\n", orUnknown(modelVersion.Size))
+	fmt.Fprintf(w, "creation_time:\t%s\n", orUnknown(modelVersion.CreationTime))
+
+	if modelVersion.Module != "" {
+		fmt.Fprintf(w, "module:\t%s\n", modelVersion.Module)
+	}
+
+	if modelVersion.Description != "" {
+		fmt.Fprintf(w, "description:\t%s\n", modelVersion.Description)
+	}
+
+	if len(modelVersion.Labels) > 0 {
+		fmt.Fprintln(w, "labels:")
+
+		keys := make([]string, 0, len(modelVersion.Labels))
+		for k := range modelVersion.Labels {
+			keys = append(keys, k)
+		}
+
+		// Sorted, because ranging a map would reorder the block on every call.
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			fmt.Fprintf(w, "  %s:\t%s\n", k, modelVersion.Labels[k])
+		}
+	}
+
+	writeModelInfo(w, modelVersion.Info)
+
+	return w.Flush()
+}
+
+// writeModelInfo renders what the checkpoint states about itself.
+//
+// Every value is shown with where it came from, because the values do not carry
+// equal weight: one read out of the checkpoint is a fact about the files, one
+// derived is a documented convention applied to those facts, and one a person
+// typed is a claim about them. A field the registry looked for and could not
+// establish — one named in missing_fields — is shown as unknown rather than left
+// blank, so that a gap in the metadata cannot be misread as a rendering gap.
+// A field that is absent without being named there does not apply to this model
+// (expert counts on a dense model, say) and is not shown at all.
+func writeModelInfo(w io.Writer, info *v1.ModelInfo) {
+	if info == nil {
+		return
+	}
+
+	fmt.Fprintln(w, "info:")
+
+	missing := make(map[string]bool, len(info.MissingFields))
+	for _, field := range info.MissingFields {
+		missing[field] = true
+	}
+
+	for _, field := range infoFields {
+		value := field.read(info)
+
+		switch {
+		case value != "":
+			fmt.Fprintf(w, "  %s:\t%s%s\n", field.name, value, sourceSuffix(info.FieldSources[field.name]))
+		case missing[field.name]:
+			fmt.Fprintf(w, "  %s:\t%s\n", field.name, unknownValue)
+		}
+
+		delete(missing, field.name)
+	}
+
+	// A server newer than this build can report a field this build has no column
+	// for. Naming it is more useful than dropping it: the reader learns the
+	// registry looked and came up empty, which is the whole point of the list.
+	remaining := make([]string, 0, len(missing))
+	for field := range missing {
+		remaining = append(remaining, field)
+	}
+
+	sort.Strings(remaining)
+
+	for _, field := range remaining {
+		fmt.Fprintf(w, "  %s:\t%s\n", field, unknownValue)
+	}
+}
+
+// sourceSuffix annotates a value with its provenance. A value with no recorded
+// provenance — a catalog written before provenance was tracked — is left
+// unannotated rather than labelled unknown, which would read as a missing value.
+func sourceSuffix(source string) string {
+	if source == "" {
+		return ""
+	}
+
+	return "  (" + source + ")"
+}
+
+func formatInt(value *int) string {
+	if value == nil {
+		return ""
+	}
+
+	return strconv.Itoa(*value)
+}
+
+func formatBool(value *bool) string {
+	if value == nil {
+		return ""
+	}
+
+	return strconv.FormatBool(*value)
 }

--- a/cmd/neutree-cli/app/cmd/model/get_test.go
+++ b/cmd/neutree-cli/app/cmd/model/get_test.go
@@ -1,0 +1,151 @@
+package model
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// detailLines renders a version and returns the output with the tabwriter's
+// alignment collapsed, so assertions read like the labels and values they check.
+func detailLines(t *testing.T, modelName string, modelVersion *v1.ModelVersion) []string {
+	t.Helper()
+
+	var out bytes.Buffer
+	require.NoError(t, renderModelDetail(&out, modelName, modelVersion))
+
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = strings.Join(strings.Fields(line), " ")
+	}
+
+	return lines
+}
+
+func TestGetLabelsAreAPIFieldNames(t *testing.T) {
+	lines := detailLines(t, "demo", &v1.ModelVersion{
+		Name:         "v1",
+		Alias:        "pet",
+		Size:         "64 B",
+		CreationTime: "2026-06-25T00:00:00Z",
+	})
+
+	require.Equal(t, []string{
+		"model: demo",
+		"version: v1",
+		"alias: pet",
+		"size: 64 B",
+		"creation_time: 2026-06-25T00:00:00Z",
+	}, lines)
+}
+
+// An unset alias and an unestablished field are different facts and must not
+// render alike: "nobody named this version" is not "the registry could not tell".
+func TestGetDistinguishesUnsetAliasFromUnknownField(t *testing.T) {
+	lines := detailLines(t, "demo", &v1.ModelVersion{Name: "v1", CreationTime: "2026-06-25T00:00:00Z"})
+
+	require.Contains(t, lines, "alias: "+unsetValue)
+	require.Contains(t, lines, "size: "+unknownValue)
+	require.NotContains(t, lines, "alias: "+unknownValue)
+}
+
+func TestGetRendersModelInfoWithProvenance(t *testing.T) {
+	layers := 28
+	headDim := 128
+
+	lines := detailLines(t, "demo", &v1.ModelVersion{
+		Name: "v1",
+		Info: &v1.ModelInfo{
+			ParameterCount:  "7615616512",
+			Architecture:    "Qwen2ForCausalLM",
+			NumHiddenLayers: &layers,
+			HeadDim:         &headDim,
+			ContextLength:   "32K",
+			FieldSources: map[string]string{
+				v1.ModelInfoFieldParameterCount:  v1.ModelInfoSourceAuto,
+				v1.ModelInfoFieldArchitecture:    v1.ModelInfoSourceAuto,
+				v1.ModelInfoFieldNumHiddenLayers: v1.ModelInfoSourceAuto,
+				v1.ModelInfoFieldHeadDim:         v1.ModelInfoSourceDerived,
+				v1.ModelInfoFieldContextLength:   v1.ModelInfoSourceManual,
+			},
+			MissingFields: []string{v1.ModelInfoFieldQuantization},
+		},
+	})
+
+	require.Contains(t, lines, "info:")
+	require.Contains(t, lines, "parameter_count: 7615616512 (auto)")
+	require.Contains(t, lines, "head_dim: 128 (derived)")
+	require.Contains(t, lines, "context_length: 32K (manual)")
+
+	// Named in missing_fields: the registry looked and came up empty.
+	require.Contains(t, lines, "quantization: "+unknownValue)
+
+	// Absent without being named there: the field does not apply to this model,
+	// so listing it as unknown would invent a gap.
+	for _, line := range lines {
+		require.NotEqual(t, "num_experts: "+unknownValue, line)
+		require.NotEqual(t, "is_moe: "+unknownValue, line)
+	}
+}
+
+// A value carried over from a catalog written before provenance was tracked has
+// no source. It is shown plainly; annotating it "unknown" would read as a
+// missing value rather than an unrecorded origin.
+func TestGetLeavesUnrecordedProvenanceUnannotated(t *testing.T) {
+	lines := detailLines(t, "demo", &v1.ModelVersion{
+		Name: "v1",
+		Info: &v1.ModelInfo{ParameterCount: "72.7B"},
+	})
+
+	require.Contains(t, lines, "parameter_count: 72.7B")
+}
+
+// A server ahead of this build can report a field it has no row for. Naming it
+// is the point of missing_fields, so it is printed rather than dropped.
+func TestGetReportsUnrecognisedMissingFields(t *testing.T) {
+	lines := detailLines(t, "demo", &v1.ModelVersion{
+		Name: "v1",
+		Info: &v1.ModelInfo{MissingFields: []string{"vocab_size", v1.ModelInfoFieldArchitecture}},
+	})
+
+	require.Contains(t, lines, "architecture: "+unknownValue)
+	require.Contains(t, lines, "vocab_size: "+unknownValue)
+}
+
+// A listing leaves Info nil rather than opening every checkpoint; that is not a
+// model whose every field is unknown, so no info block is written at all.
+func TestGetOmitsInfoBlockWhenAbsent(t *testing.T) {
+	lines := detailLines(t, "demo", &v1.ModelVersion{Name: "v1"})
+
+	require.NotContains(t, lines, "info:")
+}
+
+func TestGetSortsLabelsForAStableBlock(t *testing.T) {
+	lines := detailLines(t, "demo", &v1.ModelVersion{
+		Name:   "v1",
+		Labels: map[string]string{"zone": "b", "app": "chat", "tier": "gold"},
+	})
+
+	start := len(lines) - 3
+	require.Equal(t, []string{"app: chat", "tier: gold", "zone: b"}, lines[start:])
+}
+
+func TestFormatPointerValues(t *testing.T) {
+	value := 7
+	yes := true
+
+	require.Equal(t, "7", formatInt(&value))
+	require.Equal(t, "", formatInt(nil))
+	require.Equal(t, "true", formatBool(&yes))
+	require.Equal(t, "", formatBool(nil))
+
+	// A zero is a value, not an absence — which is why these fields are pointers.
+	zero := 0
+	no := false
+	require.Equal(t, "0", formatInt(&zero))
+	require.Equal(t, "false", formatBool(&no))
+}

--- a/cmd/neutree-cli/app/cmd/model/list.go
+++ b/cmd/neutree-cli/app/cmd/model/list.go
@@ -100,6 +100,7 @@ func runList(opts *listOptions) error {
 
 	// Create client
 	c := client.NewClient(global.ServerURL, clientOptions...)
+
 	_, err := c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
 	if err != nil {
 		return fmt.Errorf("failed to get model registry %s: %w", registry, err)

--- a/cmd/neutree-cli/app/cmd/model/list.go
+++ b/cmd/neutree-cli/app/cmd/model/list.go
@@ -2,74 +2,217 @@ package model
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
 	"github.com/neutree-ai/neutree/pkg/client"
 )
 
+// listColumn binds a column's header to the value it renders. The header and
+// the row used to be two independent literals that had to be edited in step;
+// pairing them means a new column can only be added in one place.
+//
+// Headers are the upper-cased JSON names of the fields they show, so a reader
+// can map a column onto the API payload — and onto the UI, which names the same
+// fields the same way — without a glossary.
+type listColumn struct {
+	header string
+	value  func(model v1.GeneralModel) string
+}
+
+// listColumns is the shape of `model list` output.
+//
+// A model can hold several versions but the row shows one, so the columns below
+// the name describe the first version, exactly as they did before the alias
+// column existed.
+var listColumns = []listColumn{
+	{
+		header: "NAME",
+		value:  func(model v1.GeneralModel) string { return model.Name },
+	},
+	{
+		header: "VERSIONS",
+		value:  summariseVersions,
+	},
+	{
+		// An alias is optional, so an empty one renders as unset rather than as
+		// unknown: nobody named this version, which is a fact, not a gap.
+		header: "ALIAS",
+		value: func(model v1.GeneralModel) string {
+			return orUnset(versionField(model, func(v v1.ModelVersion) string { return v.Alias }))
+		},
+	},
+	{
+		header: "SIZE",
+		value: func(model v1.GeneralModel) string {
+			return orUnknown(versionField(model, func(v v1.ModelVersion) string { return v.Size }))
+		},
+	},
+	{
+		header: "CREATION_TIME",
+		value: func(model v1.GeneralModel) string {
+			return orUnknown(versionField(model, func(v v1.ModelVersion) string { return v.CreationTime }))
+		},
+	},
+}
+
+type listOptions struct {
+	output string
+	limit  int
+	offset int
+}
+
 func NewListCmd() *cobra.Command {
+	opts := &listOptions{}
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all models in the registry",
 		Long:  `List all models in the registry with their basic information`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			clientOptions := []client.ClientOption{
-				client.WithAPIKey(global.APIKey),
-			}
-
-			if global.Insecure {
-				clientOptions = append(clientOptions, client.WithInsecureSkipVerify())
-			}
-
-			// Create client
-			c := client.NewClient(global.ServerURL, clientOptions...)
-			_, err := c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
-			if err != nil {
-				return fmt.Errorf("failed to get model registry %s: %w", registry, err)
-			}
-
-			// List models
-			models, err := c.Models.List(workspace, registry, "")
-			if err != nil {
-				return fmt.Errorf("failed to list models: %w", err)
-			}
-
-			// Use tabwriter to format output
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tVERSIONS\tSIZE\tCREATION TIME")
-
-			for _, model := range models {
-				versions := ""
-				size := ""
-				creationTime := ""
-
-				if len(model.Versions) > 0 {
-					// Show the first version and a count if there are more
-					versions = model.Versions[0].Name
-					if len(model.Versions) > 1 {
-						versions += fmt.Sprintf(" (+%d more)", len(model.Versions)-1)
-					}
-
-					// Use the first version's size and creation time
-					size = model.Versions[0].Size
-					creationTime = model.Versions[0].CreationTime
-				}
-
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
-					model.Name,
-					versions,
-					size,
-					creationTime)
-			}
-			w.Flush()
-
-			return nil
+			return runList(opts)
 		},
 	}
 
+	addOutputFlag(cmd, &opts.output)
+	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Maximum number of models to return (0 uses the server default)")
+	cmd.Flags().IntVar(&opts.offset, "offset", 0, "Number of models to skip before the first returned one")
+
 	return cmd
+}
+
+func runList(opts *listOptions) error {
+	clientOptions := []client.ClientOption{
+		client.WithAPIKey(global.APIKey),
+	}
+
+	if global.Insecure {
+		clientOptions = append(clientOptions, client.WithInsecureSkipVerify())
+	}
+
+	// Create client
+	c := client.NewClient(global.ServerURL, clientOptions...)
+	_, err := c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
+	if err != nil {
+		return fmt.Errorf("failed to get model registry %s: %w", registry, err)
+	}
+
+	// List models
+	models, err := c.Models.List(workspace, registry, client.ModelListOptions{
+		Limit:  opts.limit,
+		Offset: opts.offset,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list models: %w", err)
+	}
+
+	printed, err := printPayload(os.Stdout, opts.output, models.Raw)
+	if err != nil || printed {
+		return err
+	}
+
+	if err := renderModelTable(os.Stdout, models.Models); err != nil {
+		return err
+	}
+
+	// The page summary is an aside for a human, so it goes to stderr and leaves
+	// stdout a clean table.
+	fmt.Fprintln(os.Stderr, summarisePage(models))
+
+	return nil
+}
+
+// renderModelTable writes the listing as a tab-aligned table.
+func renderModelTable(out io.Writer, models []v1.GeneralModel) error {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintln(w, strings.Join(listHeader(), "\t"))
+
+	for _, model := range models {
+		fmt.Fprintln(w, strings.Join(listRow(model), "\t"))
+	}
+
+	return w.Flush()
+}
+
+// listHeader and listRow both walk listColumns, so a column added there lands in
+// the header and in every row at once.
+func listHeader() []string {
+	headers := make([]string, len(listColumns))
+	for i, column := range listColumns {
+		headers[i] = column.header
+	}
+
+	return headers
+}
+
+func listRow(model v1.GeneralModel) []string {
+	values := make([]string, len(listColumns))
+	for i, column := range listColumns {
+		values[i] = column.value(model)
+	}
+
+	return values
+}
+
+// summarisePage describes which slice of the result set was printed. The total
+// comes from the Content-Range header and is unknown for a registry that cannot
+// count its matches, which is reported as such rather than guessed at.
+func summarisePage(models *client.ModelList) string {
+	total := unknownValue
+	if models.Total != nil {
+		total = fmt.Sprintf("%d", *models.Total)
+	}
+
+	if len(models.Models) == 0 {
+		return fmt.Sprintf("No models shown (total: %s)", total)
+	}
+
+	return fmt.Sprintf("Showing models %d-%d (total: %s)",
+		models.Offset+1, models.Offset+len(models.Models), total)
+}
+
+// summariseVersions names the first version and counts the rest.
+func summariseVersions(model v1.GeneralModel) string {
+	if len(model.Versions) == 0 {
+		return unsetValue
+	}
+
+	versions := model.Versions[0].Name
+	if len(model.Versions) > 1 {
+		versions += fmt.Sprintf(" (+%d more)", len(model.Versions)-1)
+	}
+
+	return versions
+}
+
+// versionField reads a field off the version the row describes.
+func versionField(model v1.GeneralModel, read func(v1.ModelVersion) string) string {
+	if len(model.Versions) == 0 {
+		return ""
+	}
+
+	return read(model.Versions[0])
+}
+
+func orUnknown(value string) string {
+	if value == "" {
+		return unknownValue
+	}
+
+	return value
+}
+
+func orUnset(value string) string {
+	if value == "" {
+		return unsetValue
+	}
+
+	return value
 }

--- a/cmd/neutree-cli/app/cmd/model/list.go
+++ b/cmd/neutree-cli/app/cmd/model/list.go
@@ -64,6 +64,7 @@ var listColumns = []listColumn{
 
 type listOptions struct {
 	output string
+	search string
 	limit  int
 	offset int
 }
@@ -81,6 +82,7 @@ func NewListCmd() *cobra.Command {
 	}
 
 	addOutputFlag(cmd, &opts.output)
+	cmd.Flags().StringVar(&opts.search, "search", "", "Only list models whose name matches this term")
 	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Maximum number of models to return (0 uses the server default)")
 	cmd.Flags().IntVar(&opts.offset, "offset", 0, "Number of models to skip before the first returned one")
 
@@ -103,13 +105,16 @@ func runList(opts *listOptions) error {
 		return fmt.Errorf("failed to get model registry %s: %w", registry, err)
 	}
 
-	// List models
+	// List models. The registry is named in the error because not every registry
+	// can serve every listing — a public one refuses to page from an offset —
+	// and a refusal that does not say which registry refused reads like a bug.
 	models, err := c.Models.List(workspace, registry, client.ModelListOptions{
+		Search: opts.search,
 		Limit:  opts.limit,
 		Offset: opts.offset,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list models: %w", err)
+		return fmt.Errorf("failed to list models in registry %q: %w", registry, err)
 	}
 
 	printed, err := printPayload(os.Stdout, opts.output, models.Raw)

--- a/cmd/neutree-cli/app/cmd/model/list_test.go
+++ b/cmd/neutree-cli/app/cmd/model/list_test.go
@@ -1,0 +1,89 @@
+package model
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+// Column names are the upper-cased JSON names of the fields they show, which is
+// the only thing that makes a column checkable against the API payload.
+func TestListHeaderNamesAPIFields(t *testing.T) {
+	require.Equal(t, []string{"NAME", "VERSIONS", "ALIAS", "SIZE", "CREATION_TIME"}, listHeader())
+}
+
+// The header and the rows are generated from one column list, so they cannot
+// drift apart the way two hand-synchronised literals could. This asserts the
+// property rather than the current column count: whatever listColumns holds,
+// every row is as wide as the header.
+func TestListRowsAreAsWideAsTheHeader(t *testing.T) {
+	models := []v1.GeneralModel{
+		{Name: "a", Versions: []v1.ModelVersion{{Name: "v1", Size: "64 B", CreationTime: "t", Alias: "pet"}}},
+		{Name: "b"},
+	}
+
+	for _, model := range models {
+		require.Len(t, listRow(model), len(listHeader()), "model %q", model.Name)
+	}
+}
+
+func TestListRowRendersAliasAndPlaceholders(t *testing.T) {
+	aliased := v1.GeneralModel{Name: "aliased", Versions: []v1.ModelVersion{
+		{Name: "v1", Alias: "pet", Size: "64 B", CreationTime: "2026-06-25T00:00:00Z"},
+	}}
+	require.Equal(t,
+		[]string{"aliased", "v1", "pet", "64 B", "2026-06-25T00:00:00Z"},
+		listRow(aliased))
+
+	// Nobody named this version and the registry reported no size: two different
+	// absences, rendered differently on purpose.
+	bare := v1.GeneralModel{Name: "bare", Versions: []v1.ModelVersion{
+		{Name: "v1", CreationTime: "2026-06-25T00:00:00Z"},
+		{Name: "v2"},
+	}}
+	require.Equal(t,
+		[]string{"bare", "v1 (+1 more)", unsetValue, unknownValue, "2026-06-25T00:00:00Z"},
+		listRow(bare))
+
+	require.Equal(t,
+		[]string{"empty", unsetValue, unsetValue, unknownValue, unknownValue},
+		listRow(v1.GeneralModel{Name: "empty"}))
+}
+
+func TestRenderModelTableWritesOneLinePerModel(t *testing.T) {
+	var out bytes.Buffer
+
+	models := []v1.GeneralModel{
+		{Name: "a", Versions: []v1.ModelVersion{{Name: "v1"}}},
+		{Name: "b", Versions: []v1.ModelVersion{{Name: "v1"}}},
+	}
+
+	require.NoError(t, renderModelTable(&out, models))
+
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	require.Len(t, lines, len(models)+1)
+	require.True(t, strings.HasPrefix(lines[0], "NAME"))
+	require.True(t, strings.HasPrefix(lines[1], "a"))
+	require.True(t, strings.HasPrefix(lines[2], "b"))
+}
+
+func TestSummarisePageReportsTheServersTotal(t *testing.T) {
+	models := []v1.GeneralModel{{Name: "a"}, {Name: "b"}}
+	total := 42
+
+	require.Equal(t, "Showing models 21-22 (total: 42)",
+		summarisePage(&client.ModelList{Models: models, Offset: 20, Total: &total}))
+
+	// A registry that cannot count what matched leaves the total unknown; the
+	// summary says so rather than reporting the page size as the total.
+	require.Equal(t, "Showing models 1-2 (total: unknown)",
+		summarisePage(&client.ModelList{Models: models}))
+
+	require.Equal(t, "No models shown (total: 0)",
+		summarisePage(&client.ModelList{Total: new(int)}))
+}

--- a/cmd/neutree-cli/app/cmd/model/output.go
+++ b/cmd/neutree-cli/app/cmd/model/output.go
@@ -1,0 +1,112 @@
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// Output formats accepted by the model subcommands, matching `neutree-cli get`.
+const (
+	outputTable = "table"
+	outputJSON  = "json"
+	outputYAML  = "yaml"
+)
+
+// Placeholders for the two ways a rendered field can carry no value. They are
+// deliberately different strings: "the registry could not establish this" and
+// "nobody has set this" are different facts, and a reader who cannot tell them
+// apart will read an unparsed checkpoint as a deliberately blank one.
+const (
+	// unknownValue renders a field named in the payload's missing_fields.
+	unknownValue = "unknown"
+	// unsetValue renders a field that is simply not set, an alias above all.
+	unsetValue = "-"
+)
+
+// addOutputFlag registers the -o/--output flag shared by the model subcommands.
+func addOutputFlag(cmd *cobra.Command, target *string) {
+	cmd.Flags().StringVarP(target, "output", "o", outputTable,
+		fmt.Sprintf("Output format: %s, %s, %s", outputTable, outputJSON, outputYAML))
+}
+
+// printPayload renders the server's response in the requested machine-readable
+// format, or reports false when the format asks for the human-readable table
+// and the caller has to render it itself.
+//
+// Both formats are re-serialised from the response bytes rather than from a
+// decoded struct, so every field the server sent survives verbatim, in the order
+// it sent them, whether or not this build has a Go field for it. That is what
+// makes `-o json` usable as the check that the CLI, the API and the UI name the
+// same things the same way.
+func printPayload(w io.Writer, format string, raw json.RawMessage) (bool, error) {
+	switch format {
+	case outputTable:
+		return false, nil
+	case outputJSON:
+		return true, printJSON(w, raw)
+	case outputYAML:
+		return true, printYAML(w, raw)
+	default:
+		return true, fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+// printJSON re-indents the response body. json.Indent only inserts whitespace,
+// so the payload itself is untouched.
+func printJSON(w io.Writer, raw json.RawMessage) error {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, raw, "", "  "); err != nil {
+		return fmt.Errorf("failed to parse response as JSON: %w", err)
+	}
+
+	buf.WriteByte('\n')
+
+	_, err := w.Write(buf.Bytes())
+
+	return err
+}
+
+// printYAML converts the response body to YAML.
+//
+// The conversion goes through a yaml.Node rather than a map: a map loses the
+// server's field order, and decoding JSON numbers into interface{} turns them
+// into float64, which would print a large parameter count in exponent notation.
+// YAML 1.2 is a superset of JSON, so the parser reads the body directly.
+func printYAML(w io.Writer, raw json.RawMessage) error {
+	var node yaml.Node
+	if err := yaml.Unmarshal(raw, &node); err != nil {
+		return fmt.Errorf("failed to parse response as JSON: %w", err)
+	}
+
+	// An empty document decodes to a zero node that the encoder rejects.
+	if node.Kind == 0 {
+		return nil
+	}
+
+	plainStyle(&node)
+
+	out, err := yaml.Marshal(&node)
+	if err != nil {
+		return fmt.Errorf("failed to marshal YAML: %w", err)
+	}
+
+	_, err = w.Write(out)
+
+	return err
+}
+
+// plainStyle clears the flow and quoting styles the parser recorded while
+// reading the JSON body, so the output is block-style YAML instead of a
+// re-indented copy of the JSON.
+func plainStyle(node *yaml.Node) {
+	node.Style = 0
+
+	for _, child := range node.Content {
+		plainStyle(child)
+	}
+}

--- a/cmd/neutree-cli/app/cmd/model/output.go
+++ b/cmd/neutree-cli/app/cmd/model/output.go
@@ -102,11 +102,42 @@ func printYAML(w io.Writer, raw json.RawMessage) error {
 
 // plainStyle clears the flow and quoting styles the parser recorded while
 // reading the JSON body, so the output is block-style YAML instead of a
-// re-indented copy of the JSON.
+// re-indented copy of the JSON — except where dropping the quotes would change
+// what the value is.
 func plainStyle(node *yaml.Node) {
-	node.Style = 0
+	if node.Kind == yaml.ScalarNode {
+		node.Style = scalarStyle(node)
+	} else {
+		node.Style = 0
+	}
 
 	for _, child := range node.Content {
 		plainStyle(child)
 	}
+}
+
+// yaml11Booleans are the spellings YAML 1.1 reads as booleans. YAML 1.2 keeps
+// only true and false, and the encoder already quotes a string that spells one
+// of those; the rest are listed here.
+var yaml11Booleans = map[string]bool{
+	"y": true, "Y": true, "yes": true, "Yes": true, "YES": true,
+	"n": true, "N": true, "no": true, "No": true, "NO": true,
+	"on": true, "On": true, "ON": true, "off": true, "Off": true, "OFF": true,
+}
+
+// scalarStyle picks the style to write a scalar with: plain, unless it is a
+// string that a YAML 1.1 reader would take for a boolean.
+//
+// The encoder already keeps a string quoted when YAML 1.2 would resolve it to
+// something else, which covers numbers, null and true/false — so a parameter
+// count of "7615616512" survives as a string. It does not cover the older
+// boolean spellings, which are still what PyYAML and ruby's YAML read: a label
+// value of "no" would come back as false there. Model info holds no such value,
+// but labels are free-form, so the quotes stay.
+func scalarStyle(node *yaml.Node) yaml.Style {
+	if node.Tag == "!!str" && yaml11Booleans[node.Value] {
+		return yaml.DoubleQuotedStyle
+	}
+
+	return 0
 }

--- a/cmd/neutree-cli/app/cmd/model/output_test.go
+++ b/cmd/neutree-cli/app/cmd/model/output_test.go
@@ -1,0 +1,114 @@
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// The acceptance this whole flag exists for: what `-o json` prints parses back
+// to exactly what the server sent, field for field — including a field this
+// build has no Go type for, which a decode/re-encode round trip would drop.
+func TestPrintJSONReproducesThePayloadFieldForField(t *testing.T) {
+	payload := `{"name":"v1","alias":"pet","info":{"parameter_count":"7615616512",` +
+		`"field_sources":{"parameter_count":"auto"},"missing_fields":["quantization"]},"future_field":{"a":[1,2]}}`
+
+	var out bytes.Buffer
+
+	printed, err := printPayload(&out, outputJSON, json.RawMessage(payload))
+	require.NoError(t, err)
+	require.True(t, printed)
+
+	var want, got any
+	require.NoError(t, json.Unmarshal([]byte(payload), &want))
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Equal(t, want, got)
+}
+
+func TestPrintYAMLReproducesThePayloadFieldForField(t *testing.T) {
+	payload := `[{"name":"demo","versions":[{"name":"v1","alias":"pet","future_field":7}]}]`
+
+	var out bytes.Buffer
+
+	printed, err := printPayload(&out, outputYAML, json.RawMessage(payload))
+	require.NoError(t, err)
+	require.True(t, printed)
+
+	var want, got any
+	require.NoError(t, json.Unmarshal([]byte(payload), &want))
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &got))
+
+	// YAML decodes integers as int and JSON as float64, so compare through a
+	// common encoding rather than by Go type.
+	wantJSON, err := json.Marshal(want)
+	require.NoError(t, err)
+	gotJSON, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.JSONEq(t, string(wantJSON), string(gotJSON))
+}
+
+// The block style is what makes YAML output worth having over JSON; a
+// re-indented copy of the JSON would be pointless.
+func TestPrintYAMLEmitsBlockStyle(t *testing.T) {
+	var out bytes.Buffer
+
+	_, err := printPayload(&out, outputYAML, json.RawMessage(`{"name":"v1","alias":"pet"}`))
+	require.NoError(t, err)
+	require.Equal(t, "name: v1\nalias: pet\n", out.String())
+}
+
+// A large parameter count must survive as an integer. Decoding JSON numbers into
+// interface{} would turn it into a float64 and print it in exponent notation.
+func TestPrintYAMLKeepsLargeIntegersExact(t *testing.T) {
+	var out bytes.Buffer
+
+	_, err := printPayload(&out, outputYAML, json.RawMessage(`{"parameter_count":671026419200}`))
+	require.NoError(t, err)
+	require.Equal(t, "parameter_count: 671026419200\n", out.String())
+}
+
+// A string that looks like a number has to come back a string, or the output
+// stops being a faithful rendering of the payload.
+func TestPrintYAMLQuotesAmbiguousStrings(t *testing.T) {
+	var out bytes.Buffer
+
+	_, err := printPayload(&out, outputYAML, json.RawMessage(`{"parameter_count":"7615616512","is_moe":"no"}`))
+	require.NoError(t, err)
+	require.Equal(t, "parameter_count: \"7615616512\"\nis_moe: \"no\"\n", out.String())
+}
+
+func TestPrintPayloadLeavesTheTableToTheCaller(t *testing.T) {
+	var out bytes.Buffer
+
+	printed, err := printPayload(&out, outputTable, json.RawMessage(`{}`))
+	require.NoError(t, err)
+	require.False(t, printed)
+	require.Empty(t, out.String())
+}
+
+func TestPrintPayloadRejectsUnknownFormats(t *testing.T) {
+	var out bytes.Buffer
+
+	_, err := printPayload(&out, "toml", json.RawMessage(`{}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported output format: toml")
+}
+
+// An empty listing is a legitimate result: both formats must emit a parseable
+// empty document rather than prose or nothing at all.
+func TestPrintPayloadRendersAnEmptyListing(t *testing.T) {
+	var out bytes.Buffer
+
+	_, err := printPayload(&out, outputJSON, json.RawMessage(`[]`))
+	require.NoError(t, err)
+	require.Equal(t, "[]\n", out.String())
+
+	out.Reset()
+
+	_, err = printPayload(&out, outputYAML, json.RawMessage(`[]`))
+	require.NoError(t, err)
+	require.Equal(t, "[]\n", out.String())
+}

--- a/cmd/neutree-cli/app/cmd/model/output_test.go
+++ b/cmd/neutree-cli/app/cmd/model/output_test.go
@@ -80,6 +80,29 @@ func TestPrintYAMLQuotesNumericStrings(t *testing.T) {
 	require.Equal(t, "parameter_count: \"7615616512\"\n", out.String())
 }
 
+// Labels are free-form, so a label value can spell one of the booleans YAML 1.1
+// recognises. go-yaml reads it back as a string either way, but PyYAML and
+// ruby's YAML do not — and output meant to be read by other tools should not
+// depend on which YAML version read it.
+func TestPrintYAMLQuotesYAML11BooleanSpellings(t *testing.T) {
+	var out bytes.Buffer
+
+	_, err := printPayload(&out, outputYAML,
+		json.RawMessage(`{"labels":{"a":"no","b":"Yes","c":"off","d":"N","e":"north"}}`))
+	require.NoError(t, err)
+	require.Equal(t, "labels:\n    a: \"no\"\n    b: \"Yes\"\n    c: \"off\"\n    d: \"N\"\n    e: north\n", out.String())
+}
+
+// The quoting is for strings only. A real boolean stays a bare boolean, or the
+// rendering would misreport the payload in the other direction.
+func TestPrintYAMLLeavesRealBooleansBare(t *testing.T) {
+	var out bytes.Buffer
+
+	_, err := printPayload(&out, outputYAML, json.RawMessage(`{"is_moe":false,"quantized":true}`))
+	require.NoError(t, err)
+	require.Equal(t, "is_moe: false\nquantized: true\n", out.String())
+}
+
 func TestPrintPayloadLeavesTheTableToTheCaller(t *testing.T) {
 	var out bytes.Buffer
 

--- a/cmd/neutree-cli/app/cmd/model/output_test.go
+++ b/cmd/neutree-cli/app/cmd/model/output_test.go
@@ -70,14 +70,14 @@ func TestPrintYAMLKeepsLargeIntegersExact(t *testing.T) {
 	require.Equal(t, "parameter_count: 671026419200\n", out.String())
 }
 
-// A string that looks like a number has to come back a string, or the output
-// stops being a faithful rendering of the payload.
-func TestPrintYAMLQuotesAmbiguousStrings(t *testing.T) {
+// A parameter count is a string of digits. It has to come back a string, or the
+// output stops being a faithful rendering of the payload.
+func TestPrintYAMLQuotesNumericStrings(t *testing.T) {
 	var out bytes.Buffer
 
-	_, err := printPayload(&out, outputYAML, json.RawMessage(`{"parameter_count":"7615616512","is_moe":"no"}`))
+	_, err := printPayload(&out, outputYAML, json.RawMessage(`{"parameter_count":"7615616512"}`))
 	require.NoError(t, err)
-	require.Equal(t, "parameter_count: \"7615616512\"\nis_moe: \"no\"\n", out.String())
+	require.Equal(t, "parameter_count: \"7615616512\"\n", out.String())
 }
 
 func TestPrintPayloadLeavesTheTableToTheCaller(t *testing.T) {

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -72,14 +73,56 @@ func NewModelsService(client *Client) *ModelsService {
 	}
 }
 
-// List lists all models in the specified registry
-func (s *ModelsService) List(workspace, registry, search string) ([]v1.GeneralModel, error) {
-	url := fmt.Sprintf("%s/api/v1/workspaces/%s/model_registries/%s/models", s.client.baseURL, workspace, registry)
-	if search != "" {
-		url = fmt.Sprintf("%s?search=%s", url, search)
+// ModelListOptions narrows a model listing. A zero Limit asks for the server's
+// default page size, and a zero Offset for the first page.
+type ModelListOptions struct {
+	Search string
+	Limit  int
+	Offset int
+}
+
+// ModelList is one page of a model listing.
+//
+// Raw is the response body exactly as the server sent it. Callers that render
+// the payload rather than read fields off it should use Raw: a decode/re-encode
+// round trip through the structs below silently rewrites the payload (dropping
+// fields this build does not know about, and materialising ones the server
+// omitted), which is precisely what a machine-readable output format must not do.
+type ModelList struct {
+	Models []v1.GeneralModel
+	Raw    json.RawMessage
+
+	// Offset is the index of the first item of this page within the full result
+	// set, and Total the size of that set. Both come from the Content-Range
+	// response header; the body stays a bare array. Total is nil when the
+	// registry cannot count what matched (the header carries "*" in its place),
+	// which is not the same as counting zero.
+	Offset int
+	Total  *int
+}
+
+// List lists models in the specified registry.
+func (s *ModelsService) List(workspace, registry string, opts ModelListOptions) (*ModelList, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/workspaces/%s/model_registries/%s/models", s.client.baseURL, workspace, registry)
+
+	query := url.Values{}
+	if opts.Search != "" {
+		query.Set("search", opts.Search)
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	if opts.Limit > 0 {
+		query.Set("limit", strconv.Itoa(opts.Limit))
+	}
+
+	if opts.Offset > 0 {
+		query.Set("offset", strconv.Itoa(opts.Offset))
+	}
+
+	if len(query) > 0 {
+		endpoint = endpoint + "?" + query.Encode()
+	}
+
+	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -90,27 +133,65 @@ func (s *ModelsService) List(workspace, registry, search string) ([]v1.GeneralMo
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	var models []v1.GeneralModel
-	if err := json.NewDecoder(resp.Body).Decode(&models); err != nil {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
 		return nil, err
 	}
 
-	return models, nil
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	result := &ModelList{Raw: body}
+	if err := json.Unmarshal(body, &result.Models); err != nil {
+		return nil, err
+	}
+
+	result.Offset, result.Total = parseContentRange(resp.Header.Get("Content-Range"))
+
+	return result, nil
+}
+
+// parseContentRange reads the PostgREST-style "first-last/total" header the
+// listing endpoint answers with, returning the offset of the page and the total
+// number of matches. An absent, malformed or open-ended ("*") part yields a zero
+// offset and a nil total, so a server that cannot count is indistinguishable
+// from one that predates the header — both simply leave the total unknown.
+func parseContentRange(header string) (offset int, total *int) {
+	rangePart, totalPart, found := strings.Cut(strings.TrimSpace(header), "/")
+	if !found {
+		return 0, nil
+	}
+
+	if first, _, ok := strings.Cut(rangePart, "-"); ok {
+		if parsed, err := strconv.Atoi(first); err == nil && parsed >= 0 {
+			offset = parsed
+		}
+	}
+
+	if parsed, err := strconv.Atoi(totalPart); err == nil && parsed >= 0 {
+		total = &parsed
+	}
+
+	return offset, total
+}
+
+// ModelDetail is one model version's detail response. As with ModelList, Raw is
+// the untouched response body and is what machine-readable output must render.
+type ModelDetail struct {
+	Version *v1.ModelVersion
+	Raw     json.RawMessage
 }
 
 // Get retrieves detailed information about a specific model version
-func (s *ModelsService) Get(workspace, registry, modelName, version string) (*v1.ModelVersion, error) {
-	url := fmt.Sprintf("%s/api/v1/workspaces/%s/model_registries/%s/models/%s", s.client.baseURL, workspace, registry, modelName)
+func (s *ModelsService) Get(workspace, registry, modelName, version string) (*ModelDetail, error) {
+	endpoint := fmt.Sprintf("%s/api/v1/workspaces/%s/model_registries/%s/models/%s",
+		s.client.baseURL, workspace, registry, modelName)
 	if version != "" && version != v1.LatestVersion {
-		url = fmt.Sprintf("%s?version=%s", url, version)
+		endpoint = endpoint + "?" + url.Values{"version": []string{version}}.Encode()
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -121,17 +202,21 @@ func (s *ModelsService) Get(workspace, registry, modelName, version string) (*v1
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	var modelVersion v1.ModelVersion
-	if err := json.NewDecoder(resp.Body).Decode(&modelVersion); err != nil {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
 		return nil, err
 	}
 
-	return &modelVersion, nil
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	modelVersion := &v1.ModelVersion{}
+	if err := json.Unmarshal(body, modelVersion); err != nil {
+		return nil, err
+	}
+
+	return &ModelDetail{Version: modelVersion, Raw: body}, nil
 }
 
 // Delete removes a specific model from the registry

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -97,6 +97,11 @@ type ModelList struct {
 	// response header; the body stays a bare array. Total is nil when the
 	// registry cannot count what matched (the header carries "*" in its place),
 	// which is not the same as counting zero.
+	//
+	// When the header names no range — it is absent, malformed, or reports the
+	// empty page as "*" — Offset falls back to the offset that was asked for.
+	// Reporting position 0 for a page fetched from offset 20 would be a wrong
+	// number rather than an absent one.
 	Offset int
 	Total  *int
 }
@@ -139,33 +144,41 @@ func (s *ModelsService) List(workspace, registry string, opts ModelListOptions) 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(body))
+		return nil, responseError(resp.StatusCode, body)
 	}
 
-	result := &ModelList{Raw: body}
+	result := &ModelList{Raw: body, Offset: opts.Offset}
 	if err := json.Unmarshal(body, &result.Models); err != nil {
 		return nil, err
 	}
 
-	result.Offset, result.Total = parseContentRange(resp.Header.Get("Content-Range"))
+	offset, offsetKnown, total := parseContentRange(resp.Header.Get("Content-Range"))
+	if offsetKnown {
+		result.Offset = offset
+	}
+
+	result.Total = total
 
 	return result, nil
 }
 
 // parseContentRange reads the PostgREST-style "first-last/total" header the
-// listing endpoint answers with, returning the offset of the page and the total
-// number of matches. An absent, malformed or open-ended ("*") part yields a zero
-// offset and a nil total, so a server that cannot count is indistinguishable
-// from one that predates the header — both simply leave the total unknown.
-func parseContentRange(header string) (offset int, total *int) {
+// listing endpoint answers with, returning the offset of the page, whether the
+// header named it at all, and the total number of matches.
+//
+// The two unknowns are reported separately because they arise separately: a
+// public registry answers "0-9/*", naming the range but unable to count the
+// catalogue behind it, while a server that predates the header names neither. A
+// nil total therefore says nothing about whether the offset is trustworthy.
+func parseContentRange(header string) (offset int, offsetKnown bool, total *int) {
 	rangePart, totalPart, found := strings.Cut(strings.TrimSpace(header), "/")
 	if !found {
-		return 0, nil
+		return 0, false, nil
 	}
 
 	if first, _, ok := strings.Cut(rangePart, "-"); ok {
 		if parsed, err := strconv.Atoi(first); err == nil && parsed >= 0 {
-			offset = parsed
+			offset, offsetKnown = parsed, true
 		}
 	}
 
@@ -173,7 +186,24 @@ func parseContentRange(header string) (offset int, total *int) {
 		total = &parsed
 	}
 
-	return offset, total
+	return offset, offsetKnown, total
+}
+
+// responseError turns a failed model request into an error carrying what the
+// server actually said. These endpoints answer with a JSON body holding a
+// "message", and some of those messages are the whole point of the response —
+// a registry refusing to page from an offset is stating a limit, not failing —
+// so the message leads and the status code follows it in parentheses.
+func responseError(statusCode int, body []byte) error {
+	var payload struct {
+		Message string `json:"message"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err == nil && payload.Message != "" {
+		return fmt.Errorf("%s (HTTP %d)", payload.Message, statusCode)
+	}
+
+	return fmt.Errorf("server returned non-200 status: %d, body: %s", statusCode, string(body))
 }
 
 // ModelDetail is one model version's detail response. As with ModelList, Raw is
@@ -208,7 +238,7 @@ func (s *ModelsService) Get(workspace, registry, modelName, version string) (*Mo
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned non-200 status: %d, body: %s", resp.StatusCode, string(body))
+		return nil, responseError(resp.StatusCode, body)
 	}
 
 	modelVersion := &v1.ModelVersion{}

--- a/pkg/client/model_test.go
+++ b/pkg/client/model_test.go
@@ -35,3 +35,127 @@ func TestFinalizePushPostsImportedMetadata(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestListKeepsResponseBodyAndReadsContentRange(t *testing.T) {
+	// A field this build has no Go field for, to show that the raw body a caller
+	// renders is the server's, not a re-encoding of what the structs captured.
+	body := `[{"name":"demo","versions":[{"name":"v1","creation_time":"2026-06-25T00:00:00Z","alias":"pet","future_field":7}]}]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/workspaces/default/model_registries/registry/models", r.URL.Path)
+		require.Equal(t, "10", r.URL.Query().Get("limit"))
+		require.Equal(t, "20", r.URL.Query().Get("offset"))
+		require.Equal(t, "a b&c", r.URL.Query().Get("search"))
+
+		w.Header().Set("Content-Range", "20-20/42")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+
+	models, err := c.Models.List("default", "registry", ModelListOptions{Search: "a b&c", Limit: 10, Offset: 20})
+	require.NoError(t, err)
+
+	require.Equal(t, body, string(models.Raw))
+	require.Equal(t, 20, models.Offset)
+	require.NotNil(t, models.Total)
+	require.Equal(t, 42, *models.Total)
+
+	require.Len(t, models.Models, 1)
+	require.Equal(t, "demo", models.Models[0].Name)
+	require.Equal(t, "pet", models.Models[0].Versions[0].Alias)
+}
+
+func TestListOmitsUnsetQueryParameters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.URL.RawQuery)
+
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+
+	models, err := c.Models.List("default", "registry", ModelListOptions{})
+	require.NoError(t, err)
+	require.Empty(t, models.Models)
+	require.Nil(t, models.Total)
+}
+
+func TestGetKeepsResponseBody(t *testing.T) {
+	body := `{"name":"v1","size":"64 B","alias":"pet","info":{"parameter_count":"7615616512",` +
+		`"field_sources":{"parameter_count":"auto"},"missing_fields":["quantization"]}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/workspaces/default/model_registries/registry/models/demo", r.URL.Path)
+		require.Equal(t, "v1", r.URL.Query().Get("version"))
+
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+
+	detail, err := c.Models.Get("default", "registry", "demo", "v1")
+	require.NoError(t, err)
+
+	require.Equal(t, body, string(detail.Raw))
+	require.Equal(t, "pet", detail.Version.Alias)
+	require.Equal(t, "7615616512", detail.Version.Info.ParameterCount)
+	require.Equal(t, []string{"quantization"}, detail.Version.Info.MissingFields)
+}
+
+func TestGetOmitsLatestVersionFromQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.URL.RawQuery)
+
+		_, _ = w.Write([]byte(`{"name":"v1"}`))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+
+	detail, err := c.Models.Get("default", "registry", "demo", v1.LatestVersion)
+	require.NoError(t, err)
+	require.Equal(t, "v1", detail.Version.Name)
+}
+
+func TestParseContentRange(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		offset int
+		total  *int
+	}{
+		{name: "counted page", header: "0-9/57", offset: 0, total: ptr(57)},
+		{name: "later page", header: "20-29/57", offset: 20, total: ptr(57)},
+		// A public registry reports the page it served but cannot count the
+		// catalogue behind it.
+		{name: "uncountable total", header: "0-9/*", offset: 0, total: nil},
+		{name: "empty page", header: "*/0", offset: 0, total: ptr(0)},
+		{name: "absent header", header: "", offset: 0, total: nil},
+		{name: "malformed header", header: "nonsense", offset: 0, total: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			offset, total := parseContentRange(tt.header)
+			require.Equal(t, tt.offset, offset)
+
+			if tt.total == nil {
+				require.Nil(t, total)
+
+				return
+			}
+
+			require.NotNil(t, total)
+			require.Equal(t, *tt.total, *total)
+		})
+	}
+}
+
+func ptr(value int) *int {
+	return &value
+}

--- a/pkg/client/model_test.go
+++ b/pkg/client/model_test.go
@@ -84,6 +84,73 @@ func TestListOmitsUnsetQueryParameters(t *testing.T) {
 	require.Nil(t, models.Total)
 }
 
+// A server that names no range must not be read as one reporting the first
+// page: the offset that was asked for is the only thing known about where this
+// page sits, and reporting 0 instead would be a wrong number, not a missing one.
+func TestListFallsBackToTheRequestedOffset(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		offset int
+	}{
+		{name: "no header", header: "", offset: 20},
+		{name: "malformed header", header: "nonsense", offset: 20},
+		{name: "empty page names no range", header: "*/42", offset: 20},
+		// A header that does name the range wins: the server is the authority on
+		// where it actually started.
+		{name: "header wins", header: "17-18/42", offset: 17},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.header != "" {
+					w.Header().Set("Content-Range", tt.header)
+				}
+
+				_, _ = w.Write([]byte(`[{"name":"demo","versions":[]}]`))
+			}))
+			defer server.Close()
+
+			c := NewClient(server.URL, WithAPIKey("api-key"))
+
+			models, err := c.Models.List("default", "registry", ModelListOptions{Offset: 20})
+			require.NoError(t, err)
+			require.Equal(t, tt.offset, models.Offset)
+		})
+	}
+}
+
+// A registry refusing to page from an offset is stating a limit. The message
+// saying so is the useful part of the response, so it must not be buried in a
+// transport-level wrapper.
+func TestListSurfacesTheServersMessage(t *testing.T) {
+	const message = "This model registry cannot list models this way: " +
+		"operation not supported by this model registry"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"` + message + `"}`))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+
+	_, err := c.Models.List("default", "registry", ModelListOptions{Offset: 2})
+	require.Error(t, err)
+	require.Equal(t, message+" (HTTP 400)", err.Error())
+}
+
+// A body that carries no message still has to reach the user intact — it is all
+// there is to go on.
+func TestResponseErrorFallsBackToTheRawBody(t *testing.T) {
+	err := responseError(http.StatusBadGateway, []byte("<html>gateway</html>"))
+	require.EqualError(t, err, "server returned non-200 status: 502, body: <html>gateway</html>")
+
+	err = responseError(http.StatusInternalServerError, []byte(`{"message":""}`))
+	require.EqualError(t, err, `server returned non-200 status: 500, body: {"message":""}`)
+}
+
 func TestGetKeepsResponseBody(t *testing.T) {
 	body := `{"name":"v1","size":"64 B","alias":"pet","info":{"parameter_count":"7615616512",` +
 		`"field_sources":{"parameter_count":"auto"},"missing_fields":["quantization"]}}`
@@ -124,25 +191,29 @@ func TestGetOmitsLatestVersionFromQuery(t *testing.T) {
 
 func TestParseContentRange(t *testing.T) {
 	tests := []struct {
-		name   string
-		header string
-		offset int
-		total  *int
+		name        string
+		header      string
+		offset      int
+		offsetKnown bool
+		total       *int
 	}{
-		{name: "counted page", header: "0-9/57", offset: 0, total: ptr(57)},
-		{name: "later page", header: "20-29/57", offset: 20, total: ptr(57)},
+		{name: "counted page", header: "0-9/57", offset: 0, offsetKnown: true, total: ptr(57)},
+		{name: "later page", header: "20-29/57", offset: 20, offsetKnown: true, total: ptr(57)},
 		// A public registry reports the page it served but cannot count the
-		// catalogue behind it.
-		{name: "uncountable total", header: "0-9/*", offset: 0, total: nil},
-		{name: "empty page", header: "*/0", offset: 0, total: ptr(0)},
-		{name: "absent header", header: "", offset: 0, total: nil},
-		{name: "malformed header", header: "nonsense", offset: 0, total: nil},
+		// catalogue behind it. The range is still authoritative.
+		{name: "uncountable total", header: "0-9/*", offset: 0, offsetKnown: true, total: nil},
+		// The converse: a counted result whose page names no range.
+		{name: "empty page", header: "*/0", offset: 0, offsetKnown: false, total: ptr(0)},
+		{name: "absent header", header: "", offset: 0, offsetKnown: false, total: nil},
+		{name: "malformed header", header: "nonsense", offset: 0, offsetKnown: false, total: nil},
+		{name: "non-numeric range", header: "a-b/57", offset: 0, offsetKnown: false, total: ptr(57)},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			offset, total := parseContentRange(tt.header)
+			offset, offsetKnown, total := parseContentRange(tt.header)
 			require.Equal(t, tt.offset, offset)
+			require.Equal(t, tt.offsetKnown, offsetKnown)
 
 			if tt.total == nil {
 				require.Nil(t, total)


### PR DESCRIPTION
NEU-621. Stacked on `neu-620-model-metadata-registry-api`, so the diff is CLI-only. Nothing under `internal/` or `api/` is touched.

## Why

`model list` / `model get` render a hand-written table and nothing else. NEU-620 gives the registry an alias per version and a `info` block describing the checkpoint — with `field_sources` saying where each value came from and `missing_fields` naming what could not be established — and none of it has anywhere to go. There is also no way to check the acceptance this metadata work rests on, that the CLI, the API and the UI name the same things the same way: a hand-written column heading cannot be diffed against a payload.

## What

**`-o table|json|yaml`**, matching `neutree-cli get`. Both machine formats are re-serialised from the response bytes, never from a decoded struct: a struct round trip drops fields this build has no Go type for and materialises ones the server omitted. That is what makes `-o json` usable as the naming check — it is the payload, not a rendering of it.

- JSON goes through `json.Indent`, which only inserts whitespace.
- YAML goes through a `yaml.Node`, which keeps the server's field order and keeps a large parameter count an integer. Decoding into `interface{}` would lose the order and print the count in exponent notation.

**Every column and label is named after the API field it shows** — `creation_time`, `parameter_count`, `field_sources`. Two labels in `get` come from the request rather than the body, because the body is a version: its `name` field is the version and it carries no model name at all, so the two are labelled with the path and query parameters that selected them, `model` and `version`.

**`list`** gains an `ALIAS` column, and `--limit` / `--offset`. The total is read from the `Content-Range` header, per NEU-620; a registry that cannot count what matched reports its total as unknown rather than having the page size passed off as one. The page summary goes to stderr so stdout stays a clean stream in every format.

**`get`** renders the alias, and the model info with each value's provenance:

```
info:
  parameter_count:          unknown
  context_length:           32768  (auto)
  architecture:             Qwen2ForCausalLM  (auto)
  num_key_value_heads:      2  (auto)
  head_dim:                 64  (derived)
```

A field named in `missing_fields` shows as `unknown` instead of blank, so a gap in the metadata cannot be misread as a gap in the rendering. A field absent *without* being named there does not apply to this model — expert counts on a dense model — and is not shown at all. A field the registry reports as missing but this build has no row for is still printed; naming it is the point of `missing_fields`.

**The two absences render differently on purpose.** An unset alias is `-`, an unestablished field is `unknown`. "Nobody named this version" and "the registry could not tell" are different facts, and a reader who cannot separate them will read an unparsed checkpoint as a deliberately blank one. An unset alias is not a gap: the version still answers to its physical name, which the `NAME` column already carries.

**The list header and rows are generated from one column list.** They were two literals — a header string and a `Fprintf` format string — that had to be edited in step by hand, which is the kind of thing that only stays correct until someone adds a column. `TestListRowsAreAsWideAsTheHeader` asserts the property rather than today's column count.

No interactive rename command: aliases are changed through the API.

## Client

`Models.List` and `Models.Get` now return the response bytes alongside the decoded structs, and `List` takes `ModelListOptions` and reports the `Content-Range` offset and total. Query parameters are built with `url.Values` — the search term used to be interpolated into the URL raw.

## Tests

`push_test.go` is unmodified and passes. New coverage: the JSON/YAML output reproduces the payload field for field including a field the structs do not know; YAML keeps block style, exact large integers and quoted numeric strings; the header names API fields; rows stay as wide as the header; the alias and unknown placeholders; provenance annotation for auto/derived/manual, with unrecorded provenance left unannotated; `Content-Range` parsing, including the uncountable `*` total.

## Verification

CI does not run on a stacked PR — no workflow triggers on a base other than `main` — so this was checked by hand.

- `go build ./...` passes. `make test` leaves no file modified by `fmt` / `lint --fix` / `mockgen`, and fails only in `controllers` and `internal/observability/manager`; both failures reproduce unchanged on the base branch.
- Run against a live control plane serving the NEU-620 branch, over a private NFS registry and a Hugging Face one:
  - `model get -o json` is identical to the API response for the same model — every field, and the key order too.
  - GQA model: `num_key_value_heads` 2 and `parameter_dtype` marked `auto`, `head_dim` marked `derived`, `parameter_count` reported `unknown` because the checkpoint has no safetensors to sum. MoE model: `is_moe`, `num_experts` and `num_experts_per_token` present and `auto`. A model with no `config.json`: every field `unknown`, none invented from the directory name.
  - `--limit 2 --offset 2` prints the third and fourth models and reports `total: 5`, matching `Content-Range: 2-3/5`. The public registry answers `0-2/*` and the summary says `total: unknown`.
  - A version with an alias shows it; the four without show `-`. Public-registry rows, which carry no size, show `unknown`.

Only read paths were exercised; no resource on that environment was modified.
