### PR TITLE
fix: revoke gateway credential before deleting an API key (NEU-650)

### DIFF
--- a/controllers/api_key_controller.go
+++ b/controllers/api_key_controller.go
@@ -47,8 +47,6 @@ func (c *ApiKeyController) sync(obj *v1.ApiKey) error {
 	var err error
 
 	if obj.Metadata != nil && obj.Metadata.DeletionTimestamp != "" {
-		isForceDelete := v1.IsForceDelete(obj.Metadata.Annotations)
-
 		if obj.Status != nil && obj.Status.Phase == v1.ApiKeyPhaseDELETED {
 			klog.Infof("ApiKey %s already marked as deleted, removing from DB", obj.Metadata.Name)
 
@@ -61,23 +59,33 @@ func (c *ApiKeyController) sync(obj *v1.ApiKey) error {
 			return nil
 		}
 
-		klog.Infof("Deleting api_key %s (force=%v)", obj.Metadata.Name, isForceDelete)
+		klog.Infof("Deleting api_key %s", obj.Metadata.Name)
 
-		deleteErr := c.gw.DeleteAPIKey(obj)
+		// The gateway credential must actually be revoked before the key may advance to
+		// DELETED, and unlike every other resource an api_key does not honour the
+		// force-delete annotation (NEU-650). DeleteAPIKey is idempotent — an
+		// already-absent consumer reports success — so the only way it fails is the
+		// gateway being unreachable, exactly when the consumer probably still exists.
+		// Advancing regardless would let the next reconcile drop the DB row and strand
+		// an orphaned consumer: the key keeps working on the data plane forever with
+		// nothing left in the control plane to reap it. Surface the error and retry.
+		if deleteErr := c.gw.DeleteAPIKey(obj); deleteErr != nil {
+			if updateErr := c.updateStatus(obj, currentApiKeyPhase(obj), deleteErr); updateErr != nil {
+				klog.Errorf("failed to update api_key %s/%s status: %v",
+					obj.Metadata.Workspace, obj.Metadata.Name, updateErr)
+			}
 
-		updateErr := c.updateStatus(obj, v1.ApiKeyPhaseDELETED, deleteErr)
-		if updateErr != nil {
-			klog.Errorf("failed to update api_key %s/%s status: %v",
-				obj.Metadata.Workspace, obj.Metadata.Name, updateErr)
-
-			return errors.Wrapf(updateErr, "failed to update api_key %s/%s status",
+			return errors.Wrapf(deleteErr, "failed to delete api_key %s/%s from gateway",
 				obj.Metadata.Workspace, obj.Metadata.Name)
 		}
 
-		LogForceDeletionWarning(isForceDelete, "api_key", obj.Metadata.Workspace, obj.Metadata.Name, deleteErr)
+		err = c.updateStatus(obj, v1.ApiKeyPhaseDELETED, nil)
+		if err != nil {
+			klog.Errorf("failed to update api_key %s/%s status: %v",
+				obj.Metadata.Workspace, obj.Metadata.Name, err)
 
-		if deleteErr != nil && !isForceDelete {
-			return deleteErr
+			return errors.Wrapf(err, "failed to update api_key %s/%s status",
+				obj.Metadata.Workspace, obj.Metadata.Name)
 		}
 
 		return nil
@@ -107,12 +115,25 @@ func (c *ApiKeyController) sync(obj *v1.ApiKey) error {
 	return nil
 }
 
+// currentApiKeyPhase reports the phase the key is already in, used when a failed
+// delete must record an error without moving the key forward.
+func currentApiKeyPhase(obj *v1.ApiKey) v1.ApiKeyPhase {
+	if obj.Status == nil {
+		return ""
+	}
+
+	return obj.Status.Phase
+}
+
 func (c *ApiKeyController) updateStatus(obj *v1.ApiKey, phase v1.ApiKeyPhase, err error) error {
 	newStatus := &v1.ApiKeyStatus{
 		LastTransitionTime: FormatStatusTime(),
 		Phase:              phase,
-		SkValue:            obj.Status.SkValue,
 		ErrorMessage:       FormatErrorForStatus(err),
+	}
+
+	if obj.Status != nil {
+		newStatus.SkValue = obj.Status.SkValue
 	}
 
 	return c.storage.UpdateApiKey(obj.ID, &v1.ApiKey{Status: newStatus})

--- a/controllers/api_key_controller_test.go
+++ b/controllers/api_key_controller_test.go
@@ -45,10 +45,34 @@ func testApiKey(id string, phase v1.ApiKeyPhase) *v1.ApiKey {
 	return apiKey
 }
 
+// newTestApiKeyControllerWithFailingGateway builds a controller whose gateway
+// rejects the delete, standing in for an unreachable gateway.
+func newTestApiKeyControllerWithFailingGateway(storage *storagemocks.MockStorage) *ApiKeyController {
+	gw := &gatewaymocks.MockGateway{}
+	gw.On("SyncAPIKey", mock.Anything).Return(nil)
+	gw.On("DeleteAPIKey", mock.Anything).Return(assert.AnError)
+
+	c, _ := NewApiKeyController(&ApiKeyControllerOption{
+		Storage: storage,
+		Gw:      gw,
+	})
+
+	return c
+}
+
 // testApiKeyWithDeletionTimestamp is a helper to create a ApiKey object marked for deletion.
 func testApiKeyWithDeletionTimestamp(id string, phase v1.ApiKeyPhase) *v1.ApiKey {
 	apiKey := testApiKey(id, phase)
 	apiKey.Metadata.DeletionTimestamp = time.Now().Format(time.RFC3339Nano)
+	return apiKey
+}
+
+// testApiKeyForceDeleted marks the key for deletion and adds the force-delete
+// annotation, which api_key deliberately does not honour.
+func testApiKeyForceDeleted(id string, phase v1.ApiKeyPhase) *v1.ApiKey {
+	apiKey := testApiKeyWithDeletionTimestamp(id, phase)
+	apiKey.Metadata.Annotations = v1.WithForceDeleteAnnotation(apiKey.Metadata.Annotations)
+
 	return apiKey
 }
 
@@ -114,6 +138,46 @@ func TestApiKeyController_Sync_Deletion(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			mockStorage.AssertExpectations(t)
+		})
+	}
+}
+
+// TestApiKeyController_Sync_Deletion_GatewayUnreachable pins NEU-650: a key whose
+// gateway credential could not be revoked must not advance to DELETED, with or
+// without the force-delete annotation. Advancing would let the next reconcile drop
+// the DB row and leave an orphaned consumer keeping the key alive on the data plane.
+func TestApiKeyController_Sync_Deletion_GatewayUnreachable(t *testing.T) {
+	apiKeyID := "test-id"
+
+	tests := []struct {
+		name  string
+		input *v1.ApiKey
+	}{
+		{
+			name:  "gateway delete failed -> phase not advanced",
+			input: testApiKeyWithDeletionTimestamp(apiKeyID, v1.ApiKeyPhaseCREATED),
+		},
+		{
+			name:  "gateway delete failed with force-delete annotation -> phase still not advanced",
+			input: testApiKeyForceDeleted(apiKeyID, v1.ApiKeyPhaseCREATED),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := &storagemocks.MockStorage{}
+			mockStorage.On("UpdateApiKey", apiKeyID, mock.MatchedBy(func(r *v1.ApiKey) bool {
+				return r.Status != nil && r.Status.Phase != v1.ApiKeyPhaseDELETED && r.Status.ErrorMessage != ""
+			})).Return(nil).Once()
+
+			c := newTestApiKeyControllerWithFailingGateway(mockStorage)
+
+			err := c.sync(tt.input)
+
+			assert.Error(t, err)
+			// The DB row must survive so a later reconcile can retry the revocation.
+			mockStorage.AssertNotCalled(t, "DeleteApiKey", mock.Anything)
 			mockStorage.AssertExpectations(t)
 		})
 	}

--- a/internal/routes/proxies/api_key_proxy.go
+++ b/internal/routes/proxies/api_key_proxy.go
@@ -13,5 +13,5 @@ func RegisterAPIKeyRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 	handler := CreateStructProxyHandler[v1.ApiKey](deps, "api_keys")
 
 	proxyGroup.GET("", handler)
-	proxyGroup.PATCH("", handler)
+	proxyGroup.PATCH("", rejectAPIKeyForceDelete(), handler)
 }

--- a/internal/routes/proxies/api_key_validation.go
+++ b/internal/routes/proxies/api_key_validation.go
@@ -1,0 +1,112 @@
+package proxies
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// rejectAPIKeyForceDelete refuses any api_key write carrying the force-delete
+// annotation.
+//
+// Force delete exists so a resource whose external state cannot be reached is not
+// stuck forever, trading an orphaned resource for a control plane the user can move
+// on from. For an api_key that external state is the gateway consumer gating
+// data-plane access, so the trade does not hold: skipping it leaves a credential
+// that still works on the gateway with nothing left in the control plane to revoke
+// it (NEU-650). The controller therefore ignores the annotation, and this rejects it
+// at the edge so a caller who sets it learns why it had no effect instead of
+// believing the key was force-deleted.
+//
+// Only api_key is affected — cluster, endpoint and static_node keep force delete,
+// where the leak is compute and cost rather than a live credential.
+func rejectAPIKeyForceDelete() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodPatch && c.Request.Method != http.MethodPost {
+			c.Next()
+			return
+		}
+
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, &validationError{
+				Code:    apiKeyInvalidPayloadCode,
+				Message: "invalid api_key payload",
+				Hint:    err.Error(),
+			})
+			c.Abort()
+
+			return
+		}
+
+		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+
+		if len(bytes.TrimSpace(body)) == 0 {
+			c.Next()
+			return
+		}
+
+		if !payloadHasForceDeleteAnnotation(body) {
+			c.Next()
+			return
+		}
+
+		c.JSON(http.StatusBadRequest, &validationError{
+			Code:    apiKeyForceDeleteRejectedCode,
+			Message: "api_key does not support force delete",
+			Hint: "Deleting an API key must revoke its gateway credential first; forcing the deletion would leave " +
+				"the key usable on the gateway with no way to revoke it. Remove the " + v1.ForceDeleteAnnotationKey +
+				" annotation and retry — if the deletion does not complete, the gateway is unreachable and needs " +
+				"to be restored.",
+		})
+		c.Abort()
+	}
+}
+
+const (
+	apiKeyInvalidPayloadCode      = "10225"
+	apiKeyForceDeleteRejectedCode = "10226"
+)
+
+// payloadHasForceDeleteAnnotation reports whether the request body sets the
+// force-delete annotation. Bodies that do not parse as an api_key are passed
+// through untouched for PostgREST to reject, so that malformed input keeps its
+// existing error rather than being reported as a force-delete problem.
+func payloadHasForceDeleteAnnotation(body []byte) bool {
+	trimmed := bytes.TrimSpace(body)
+
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var apiKeys []v1.ApiKey
+		if err := json.Unmarshal(trimmed, &apiKeys); err != nil {
+			return false
+		}
+
+		for i := range apiKeys {
+			if apiKeyHasForceDeleteAnnotation(&apiKeys[i]) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	var apiKey v1.ApiKey
+	if err := json.Unmarshal(trimmed, &apiKey); err != nil {
+		return false
+	}
+
+	return apiKeyHasForceDeleteAnnotation(&apiKey)
+}
+
+func apiKeyHasForceDeleteAnnotation(apiKey *v1.ApiKey) bool {
+	if apiKey.Metadata == nil {
+		return false
+	}
+
+	return v1.IsForceDelete(apiKey.Metadata.Annotations)
+}

--- a/internal/routes/proxies/api_key_validation_test.go
+++ b/internal/routes/proxies/api_key_validation_test.go
@@ -1,0 +1,159 @@
+package proxies
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// newAPIKeyForceDeleteRouter mounts the middleware in front of a stub handler so
+// tests can observe both the rejection and the pass-through path.
+func newAPIKeyForceDeleteRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	stub := func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"proxied": true})
+	}
+
+	r.GET("/api_keys", rejectAPIKeyForceDelete(), stub)
+	r.PATCH("/api_keys", rejectAPIKeyForceDelete(), stub)
+
+	return r
+}
+
+func TestRejectAPIKeyForceDelete(t *testing.T) {
+	softDelete := `{"metadata":{"name":"k","workspace":"default","deletion_timestamp":"2026-08-05T07:20:48Z"}}`
+	forceSoftDelete := `{"metadata":{"name":"k","workspace":"default","deletion_timestamp":"2026-08-05T07:20:48Z",` +
+		`"annotations":{"neutree.ai/force-delete":"true"}}}`
+
+	tests := []struct {
+		name         string
+		method       string
+		body         string
+		expectStatus int
+		expectCode   string
+	}{
+		{
+			name:         "plain soft delete passes through",
+			method:       http.MethodPatch,
+			body:         softDelete,
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "ordinary update passes through",
+			method:       http.MethodPatch,
+			body:         `{"spec":{"limits":{"rps":10}}}`,
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "force delete is rejected",
+			method:       http.MethodPatch,
+			body:         forceSoftDelete,
+			expectStatus: http.StatusBadRequest,
+			expectCode:   apiKeyForceDeleteRejectedCode,
+		},
+		{
+			name:   "force-delete annotation is rejected even without a deletion timestamp",
+			method: http.MethodPatch,
+			body: `{"metadata":{"name":"k","workspace":"default",` +
+				`"annotations":{"neutree.ai/force-delete":"true"}}}`,
+			expectStatus: http.StatusBadRequest,
+			expectCode:   apiKeyForceDeleteRejectedCode,
+		},
+		{
+			name:         "force delete inside a bulk array is rejected",
+			method:       http.MethodPatch,
+			body:         "[" + softDelete + "," + forceSoftDelete + "]",
+			expectStatus: http.StatusBadRequest,
+			expectCode:   apiKeyForceDeleteRejectedCode,
+		},
+		{
+			name:         "annotation set to a value other than true passes through",
+			method:       http.MethodPatch,
+			body:         `{"metadata":{"name":"k","annotations":{"neutree.ai/force-delete":"false"}}}`,
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "other annotations pass through",
+			method:       http.MethodPatch,
+			body:         `{"metadata":{"name":"k","annotations":{"neutree.ai/other":"true"}}}`,
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "empty body passes through",
+			method:       http.MethodPatch,
+			body:         "",
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "unparsable body is left to postgrest",
+			method:       http.MethodPatch,
+			body:         `{"metadata":`,
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "reads are not inspected",
+			method:       http.MethodGet,
+			body:         "",
+			expectStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newAPIKeyForceDeleteRouter()
+
+			req := httptest.NewRequest(tt.method, "/api_keys?id=eq.1", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectStatus, w.Code)
+
+			if tt.expectCode == "" {
+				return
+			}
+
+			var got validationError
+			assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+			assert.Equal(t, tt.expectCode, got.Code)
+			assert.Contains(t, got.Message, "force delete")
+		})
+	}
+}
+
+// TestRejectAPIKeyForceDeletePreservesBody guards the read-and-restore: the
+// downstream proxy must still see the original payload.
+func TestRejectAPIKeyForceDeletePreservesBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := `{"metadata":{"name":"k","deletion_timestamp":"2026-08-05T07:20:48Z"}}`
+
+	var seen string
+
+	r := gin.New()
+	r.PATCH("/api_keys", rejectAPIKeyForceDelete(), func(c *gin.Context) {
+		raw, err := c.GetRawData()
+		assert.NoError(t, err)
+
+		seen = string(raw)
+
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPatch, "/api_keys?id=eq.1", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, body, seen)
+}


