### PR TITLE
build: migrate package checksums to SHA256

### DIFF
--- a/scripts/builder/build-engine-package.sh
+++ b/scripts/builder/build-engine-package.sh
@@ -547,10 +547,10 @@ if [ -z "$MANIFEST_ONLY" ]; then
     print_info "Standalone manifest copied to: $OUTPUT_DIR/$MANIFEST_OUTPUT"
     # Calculate checksum
     print_info "Calculating checksum..."
-    if command -v md5sum &> /dev/null; then
-        md5sum "$OUTPUT_DIR/$OUTPUT_FILE" > "${OUTPUT_DIR}/${OUTPUT_FILE}.md5"
+    if command -v sha256sum &> /dev/null; then
+        sha256sum "$OUTPUT_DIR/$OUTPUT_FILE" > "${OUTPUT_DIR}/${OUTPUT_FILE}.sha256"
     else
-        md5 "$OUTPUT_DIR/$OUTPUT_FILE" | awk '{print $4}' > "${OUTPUT_DIR}/${OUTPUT_FILE}.md5"
+        shasum -a 256 "$OUTPUT_DIR/$OUTPUT_FILE" > "${OUTPUT_DIR}/${OUTPUT_FILE}.sha256"
     fi
 
     # Get package size

--- a/scripts/builder/build-package.sh
+++ b/scripts/builder/build-package.sh
@@ -357,10 +357,10 @@ cd "$CURRENT_DIR" || exit 1
 
 # Calculate checksum
 log_info "Calculating checksum..."
-if command -v md5sum &> /dev/null; then
-    md5sum "$PACKAGE_FILE" > "${PACKAGE_FILE}.md5"
+if command -v sha256sum &> /dev/null; then
+    sha256sum "$PACKAGE_FILE" > "${PACKAGE_FILE}.sha256"
 else
-    md5 "$PACKAGE_FILE" | awk '{print $4}' > "${PACKAGE_FILE}.md5"
+    shasum -a 256 "$PACKAGE_FILE" > "${PACKAGE_FILE}.sha256"
 fi
 
 # Clean up
@@ -368,4 +368,4 @@ rm -rf "$TEMP_DIR"
 
 log_info "Package created successfully: $PACKAGE_FILE"
 log_info "Package size: $(du -h "$PACKAGE_FILE" | cut -f1)"
-log_info "Checksum: $(cat "${PACKAGE_FILE}.md5")"
+log_info "Checksum: $(cat "${PACKAGE_FILE}.sha256")"


### PR DESCRIPTION
## Issue

n/a

## Summary

Migrate offline package checksum artifacts from MD5 to SHA-256. Generated packages now publish `.sha256` sidecars so consumers can verify downloads with a modern checksum algorithm.

## Changes

- Use `sha256sum` for package and engine-package checksum generation when available.
- Use `shasum -a 256` as the macOS-compatible fallback.
- Rename generated checksum sidecars from `.md5` to `.sha256`, including package output logging.

## Test Plan

### Unit test

Not applicable: this change only modifies package build shell scripts.

### DB test

Not applicable: no database code or schema changes.

### E2E test

Not applicable: no deployed runtime behavior is affected.

- Passed `bash -n scripts/builder/build-package.sh scripts/builder/build-engine-package.sh`.
- Verified `sha256sum` and `shasum -a 256` produce the same digest for identical input.

## Risk & Rollback

Existing consumers must switch from `.md5` to `.sha256` sidecars. Revert this commit to restore the prior artifact format.