### PR DESCRIPTION
## Issue

NEU-650

## Summary

Deleting an API key is supposed to revoke its gateway credential before the record goes away. It did not: `updateStatus` advanced the key to phase `DELETED` regardless of whether `gw.DeleteAPIKey` succeeded, so the next reconcile took the "already marked as deleted" branch and dropped the DB row. The gateway consumer survived, and with the DB row gone nothing in the control plane could ever reap it — the key kept working on the data plane permanently. The `force-delete` annotation made this the expected outcome, but a transient gateway failure reached the same state on its own, since the non-force path returned an error only after the `DELETED` status had already been persisted.

API keys now also opt out of force delete entirely. `DeleteAPIKey` is already idempotent — an absent consumer reports success — so the only way it fails is the gateway being unreachable, which is exactly when the consumer probably still exists and the DB row must be kept. Force delete therefore has no case where it helps and one where it leaves an unrevocable credential. Other resource types are untouched: for a cluster or an endpoint the leak is compute and cost, which is recoverable, not a live credential.

## Changes

- `controllers/api_key_controller.go`: advance to `DELETED` only after the gateway revocation succeeds. On failure, record the error on `status.error_message`, keep the current phase, and return the error so the reconcile retries. The `force-delete` annotation is no longer read.
- `controllers/api_key_controller.go`: guard the `obj.Status.SkValue` dereference in `updateStatus`, which the new failure path can reach with a nil status.
- `internal/routes/proxies/api_key_validation.go` (new): reject any `api_keys` write carrying `neutree.ai/force-delete: true` with HTTP 400 and error code `10226`, so a caller who sets the annotation is told why it had no effect rather than believing the key was force-deleted. Rejection is keyed on the annotation alone, not on the annotation plus a deletion timestamp, so the annotation can never be persisted by a separate request and used later.
- Tests: gateway-unreachable cases assert the phase does not advance and the DB row is not deleted, with and without the annotation; middleware cases cover pass-through, rejection, bulk arrays, non-`true` values, empty and malformed bodies, and body restoration for the downstream proxy.

## Test Plan

- [x] Unit: `go test ./controllers/... ./internal/routes/...` — all pass.
- [x] Lint: `golangci-lint run` via the pre-commit gate — clean.
- [ ] E2E: not affected — no API surface change beyond rejecting an annotation that previously produced an unrecoverable state.
- [ ] DB integration (`make db-test`): not affected — no schema change.

Manual verification worth doing before release: create a key, make the gateway unreachable, attempt a delete with and without the annotation, and confirm the key stays visible with an error on its status; then restore the gateway and confirm the delete completes and the consumer is gone.

## Risk & Rollback

No schema change. One user-visible behaviour change: a delete request carrying `neutree.ai/force-delete: true` on an API key now returns 400 instead of appearing to succeed. That path previously produced an orphaned credential, so nothing depended on it working. A key whose gateway is unreachable now stays in the list with an error on its status instead of disappearing — the deletion completes on its own once the gateway is reachable again.

Rollback is a plain revert; no migration or data cleanup is involved.

Not addressed here: `api.api_keys.user_id` is declared `ON DELETE CASCADE` against `api.user_profiles`, so deleting a user removes their API key rows in the database and bypasses the controller entirely, producing the same orphaned consumers by a third route. That is a separate fix.
