### PR TITLE
feat(model-registry): Hugging Face provider enhancement, availability status and built-in registry provisioning (NEU-624)

### DIFF
--- a/api/v1/constants.go
+++ b/api/v1/constants.go
@@ -10,6 +10,36 @@ const (
 )
 
 const (
+	// BuiltinAnnotationKey marks a resource the control plane provisions and owns.
+	// Provisioning only ever updates resources carrying it, so one that shares a
+	// name with something a user made is never adopted; the API keys off it to
+	// refuse edits that make no sense on a managed resource.
+	BuiltinAnnotationKey   = "neutree.ai/builtin"
+	BuiltinAnnotationValue = "true"
+)
+
+// IsBuiltin reports whether the control plane provisioned this resource.
+func IsBuiltin(annotations map[string]string) bool {
+	if annotations == nil {
+		return false
+	}
+
+	return annotations[BuiltinAnnotationKey] == BuiltinAnnotationValue
+}
+
+// WithBuiltinAnnotation returns a copy of annotations marked as built-in.
+func WithBuiltinAnnotation(annotations map[string]string) map[string]string {
+	next := make(map[string]string, len(annotations)+1)
+	for key, value := range annotations {
+		next[key] = value
+	}
+
+	next[BuiltinAnnotationKey] = BuiltinAnnotationValue
+
+	return next
+}
+
+const (
 	DefaultModelCacheRelativePath = "default"
 
 	DefaultSSHClusterModelCacheMountPath = "/home/ray/.neutree/models-cache"

--- a/api/v1/model_registry_types.go
+++ b/api/v1/model_registry_types.go
@@ -22,6 +22,26 @@ const (
 	BentoMLModelRegistryType     = "bentoml"
 )
 
+// A registry is either public — a hosted catalogue someone else operates, which
+// can only be read and cannot be measured — or private. Most behaviour follows
+// from that rather than from the registry kind, so the mapping lives here and in
+// the api.visibility computed column, which must be kept in step with it.
+const (
+	ModelRegistryVisibilityPublic  = "public"
+	ModelRegistryVisibilityPrivate = "private"
+)
+
+// VisibilityForModelRegistryType states whether a registry kind is public.
+// Unknown kinds are private: a kind this build does not know about is not one
+// whose contents are on someone else's hub.
+func VisibilityForModelRegistryType(registryType ModelRegistryType) string {
+	if registryType == HuggingFaceModelRegistryType {
+		return ModelRegistryVisibilityPublic
+	}
+
+	return ModelRegistryVisibilityPrivate
+}
+
 type BentoMLModelRegistryConnectType string
 
 const (
@@ -56,9 +76,15 @@ type ModelRegistryStats struct {
 }
 
 type ModelRegistryStatus struct {
-	ErrorMessage       string             `json:"error_message,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	// LastTransitionTime is when the phase last changed, so it cannot answer "when
+	// was this last checked" — see LastCheckedAt.
 	LastTransitionTime string             `json:"last_transition_time,omitempty"`
 	Phase              ModelRegistryPhase `json:"phase,omitempty"`
+	// LastCheckedAt is when connectivity was last verified, whatever the outcome.
+	// This is the timestamp to show beside a reachability state. It is written back
+	// on a throttle, so it trails the real check by up to that interval.
+	LastCheckedAt string `json:"last_checked_at,omitempty"`
 	// Stats is written by the statistics path, not by the connectivity
 	// reconcile. PostgREST replaces a composite-type column as a whole, so every
 	// writer of this status has to carry Stats forward or it is nulled out.
@@ -72,6 +98,11 @@ type ModelRegistry struct {
 	Metadata   *Metadata            `json:"metadata,omitempty"`
 	Spec       *ModelRegistrySpec   `json:"spec,omitempty"`
 	Status     *ModelRegistryStatus `json:"status,omitempty"`
+	// Visibility is "public" or "private", derived by the api.visibility computed
+	// column rather than stored. PostgREST omits computed fields from select=*, so
+	// it is populated only for a caller that asks: "?select=*,visibility". It is
+	// never accepted on a write.
+	Visibility string `json:"visibility,omitempty"`
 }
 
 func (r ModelRegistry) Key() string {

--- a/cmd/neutree-api/app/config/config.go
+++ b/cmd/neutree-api/app/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/gin-gonic/gin"
 
 	"github.com/neutree-ai/neutree/internal/middleware"
@@ -28,6 +30,10 @@ type APIConfig struct {
 	// Server configuration
 	ServerConfig *ServerConfig
 	StaticConfig *StaticConfig
+
+	// PublicRegistryQueryCacheTTL is how long a public model registry's query
+	// results are reused. Zero uses the model registry package's default.
+	PublicRegistryQueryCacheTTL time.Duration
 
 	// External services
 	StorageAccessURL string

--- a/cmd/neutree-api/app/factory.go
+++ b/cmd/neutree-api/app/factory.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/neutree-ai/neutree/cmd/neutree-api/app/config"
 	"github.com/neutree-ai/neutree/internal/middleware"
+	"github.com/neutree-ai/neutree/internal/model_registry"
 	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/internal/routes/auth"
 	"github.com/neutree-ai/neutree/internal/routes/clusters"
@@ -35,6 +36,10 @@ func ModelsRouteFactory(register ModelRegisterFunc) RouteFactory {
 		register(deps.Group, deps.Middlewares, &models.Dependencies{
 			Storage:    deps.Config.Storage,
 			AuthConfig: deps.Config.AuthConfig,
+			// One cache per process, built here so that every model route shares
+			// it: the handler that invalidates it has to be looking at the same
+			// entries as the handler that filled it.
+			QueryCache: model_registry.NewQueryCache(deps.Config.PublicRegistryQueryCacheTTL),
 		})
 
 		return nil

--- a/cmd/neutree-api/app/options/api.go
+++ b/cmd/neutree-api/app/options/api.go
@@ -1,7 +1,11 @@
 package options
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
+
+	"github.com/neutree-ai/neutree/internal/model_registry"
 )
 
 // APIOptions holds API application configuration options
@@ -9,13 +13,18 @@ type APIOptions struct {
 	GinMode   string
 	StaticDir string
 	Version   string
+	// PublicRegistryQueryCacheTTL is how long a public model registry's answer to
+	// a search or a page is reused before the hub is asked again. Zero or less
+	// falls back to the package default.
+	PublicRegistryQueryCacheTTL time.Duration
 }
 
 // NewAPIOptions creates new API options with default values
 func NewAPIOptions() *APIOptions {
 	return &APIOptions{
-		GinMode:   "release",
-		StaticDir: "./public",
+		GinMode:                     "release",
+		StaticDir:                   "./public",
+		PublicRegistryQueryCacheTTL: model_registry.DefaultQueryCacheTTL,
 	}
 }
 
@@ -23,6 +32,8 @@ func NewAPIOptions() *APIOptions {
 func (o *APIOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.GinMode, "gin-mode", o.GinMode, "gin mode: debug, release, test")
 	fs.StringVar(&o.StaticDir, "static-dir", o.StaticDir, "directory for static files")
+	fs.DurationVar(&o.PublicRegistryQueryCacheTTL, "public-registry-query-cache-ttl", o.PublicRegistryQueryCacheTTL,
+		"how long a public model registry's query results are reused before the hub is asked again")
 }
 
 // Validate validates API options

--- a/cmd/neutree-api/app/options/options.go
+++ b/cmd/neutree-api/app/options/options.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/neutree-ai/neutree/cmd/neutree-api/app/config"
 	"github.com/neutree-ai/neutree/internal/middleware"
+	"github.com/neutree-ai/neutree/internal/routes"
 	"github.com/neutree-ai/neutree/internal/util"
 	"github.com/neutree-ai/neutree/internal/version"
 	"github.com/neutree-ai/neutree/pkg/storage"
@@ -79,6 +80,11 @@ func (o *Options) Config() (*config.APIConfig, error) {
 	// Create gin engine
 	engine := gin.Default()
 
+	// A public model registry names its models "org/model", so the router has to
+	// match on the escaped path. See routes.ConfigureEngine for what that changes
+	// across the whole API and what it does not.
+	routes.ConfigureEngine(engine)
+
 	// Configure JWT authentication
 	authConfig := middleware.AuthConfig{
 		JwtSecret: o.Storage.JwtSecret,
@@ -105,6 +111,8 @@ func (o *Options) Config() (*config.APIConfig, error) {
 		StaticConfig: &config.StaticConfig{
 			Dir: o.API.StaticDir,
 		},
+
+		PublicRegistryQueryCacheTTL: o.API.PublicRegistryQueryCacheTTL,
 
 		StorageAccessURL: o.Storage.AccessURL,
 		AuthEndpoint:     o.External.AuthEndpoint,

--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -13,6 +13,7 @@ import (
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/constants"
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/util"
 	"github.com/neutree-ai/neutree/internal/componentversion"
+	"github.com/neutree-ai/neutree/internal/model_registry"
 	"github.com/neutree-ai/neutree/pkg/command"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
@@ -28,6 +29,12 @@ type neutreeCoreInstallOptions struct {
 	adminPassword         string
 
 	victorialogsRetentionPeriod string
+
+	// enablePublicModelRegistries provisions the built-in public model
+	// registries. Off by default so an air-gapped install does not ship a
+	// registry it can never reach.
+	enablePublicModelRegistries bool
+	huggingFaceEndpoint         string
 }
 
 // defaultVictoriaLogsRetentionPeriod is the default VictoriaLogs log retention
@@ -56,6 +63,8 @@ Configuration Options:
   --grafana-url            Grafana dashboard URL for system info API
   --version                Component version (default: CLI release version, or v0.0.1 for non-release/local builds)
   --victorialogs-retention-period VictoriaLogs log retention period (default: 30d; e.g. 30d, 90d, 1y)
+  --enable-public-model-registries Provision built-in read-only public model registries (default: false)
+  --hugging-face-endpoint  Address the built-in Hugging Face registry points at, e.g. an in-network mirror
 
 Examples:
   # Basic installation
@@ -87,6 +96,11 @@ Examples:
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.version, "version", defaultNeutreeCoreVersion(), "neutree core version")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.victorialogsRetentionPeriod, "victorialogs-retention-period",
 		defaultVictoriaLogsRetentionPeriod, "VictoriaLogs log retention period (e.g. 30d, 90d, 1y)")
+	neutreeCoreInstallCmd.PersistentFlags().BoolVar(&options.enablePublicModelRegistries, "enable-public-model-registries", false,
+		"provision built-in read-only model registries for the supported public hubs")
+	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.huggingFaceEndpoint, "hugging-face-endpoint",
+		model_registry.DefaultHuggingFaceEndpoint,
+		"address the built-in Hugging Face registry points at, e.g. an in-network mirror")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.adminPassword, "admin-password", "", "the password for the neutree admin user."+
 		"it is valid when starting neutree core for the first time. "+
 		"It is recommended to change it quickly after installation.")
@@ -199,6 +213,19 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 		options.victorialogsRetentionPeriod = defaultVictoriaLogsRetentionPeriod
 	}
 
+	// The compose template renders the two model-registry flags only when the
+	// feature is on, so the "off" case emits no argument at all rather than an
+	// explicit false — same shape as the optional URLs next to it.
+	builtinPublicModelRegistries := ""
+	if options.enablePublicModelRegistries {
+		builtinPublicModelRegistries = "true"
+	}
+
+	huggingFaceEndpoint := options.huggingFaceEndpoint
+	if huggingFaceEndpoint == "" {
+		huggingFaceEndpoint = model_registry.DefaultHuggingFaceEndpoint
+	}
+
 	templateParams := map[string]string{
 		"NeutreeCoreWorkDir":           coreWorkDir,
 		"JwtSecret":                    options.jwtSecret,
@@ -217,6 +244,8 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 		"KongPluginQuotaChecksum":      pluginChecksums["neutree-ai-quota"],
 		"NodeIP":                       options.nodeIP,
 		"AdminPassword":                options.adminPassword,
+		"BuiltinPublicModelRegistries": builtinPublicModelRegistries,
+		"HuggingFaceEndpoint":          huggingFaceEndpoint,
 	}
 
 	err = util.BatchParseTemplateFiles(tempplateFiles, templateParams)

--- a/cmd/neutree-core/app/config/config.go
+++ b/cmd/neutree-core/app/config/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/neutree-ai/neutree/internal/auth"
 	"github.com/neutree-ai/neutree/internal/engine"
 	"github.com/neutree-ai/neutree/internal/gateway"
+	"github.com/neutree-ai/neutree/internal/model_registry"
 	"github.com/neutree-ai/neutree/internal/observability/manager"
 	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/pkg/scheme"
@@ -20,6 +21,12 @@ type ControllerConfig struct {
 type ClusterControllerConfig struct {
 	DefaultClusterVersion string
 	MetricsRemoteWriteURL string
+}
+
+// ModelRegistryConfig is what this deployment provisions and offers in the way
+// of model registries.
+type ModelRegistryConfig struct {
+	Builtin model_registry.BuiltinConfig
 }
 
 type ServerConfig struct {
@@ -46,6 +53,9 @@ type CoreConfig struct {
 
 	// core server config
 	ServerConfig *ServerConfig
+
+	// model registry provisioning config
+	ModelRegistryConfig *ModelRegistryConfig
 
 	Scheme *scheme.Scheme
 }

--- a/cmd/neutree-core/app/factory.go
+++ b/cmd/neutree-core/app/factory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/neutree-ai/neutree/cmd/neutree-core/app/config"
 	"github.com/neutree-ai/neutree/controllers"
 	"github.com/neutree-ai/neutree/internal/cluster/staticnode"
+	"github.com/neutree-ai/neutree/internal/model_registry"
 	"github.com/neutree-ai/neutree/pkg/scheme"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
@@ -153,8 +154,9 @@ func NewRoleAssignmentControllerFactory() ControllerFactory {
 func NewWorkspaceControllerFactory() ControllerFactory {
 	return func(opts *ControllerOptions) (controllers.Controller, error) {
 		workspaceController, err := controllers.NewWorkspaceController(&controllers.WorkspaceControllerOption{
-			Storage:        opts.config.Storage,
-			EngineRegistry: opts.config.EngineRegistry,
+			Storage:           opts.config.Storage,
+			EngineRegistry:    opts.config.EngineRegistry,
+			BuiltinRegistries: builtinModelRegistryConfig(opts),
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create workspace controller")
@@ -371,4 +373,15 @@ func NewExternalEndpointControllerFactory() ControllerFactory {
 
 		return ctrl, nil
 	}
+}
+
+// builtinModelRegistryConfig reads the built-in registry configuration, treating
+// its absence as "provision nothing". A build or a test that leaves the section
+// unset gets an offline deployment, which is the safe end of the switch.
+func builtinModelRegistryConfig(opts *ControllerOptions) model_registry.BuiltinConfig {
+	if opts.config.ModelRegistryConfig == nil {
+		return model_registry.BuiltinConfig{}
+	}
+
+	return opts.config.ModelRegistryConfig.Builtin
 }

--- a/cmd/neutree-core/app/options/model_registry.go
+++ b/cmd/neutree-core/app/options/model_registry.go
@@ -1,0 +1,38 @@
+package options
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+// ModelRegistryOptions configures the model registries the control plane
+// provisions for itself.
+type ModelRegistryOptions struct {
+	// EnableBuiltinPublicRegistries provisions a read-only registry for each
+	// supported public hub into every workspace.
+	//
+	// Off by default, and deliberately so: an installation with no route out to
+	// the internet that shipped one enabled would show every user a registry
+	// permanently stuck in Failed.
+	EnableBuiltinPublicRegistries bool
+	// HuggingFaceEndpoint is the address the built-in Hugging Face registry
+	// points at — the Hub, or a mirror reachable from inside the network. It has
+	// no effect unless the built-in registries are enabled.
+	HuggingFaceEndpoint string
+}
+
+func NewModelRegistryOptions() *ModelRegistryOptions {
+	return &ModelRegistryOptions{
+		EnableBuiltinPublicRegistries: false,
+		HuggingFaceEndpoint:           model_registry.DefaultHuggingFaceEndpoint,
+	}
+}
+
+func (o *ModelRegistryOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.EnableBuiltinPublicRegistries, "enable-builtin-public-model-registries",
+		o.EnableBuiltinPublicRegistries,
+		"provision a built-in read-only model registry for each supported public hub in every workspace")
+	fs.StringVar(&o.HuggingFaceEndpoint, "hugging-face-endpoint", o.HuggingFaceEndpoint,
+		"address the built-in Hugging Face registry points at, e.g. an in-network mirror")
+}

--- a/cmd/neutree-core/app/options/options.go
+++ b/cmd/neutree-core/app/options/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/neutree-ai/neutree/cmd/neutree-core/app/config"
 	"github.com/neutree-ai/neutree/internal/engine"
 	"github.com/neutree-ai/neutree/internal/gateway"
+	"github.com/neutree-ai/neutree/internal/model_registry"
 	"github.com/neutree-ai/neutree/internal/observability/manager"
 	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/internal/util"
@@ -25,6 +26,7 @@ type NeutreeCoreOptions struct {
 	Observability *ObservabilityOptions
 	Cluster       *ClusterOptions
 	Auth          *AuthOptions
+	ModelRegistry *ModelRegistryOptions
 }
 
 func NewOptions() *NeutreeCoreOptions {
@@ -36,6 +38,7 @@ func NewOptions() *NeutreeCoreOptions {
 		Observability: NewObservabilityOptions(),
 		Cluster:       NewClusterOptions(),
 		Auth:          NewAuthOptions(),
+		ModelRegistry: NewModelRegistryOptions(),
 	}
 }
 
@@ -47,6 +50,7 @@ func (o *NeutreeCoreOptions) AddFlags(fs *pflag.FlagSet) {
 	o.Observability.AddFlags(fs)
 	o.Cluster.AddFlags(fs)
 	o.Auth.AddFlags(fs)
+	o.ModelRegistry.AddFlags(fs)
 }
 
 func (o *NeutreeCoreOptions) Validate() error {
@@ -166,6 +170,12 @@ func (o *NeutreeCoreOptions) Config(scheme *scheme.Scheme) (*config.CoreConfig, 
 	c.ServerConfig = &config.ServerConfig{
 		Port: o.Server.Port,
 		Host: o.Server.Host,
+	}
+	c.ModelRegistryConfig = &config.ModelRegistryConfig{
+		Builtin: model_registry.BuiltinConfig{
+			Enabled:             o.ModelRegistry.EnableBuiltinPublicRegistries,
+			HuggingFaceEndpoint: o.ModelRegistry.HuggingFaceEndpoint,
+		},
 	}
 
 	jwtToken, err := storage.CreateServiceToken(o.Storage.JwtSecret)

--- a/contributing/database.md
+++ b/contributing/database.md
@@ -12,7 +12,7 @@
 
 - Location: `db/migrations/`.
 - Naming: `NNN_<description>.up.sql` + `NNN_<description>.down.sql`.
-- Current highest number: **083** — start new migrations at 084.
+- Current highest number: **084** — start new migrations at 085.
 - Any migration that touches RLS or permissions must ship with an integration test under `db/dbtest/`.
 - **Redefining an existing function**: `CREATE OR REPLACE` replaces the whole body, so base it on the *latest* migration that defines the function, not the first one you find. `grep -l 'FUNCTION api.<name>' db/migrations/*.up.sql` lists them all — copying an older body silently reverts every change made in between.
 

--- a/controllers/force_delete_integration_test.go
+++ b/controllers/force_delete_integration_test.go
@@ -506,6 +506,11 @@ func TestForceDelete_WorkspaceController(t *testing.T) {
 			// Mock ListEngine for DeleteWorkspaceEngine
 			mockStorage.On("ListEngine", mock.Anything).Return([]v1.Engine{}, nil).Once()
 
+			// Workspace teardown also removes the model registries the control plane
+			// provisioned, so that they are not left pointing at a workspace that no
+			// longer exists.
+			mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{}, nil).Once()
+
 			// Mock UpdateWorkspace for status update
 			mockStorage.On("UpdateWorkspace", "1", mock.MatchedBy(func(w *v1.Workspace) bool {
 				return w.Status != nil && w.Status.Phase == tt.wantPhase

--- a/controllers/model_registry_checked_at_test.go
+++ b/controllers/model_registry_checked_at_test.go
@@ -1,0 +1,218 @@
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+	modelregistrymocks "github.com/neutree-ai/neutree/internal/model_registry/mocks"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+// newCheckedAtController builds a controller with a stopped clock, so what a
+// reconcile does with the recorded check time is observable rather than a matter
+// of timing.
+func newCheckedAtController(t *testing.T, storage *storagemocks.MockStorage,
+	registry *modelregistrymocks.MockModelRegistry, now time.Time) *ModelRegistryController {
+	t.Helper()
+
+	model_registry.NewModelRegistry = func(obj *v1.ModelRegistry) (model_registry.ModelRegistry, error) {
+		return registry, nil
+	}
+
+	c := &ModelRegistryController{
+		storage: storage,
+		stats:   model_registry.StatsAggregator{Now: func() time.Time { return now }},
+		now:     func() time.Time { return now },
+	}
+	c.syncHandler = c.sync
+
+	return c
+}
+
+// connectedRegistry is a registry that has been up and measured recently, so
+// neither the statistics nor anything else gives the reconcile a reason to write.
+func connectedRegistry(now time.Time, checkedAgo time.Duration, connectedAt string) *v1.ModelRegistry {
+	return &v1.ModelRegistry{
+		ID:       1,
+		Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
+		Status: &v1.ModelRegistryStatus{
+			Phase:              v1.ModelRegistryPhaseCONNECTED,
+			LastTransitionTime: connectedAt,
+			LastCheckedAt:      now.Add(-checkedAgo).Format(time.RFC3339Nano),
+			Stats: &v1.ModelRegistryStats{
+				ModelCount:     3,
+				StorageBytes:   4096,
+				StatsUpdatedAt: now.Format(time.RFC3339Nano),
+			},
+		},
+	}
+}
+
+// The registry has been reachable for three days. Its check time keeps moving;
+// the moment it came up does not.
+func TestModelRegistryController_HealthyRegistryAdvancesOnlyTheCheckTime(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	connectedAt := now.Add(-72 * time.Hour).Format(time.RFC3339Nano)
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockRegistry := &modelregistrymocks.MockModelRegistry{}
+	// Since #526 every reconcile re-establishes the connection before checking it,
+	// so that a mount that vanished underneath a Connected registry is restored
+	// rather than merely reported. What this test is about — which status writes
+	// that produces — is unchanged.
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("HealthyCheck").Return(nil)
+
+	var written *v1.ModelRegistryStatus
+
+	mockStorage.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
+		obj, ok := args.Get(1).(*v1.ModelRegistry)
+		if !ok {
+			t.Fatalf("unexpected update payload %T", args.Get(1))
+		}
+
+		written = obj.Status
+	}).Return(nil)
+
+	c := newCheckedAtController(t, mockStorage, mockRegistry, now)
+
+	// Two minutes since the last recorded check: past the write interval.
+	assert.NoError(t, c.sync(connectedRegistry(now, 2*time.Minute, connectedAt)))
+
+	if assert.NotNil(t, written) {
+		assert.Equal(t, v1.ModelRegistryPhaseCONNECTED, written.Phase)
+		assert.Equal(t, now.Format(time.RFC3339Nano), written.LastCheckedAt)
+		assert.Equal(t, connectedAt, written.LastTransitionTime,
+			"a re-check that confirms what was already true is not a transition")
+		// The reconcile did not re-measure, so the counters have to be carried
+		// forward or the composite column is nulled.
+		assert.Equal(t, 3, written.Stats.ModelCount)
+	}
+
+	mockStorage.AssertExpectations(t)
+	mockRegistry.AssertExpectations(t)
+}
+
+// The reconcile runs every ten seconds. Persisting each unchanged result would
+// be a stream of writes saying nothing.
+func TestModelRegistryController_UnchangedResultIsNotRewrittenEveryCycle(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	connectedAt := now.Add(-72 * time.Hour).Format(time.RFC3339Nano)
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockRegistry := &modelregistrymocks.MockModelRegistry{}
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("HealthyCheck").Return(nil)
+
+	c := newCheckedAtController(t, mockStorage, mockRegistry, now)
+
+	assert.NoError(t, c.sync(connectedRegistry(now, 5*time.Second, connectedAt)))
+
+	mockStorage.AssertNotCalled(t, "UpdateModelRegistry", mock.Anything, mock.Anything)
+	mockRegistry.AssertExpectations(t)
+}
+
+// Both reasons are non-empty, so a check for "is there an error" reports no
+// change and leaves a stale reason on display.
+func TestModelRegistryController_ChangedFailureReasonIsWritten(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	failedAt := now.Add(-time.Hour).Format(time.RFC3339Nano)
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockRegistry := &modelregistrymocks.MockModelRegistry{}
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("Connect").Return(assert.AnError)
+
+	var written *v1.ModelRegistryStatus
+
+	mockStorage.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
+		obj, ok := args.Get(1).(*v1.ModelRegistry)
+		if !ok {
+			t.Fatalf("unexpected update payload %T", args.Get(1))
+		}
+
+		written = obj.Status
+	}).Return(nil)
+
+	c := newCheckedAtController(t, mockStorage, mockRegistry, now)
+
+	failed := &v1.ModelRegistry{
+		ID:       1,
+		Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
+		Status: &v1.ModelRegistryStatus{
+			Phase:              v1.ModelRegistryPhaseFAILED,
+			LastTransitionTime: failedAt,
+			// Checked a moment ago, so nothing but the changed reason can be what
+			// triggers the write.
+			LastCheckedAt: now.Add(-time.Second).Format(time.RFC3339Nano),
+			ErrorMessage:  "invalid Hugging Face API token",
+		},
+	}
+
+	assert.Error(t, c.sync(failed))
+
+	if assert.NotNil(t, written) {
+		assert.Equal(t, v1.ModelRegistryPhaseFAILED, written.Phase)
+		assert.NotEqual(t, "invalid Hugging Face API token", written.ErrorMessage)
+		assert.NotEmpty(t, written.ErrorMessage)
+		assert.Equal(t, failedAt, written.LastTransitionTime,
+			"still failing is not a new transition")
+	}
+
+	mockStorage.AssertExpectations(t)
+	mockRegistry.AssertExpectations(t)
+}
+
+// Deleting a registry says nothing about whether it was answering, so the
+// recorded check time is left where it was rather than moved.
+func TestModelRegistryController_DeletionDoesNotCountAsACheck(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	checkedAt := now.Add(-30 * time.Second).Format(time.RFC3339Nano)
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockRegistry := &modelregistrymocks.MockModelRegistry{}
+	mockRegistry.On("Disconnect").Return(nil)
+
+	var written *v1.ModelRegistryStatus
+
+	mockStorage.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
+		obj, ok := args.Get(1).(*v1.ModelRegistry)
+		if !ok {
+			t.Fatalf("unexpected update payload %T", args.Get(1))
+		}
+
+		written = obj.Status
+	}).Return(nil)
+
+	c := newCheckedAtController(t, mockStorage, mockRegistry, now)
+
+	deleting := &v1.ModelRegistry{
+		ID: 1,
+		Metadata: &v1.Metadata{
+			Name:              "test",
+			Workspace:         "default",
+			DeletionTimestamp: now.Format(time.RFC3339Nano),
+		},
+		Status: &v1.ModelRegistryStatus{
+			Phase:         v1.ModelRegistryPhaseCONNECTED,
+			LastCheckedAt: checkedAt,
+			Stats:         &v1.ModelRegistryStats{ModelCount: 3},
+		},
+	}
+
+	assert.NoError(t, c.sync(deleting))
+
+	if assert.NotNil(t, written) {
+		assert.Equal(t, v1.ModelRegistryPhaseDELETED, written.Phase)
+		assert.Equal(t, checkedAt, written.LastCheckedAt)
+		assert.Equal(t, 3, written.Stats.ModelCount)
+	}
+
+	mockStorage.AssertExpectations(t)
+	mockRegistry.AssertExpectations(t)
+}

--- a/controllers/model_registry_controller.go
+++ b/controllers/model_registry_controller.go
@@ -15,6 +15,11 @@ import (
 type ModelRegistryController struct {
 	storage storage.Storage
 	stats   model_registry.StatsAggregator
+	// checkedAtWriteInterval is how far the recorded check time may trail the real
+	// one before an otherwise unchanged status is written back.
+	checkedAtWriteInterval time.Duration
+	// now overrides the clock in tests.
+	now func() time.Time
 
 	syncHandler func(modelRegistry *v1.ModelRegistry) error
 }
@@ -24,17 +29,29 @@ type ModelRegistryControllerOption struct {
 	// StatsStaleAfter overrides how long collected registry counters stay usable
 	// before the tree is walked again. Zero uses the package default.
 	StatsStaleAfter time.Duration
+	// CheckedAtWriteInterval overrides how often an unchanged reachability result
+	// is persisted purely to advance its timestamp. Zero uses the package default.
+	CheckedAtWriteInterval time.Duration
 }
 
 func NewModelRegistryController(option *ModelRegistryControllerOption) (*ModelRegistryController, error) {
 	c := &ModelRegistryController{
-		storage: option.Storage,
-		stats:   model_registry.StatsAggregator{StaleAfter: option.StatsStaleAfter},
+		storage:                option.Storage,
+		stats:                  model_registry.StatsAggregator{StaleAfter: option.StatsStaleAfter},
+		checkedAtWriteInterval: option.CheckedAtWriteInterval,
 	}
 
 	c.syncHandler = c.sync
 
 	return c, nil
+}
+
+func (c *ModelRegistryController) clock() time.Time {
+	if c.now == nil {
+		return time.Now()
+	}
+
+	return c.now()
 }
 
 func (c *ModelRegistryController) Reconcile(obj interface{}) error {
@@ -63,7 +80,7 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 		return c.syncDeletion(obj)
 	}
 
-	// Defer block to handle status updates for non-deletion paths
+	// Reaching here means the registry was checked, whatever the outcome.
 	defer func() {
 		// Determine phase based on error
 		phase := v1.ModelRegistryPhaseCONNECTED
@@ -71,16 +88,20 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 			phase = v1.ModelRegistryPhaseFAILED
 		}
 
-		// Skip update if already in correct phase, no error change, and the
-		// counters were not recomputed. The recomputation has to be written even
-		// when the counters came out identical: its timestamp is what stops the
-		// next reconcile, ten seconds later, from walking the model tree again.
-		if !statsRefreshed && obj.Status != nil && obj.Status.Phase == phase &&
-			(err != nil) == (obj.Status.ErrorMessage != "") {
+		errMessage := FormatErrorForStatus(err)
+		now := c.clock()
+
+		// What is written back, and when, is decided in one place shared with the retry
+		// endpoint.
+		if !model_registry.NeedsStatusWrite(obj.Status, phase, errMessage, statsRefreshed,
+			now, c.checkedAtWriteInterval) {
 			return
 		}
 
-		updateErr := c.updateStatus(obj, phase, err, stats)
+		newStatus := model_registry.NextStatus(obj.Status, phase, errMessage, now)
+		newStatus.Stats = stats
+
+		updateErr := c.updateStatus(obj, newStatus)
 		if updateErr != nil {
 			klog.Errorf("failed to update model registry %s/%s status: %v",
 				obj.Metadata.Workspace, obj.Metadata.Name, updateErr)
@@ -163,7 +184,12 @@ func (c *ModelRegistryController) syncDeletion(obj *v1.ModelRegistry) error {
 		phase = v1.ModelRegistryPhaseFAILED
 	}
 
-	updateErr := c.updateStatus(obj, phase, deleteErr, currentStats(obj))
+	// A deletion is not a reachability check, so the recorded check time is carried
+	// over rather than moved.
+	newStatus := model_registry.NextStatus(obj.Status, phase, FormatErrorForStatus(deleteErr), c.clock())
+	newStatus.LastCheckedAt = currentCheckedAt(obj)
+
+	updateErr := c.updateStatus(obj, newStatus)
 	if updateErr != nil {
 		klog.Errorf("failed to update model registry %s/%s status: %v",
 			obj.Metadata.Workspace, obj.Metadata.Name, updateErr)
@@ -189,19 +215,20 @@ func currentStats(obj *v1.ModelRegistry) *v1.ModelRegistryStats {
 	return obj.Status.Stats
 }
 
-func (c *ModelRegistryController) updateStatus(obj *v1.ModelRegistry, phase v1.ModelRegistryPhase,
-	err error, stats *v1.ModelRegistryStats) error {
-	newStatus := &v1.ModelRegistryStatus{
-		LastTransitionTime: FormatStatusTime(),
-		Phase:              phase,
-		ErrorMessage:       FormatErrorForStatus(err),
-		// PostgREST replaces a composite-type column as a whole, so any attribute
-		// missing from the PATCH body is nulled rather than left alone. Stats is
-		// therefore always passed in — carried forward from the observed object
-		// when this reconcile did not recompute it — or every phase or error
-		// transition wipes it. Same reason as ClusterController.updateStatus.
-		Stats: stats,
+func currentCheckedAt(obj *v1.ModelRegistry) string {
+	if obj.Status == nil {
+		return ""
 	}
 
+	return obj.Status.LastCheckedAt
+}
+
+// updateStatus persists a status built by model_registry.NextStatus.
+//
+// PostgREST replaces a composite-type column as a whole, so every attribute has
+// to be present in what is passed here — carried forward when this reconcile did
+// not produce a new value — or a phase change wipes the statistics and the check
+// time with it.
+func (c *ModelRegistryController) updateStatus(obj *v1.ModelRegistry, newStatus *v1.ModelRegistryStatus) error {
 	return c.storage.UpdateModelRegistry(strconv.Itoa(obj.ID), &v1.ModelRegistry{Status: newStatus})
 }

--- a/controllers/model_registry_controller_test.go
+++ b/controllers/model_registry_controller_test.go
@@ -601,9 +601,24 @@ func TestModelRegistryController_Sync_PublicRegistryHasNoStats(t *testing.T) {
 		Metadata: &v1.Metadata{Name: "public", Workspace: "default"},
 		Status:   &v1.ModelRegistryStatus{Phase: v1.ModelRegistryPhaseCONNECTED},
 	}
+	var written *v1.ModelRegistryStatus
+
+	// The phase did not change and nothing was measured, but the check still
+	// happened, and recording when a registry was last checked is the one thing
+	// that has to be written even when the answer is the same as last time.
+	mockStorage.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
+		obj := args.Get(1).(*v1.ModelRegistry) //nolint:errcheck
+		written = obj.Status
+	}).Return(nil)
+
 	assert.NoError(t, c.sync(obj))
 
-	// Nothing measured, nothing to write: the phase did not change either.
-	mockStorage.AssertNotCalled(t, "UpdateModelRegistry", mock.Anything, mock.Anything)
 	assert.Nil(t, obj.Status.Stats)
+
+	if assert.NotNil(t, written) {
+		assert.Equal(t, v1.ModelRegistryPhaseCONNECTED, written.Phase)
+		assert.NotEmpty(t, written.LastCheckedAt)
+		// Still no counters: a public registry's storage is not ours to measure.
+		assert.Nil(t, written.Stats)
+	}
 }

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/engine"
+	"github.com/neutree-ai/neutree/internal/model_registry"
 	"github.com/neutree-ai/neutree/internal/util"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
@@ -18,17 +19,23 @@ type WorkspaceController struct {
 	syncHandler func(workspace *v1.Workspace) error // Added syncHandler field
 
 	engineRegistry engine.Registry
+	// builtinRegistries is what this deployment provisions into every workspace.
+	builtinRegistries model_registry.BuiltinConfig
 }
 
 type WorkspaceControllerOption struct {
 	Storage        storage.Storage
 	EngineRegistry engine.Registry
+	// BuiltinRegistries configures the built-in model registries. The zero value
+	// provisions none, which is what an offline deployment wants.
+	BuiltinRegistries model_registry.BuiltinConfig
 }
 
 func NewWorkspaceController(option *WorkspaceControllerOption) (*WorkspaceController, error) {
 	c := &WorkspaceController{
-		storage:        option.Storage,
-		engineRegistry: option.EngineRegistry,
+		storage:           option.Storage,
+		engineRegistry:    option.EngineRegistry,
+		builtinRegistries: option.BuiltinRegistries,
 	}
 
 	c.syncHandler = c.sync
@@ -73,6 +80,9 @@ func (c *WorkspaceController) sync(obj *v1.Workspace) error {
 		klog.Infof("Deleting workspace %s (force=%v)", obj.Metadata.Name, isForceDelete)
 
 		deleteErr := c.DeleteWorkspaceEngine(obj)
+		if deleteErr == nil {
+			deleteErr = c.DeleteWorkspaceModelRegistry(obj)
+		}
 
 		// For non-force delete, return error immediately without updating status
 		if deleteErr != nil && !isForceDelete {
@@ -108,6 +118,11 @@ func (c *WorkspaceController) sync(obj *v1.Workspace) error {
 		err = c.syncWorkspaceEngine(*obj)
 		if err != nil {
 			return errors.Wrapf(err, "failed to sync workspace %s engine", obj.Metadata.Name)
+		}
+
+		err = c.syncWorkspaceModelRegistry(*obj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to sync workspace %s model registry", obj.Metadata.Name)
 		}
 	}
 

--- a/controllers/workspace_controller_test.go
+++ b/controllers/workspace_controller_test.go
@@ -88,6 +88,9 @@ func TestWorkspaceController_Sync_Deletion(t *testing.T) {
 			input: testWorkspaceWithDeletionTimestamp(workspaceID, v1.WorkspacePhaseCREATED),
 			mockSetup: func(s *storagemocks.MockStorage) {
 				s.On("ListEngine", mock.Anything).Return(nil, nil)
+				// Teardown also removes the model registries the control plane
+				// provisioned into this workspace.
+				s.On("ListModelRegistry", mock.Anything).Return(nil, nil)
 				s.On("UpdateWorkspace", workspaceIDStr, mock.MatchedBy(func(r *v1.Workspace) bool {
 					return r.Status != nil && r.Status.Phase == v1.WorkspacePhaseDELETED && r.Status.ErrorMessage == ""
 				})).Return(nil).Once()
@@ -99,6 +102,9 @@ func TestWorkspaceController_Sync_Deletion(t *testing.T) {
 			input: testWorkspaceWithDeletionTimestamp(workspaceID, v1.WorkspacePhasePENDING),
 			mockSetup: func(s *storagemocks.MockStorage) {
 				s.On("ListEngine", mock.Anything).Return(nil, nil)
+				// Teardown also removes the model registries the control plane
+				// provisioned into this workspace.
+				s.On("ListModelRegistry", mock.Anything).Return(nil, nil)
 				s.On("UpdateWorkspace", workspaceIDStr, mock.MatchedBy(func(r *v1.Workspace) bool {
 					return r.Status != nil && r.Status.Phase == v1.WorkspacePhaseDELETED
 				})).Return(assert.AnError).Once()
@@ -110,6 +116,9 @@ func TestWorkspaceController_Sync_Deletion(t *testing.T) {
 			input: testWorkspaceWithDeletionTimestamp(workspaceID, ""), // No initial status
 			mockSetup: func(s *storagemocks.MockStorage) {
 				s.On("ListEngine", mock.Anything).Return(nil, nil)
+				// Teardown also removes the model registries the control plane
+				// provisioned into this workspace.
+				s.On("ListModelRegistry", mock.Anything).Return(nil, nil)
 				s.On("UpdateWorkspace", workspaceIDStr, mock.MatchedBy(func(r *v1.Workspace) bool {
 					return r.Status != nil && r.Status.Phase == v1.WorkspacePhaseDELETED && r.Status.ErrorMessage == ""
 				})).Return(nil).Once()

--- a/controllers/workspace_model_registry.go
+++ b/controllers/workspace_model_registry.go
@@ -1,0 +1,136 @@
+package controllers
+
+import (
+	"strconv"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// syncWorkspaceModelRegistry provisions this deployment's built-in model
+// registries into a workspace, idempotently, on every reconcile — the same shape
+// as the built-in engines beside it.
+//
+// The switch governs provisioning only. Turning it off stops new registries being
+// created; it does not remove ones already provisioned, which stay until a person
+// deletes them.
+func (c *WorkspaceController) syncWorkspaceModelRegistry(workspace v1.Workspace) error {
+	workspaceName := workspace.Metadata.Name
+
+	for _, desired := range model_registry.BuiltinModelRegistries(c.builtinRegistries, workspaceName) {
+		existing, err := c.listModelRegistriesByName(workspaceName, desired.Metadata.Name)
+		if err != nil {
+			return err
+		}
+
+		if err := c.createOrUpdateBuiltinModelRegistry(desired, existing); err != nil {
+			return errors.Wrapf(err, "failed to create or update built-in model registry %s for workspace %s",
+				desired.Metadata.Name, workspaceName)
+		}
+	}
+
+	return nil
+}
+
+func (c *WorkspaceController) createOrUpdateBuiltinModelRegistry(desired *v1.ModelRegistry,
+	existing []v1.ModelRegistry) error {
+	if len(existing) == 0 {
+		return c.storage.CreateModelRegistry(desired)
+	}
+
+	current := existing[0]
+
+	// Not ours. Adopting it would start managing a resource its owner is using;
+	// leaving it alone only means this deployment has no built-in registry here.
+	if current.Metadata == nil || !v1.IsBuiltin(current.Metadata.Annotations) {
+		klog.V(4).Infof("model registry %s/%s exists and is not built-in, leaving it alone",
+			desired.Metadata.Workspace, desired.Metadata.Name)
+
+		return nil
+	}
+
+	// Being reaped. Re-pointing it would race the deletion; once the row is gone the
+	// next reconcile provisions it afresh.
+	if current.Metadata.DeletionTimestamp != "" {
+		return nil
+	}
+
+	if current.Spec != nil && current.Spec.Type == desired.Spec.Type && current.Spec.Url == desired.Spec.Url {
+		return nil
+	}
+
+	klog.Infof("Updating built-in model registry %s/%s to %s",
+		desired.Metadata.Workspace, desired.Metadata.Name, desired.Spec.Url)
+
+	// Credentials are carried over: a token a user attached is theirs, and PostgREST
+	// replaces the whole composite, so omitting it would delete it.
+	spec := *desired.Spec
+	if current.Spec != nil {
+		spec.Credentials = current.Spec.Credentials
+	}
+
+	return c.storage.UpdateModelRegistry(strconv.Itoa(current.ID), &v1.ModelRegistry{Spec: &spec})
+}
+
+func (c *WorkspaceController) listModelRegistriesByName(workspace, name string) ([]v1.ModelRegistry, error) {
+	registries, err := c.storage.ListModelRegistry(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->workspace",
+				Operator: "eq",
+				Value:    strconv.Quote(workspace),
+			},
+			{
+				Column:   "metadata->name",
+				Operator: "eq",
+				Value:    strconv.Quote(name),
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list model registries for workspace %s", workspace)
+	}
+
+	return registries, nil
+}
+
+// DeleteWorkspaceModelRegistry removes the built-in registries the control plane
+// put in a workspace that is being torn down.
+//
+// Only built-in ones: a registry the user created is theirs, and workspace
+// deletion is already refused while any of those remain. Without this they would
+// be left behind as rows pointing at a workspace that no longer exists, since
+// nothing else claims them — the deletion validator deliberately does not count
+// them.
+func (c *WorkspaceController) DeleteWorkspaceModelRegistry(workspace *v1.Workspace) error {
+	registries, err := c.storage.ListModelRegistry(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->workspace",
+				Operator: "eq",
+				Value:    strconv.Quote(workspace.Metadata.Name),
+			},
+		},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to list model registries for workspace %s", workspace.Metadata.Name)
+	}
+
+	for i := range registries {
+		registry := registries[i]
+		if registry.Metadata == nil || !v1.IsBuiltin(registry.Metadata.Annotations) {
+			continue
+		}
+
+		if err := c.storage.DeleteModelRegistry(strconv.Itoa(registry.ID)); err != nil {
+			return errors.Wrapf(err, "failed to delete built-in model registry %s/%s",
+				workspace.Metadata.Name, registry.Metadata.Name)
+		}
+	}
+
+	return nil
+}

--- a/controllers/workspace_model_registry_test.go
+++ b/controllers/workspace_model_registry_test.go
@@ -1,0 +1,231 @@
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+func newBuiltinRegistryController(storage *storagemocks.MockStorage,
+	config model_registry.BuiltinConfig) *WorkspaceController {
+	c, _ := NewWorkspaceController(&WorkspaceControllerOption{
+		Storage:           storage,
+		BuiltinRegistries: config,
+	})
+
+	return c
+}
+
+func builtinRegistryRow(id int, url string) v1.ModelRegistry {
+	return v1.ModelRegistry{
+		ID: id,
+		Metadata: &v1.Metadata{
+			Name:        model_registry.BuiltinHuggingFaceRegistryName,
+			Workspace:   "default",
+			Annotations: v1.WithBuiltinAnnotation(nil),
+		},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.HuggingFaceModelRegistryType,
+			Url:  url,
+		},
+	}
+}
+
+func workspaceNamed(name string) v1.Workspace {
+	return v1.Workspace{
+		ID:       1,
+		Metadata: &v1.Metadata{Name: name},
+		Status:   &v1.WorkspaceStatus{Phase: v1.WorkspacePhaseCREATED},
+	}
+}
+
+func TestSyncWorkspaceModelRegistry_ProvisionsWhenEnabled(t *testing.T) {
+	mockStorage := &storagemocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{}, nil)
+
+	var created *v1.ModelRegistry
+
+	mockStorage.On("CreateModelRegistry", mock.Anything).Run(func(args mock.Arguments) {
+		created, _ = args.Get(0).(*v1.ModelRegistry)
+	}).Return(nil)
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
+		Enabled:             true,
+		HuggingFaceEndpoint: "https://hf-mirror.example",
+	})
+
+	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
+
+	require.NotNil(t, created)
+	assert.Equal(t, model_registry.BuiltinHuggingFaceRegistryName, created.Metadata.Name)
+	assert.Equal(t, "default", created.Metadata.Workspace)
+	assert.Equal(t, "https://hf-mirror.example", created.Spec.Url)
+	assert.True(t, v1.IsBuiltin(created.Metadata.Annotations))
+
+	mockStorage.AssertExpectations(t)
+}
+
+// An offline deployment is the default, and it must not produce a registry it
+// can never reach.
+func TestSyncWorkspaceModelRegistry_ProvisionsNothingWhenDisabled(t *testing.T) {
+	mockStorage := &storagemocks.MockStorage{}
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{})
+
+	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
+
+	mockStorage.AssertNotCalled(t, "CreateModelRegistry", mock.Anything)
+	mockStorage.AssertNotCalled(t, "UpdateModelRegistry", mock.Anything, mock.Anything)
+	// Nothing is even looked up: the switch governs provisioning, so with it off
+	// there is nothing to reconcile against.
+	mockStorage.AssertNotCalled(t, "ListModelRegistry", mock.Anything)
+}
+
+// The switch decides whether registries are provisioned from now on. It does not
+// decide whether the ones already there stay: removing a registry that endpoints
+// may be serving models from is a decision someone has to be present for, and a
+// configuration flag flipped during an upgrade is nobody being present.
+func TestSyncWorkspaceModelRegistry_TurningTheSwitchOffLeavesProvisionedRegistries(t *testing.T) {
+	mockStorage := &storagemocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).
+		Return([]v1.ModelRegistry{builtinRegistryRow(4, "https://huggingface.co")}, nil).Maybe()
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{})
+
+	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
+
+	mockStorage.AssertNotCalled(t, "UpdateModelRegistry", mock.Anything, mock.Anything)
+	mockStorage.AssertNotCalled(t, "DeleteModelRegistry", mock.Anything)
+}
+
+func TestSyncWorkspaceModelRegistry_RepointsAtANewMirror(t *testing.T) {
+	mockStorage := &storagemocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).
+		Return([]v1.ModelRegistry{builtinRegistryRow(4, "https://huggingface.co")}, nil)
+
+	var updated *v1.ModelRegistry
+
+	mockStorage.On("UpdateModelRegistry", "4", mock.Anything).Run(func(args mock.Arguments) {
+		updated, _ = args.Get(1).(*v1.ModelRegistry)
+	}).Return(nil)
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
+		Enabled:             true,
+		HuggingFaceEndpoint: "https://hf-mirror.example",
+	})
+
+	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
+
+	require.NotNil(t, updated)
+	assert.Equal(t, "https://hf-mirror.example", updated.Spec.Url)
+	mockStorage.AssertExpectations(t)
+}
+
+func TestSyncWorkspaceModelRegistry_LeavesAMatchingRegistryAlone(t *testing.T) {
+	mockStorage := &storagemocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).
+		Return([]v1.ModelRegistry{builtinRegistryRow(4, "https://huggingface.co")}, nil)
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{Enabled: true})
+
+	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
+
+	mockStorage.AssertNotCalled(t, "UpdateModelRegistry", mock.Anything, mock.Anything)
+	mockStorage.AssertNotCalled(t, "CreateModelRegistry", mock.Anything)
+}
+
+// Provisioning must never adopt a registry a user created, even one sitting
+// under the name the control plane would have used.
+func TestSyncWorkspaceModelRegistry_NeverTouchesAUserRegistry(t *testing.T) {
+	userOwned := builtinRegistryRow(4, "https://huggingface.co")
+	userOwned.Metadata.Annotations = nil
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{userOwned}, nil)
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
+		Enabled:             true,
+		HuggingFaceEndpoint: "https://elsewhere.example",
+	})
+
+	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
+
+	mockStorage.AssertNotCalled(t, "UpdateModelRegistry", mock.Anything, mock.Anything)
+	mockStorage.AssertNotCalled(t, "CreateModelRegistry", mock.Anything)
+}
+
+// A row already on its way out is left to the teardown that is under way.
+func TestSyncWorkspaceModelRegistry_SkipsARegistryBeingDeleted(t *testing.T) {
+	deleting := builtinRegistryRow(4, "https://huggingface.co")
+	deleting.Metadata.DeletionTimestamp = time.Now().UTC().Format(time.RFC3339)
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{deleting}, nil)
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
+		Enabled:             true,
+		HuggingFaceEndpoint: "https://elsewhere.example",
+	})
+
+	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
+
+	mockStorage.AssertNotCalled(t, "UpdateModelRegistry", mock.Anything, mock.Anything)
+	mockStorage.AssertNotCalled(t, "CreateModelRegistry", mock.Anything)
+}
+
+// Credentials a user attached to the built-in registry are theirs; re-pointing
+// the URL must not take them away.
+func TestSyncWorkspaceModelRegistry_KeepsUserSuppliedCredentials(t *testing.T) {
+	stored := builtinRegistryRow(4, "https://huggingface.co")
+	stored.Spec.Credentials = "hf_token"
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{stored}, nil)
+
+	var updated *v1.ModelRegistry
+
+	mockStorage.On("UpdateModelRegistry", "4", mock.Anything).Run(func(args mock.Arguments) {
+		updated, _ = args.Get(1).(*v1.ModelRegistry)
+	}).Return(nil)
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
+		Enabled:             true,
+		HuggingFaceEndpoint: "https://hf-mirror.example",
+	})
+
+	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
+
+	require.NotNil(t, updated)
+	assert.Equal(t, "hf_token", updated.Spec.Credentials)
+}
+
+// A workspace being torn down takes its provisioned registries with it, or they
+// are left pointing at a workspace that no longer exists — nothing else claims
+// them, because the deletion validator deliberately does not count them.
+func TestDeleteWorkspaceModelRegistry(t *testing.T) {
+	userOwned := builtinRegistryRow(9, "nfs://server/models")
+	userOwned.Metadata.Name = "mine"
+	userOwned.Metadata.Annotations = nil
+
+	mockStorage := &storagemocks.MockStorage{}
+	mockStorage.On("ListModelRegistry", mock.Anything).
+		Return([]v1.ModelRegistry{builtinRegistryRow(4, "https://huggingface.co"), userOwned}, nil)
+	mockStorage.On("DeleteModelRegistry", "4").Return(nil)
+
+	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{Enabled: true})
+
+	workspace := workspaceNamed("default")
+	require.NoError(t, c.DeleteWorkspaceModelRegistry(&workspace))
+
+	// Only the provisioned one. A user's registry is theirs, and workspace
+	// deletion is already refused while any remain.
+	mockStorage.AssertNotCalled(t, "DeleteModelRegistry", "9")
+	mockStorage.AssertExpectations(t)
+}

--- a/db/dbtest/model_registry_stats_test.go
+++ b/db/dbtest/model_registry_stats_test.go
@@ -60,10 +60,13 @@ func TestModelRegistryStatusPatchReplacesWholeComposite(t *testing.T) {
 	id := createTestModelRegistry(t, db, s, "patch-semantics")
 
 	// Populate every attribute of the composite, including ones the Go struct
-	// used for the PATCH below does not send.
+	// used for the PATCH below does not send. The attribute order is the order
+	// they were added in: phase, last_transition_time, error_message, then stats
+	// (081) and last_checked_at (084).
 	_, err := db.Exec(`UPDATE api.model_registries
 		SET status = ROW('Connected', '2026-01-01T00:00:00Z', 'previous failure',
-		                 '{"model_count": 3, "storage_bytes": 4096}'::jsonb)::api.model_registry_status
+		                 '{"model_count": 3, "storage_bytes": 4096}'::jsonb,
+		                 '2026-01-01T00:00:00Z')::api.model_registry_status
 		WHERE id = $1`, id)
 	require.NoError(t, err)
 
@@ -79,20 +82,25 @@ func TestModelRegistryStatusPatchReplacesWholeComposite(t *testing.T) {
 		phaseSet, timeSet bool
 		errorMessageNull  bool
 		statsNull         bool
+		lastCheckedAtNull bool
 	)
 
 	require.NoError(t, db.QueryRow(`SELECT
 			(status).phase IS NOT NULL,
 			(status).last_transition_time IS NOT NULL,
 			(status).error_message IS NULL,
-			(status).stats IS NULL
+			(status).stats IS NULL,
+			(status).last_checked_at IS NULL
 		FROM api.model_registries WHERE id = $1`, id).
-		Scan(&phaseSet, &timeSet, &errorMessageNull, &statsNull))
+		Scan(&phaseSet, &timeSet, &errorMessageNull, &statsNull, &lastCheckedAtNull))
 
 	assert.True(t, phaseSet, "attributes named in the PATCH body are written")
 	assert.True(t, timeSet, "attributes named in the PATCH body are written")
 	assert.True(t, errorMessageNull, "PostgREST replaces the whole composite: error_message should be nulled")
 	assert.True(t, statsNull, "PostgREST replaces the whole composite: stats should be nulled")
+	assert.True(t, lastCheckedAtNull,
+		"PostgREST replaces the whole composite: last_checked_at should be nulled too, which is why "+
+			"model_registry.NextStatus has to carry it forward")
 }
 
 // TestModelRegistryStatsSurviveConnectivityReconcile is the regression test for
@@ -109,7 +117,8 @@ func TestModelRegistryStatsSurviveConnectivityReconcile(t *testing.T) {
 
 	_, err := db.Exec(`UPDATE api.model_registries
 		SET status = ROW('Connected', '2026-01-01T00:00:00Z', NULL,
-		                 '{"model_count": 3, "storage_bytes": 4096, "stats_updated_at": "2026-01-01T00:00:00Z"}'::jsonb)::api.model_registry_status
+		                 '{"model_count": 3, "storage_bytes": 4096, "stats_updated_at": "2026-01-01T00:00:00Z"}'::jsonb,
+		                 '2026-01-01T00:00:00Z')::api.model_registry_status
 		WHERE id = $1`, id)
 	require.NoError(t, err)
 
@@ -144,6 +153,13 @@ func TestModelRegistryStatsSurviveConnectivityReconcile(t *testing.T) {
 	assert.Equal(t, 3, after.Status.Stats.ModelCount)
 	assert.Equal(t, int64(4096), after.Status.Stats.StorageBytes)
 	assert.Equal(t, "2026-01-01T00:00:00Z", after.Status.Stats.StatsUpdatedAt)
+
+	// The other half of the same write: the reconcile did check the registry, so
+	// the check time moves rather than being carried over. This is the only place
+	// last_checked_at (084) is exercised against a real PostgREST.
+	require.NotEmpty(t, after.Status.LastCheckedAt, "a reconcile records when it checked")
+	assert.NotEqual(t, "2026-01-01T00:00:00Z", after.Status.LastCheckedAt,
+		"the seeded check time is stale, so this reconcile must have replaced it")
 }
 
 // TestModelRegistryStatsReadableThroughPostgREST checks the new attribute is

--- a/db/migrations/084_model_registry_checked_at_and_visibility.down.sql
+++ b/db/migrations/084_model_registry_checked_at_and_visibility.down.sql
@@ -1,0 +1,5 @@
+DROP FUNCTION IF EXISTS api.visibility(api.model_registries);
+
+ALTER TYPE api.model_registry_status DROP ATTRIBUTE IF EXISTS last_checked_at;
+
+NOTIFY pgrst, 'reload schema';

--- a/db/migrations/084_model_registry_checked_at_and_visibility.up.sql
+++ b/db/migrations/084_model_registry_checked_at_and_visibility.up.sql
@@ -1,0 +1,25 @@
+-- NEU-624: when a model registry was last checked, and whether it is public.
+
+-- last_transition_time answers "when did the phase last change", which cannot
+-- serve as a check time: a registry reachable for days still reports the moment
+-- it first connected. Every writer of this composite must carry this attribute
+-- forward, or a partial PATCH nulls it (see model_registry.NextStatus).
+ALTER TYPE api.model_registry_status ADD ATTRIBUTE last_checked_at TIMESTAMPTZ;
+
+-- Public vs private is derived from the registry kind, and clients need it to
+-- filter the list and to know that storage figures and write operations are
+-- absent. A computed field rather than a stored column: nothing has to keep it
+-- true, it can be selected ("?select=*,visibility") and filtered
+-- ("?visibility=eq.public"), and it is never accepted on a write.
+--
+-- Must be kept in step with v1.VisibilityForModelRegistryType, which is the same
+-- rule for callers inside the control plane.
+CREATE FUNCTION api.visibility(registry api.model_registries)
+RETURNS TEXT AS $$
+    SELECT CASE
+        WHEN (registry.spec).type = 'hugging-face' THEN 'public'
+        ELSE 'private'
+    END;
+$$ LANGUAGE sql STABLE;
+
+NOTIFY pgrst, 'reload schema';

--- a/deploy/chart/neutree/templates/neutree-core-deployment.yaml
+++ b/deploy/chart/neutree/templates/neutree-core-deployment.yaml
@@ -42,6 +42,10 @@ spec:
             - --gateway-admin-url=http://{{ include "neutree.fullname" . }}-kong-admin:8001
             - --gateway-log-remote-write-url=http://{{ include "neutree.fullname" . }}-vector:30122
             - --auth-endpoint=http://{{ include "neutree.fullname" . }}-auth-service:9999
+            {{- if .Values.publicModelRegistries.enabled }}
+            - --enable-builtin-public-model-registries
+            - --hugging-face-endpoint={{ .Values.publicModelRegistries.huggingFace.url }}
+            {{- end }}
           image: {{ include "neutree.image" (dict "global" .Values.global "componentRegistry" .Values.core.image.registry "repository" .Values.core.image.repository "tag" .Values.core.image.tag "defaultTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.core.image.pullPolicy }}
           securityContext:

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -32,6 +32,20 @@ system:
   # AI inference trace APIs and the Vector trace pipeline altogether.
   aiTraceStoreUrl: ""
 
+# Built-in public model registries. These are read-only catalogues hosted
+# outside the deployment, so they are off by default: an installation with no
+# route to the internet would otherwise show every user a registry stuck in
+# Failed.
+publicModelRegistries:
+  # Provision a built-in registry for each supported public hub into every
+  # workspace. Turning this back off withdraws the registries the control plane
+  # provisioned; registries created by hand are never touched.
+  enabled: false
+  huggingFace:
+    # Address the built-in Hugging Face registry points at. Set this to a mirror
+    # reachable from inside the network when the Hub itself is not.
+    url: "https://huggingface.co"
+
 metrics:
   # Specify the URL for remote write if using an external metrics storage system.
   # This explicit value takes precedence over the embedded VictoriaMetrics

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -188,6 +188,10 @@ services:
       - --core-server-port=3001
       - --core-server-host=0.0.0.0
       - --auth-endpoint=http://auth:9999
+{{ if .BuiltinPublicModelRegistries }}
+      - --enable-builtin-public-model-registries
+      - --hugging-face-endpoint={{ .HuggingFaceEndpoint }}
+{{ end }}
     volumes:
       - {{ .NeutreeCoreWorkDir }}/collect:/etc/neutree/collect
     ports:

--- a/internal/model_registry/builtin.go
+++ b/internal/model_registry/builtin.go
@@ -1,0 +1,65 @@
+package model_registry
+
+import (
+	"strings"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+const (
+	// BuiltinHuggingFaceRegistryName is the name the built-in public registry is
+	// provisioned under, in every workspace that has it.
+	BuiltinHuggingFaceRegistryName = "public-hugging-face"
+	// DefaultHuggingFaceEndpoint is the Hub itself, used when the built-in
+	// registry is enabled without naming a mirror.
+	DefaultHuggingFaceEndpoint = "https://huggingface.co"
+)
+
+// BuiltinConfig says whether this installation offers public model registries,
+// and at which address. Enabled defaults to false so that an installation with
+// no route to the internet does not show every user a registry stuck in Failed.
+type BuiltinConfig struct {
+	// Enabled provisions the built-in public registries.
+	Enabled bool
+	// HuggingFaceEndpoint is the Hub address to use — a mirror inside the network,
+	// or the Hub itself. Empty means DefaultHuggingFaceEndpoint.
+	HuggingFaceEndpoint string
+}
+
+func (c BuiltinConfig) huggingFaceEndpoint() string {
+	endpoint := strings.TrimSpace(c.HuggingFaceEndpoint)
+	if endpoint == "" {
+		return DefaultHuggingFaceEndpoint
+	}
+
+	return strings.TrimSuffix(endpoint, "/")
+}
+
+// BuiltinModelRegistries returns the registries this deployment provisions for a
+// workspace, or nothing when public registries are disabled.
+//
+// Every registry it returns carries the built-in annotation, which is the only
+// thing distinguishing a provisioned registry from a user's. Provisioning and
+// the API's write guard both key off it, so a registry created here without it
+// would be adopted from — and editable as — a user's own.
+func BuiltinModelRegistries(config BuiltinConfig, workspace string) []*v1.ModelRegistry {
+	if !config.Enabled {
+		return nil
+	}
+
+	return []*v1.ModelRegistry{
+		{
+			APIVersion: "v1",
+			Kind:       "ModelRegistry",
+			Metadata: &v1.Metadata{
+				Name:        BuiltinHuggingFaceRegistryName,
+				Workspace:   workspace,
+				Annotations: v1.WithBuiltinAnnotation(nil),
+			},
+			Spec: &v1.ModelRegistrySpec{
+				Type: v1.HuggingFaceModelRegistryType,
+				Url:  config.huggingFaceEndpoint(),
+			},
+		},
+	}
+}

--- a/internal/model_registry/builtin_test.go
+++ b/internal/model_registry/builtin_test.go
@@ -1,0 +1,83 @@
+package model_registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+func TestBuiltinModelRegistries(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   BuiltinConfig
+		wantURL  string
+		wantNone bool
+	}{
+		{
+			// The default. An installation with no route out would otherwise show
+			// every user a registry permanently stuck in Failed.
+			name:     "disabled provisions nothing",
+			config:   BuiltinConfig{},
+			wantNone: true,
+		},
+		{
+			name:     "disabled even with an endpoint configured",
+			config:   BuiltinConfig{HuggingFaceEndpoint: "https://hf-mirror.example"},
+			wantNone: true,
+		},
+		{
+			name:    "enabled without an endpoint uses the hub",
+			config:  BuiltinConfig{Enabled: true},
+			wantURL: DefaultHuggingFaceEndpoint,
+		},
+		{
+			name:    "enabled with a mirror",
+			config:  BuiltinConfig{Enabled: true, HuggingFaceEndpoint: "https://hf-mirror.example/"},
+			wantURL: "https://hf-mirror.example",
+		},
+		{
+			name:    "blank endpoint falls back to the hub",
+			config:  BuiltinConfig{Enabled: true, HuggingFaceEndpoint: "   "},
+			wantURL: DefaultHuggingFaceEndpoint,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuiltinModelRegistries(tt.config, "default")
+
+			if tt.wantNone {
+				assert.Empty(t, got)
+
+				return
+			}
+
+			require.Len(t, got, 1)
+
+			registry := got[0]
+			assert.Equal(t, BuiltinHuggingFaceRegistryName, registry.Metadata.Name)
+			assert.Equal(t, "default", registry.Metadata.Workspace)
+			assert.Equal(t, v1.ModelRegistryType(v1.HuggingFaceModelRegistryType), registry.Spec.Type)
+			assert.Equal(t, tt.wantURL, registry.Spec.Url)
+			// The annotation is what makes withdrawal safe: it is the only thing
+			// telling a provisioned registry from one a user created by hand.
+			assert.True(t, v1.IsBuiltin(registry.Metadata.Annotations))
+			// A public registry is read-only, so it carries no credentials of its
+			// own. Anything a user attaches later is theirs.
+			assert.Empty(t, registry.Spec.Credentials)
+		})
+	}
+}
+
+func TestBuiltinModelRegistriesArePublic(t *testing.T) {
+	// The registries this provisions must be the ones the cache and the storage
+	// figures treat as public — one rule, not two.
+	got := BuiltinModelRegistries(BuiltinConfig{Enabled: true}, "default")
+	require.Len(t, got, 1)
+
+	assert.Equal(t, v1.ModelRegistryVisibilityPublic,
+		v1.VisibilityForModelRegistryType(got[0].Spec.Type))
+}

--- a/internal/model_registry/file_based.go
+++ b/internal/model_registry/file_based.go
@@ -3,10 +3,12 @@ package model_registry
 import (
 	"io"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pkg/errors"
 
@@ -15,6 +17,9 @@ import (
 	"github.com/neutree-ai/neutree/internal/model_registry/modelmeta"
 	"github.com/neutree-ai/neutree/internal/nfs"
 )
+
+// readmeFileName is the model card a private registry serves verbatim.
+const readmeFileName = "README.md"
 
 const nfsHealthCheckTimeout = time.Minute
 
@@ -137,6 +142,62 @@ func (s *bentomlStore) GetModelDetail(name, version string) (*v1.ModelVersion, e
 	detail.Info.MergeManual(manual)
 
 	return detail, nil
+}
+
+func (s *bentomlStore) GetReadme(name, version string) (*Readme, error) {
+	model, err := bentoml.GetModelDetail(s.path, name, version)
+	if err != nil {
+		return nil, err
+	}
+
+	readmePath := filepath.Join(bentoml.ModelDir(s.path, model.Name, model.Version), readmeFileName)
+
+	file, err := os.Open(readmePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, errors.Wrapf(ErrNotFound, "model %s:%s has no %s", name, version, readmeFileName)
+		}
+
+		return nil, errors.Wrapf(err, "failed to read %s of model %s:%s", readmeFileName, name, version)
+	}
+	defer file.Close()
+
+	readme, err := readCappedReadme(file)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s of model %s:%s", readmeFileName, name, version)
+	}
+
+	return readme, nil
+}
+
+// readCappedReadme reads at most MaxReadmeBytes, plus one byte so that "exactly
+// at the limit" can be told from "longer than the limit".
+func readCappedReadme(source io.Reader) (*Readme, error) {
+	content, err := io.ReadAll(io.LimitReader(source, MaxReadmeBytes+1))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(content) > MaxReadmeBytes {
+		return &Readme{Content: string(truncateUTF8(content, MaxReadmeBytes)), Truncated: true}, nil
+	}
+
+	return &Readme{Content: string(content)}, nil
+}
+
+// truncateUTF8 cuts at or before limit without splitting a rune. A document cut
+// short is expected; a character cut in half is a decoding error downstream.
+func truncateUTF8(content []byte, limit int) []byte {
+	if len(content) <= limit {
+		return content
+	}
+
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(content[cut]) {
+		cut--
+	}
+
+	return content[:cut]
 }
 
 func (s *bentomlStore) DeleteModel(name, version string) error {

--- a/internal/model_registry/file_based_list_test.go
+++ b/internal/model_registry/file_based_list_test.go
@@ -1,10 +1,12 @@
 package model_registry
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -262,6 +264,61 @@ func TestSetManualModelInfo_LeavesPhysicalCoordinatesAlone(t *testing.T) {
 	version, err := store.GetModelVersion("qwen3", "v1")
 	require.NoError(t, err)
 	assert.Equal(t, "v1", version.Name)
+}
+
+func TestGetReadme(t *testing.T) {
+	home := t.TempDir()
+	dir := writeStoredModel(t, home, "qwen3", "v1", nil)
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	_, err := store.GetReadme("qwen3", "v1")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Qwen3\n"), 0o600))
+
+	readme, err := store.GetReadme("qwen3", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, "# Qwen3\n", readme.Content)
+	assert.False(t, readme.Truncated)
+}
+
+// A README is content from outside this system: a file anyone with push rights
+// can write. It is read up to a limit rather than in full, and a reader is told
+// when it was cut so it can say so.
+func TestGetReadme_CapsWhatItReads(t *testing.T) {
+	home := t.TempDir()
+	dir := writeStoredModel(t, home, "qwen3", "v1", nil)
+
+	oversized := bytes.Repeat([]byte("a"), MaxReadmeBytes+4096)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), oversized, 0o600))
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	readme, err := store.GetReadme("qwen3", "v1")
+	require.NoError(t, err)
+	assert.True(t, readme.Truncated)
+	assert.Len(t, readme.Content, MaxReadmeBytes)
+}
+
+// Cutting a document short is expected; cutting a character in half is a
+// decoding error in whatever displays the result.
+func TestGetReadme_TruncatesOnARuneBoundary(t *testing.T) {
+	home := t.TempDir()
+	dir := writeStoredModel(t, home, "qwen3", "v1", nil)
+
+	// Three-byte runes do not divide the limit evenly, so the cut lands inside
+	// one unless it is moved back.
+	multibyte := bytes.Repeat([]byte("千"), MaxReadmeBytes)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), multibyte, 0o600))
+
+	store := &localFile{bentomlStore: bentomlStore{path: home}}
+
+	readme, err := store.GetReadme("qwen3", "v1")
+	require.NoError(t, err)
+	assert.True(t, readme.Truncated)
+	assert.True(t, utf8.ValidString(readme.Content))
+	assert.LessOrEqual(t, len(readme.Content), MaxReadmeBytes)
 }
 
 func TestCollectUsage(t *testing.T) {

--- a/internal/model_registry/hugging_face.go
+++ b/internal/model_registry/hugging_face.go
@@ -1,6 +1,7 @@
 package model_registry
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -13,7 +14,10 @@ import (
 
 	"github.com/pkg/errors"
 
+	"k8s.io/klog/v2"
+
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry/modelmeta"
 )
 
 var (
@@ -35,6 +39,11 @@ var (
 const (
 	listModelPath = "/api/models"
 	whoamiPath    = "/api/whoami-v2"
+	configFile    = "config.json"
+	// defaultRevision is the branch a Hub repository serves when no revision is
+	// named. Our listings report every Hub model as v1.LatestVersion, which is the
+	// same idea under a different name, so that is what it maps to.
+	defaultRevision = "main"
 )
 
 // errHuggingFaceNotSupported wraps ErrNotSupported so a caller can tell "a
@@ -42,6 +51,29 @@ const (
 // clear refusal instead of a server error. Hugging Face is read-only here; the
 // write and detail operations are not implemented against it.
 var errHuggingFaceNotSupported = errors.Wrap(ErrNotSupported, "operation not supported for Hugging Face registry")
+
+var (
+	// ErrUnauthorized is returned when the hub refused the request over
+	// credentials: no token where one is needed, or one that is expired or lacks
+	// access. Retrying never helps, so callers must not treat it as an outage.
+	ErrUnauthorized = errors.New("model registry rejected the credentials")
+	// ErrRateLimited is returned when the hub was still throttling after the
+	// retries below. The registry is working and the request is valid; the answer
+	// is to come back later.
+	ErrRateLimited = errors.New("model registry is rate limiting requests")
+)
+
+const (
+	// These bound the retry budget. It is small because the retries happen inside
+	// an HTTP handler somebody is waiting on: past a couple of seconds the useful
+	// answer is ErrRateLimited, which the caller can act on.
+	hubRetryAttempts  = 3
+	hubRetryBaseDelay = 300 * time.Millisecond
+	hubRetryMaxDelay  = 2 * time.Second
+	// hubErrorBodyLimit bounds how much of an error body is quoted, since the
+	// endpoint may be a misconfigured proxy serving a whole HTML page.
+	hubErrorBodyLimit = 1024
+)
 
 type huggingFace struct {
 	apiToken string
@@ -177,19 +209,19 @@ func (hf *huggingFace) getModelsList(options ListOption) ([]HuggingFaceModel, er
 		req.Header.Set("Authorization", "Bearer "+hf.apiToken)
 	}
 
-	resp, err := hf.client.Do(req)
+	resp, err := hf.doWithRetry(req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to list models")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, hf.responseError(resp, "failed to list models")
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to list models: %s", string(body))
 	}
 
 	var models []HuggingFaceModel
@@ -209,19 +241,19 @@ func (hf *huggingFace) whoami() (string, error) {
 
 	req.Header.Set("Authorization", "Bearer "+hf.apiToken)
 
-	resp, err := hf.client.Do(req)
+	resp, err := hf.doWithRetry(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return "", hf.responseError(resp, "failed to validate Hugging Face API token")
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("failed to validate Hugging Face API token: %s", string(body))
 	}
 
 	var result struct {
@@ -241,10 +273,245 @@ func (hf *huggingFace) GetModelVersion(name, version string) (*v1.ModelVersion, 
 	return nil, errHuggingFaceNotSupported
 }
 
-// GetModelDetail is not implemented for HuggingFace: reading a public
-// checkpoint's files would mean downloading them.
+// GetModelDetail reads what a public checkpoint states about its own shape.
+//
+// It fetches config.json and nothing else — the weights are never downloaded —
+// and parses it with modelmeta.ParseConfig, the same parser the private path
+// uses, so a model reports the same shape whichever registry it came from.
+//
+// The parameter count comes from a second, optional call to the hub's tally of
+// the safetensors headers. Any failure there leaves the field in missing_fields
+// rather than failing the request: a detail view is useful without it.
 func (hf *huggingFace) GetModelDetail(name, version string) (*v1.ModelVersion, error) {
-	return nil, errHuggingFaceNotSupported
+	raw, err := hf.fetchFile(name, version, configFile)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
+
+	// A repository with no config.json is a real answer, not a failure: plenty of
+	// things on the Hub are not transformers checkpoints. It yields a model whose
+	// every field is missing, which is what the parser does with an empty file
+	// anyway.
+	info := modelmeta.ParseConfig(raw)
+
+	if total, ok := hf.parameterCount(name, version); ok {
+		info.ParameterCount = strconv.FormatInt(total, 10)
+		info.SetFieldSource(v1.ModelInfoFieldParameterCount, v1.ModelInfoSourceAuto)
+	} else {
+		info.MarkFieldMissing(v1.ModelInfoFieldParameterCount)
+	}
+
+	return &v1.ModelVersion{
+		Name: reportedVersion(version),
+		Info: info,
+	}, nil
+}
+
+// safetensorsInfo is the hub's tally of a repository's safetensors headers. It
+// is the same quantity the private path sums from the headers on disk, which is
+// why the value is recorded as read rather than estimated.
+type safetensorsInfo struct {
+	Total *int64 `json:"total"`
+}
+
+// parameterCount asks the hub for the model's stored tensor total. Every failure
+// — including a repository not stored as safetensors — is reported as "not
+// known" rather than as an error, so a secondary request can never fail the
+// detail view.
+func (hf *huggingFace) parameterCount(name, version string) (int64, bool) {
+	requestURL := hf.url + listModelPath + "/" + name
+	if revision := hf.revision(version); revision != defaultRevision {
+		requestURL += "/revision/" + url.PathEscape(revision)
+	}
+
+	requestURL += "?expand%5B%5D=safetensors"
+
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return 0, false
+	}
+
+	if hf.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+hf.apiToken)
+	}
+
+	resp, err := hf.doWithRetry(req)
+	if err != nil {
+		klog.V(4).Infof("no parameter count for model %s: %v", name, err)
+
+		return 0, false
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		klog.V(4).Infof("no parameter count for model %s: %s", name, resp.Status)
+
+		return 0, false
+	}
+
+	var payload struct {
+		Safetensors *safetensorsInfo `json:"safetensors"`
+	}
+
+	if err := json.NewDecoder(io.LimitReader(resp.Body, MaxReadmeBytes)).Decode(&payload); err != nil {
+		klog.V(4).Infof("no parameter count for model %s: %v", name, err)
+
+		return 0, false
+	}
+
+	if payload.Safetensors == nil || payload.Safetensors.Total == nil || *payload.Safetensors.Total <= 0 {
+		return 0, false
+	}
+
+	return *payload.Safetensors.Total, true
+}
+
+// GetReadme fetches the model card, returned exactly as stored, front matter
+// and all.
+//
+// A repository with no README and a repository that does not exist both answer
+// 404 on a file path, so both surface as ErrNotFound; the hub gives no way to
+// tell them apart here.
+func (hf *huggingFace) GetReadme(name, version string) (*Readme, error) {
+	raw, err := hf.fetchFile(name, version, readmeFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	return readCappedReadme(bytes.NewReader(raw))
+}
+
+// revision maps a version onto the hub's wire name for it: v1.LatestVersion
+// stands for the repository's default branch, anything else is passed through as
+// a branch, tag or commit.
+func (hf *huggingFace) revision(version string) string {
+	if version == "" || version == v1.LatestVersion {
+		return defaultRevision
+	}
+
+	return version
+}
+
+// reportedVersion is the version name given back to callers, and it must be the
+// one ListModels emits: a version read from a listing is what a client puts into
+// "model get <name>:<version>" and into a detail URL, so a detail that answered
+// with the hub's own "main" would name a version the listing never shows and
+// that a subsequent lookup would not resolve. The hub's branch name stays on the
+// wire only — see revision.
+func reportedVersion(version string) string {
+	if version == "" || version == defaultRevision {
+		return v1.LatestVersion
+	}
+
+	return version
+}
+
+// doWithRetry sends a request, retrying a 429 and nothing else. Transport errors
+// are left alone: the client already has a timeout, and an unreachable hub is
+// what the reachability check reports.
+func (hf *huggingFace) doWithRetry(req *http.Request) (*http.Response, error) {
+	var lastResp *http.Response
+
+	for attempt := 0; attempt < hubRetryAttempts; attempt++ {
+		resp, err := hf.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		lastResp = resp
+
+		if attempt == hubRetryAttempts-1 {
+			break
+		}
+
+		// The body is not needed and the connection is worth reusing.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, hubErrorBodyLimit)) //nolint:errcheck
+		resp.Body.Close()
+
+		time.Sleep(retryDelay(resp, attempt))
+	}
+
+	return lastResp, nil
+}
+
+// retryDelay honours the hub's Retry-After when present, capped at
+// hubRetryMaxDelay, and otherwise backs off exponentially.
+func retryDelay(resp *http.Response, attempt int) time.Duration {
+	if after := resp.Header.Get("Retry-After"); after != "" {
+		if seconds, err := strconv.Atoi(after); err == nil && seconds >= 0 {
+			delay := time.Duration(seconds) * time.Second
+			if delay > hubRetryMaxDelay {
+				return hubRetryMaxDelay
+			}
+
+			return delay
+		}
+	}
+
+	delay := hubRetryBaseDelay << attempt
+	if delay > hubRetryMaxDelay {
+		return hubRetryMaxDelay
+	}
+
+	return delay
+}
+
+// responseError turns a non-OK hub response into an error a caller can act on.
+// Credentials and throttling get their own types because the remedies differ;
+// anything else keeps the hub's own words.
+func (hf *huggingFace) responseError(resp *http.Response, context string) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, hubErrorBodyLimit)) //nolint:errcheck
+	detail := strings.TrimSpace(string(body))
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		hint := "a token is required"
+		if hf.apiToken != "" {
+			hint = "the configured token was rejected or does not grant access"
+		}
+
+		return errors.Wrapf(ErrUnauthorized, "%s: %s (%s)", context, hint, resp.Status)
+	case http.StatusTooManyRequests:
+		return errors.Wrapf(ErrRateLimited, "%s: %s", context, resp.Status)
+	default:
+		return errors.Errorf("%s: %s: %s", context, resp.Status, detail)
+	}
+}
+
+// fetchFile reads one file out of a hub repository, capped at MaxReadmeBytes.
+// The cap applies to every file: these are small metadata files, and the read is
+// from a server this deployment does not control.
+func (hf *huggingFace) fetchFile(name, version, file string) ([]byte, error) {
+	requestURL := fmt.Sprintf("%s/%s/resolve/%s/%s", hf.url, name, url.PathEscape(hf.revision(version)), file)
+
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if hf.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+hf.apiToken)
+	}
+
+	resp, err := hf.doWithRetry(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch %s of model %s", file, name)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errors.Wrapf(ErrNotFound, "model %s has no %s on the Hugging Face Hub", name, file)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, hf.responseError(resp, fmt.Sprintf("failed to fetch %s of model %s", file, name))
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, MaxReadmeBytes+1))
 }
 
 // DeleteModel returns an error for HuggingFace as it's read-only

--- a/internal/model_registry/hugging_face_test.go
+++ b/internal/model_registry/hugging_face_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/stretchr/testify/assert"
@@ -264,11 +265,6 @@ func TestHuggingFace_HealthyCheck(t *testing.T) {
 func TestHuggingFace_UnsupportedOperationsAreTyped(t *testing.T) {
 	hf := &huggingFace{url: "https://huggingface.co"}
 
-	t.Run("GetModelDetail", func(t *testing.T) {
-		_, err := hf.GetModelDetail("qwen3", "latest")
-		assert.ErrorIs(t, err, ErrNotSupported)
-	})
-
 	t.Run("SetManualModelInfo", func(t *testing.T) {
 		assert.ErrorIs(t, hf.SetManualModelInfo("qwen3", "latest", &v1.ModelInfo{}), ErrNotSupported)
 	})
@@ -293,8 +289,9 @@ func TestHuggingFace_UnsupportedOperationsAreTyped(t *testing.T) {
 	})
 
 	// The wording predates the typed error and is kept so existing messages do
-	// not change.
-	_, err := hf.GetModelDetail("qwen3", "latest")
+	// not change. Asserted against an operation that is still refused: model
+	// detail used to be one and no longer is.
+	err := hf.SetManualModelInfo("qwen3", "latest", &v1.ModelInfo{})
 	assert.Contains(t, err.Error(), "operation not supported for Hugging Face registry")
 }
 
@@ -337,4 +334,348 @@ func TestHuggingFace_ListModelsReportsAnUnknownTotal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, page.Models, 2)
 	assert.Nil(t, page.Total, "the Hub states no match count, so none may be invented")
+}
+
+// readmeResponder answers the model-card path and records what was asked for.
+func readmeResponder(t *testing.T, status int, body string) (*http.Client, *string) {
+	t.Helper()
+
+	var requested string
+
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			requested = req.URL.String()
+
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}}
+
+	return client, &requested
+}
+
+// The model card is the one part of a public model that can be read without
+// downloading the checkpoint, so it is served rather than refused.
+func TestHuggingFace_GetReadme(t *testing.T) {
+	client, requested := readmeResponder(t, http.StatusOK, "---\nlicense: apache-2.0\n---\n# Qwen3\n")
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	readme, err := hf.GetReadme("Qwen/Qwen3-8B", v1.LatestVersion)
+	assert.NoError(t, err)
+	// Verbatim markdown, front matter included: the server renders nothing.
+	assert.Equal(t, "---\nlicense: apache-2.0\n---\n# Qwen3\n", readme.Content)
+	assert.False(t, readme.Truncated)
+	// "latest" is our name for what the Hub calls the default branch.
+	assert.Equal(t, "https://huggingface.co/Qwen/Qwen3-8B/resolve/main/README.md", *requested)
+}
+
+func TestHuggingFace_GetReadmeUsesTheRequestedRevision(t *testing.T) {
+	client, requested := readmeResponder(t, http.StatusOK, "# Qwen3\n")
+	hf := &huggingFace{url: "https://hf-mirror.example", client: client}
+
+	_, err := hf.GetReadme("Qwen/Qwen3-8B", "refs/pr/1")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://hf-mirror.example/Qwen/Qwen3-8B/resolve/refs%2Fpr%2F1/README.md", *requested)
+}
+
+// "there is no model card" has to be distinguishable from "the hub could not be
+// asked", or a caller cannot tell the user which one happened.
+func TestHuggingFace_GetReadmeMissingIsNotFound(t *testing.T) {
+	client, _ := readmeResponder(t, http.StatusNotFound, "Entry not found")
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	_, err := hf.GetReadme("Qwen/Qwen3-8B", v1.LatestVersion)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// A refusal is not a missing card. TestHuggingFace_UnauthorizedIsTyped covers
+// what kind of refusal it is; this pins the part a caller branches on first.
+func TestHuggingFace_GetReadmeRefusalIsNotNotFound(t *testing.T) {
+	client, _ := readmeResponder(t, http.StatusForbidden, "gated repository")
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	_, err := hf.GetReadme("meta-llama/Llama-3-8B", v1.LatestVersion)
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNotFound)
+}
+
+func TestHuggingFace_GetReadmeIsCapped(t *testing.T) {
+	client, _ := readmeResponder(t, http.StatusOK, string(bytes.Repeat([]byte("a"), MaxReadmeBytes+4096)))
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	readme, err := hf.GetReadme("Qwen/Qwen3-8B", v1.LatestVersion)
+	assert.NoError(t, err)
+	assert.True(t, readme.Truncated)
+	assert.Len(t, readme.Content, MaxReadmeBytes)
+}
+
+// responderFor answers a fixed status/body and records every URL requested, so
+// a test can assert both the outcome and how many times the hub was asked.
+func responderFor(status int, body string, header http.Header) (*http.Client, *[]string) {
+	requested := []string{}
+
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			requested = append(requested, req.URL.String())
+
+			h := header
+			if h == nil {
+				h = make(http.Header)
+			}
+
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+				Header:     h,
+			}, nil
+		},
+	}}
+
+	return client, &requested
+}
+
+const qwen3Config = `{
+  "architectures": ["Qwen3ForCausalLM"],
+  "num_hidden_layers": 36,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 8,
+  "hidden_size": 4096,
+  "max_position_embeddings": 40960,
+  "torch_dtype": "bfloat16"
+}`
+
+// routeResponder answers each URL from a table, so a test can drive the two
+// requests a detail view makes independently. An unlisted URL is a 404, which is
+// how "the hub does not have this" is expressed.
+func routeResponder(routes map[string]string) (*http.Client, *[]string) {
+	requested := []string{}
+
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			url := req.URL.String()
+			requested = append(requested, url)
+
+			body, ok := routes[url]
+			status := http.StatusOK
+
+			if !ok {
+				body, status = "Entry not found", http.StatusNotFound
+			}
+
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(bytes.NewBufferString(body)),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}}
+
+	return client, &requested
+}
+
+const (
+	qwen3ConfigURL     = "https://huggingface.co/Qwen/Qwen3-8B/resolve/main/config.json"
+	qwen3SafetensorURL = "https://huggingface.co/api/models/Qwen/Qwen3-8B?expand%5B%5D=safetensors"
+)
+
+// The shape of a public model is readable from one small file, and its exact
+// parameter count from the hub's own tally of the weight headers. No weights are
+// downloaded either way.
+func TestHuggingFace_GetModelDetail(t *testing.T) {
+	client, requested := routeResponder(map[string]string{
+		qwen3ConfigURL:     qwen3Config,
+		qwen3SafetensorURL: `{"id":"Qwen/Qwen3-8B","safetensors":{"parameters":{"BF16":8190735360},"total":8190735360}}`,
+	})
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	detail, err := hf.GetModelDetail("Qwen/Qwen3-8B", v1.LatestVersion)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{qwen3ConfigURL, qwen3SafetensorURL}, *requested,
+		"one config file and one metadata call, nothing else")
+
+	assert.Equal(t, "Qwen3ForCausalLM", detail.Info.Architecture)
+	assert.Equal(t, 36, *detail.Info.NumHiddenLayers)
+	assert.Equal(t, 8, *detail.Info.NumKeyValueHeads)
+	// hidden_size / num_attention_heads, the one derivation the parser allows.
+	assert.Equal(t, 128, *detail.Info.HeadDim)
+	assert.Equal(t, v1.ModelInfoSourceDerived, detail.Info.FieldSources[v1.ModelInfoFieldHeadDim])
+	assert.Equal(t, v1.ModelInfoSourceAuto, detail.Info.FieldSources[v1.ModelInfoFieldNumHiddenLayers])
+
+	// The exact count, reported as read rather than estimated: it is the same sum
+	// over the same headers that the private path computes for itself.
+	assert.Equal(t, "8190735360", detail.Info.ParameterCount)
+	assert.Equal(t, v1.ModelInfoSourceAuto, detail.Info.FieldSources[v1.ModelInfoFieldParameterCount])
+	assert.NotContains(t, detail.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+}
+
+// The count is one field on a page that is useful without it. Every way of not
+// getting it is the same answer — unknown — and none of them fails the request.
+func TestHuggingFace_GetModelDetailWithoutAParameterCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses map[string]string
+	}{
+		{
+			// Not stored as safetensors: GGUF, pickle, anything else.
+			name: "the hub does not report one",
+			responses: map[string]string{
+				qwen3ConfigURL:     qwen3Config,
+				qwen3SafetensorURL: `{"id":"Qwen/Qwen3-8B"}`,
+			},
+		},
+		{
+			name: "the metadata call fails",
+			responses: map[string]string{
+				qwen3ConfigURL: qwen3Config,
+			},
+		},
+		{
+			name: "the metadata call answers something unparseable",
+			responses: map[string]string{
+				qwen3ConfigURL:     qwen3Config,
+				qwen3SafetensorURL: `<!doctype html><title>nope</title>`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, _ := routeResponder(tt.responses)
+			hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+			detail, err := hf.GetModelDetail("Qwen/Qwen3-8B", v1.LatestVersion)
+			assert.NoError(t, err, "a missing parameter count must not fail the detail view")
+
+			// The rest of the shape is still there.
+			assert.Equal(t, "Qwen3ForCausalLM", detail.Info.Architecture)
+			assert.Equal(t, 36, *detail.Info.NumHiddenLayers)
+
+			assert.Empty(t, detail.Info.ParameterCount)
+			assert.Contains(t, detail.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+			assert.NotContains(t, detail.Info.FieldSources, v1.ModelInfoFieldParameterCount)
+		})
+	}
+}
+
+// A named revision is asked about as that revision, not as the default branch.
+func TestHuggingFace_ParameterCountFollowsTheRevision(t *testing.T) {
+	client, requested := routeResponder(map[string]string{})
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	_, err := hf.GetModelDetail("Qwen/Qwen3-8B", "refs/pr/1")
+	assert.NoError(t, err)
+
+	assert.Contains(t, *requested,
+		"https://huggingface.co/api/models/Qwen/Qwen3-8B/revision/refs%2Fpr%2F1?expand%5B%5D=safetensors")
+}
+
+// Plenty of repositories on the Hub are not transformers checkpoints. That is an
+// answer, not a failure — and nothing is filled in from the repository name.
+func TestHuggingFace_GetModelDetailWithoutConfig(t *testing.T) {
+	client, _ := responderFor(http.StatusNotFound, "Entry not found", nil)
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	detail, err := hf.GetModelDetail("someone/qwen3-8b-gguf", v1.LatestVersion)
+	assert.NoError(t, err)
+
+	assert.Empty(t, detail.Info.Architecture)
+	// Nothing is filled in from "qwen3-8b" in the repository name.
+	assert.Empty(t, detail.Info.ParameterCount)
+	assert.Contains(t, detail.Info.MissingFields, v1.ModelInfoFieldArchitecture)
+	assert.Contains(t, detail.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+	assert.Contains(t, detail.Info.MissingFields, v1.ModelInfoFieldNumHiddenLayers)
+}
+
+// "It needs a token" is a different thing from "it broke", and only the first
+// has an action attached to it.
+func TestHuggingFace_UnauthorizedIsTyped(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		token  string
+		hint   string
+	}{
+		{name: "no token configured", status: http.StatusUnauthorized, hint: "a token is required"},
+		{name: "token rejected", status: http.StatusForbidden, token: "hf_bad", hint: "was rejected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, _ := responderFor(tt.status, "gated repository", nil)
+			hf := &huggingFace{url: "https://huggingface.co", client: client, apiToken: tt.token}
+
+			_, err := hf.GetReadme("meta-llama/Llama-3-8B", v1.LatestVersion)
+			assert.ErrorIs(t, err, ErrUnauthorized)
+			assert.Contains(t, err.Error(), tt.hint)
+
+			_, listErr := hf.ListModels(ListOption{Search: "llama"})
+			assert.ErrorIs(t, listErr, ErrUnauthorized)
+		})
+	}
+}
+
+// A 429 is retried, with backoff, and only for as long as somebody waiting on an
+// HTTP handler will tolerate. Still throttled after that is a typed answer, not
+// a generic failure.
+func TestHuggingFace_RateLimitIsRetriedThenReported(t *testing.T) {
+	client, requested := responderFor(http.StatusTooManyRequests, "rate limited", nil)
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	_, err := hf.ListModels(ListOption{Search: "qwen"})
+	assert.ErrorIs(t, err, ErrRateLimited)
+	assert.Len(t, *requested, hubRetryAttempts, "the request is retried before giving up")
+}
+
+func TestHuggingFace_RateLimitRecoversOnRetry(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			attempts++
+
+			if attempts == 1 {
+				return &http.Response{
+					StatusCode: http.StatusTooManyRequests,
+					Body:       io.NopCloser(bytes.NewBufferString("slow down")),
+					Header:     make(http.Header),
+				}, nil
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString("[]")),
+				Header:     make(http.Header),
+			}, nil
+		},
+	}}
+
+	hf := &huggingFace{url: "https://huggingface.co", client: client}
+
+	page, err := hf.ListModels(ListOption{Search: "qwen"})
+	assert.NoError(t, err)
+	assert.Empty(t, page.Models)
+	assert.Equal(t, 2, attempts)
+}
+
+// The hub's own Retry-After wins over our backoff, capped: it is telling us what
+// it wants, and the cap is because this is happening inside a request somebody
+// is waiting on.
+func TestHuggingFaceRetryDelay(t *testing.T) {
+	withRetryAfter := func(value string) *http.Response {
+		header := make(http.Header)
+		if value != "" {
+			header.Set("Retry-After", value)
+		}
+
+		return &http.Response{Header: header}
+	}
+
+	assert.Equal(t, time.Second, retryDelay(withRetryAfter("1"), 0))
+	assert.Equal(t, hubRetryMaxDelay, retryDelay(withRetryAfter("60"), 0), "a long Retry-After is capped")
+	assert.Equal(t, hubRetryBaseDelay, retryDelay(withRetryAfter(""), 0))
+	assert.Equal(t, 2*hubRetryBaseDelay, retryDelay(withRetryAfter(""), 1), "backoff doubles")
+	assert.Equal(t, hubRetryMaxDelay, retryDelay(withRetryAfter("not a number"), 9))
 }

--- a/internal/model_registry/mocks/mock_model_registry.go
+++ b/internal/model_registry/mocks/mock_model_registry.go
@@ -496,6 +496,65 @@ func (_c *MockModelRegistry_GetNFSVersion_Call) RunAndReturn(run func() (string,
 	return _c
 }
 
+// GetReadme provides a mock function with given fields: name, version
+func (_m *MockModelRegistry) GetReadme(name string, version string) (*model_registry.Readme, error) {
+	ret := _m.Called(name, version)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetReadme")
+	}
+
+	var r0 *model_registry.Readme
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) (*model_registry.Readme, error)); ok {
+		return rf(name, version)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) *model_registry.Readme); ok {
+		r0 = rf(name, version)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model_registry.Readme)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(name, version)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockModelRegistry_GetReadme_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetReadme'
+type MockModelRegistry_GetReadme_Call struct {
+	*mock.Call
+}
+
+// GetReadme is a helper method to define mock.On call
+//   - name string
+//   - version string
+func (_e *MockModelRegistry_Expecter) GetReadme(name interface{}, version interface{}) *MockModelRegistry_GetReadme_Call {
+	return &MockModelRegistry_GetReadme_Call{Call: _e.mock.On("GetReadme", name, version)}
+}
+
+func (_c *MockModelRegistry_GetReadme_Call) Run(run func(name string, version string)) *MockModelRegistry_GetReadme_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockModelRegistry_GetReadme_Call) Return(_a0 *model_registry.Readme, _a1 error) *MockModelRegistry_GetReadme_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockModelRegistry_GetReadme_Call) RunAndReturn(run func(string, string) (*model_registry.Readme, error)) *MockModelRegistry_GetReadme_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // HealthyCheck provides a mock function with no fields
 func (_m *MockModelRegistry) HealthyCheck() error {
 	ret := _m.Called()

--- a/internal/model_registry/model_registry.go
+++ b/internal/model_registry/model_registry.go
@@ -45,6 +45,22 @@ func KnownTotal(total int) *int {
 	return &total
 }
 
+// MaxReadmeBytes caps how much of a model's README is read. A README is content
+// from outside this system, so the limit is applied while reading rather than to
+// the response: the failure mode to avoid is an unbounded read.
+const MaxReadmeBytes = 1 << 20
+
+// Readme is a model's README exactly as stored. It is markdown and must stay
+// markdown — rendering it to HTML server-side would make every client that
+// displays it an injection target.
+type Readme struct {
+	// Content is the markdown, truncated to MaxReadmeBytes.
+	Content string
+	// Truncated says the file was longer than MaxReadmeBytes, so a reader can say
+	// so rather than presenting a cut document as complete.
+	Truncated bool
+}
+
 // RegistryUsage is a raw observation of what a registry's backing storage holds.
 // It is what the registry can see; turning it into a status is the aggregator's
 // job.
@@ -71,6 +87,11 @@ type ModelRegistry interface {
 	// the checkpoint. GetModelVersion stays the cheap call for code that only
 	// needs to resolve a version or read its recorded metadata.
 	GetModelDetail(name, version string) (*v1.ModelVersion, error)
+	// GetReadme returns the model's README.md verbatim, capped at MaxReadmeBytes.
+	// It wraps ErrNotFound when the model has no README and ErrNotSupported when
+	// the registry cannot serve one; callers distinguish the two, so they must not
+	// be collapsed.
+	GetReadme(name, version string) (*Readme, error)
 	DeleteModel(name, version string) error
 	ImportModel(reader io.Reader, name, version string, progress io.Writer) error
 	ExportModel(name, version, outputPath string) error

--- a/internal/model_registry/modelmeta/modelmeta.go
+++ b/internal/model_registry/modelmeta/modelmeta.go
@@ -39,6 +39,10 @@ var allFields = []string{
 	v1.ModelInfoFieldParameterCount,
 }
 
+// configFields is everything config.json alone can establish: all of the above
+// except the parameter count, which is only in the weight files.
+var configFields = allFields[:len(allFields)-1]
+
 // hfConfig is the subset of config.json this package reads. Every scalar is a
 // pointer so that a key present with value 0 is distinguishable from an absent
 // key — the difference between "the checkpoint says zero" and "we don't know".
@@ -88,24 +92,57 @@ func (q *quantizationConfig) bits() *int {
 // MissingFields names everything, because that file is what the rest of the
 // parse is anchored on.
 func Parse(dir string) *v1.ModelInfo {
-	info := &v1.ModelInfo{}
+	raw, err := os.ReadFile(filepath.Join(dir, ConfigFileName))
+	if err != nil {
+		raw = nil
+	}
 
-	cfg := readConfig(dir)
-	if cfg == nil {
-		info.MissingFields = append(info.MissingFields, allFields...)
+	info := ParseConfig(raw)
+
+	if decodeConfig(raw) == nil {
+		// Nothing is anchored, so the count is not read either. Appended here
+		// rather than inside ParseConfig so that the missing-field list stays in
+		// the declared order.
+		info.MarkFieldMissing(v1.ModelInfoFieldParameterCount)
 
 		return info
 	}
 
-	applyConfig(info, cfg)
 	applyParameterCount(info, dir)
 
 	return info
 }
 
-func readConfig(dir string) *hfConfig {
-	raw, err := os.ReadFile(filepath.Join(dir, ConfigFileName))
-	if err != nil {
+// ParseConfig reports what a config.json states about a checkpoint, without
+// touching the weight files.
+//
+// It exists because a public hub serves that one file over HTTP while the
+// weights stay where they are: the shape of a model — layers, heads, KV heads,
+// head_dim, experts, quantization — is readable without downloading a
+// checkpoint, and it is the same file with the same meaning either way, so it is
+// read by the same code. The parameter count is deliberately not its business:
+// that lives in the weight files, and a caller that has none has to say so
+// itself.
+//
+// Like Parse, it never fails and never guesses. Absent or malformed input yields
+// an empty ModelInfo naming every field it could not establish.
+func ParseConfig(raw []byte) *v1.ModelInfo {
+	info := &v1.ModelInfo{}
+
+	cfg := decodeConfig(raw)
+	if cfg == nil {
+		info.MissingFields = append(info.MissingFields, configFields...)
+
+		return info
+	}
+
+	applyConfig(info, cfg)
+
+	return info
+}
+
+func decodeConfig(raw []byte) *hfConfig {
+	if len(raw) == 0 {
 		return nil
 	}
 

--- a/internal/model_registry/query_cache.go
+++ b/internal/model_registry/query_cache.go
@@ -1,0 +1,269 @@
+package model_registry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/util"
+)
+
+const (
+	// DefaultQueryCacheTTL is how long a public registry's answer to a query is
+	// reused, so that browsing a hub costs one round of queries rather than one
+	// per interaction. Retry-connection invalidation, not this window, is what
+	// bounds staleness after a user fixes something.
+	DefaultQueryCacheTTL = 5 * time.Minute
+	// DefaultQueryCacheMaxEntries bounds the cache. The search term is user input,
+	// so the key space is unbounded and cannot be left to expiry alone.
+	DefaultQueryCacheMaxEntries = 512
+)
+
+// QueryCache holds recent listing results for public registries. Private
+// registries are never cached: they are local filesystems, and a model pushed a
+// moment ago has to appear at once.
+//
+// The cache is per process, so with several API replicas an invalidation only
+// reaches the replica that served the request; the rest correct themselves
+// within the TTL.
+//
+// A nil *QueryCache is usable and caches nothing.
+type QueryCache struct {
+	ttl        time.Duration
+	maxEntries int
+	// now overrides the clock in tests.
+	now func() time.Time
+
+	mu      sync.Mutex
+	entries map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	// scope is the key prefix the entry belongs to, kept so an invalidation can
+	// find every entry of one registry without parsing keys back apart.
+	scope     string
+	page      *ModelPage
+	fetchedAt time.Time
+	expiresAt time.Time
+}
+
+// QueryMeta says when an answer was read from the registry and whether it was
+// reused. A cached listing describes the hub as of FetchedAt, not as of the
+// request, and a caller cannot work that out for itself.
+type QueryMeta struct {
+	// FetchedAt is when this data was actually read from the registry.
+	FetchedAt time.Time
+	// Cached says the answer was reused rather than fetched for this request.
+	Cached bool
+}
+
+// NewQueryCache builds a cache. A ttl of zero or less means
+// DefaultQueryCacheTTL.
+func NewQueryCache(ttl time.Duration) *QueryCache {
+	if ttl <= 0 {
+		ttl = DefaultQueryCacheTTL
+	}
+
+	return &QueryCache{
+		ttl:        ttl,
+		maxEntries: DefaultQueryCacheMaxEntries,
+		entries:    map[string]cacheEntry{},
+	}
+}
+
+func (c *QueryCache) clock() time.Time {
+	if c == nil || c.now == nil {
+		return time.Now()
+	}
+
+	return c.now()
+}
+
+// ListModels answers from the cache when it can, and otherwise asks the registry
+// and records the answer. Errors are never cached, so a hub that refuses one
+// request is asked again on the next.
+func (c *QueryCache) ListModels(registry *v1.ModelRegistry, client ModelRegistry,
+	option ListOption) (*ModelPage, QueryMeta, error) {
+	if !c.cacheable(registry) {
+		page, err := client.ListModels(option)
+		if err != nil {
+			return nil, QueryMeta{}, err
+		}
+
+		return page, QueryMeta{FetchedAt: c.clock()}, nil
+	}
+
+	scope := registryScope(registry)
+	key := scope + "|" + queryKey(option)
+
+	if page, fetchedAt, ok := c.get(key); ok {
+		return page, QueryMeta{FetchedAt: fetchedAt, Cached: true}, nil
+	}
+
+	page, err := client.ListModels(option)
+	if err != nil {
+		return nil, QueryMeta{}, err
+	}
+
+	fetchedAt := c.clock()
+	c.put(scope, key, page, fetchedAt)
+
+	return page, QueryMeta{FetchedAt: fetchedAt}, nil
+}
+
+// Invalidate drops everything cached for one registry. Retry-connection calls it
+// so that a refreshed status is not shown next to results fetched before the fix.
+func (c *QueryCache) Invalidate(registry *v1.ModelRegistry) {
+	if c == nil || registry == nil {
+		return
+	}
+
+	scope := registryScope(registry)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for key, entry := range c.entries {
+		if entry.scope == scope {
+			delete(c.entries, key)
+		}
+	}
+}
+
+// cacheable reports whether this registry's listings may be reused.
+func (c *QueryCache) cacheable(registry *v1.ModelRegistry) bool {
+	if c == nil || registry == nil || registry.Spec == nil {
+		return false
+	}
+
+	return v1.VisibilityForModelRegistryType(registry.Spec.Type) == v1.ModelRegistryVisibilityPublic
+}
+
+func (c *QueryCache) get(key string) (*ModelPage, time.Time, bool) {
+	c.mu.Lock()
+	entry, ok := c.entries[key]
+
+	if ok && !c.clock().Before(entry.expiresAt) {
+		delete(c.entries, key)
+
+		ok = false
+	}
+	c.mu.Unlock()
+
+	if !ok {
+		return nil, time.Time{}, false
+	}
+
+	// A copy, because the list handler decorates what it gets with aliases; a
+	// shared page would carry one request's decorations into the next.
+	page, err := util.DeepCopyObject(entry.page)
+	if err != nil {
+		return nil, time.Time{}, false
+	}
+
+	return page, entry.fetchedAt, true
+}
+
+func (c *QueryCache) put(scope, key string, page *ModelPage, fetchedAt time.Time) {
+	stored, err := util.DeepCopyObject(page)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.entries) >= c.maxEntries {
+		c.evictLocked()
+	}
+
+	c.entries[key] = cacheEntry{
+		scope:     scope,
+		page:      stored,
+		fetchedAt: fetchedAt,
+		expiresAt: fetchedAt.Add(c.ttl),
+	}
+}
+
+// evictLocked makes room: expired entries first, otherwise the one closest to
+// expiring. Entries are few and short-lived, so an exact LRU would buy nothing.
+func (c *QueryCache) evictLocked() {
+	now := c.clock()
+	evicted := false
+
+	for key, entry := range c.entries {
+		if !now.Before(entry.expiresAt) {
+			delete(c.entries, key)
+
+			evicted = true
+		}
+	}
+
+	if evicted {
+		return
+	}
+
+	var (
+		oldestKey string
+		oldest    time.Time
+	)
+
+	for key, entry := range c.entries {
+		if oldestKey == "" || entry.expiresAt.Before(oldest) {
+			oldestKey, oldest = key, entry.expiresAt
+		}
+	}
+
+	delete(c.entries, oldestKey)
+}
+
+// registryScope identifies whose results these are. The credential is part of
+// the key because a hub shows a different catalogue to different callers — gated
+// repositories appear only for a token that may see them — so an answer fetched
+// with one credential must never be served under another. The URL is in the key
+// so that repointing a registry at another mirror starts from an empty cache.
+//
+// The credential is reduced to a digest; the value itself is not needed here.
+//
+// This depends on ModelRegistrySpec.Credentials still being populated on a
+// storage read. The api:"-" tag on it is applied by the client-facing resource
+// proxy, not by storage. If that ever changes, every scope fingerprints as
+// "anonymous" and callers start seeing each other's results, with this function
+// unchanged.
+func registryScope(registry *v1.ModelRegistry) string {
+	var (
+		workspace string
+		name      string
+		url       string
+		token     string
+	)
+
+	if registry.Metadata != nil {
+		workspace = registry.Metadata.Workspace
+		name = registry.Metadata.Name
+	}
+
+	if registry.Spec != nil {
+		url = registry.Spec.Url
+		token = registry.Spec.Credentials
+	}
+
+	return fmt.Sprintf("%s/%s/%d/%s/%s", workspace, name, registry.ID, url, credentialFingerprint(token))
+}
+
+func credentialFingerprint(credentials string) string {
+	if credentials == "" {
+		return "anonymous"
+	}
+
+	sum := sha256.Sum256([]byte(credentials))
+
+	return hex.EncodeToString(sum[:8])
+}
+
+func queryKey(option ListOption) string {
+	return fmt.Sprintf("search=%s&offset=%d&limit=%d", option.Search, option.Offset, option.Limit)
+}

--- a/internal/model_registry/query_cache_test.go
+++ b/internal/model_registry/query_cache_test.go
@@ -1,0 +1,297 @@
+package model_registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// countingRegistry answers listings from a fixed page and records how many times
+// it was asked. The count is the whole point of these tests: "the cache works"
+// is only observable as "the registry was not asked again".
+type countingRegistry struct {
+	ModelRegistry
+
+	calls int
+	page  *ModelPage
+	err   error
+}
+
+func (r *countingRegistry) ListModels(ListOption) (*ModelPage, error) {
+	r.calls++
+
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return r.page, nil
+}
+
+func publicRegistry() *v1.ModelRegistry {
+	return &v1.ModelRegistry{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "public-hugging-face", Workspace: "default"},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.HuggingFaceModelRegistryType,
+			Url:  "https://huggingface.co",
+		},
+	}
+}
+
+func onePage(names ...string) *ModelPage {
+	models := make([]v1.GeneralModel, 0, len(names))
+	for _, name := range names {
+		models = append(models, v1.GeneralModel{
+			Name:     name,
+			Versions: []v1.ModelVersion{{Name: v1.LatestVersion}},
+		})
+	}
+
+	return &ModelPage{Models: models}
+}
+
+func TestQueryCache_ReusesAnswersForOnePublicRegistry(t *testing.T) {
+	cache := NewQueryCache(0)
+	client := &countingRegistry{page: onePage("qwen/qwen3")}
+	registry := publicRegistry()
+
+	first, _, err := cache.ListModels(registry, client, ListOption{Search: "qwen", Limit: 2})
+	require.NoError(t, err)
+
+	second, _, err := cache.ListModels(registry, client, ListOption{Search: "qwen", Limit: 2})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, client.calls, "the second identical query must not reach the hub")
+	assert.Equal(t, first.Models, second.Models)
+
+	// Paging is the case this exists for, and a different page is a different
+	// question: it has to be asked.
+	_, _, err = cache.ListModels(registry, client, ListOption{Search: "qwen", Limit: 2, Offset: 2})
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.calls)
+}
+
+func TestQueryCache_KeepsCallersApart(t *testing.T) {
+	// A hub shows a different catalogue to different callers, so an answer
+	// fetched under one identity must never be served under another.
+	tests := []struct {
+		name   string
+		mutate func(*v1.ModelRegistry)
+	}{
+		{
+			name:   "different workspace",
+			mutate: func(r *v1.ModelRegistry) { r.Metadata.Workspace = "other"; r.ID = 8 },
+		},
+		{
+			name:   "different credentials",
+			mutate: func(r *v1.ModelRegistry) { r.Spec.Credentials = "hf_token" },
+		},
+		{
+			name:   "repointed at a mirror",
+			mutate: func(r *v1.ModelRegistry) { r.Spec.Url = "https://hf-mirror.example" },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := NewQueryCache(0)
+			client := &countingRegistry{page: onePage("qwen/qwen3")}
+
+			_, _, err := cache.ListModels(publicRegistry(), client, ListOption{Search: "qwen"})
+			require.NoError(t, err)
+
+			other := publicRegistry()
+			tt.mutate(other)
+
+			_, _, err = cache.ListModels(other, client, ListOption{Search: "qwen"})
+			require.NoError(t, err)
+
+			assert.Equal(t, 2, client.calls, "the second caller must not be served the first one's results")
+		})
+	}
+}
+
+func TestQueryCache_InvalidateDropsOnlyThatRegistry(t *testing.T) {
+	cache := NewQueryCache(0)
+	client := &countingRegistry{page: onePage("qwen/qwen3")}
+
+	registry := publicRegistry()
+
+	untouched := publicRegistry()
+	untouched.ID = 9
+	untouched.Metadata.Name = "another-hub"
+
+	_, _, err := cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+	_, _, err = cache.ListModels(untouched, client, ListOption{})
+	require.NoError(t, err)
+	require.Equal(t, 2, client.calls)
+
+	cache.Invalidate(registry)
+
+	_, _, err = cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+	assert.Equal(t, 3, client.calls, "the invalidated registry must be queried again")
+
+	_, _, err = cache.ListModels(untouched, client, ListOption{})
+	require.NoError(t, err)
+	assert.Equal(t, 3, client.calls, "a retry on one registry must not clear another's results")
+}
+
+func TestQueryCache_EntriesExpire(t *testing.T) {
+	cache := NewQueryCache(0)
+	client := &countingRegistry{page: onePage("qwen/qwen3")}
+	registry := publicRegistry()
+
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	cache.now = func() time.Time { return now }
+
+	_, _, err := cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+
+	now = now.Add(DefaultQueryCacheTTL - time.Second)
+
+	_, _, err = cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.calls)
+
+	now = now.Add(2 * time.Second)
+
+	_, _, err = cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.calls, "an expired entry must not be served")
+}
+
+func TestQueryCache_PrivateRegistriesAreNotCached(t *testing.T) {
+	// A private registry is a local tree: listing it is cheap, and a model pushed
+	// a second ago has to appear immediately.
+	cache := NewQueryCache(0)
+	client := &countingRegistry{page: onePage("local-model")}
+
+	registry := publicRegistry()
+	registry.Spec.Type = v1.BentoMLModelRegistryType
+
+	for i := 0; i < 3; i++ {
+		_, _, err := cache.ListModels(registry, client, ListOption{})
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 3, client.calls)
+}
+
+func TestQueryCache_FailuresAreNotCached(t *testing.T) {
+	// A hub that refused this request may well answer the next one; a cached
+	// refusal would outlive whatever caused it.
+	cache := NewQueryCache(0)
+	client := &countingRegistry{err: errors.New("502 bad gateway")}
+	registry := publicRegistry()
+
+	for i := 0; i < 2; i++ {
+		_, _, err := cache.ListModels(registry, client, ListOption{})
+		require.Error(t, err)
+	}
+
+	assert.Equal(t, 2, client.calls)
+}
+
+func TestQueryCache_ServedResultsAreIndependentCopies(t *testing.T) {
+	// The list handler decorates what it gets back with aliases. If that landed on
+	// the cached copy, one request's decorations would show up in the next one.
+	cache := NewQueryCache(0)
+	client := &countingRegistry{page: onePage("qwen/qwen3")}
+	registry := publicRegistry()
+
+	first, _, err := cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+	first.Models[0].Versions[0].Alias = "scribbled on"
+
+	second, _, err := cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+
+	assert.Empty(t, second.Models[0].Versions[0].Alias)
+}
+
+func TestQueryCache_NilCacheStillLists(t *testing.T) {
+	// Dependencies without a cache configured must not need a special case at
+	// every call site.
+	var cache *QueryCache
+
+	client := &countingRegistry{page: onePage("qwen/qwen3")}
+
+	page, _, err := cache.ListModels(publicRegistry(), client, ListOption{})
+	require.NoError(t, err)
+	assert.Len(t, page.Models, 1)
+
+	// Nothing was stored, so a second call reaches the registry again, and
+	// invalidating a cache that does not exist is a no-op rather than a panic.
+	cache.Invalidate(publicRegistry())
+
+	_, _, err = cache.ListModels(publicRegistry(), client, ListOption{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.calls)
+}
+
+func TestQueryCache_StaysBounded(t *testing.T) {
+	// The search term is user input, so the number of distinct keys is unbounded.
+	cache := NewQueryCache(0)
+	client := &countingRegistry{page: onePage("qwen/qwen3")}
+	registry := publicRegistry()
+
+	for i := 0; i < DefaultQueryCacheMaxEntries*2; i++ {
+		_, _, err := cache.ListModels(registry, client, ListOption{Search: string(rune('a' + i%26)), Offset: i})
+		require.NoError(t, err)
+	}
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	assert.LessOrEqual(t, len(cache.entries), DefaultQueryCacheMaxEntries)
+}
+
+// A cached answer describes the hub as of the moment it was fetched. Serving it
+// without saying so leaves a caller unable to tell a catalogue that has not
+// changed from a copy several minutes old.
+func TestQueryCache_ReportsWhenTheDataWasFetched(t *testing.T) {
+	cache := NewQueryCache(0)
+	client := &countingRegistry{page: onePage("qwen/qwen3")}
+	registry := publicRegistry()
+
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	cache.now = func() time.Time { return now }
+
+	_, meta, err := cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+	assert.Equal(t, now, meta.FetchedAt)
+	assert.False(t, meta.Cached)
+
+	now = now.Add(2 * time.Minute)
+
+	_, meta, err = cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+	assert.True(t, meta.Cached)
+	// The age of the data, not the age of the request.
+	assert.Equal(t, now.Add(-2*time.Minute), meta.FetchedAt)
+}
+
+func TestQueryCache_TTLIsConfigurable(t *testing.T) {
+	cache := NewQueryCache(30 * time.Second)
+	client := &countingRegistry{page: onePage("qwen/qwen3")}
+	registry := publicRegistry()
+
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	cache.now = func() time.Time { return now }
+
+	_, _, err := cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+
+	now = now.Add(45 * time.Second)
+
+	_, _, err = cache.ListModels(registry, client, ListOption{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.calls, "an entry past the configured TTL must not be served")
+}

--- a/internal/model_registry/status.go
+++ b/internal/model_registry/status.go
@@ -1,0 +1,85 @@
+package model_registry
+
+import (
+	"time"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// DefaultCheckedAtWriteInterval is how far LastCheckedAt may trail the real
+// check before an otherwise unchanged status is written back. A reachability
+// check runs on every reconcile, so without a throttle an idle deployment writes
+// its status continuously to say nothing new; with one, the displayed check time
+// is stale by up to an interval.
+const DefaultCheckedAtWriteInterval = time.Minute
+
+// NextStatus builds the status to persist after a reachability check. The
+// reconcile loop and the retry endpoint both go through it so that they cannot
+// disagree:
+//
+//   - LastTransitionTime moves only when the phase does, so a re-check that
+//     confirms what was already true does not reset it.
+//   - LastCheckedAt moves every time.
+//   - Stats are carried forward. PostgREST replaces a composite-type column as a
+//     whole, so any attribute missing from the PATCH body is nulled. Every
+//     attribute added to ModelRegistryStatus has to be carried here too.
+func NextStatus(previous *v1.ModelRegistryStatus, phase v1.ModelRegistryPhase,
+	errMessage string, now time.Time) *v1.ModelRegistryStatus {
+	next := &v1.ModelRegistryStatus{
+		Phase:              phase,
+		ErrorMessage:       errMessage,
+		LastCheckedAt:      now.Format(time.RFC3339Nano),
+		LastTransitionTime: now.Format(time.RFC3339Nano),
+	}
+
+	if previous == nil {
+		return next
+	}
+
+	next.Stats = previous.Stats
+
+	if previous.Phase == phase && previous.LastTransitionTime != "" {
+		next.LastTransitionTime = previous.LastTransitionTime
+	}
+
+	return next
+}
+
+// NeedsStatusWrite reports whether the outcome of a check is worth persisting:
+// the phase changed, the error text changed, statistics were collected, or the
+// recorded check time has fallen behind by more than checkInterval.
+//
+// The error comparison is on the text, not on whether there is one, so that a
+// registry that keeps failing for a new reason stops displaying the old one.
+func NeedsStatusWrite(previous *v1.ModelRegistryStatus, phase v1.ModelRegistryPhase,
+	errMessage string, statsRefreshed bool, now time.Time, checkInterval time.Duration) bool {
+	if statsRefreshed || previous == nil {
+		return true
+	}
+
+	if previous.Phase != phase || previous.ErrorMessage != errMessage {
+		return true
+	}
+
+	return checkedAtIsStale(previous.LastCheckedAt, now, checkInterval)
+}
+
+// checkedAtIsStale reports whether a recorded check time is old enough to be
+// worth rewriting. A missing or unparseable one always is, so a status written
+// before this field existed starts moving again.
+func checkedAtIsStale(lastCheckedAt string, now time.Time, checkInterval time.Duration) bool {
+	if lastCheckedAt == "" {
+		return true
+	}
+
+	checkedAt, err := time.Parse(time.RFC3339Nano, lastCheckedAt)
+	if err != nil {
+		return true
+	}
+
+	if checkInterval <= 0 {
+		checkInterval = DefaultCheckedAtWriteInterval
+	}
+
+	return now.Sub(checkedAt) >= checkInterval
+}

--- a/internal/model_registry/status_test.go
+++ b/internal/model_registry/status_test.go
@@ -1,0 +1,191 @@
+package model_registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+func TestNextStatus(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	earlier := now.Add(-72 * time.Hour).Format(time.RFC3339Nano)
+
+	tests := []struct {
+		name               string
+		previous           *v1.ModelRegistryStatus
+		phase              v1.ModelRegistryPhase
+		errMessage         string
+		wantTransitionTime string
+		wantStats          *v1.ModelRegistryStats
+	}{
+		{
+			// The acceptance case: a registry that has been up for days reports the
+			// moment it came up, not the moment it was last looked at.
+			name: "unchanged phase keeps the transition time",
+			previous: &v1.ModelRegistryStatus{
+				Phase:              v1.ModelRegistryPhaseCONNECTED,
+				LastTransitionTime: earlier,
+			},
+			phase:              v1.ModelRegistryPhaseCONNECTED,
+			wantTransitionTime: earlier,
+		},
+		{
+			name: "a real transition moves the transition time",
+			previous: &v1.ModelRegistryStatus{
+				Phase:              v1.ModelRegistryPhaseCONNECTED,
+				LastTransitionTime: earlier,
+			},
+			phase:              v1.ModelRegistryPhaseFAILED,
+			errMessage:         "dial tcp: connection refused",
+			wantTransitionTime: now.Format(time.RFC3339Nano),
+		},
+		{
+			// Same phase, different reason. The reason has to be replaced; the
+			// transition has not happened.
+			name: "a changed reason is not a transition",
+			previous: &v1.ModelRegistryStatus{
+				Phase:              v1.ModelRegistryPhaseFAILED,
+				LastTransitionTime: earlier,
+				ErrorMessage:       "invalid token",
+			},
+			phase:              v1.ModelRegistryPhaseFAILED,
+			errMessage:         "dial tcp: connection refused",
+			wantTransitionTime: earlier,
+		},
+		{
+			name:               "no previous status",
+			phase:              v1.ModelRegistryPhaseCONNECTED,
+			wantTransitionTime: now.Format(time.RFC3339Nano),
+		},
+		{
+			// PostgREST replaces the whole composite, so anything not carried
+			// forward here is erased on the next write.
+			name: "statistics are carried forward",
+			previous: &v1.ModelRegistryStatus{
+				Phase:              v1.ModelRegistryPhaseCONNECTED,
+				LastTransitionTime: earlier,
+				Stats:              &v1.ModelRegistryStats{ModelCount: 5, StorageBytes: 1024},
+			},
+			phase:              v1.ModelRegistryPhaseFAILED,
+			errMessage:         "gone",
+			wantTransitionTime: now.Format(time.RFC3339Nano),
+			wantStats:          &v1.ModelRegistryStats{ModelCount: 5, StorageBytes: 1024},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NextStatus(tt.previous, tt.phase, tt.errMessage, now)
+
+			assert.Equal(t, tt.phase, got.Phase)
+			assert.Equal(t, tt.errMessage, got.ErrorMessage)
+			assert.Equal(t, tt.wantTransitionTime, got.LastTransitionTime)
+			assert.Equal(t, tt.wantStats, got.Stats)
+			// Whatever else happened, the check itself was just made.
+			assert.Equal(t, now.Format(time.RFC3339Nano), got.LastCheckedAt)
+		})
+	}
+}
+
+func TestNeedsStatusWrite(t *testing.T) {
+	now := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	interval := time.Minute
+
+	connected := func(checkedAgo time.Duration, errMessage string) *v1.ModelRegistryStatus {
+		phase := v1.ModelRegistryPhaseCONNECTED
+		if errMessage != "" {
+			phase = v1.ModelRegistryPhaseFAILED
+		}
+
+		return &v1.ModelRegistryStatus{
+			Phase:         phase,
+			ErrorMessage:  errMessage,
+			LastCheckedAt: now.Add(-checkedAgo).Format(time.RFC3339Nano),
+		}
+	}
+
+	tests := []struct {
+		name           string
+		previous       *v1.ModelRegistryStatus
+		phase          v1.ModelRegistryPhase
+		errMessage     string
+		statsRefreshed bool
+		want           bool
+	}{
+		{
+			// The reconcile runs every ten seconds. Writing each one back would be
+			// a stream of updates that say nothing.
+			name:     "nothing changed and the check time is fresh",
+			previous: connected(5*time.Second, ""),
+			phase:    v1.ModelRegistryPhaseCONNECTED,
+			want:     false,
+		},
+		{
+			name:     "nothing changed but the check time has gone stale",
+			previous: connected(2*time.Minute, ""),
+			phase:    v1.ModelRegistryPhaseCONNECTED,
+			want:     true,
+		},
+		{
+			name:     "the phase changed",
+			previous: connected(5*time.Second, ""),
+			phase:    v1.ModelRegistryPhaseFAILED,
+			want:     true,
+		},
+		{
+			// Both are non-empty, so a check for "is there an error" would say
+			// nothing changed and leave a reason on display that no longer applies.
+			name:       "still failing, for a different reason",
+			previous:   connected(5*time.Second, "invalid token"),
+			phase:      v1.ModelRegistryPhaseFAILED,
+			errMessage: "dial tcp: connection refused",
+			want:       true,
+		},
+		{
+			name:       "still failing for the same reason",
+			previous:   connected(5*time.Second, "invalid token"),
+			phase:      v1.ModelRegistryPhaseFAILED,
+			errMessage: "invalid token",
+			want:       false,
+		},
+		{
+			name:           "fresh statistics must be recorded",
+			previous:       connected(5*time.Second, ""),
+			phase:          v1.ModelRegistryPhaseCONNECTED,
+			statsRefreshed: true,
+			want:           true,
+		},
+		{
+			name:  "no status at all",
+			phase: v1.ModelRegistryPhaseCONNECTED,
+			want:  true,
+		},
+		{
+			// A row written before this field existed, or one whose timestamp is
+			// unreadable, has to start moving again.
+			name:     "check time missing",
+			previous: &v1.ModelRegistryStatus{Phase: v1.ModelRegistryPhaseCONNECTED},
+			phase:    v1.ModelRegistryPhaseCONNECTED,
+			want:     true,
+		},
+		{
+			name: "check time unparseable",
+			previous: &v1.ModelRegistryStatus{
+				Phase:         v1.ModelRegistryPhaseCONNECTED,
+				LastCheckedAt: "not a timestamp",
+			},
+			phase: v1.ModelRegistryPhaseCONNECTED,
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NeedsStatusWrite(tt.previous, tt.phase, tt.errMessage, tt.statsRefreshed, now, interval)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/routes/models/errors.go
+++ b/internal/routes/models/errors.go
@@ -1,0 +1,89 @@
+package models
+
+import (
+	stderrors "errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+// Why a registry could not answer. Clients branch on these, so the distinctions
+// matter: fix the registry's credentials, wait, or look elsewhere.
+const (
+	// reasonNotFound — the registry answered and the thing is not there.
+	reasonNotFound = "not_found"
+	// reasonNotSupported — this kind of registry cannot do this at all.
+	reasonNotSupported = "not_supported"
+	// reasonUnauthorized — the registry refused our credentials. Someone has to
+	// give it a token, or a better one; retrying will not help.
+	reasonUnauthorized = "registry_unauthorized"
+	// reasonRateLimited — the registry is throttling us. Nothing is wrong; the
+	// answer is to come back later.
+	reasonRateLimited = "rate_limited"
+	// reasonUnavailable — the registry could not be reached or failed in a way we
+	// cannot classify. Worth retrying.
+	reasonUnavailable = "unavailable"
+)
+
+// refuseReadOnlyRegistry answers a write aimed at a registry that has no write
+// operations. It goes through respondRegistryError so that a refusal looks the
+// same whichever verb produced it.
+func refuseReadOnlyRegistry(c *gin.Context, context string) {
+	respondRegistryError(c, context,
+		errors.Wrap(model_registry.ErrNotSupported,
+			"this model registry is read-only"))
+}
+
+// registryAcceptsWrites reports whether a write is worth attempting. Public
+// registries are read-only, and knowing that from the stored row rather than
+// from the failed operation is what lets uploadModel refuse before reading a
+// request body. The per-operation ErrNotSupported remains the backstop.
+func registryAcceptsWrites(registry *v1.ModelRegistry) bool {
+	if registry == nil || registry.Spec == nil {
+		return true
+	}
+
+	return v1.VisibilityForModelRegistryType(registry.Spec.Type) != v1.ModelRegistryVisibilityPublic
+}
+
+// respondRegistryError answers a request that failed inside a registry and
+// reports whether it did; unrecognised errors are left to the caller.
+//
+// Status codes follow what the user can do about it: 400 when the registry as
+// configured cannot serve the request (wrong kind, or rejected credentials),
+// 404 when the thing is not there, and 429 passed through as itself.
+func respondRegistryError(c *gin.Context, context string, err error) bool {
+	switch {
+	case stderrors.Is(err, model_registry.ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{
+			"message": fmt.Sprintf("%s: not found", context),
+			"reason":  reasonNotFound,
+		})
+	case stderrors.Is(err, model_registry.ErrNotSupported):
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": fmt.Sprintf("%s: this model registry cannot do that: %v", context, err),
+			"reason":  reasonNotSupported,
+		})
+	case stderrors.Is(err, model_registry.ErrUnauthorized):
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": fmt.Sprintf("%s: %v", context, err),
+			"reason":  reasonUnauthorized,
+		})
+	case stderrors.Is(err, model_registry.ErrRateLimited):
+		klog.Warningf("%s: %v", context, err)
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			"message": fmt.Sprintf("%s: %v", context, err),
+			"reason":  reasonRateLimited,
+		})
+	default:
+		return false
+	}
+
+	return true
+}

--- a/internal/routes/models/list_cache_test.go
+++ b/internal/routes/models/list_cache_test.go
@@ -1,0 +1,104 @@
+package models
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+func registryRow(registryType v1.ModelRegistryType) []v1.ModelRegistry {
+	return []v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: registryType, Url: "https://huggingface.co"},
+	}}
+}
+
+// Paging through a public hub's results should not re-query it for every page
+// the user steps back and forth over.
+func TestListModels_PublicRegistryAnswersFromCache(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return(registryRow(v1.HuggingFaceModelRegistryType), nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("ListModels", mock.Anything).Return(&model_registry.ModelPage{
+		Models: []v1.GeneralModel{storedModel("qwen/qwen3", v1.LatestVersion)},
+	}, nil)
+
+	deps := &Dependencies{Storage: mockStorage, QueryCache: model_registry.NewQueryCache(0)}
+
+	for i := 0; i < 3; i++ {
+		c, w := newListContext(t, "search=qwen&limit=2")
+		listModels(deps)(c)
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	}
+
+	mockRegistry.AssertNumberOfCalls(t, "ListModels", 1)
+}
+
+// A private registry is a local tree: cheap to list, and a model pushed a second
+// ago has to appear immediately.
+func TestListModels_PrivateRegistryIsReadEveryTime(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return(registryRow(v1.BentoMLModelRegistryType), nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("ListModels", mock.Anything).Return(&model_registry.ModelPage{
+		Models: []v1.GeneralModel{storedModel("local", "v1")},
+	}, nil)
+
+	deps := &Dependencies{Storage: mockStorage, QueryCache: model_registry.NewQueryCache(0)}
+
+	for i := 0; i < 3; i++ {
+		c, w := newListContext(t, "")
+		listModels(deps)(c)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	mockRegistry.AssertNumberOfCalls(t, "ListModels", 3)
+}
+
+// The listing decorates the models it gets with aliases. A cached page handed
+// back by reference would collect one request's decorations and show them to the
+// next.
+func TestListModels_CachedPageIsNotDecoratedInPlace(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return(registryRow(v1.HuggingFaceModelRegistryType), nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+
+	page := &model_registry.ModelPage{Models: []v1.GeneralModel{storedModel("qwen/qwen3", v1.LatestVersion)}}
+	mockRegistry.On("ListModels", mock.Anything).Return(page, nil)
+
+	deps := &Dependencies{Storage: mockStorage, QueryCache: model_registry.NewQueryCache(0)}
+
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{{
+		ID:              1,
+		ModelRegistryID: 7,
+		ModelName:       "qwen/qwen3",
+		ModelVersion:    v1.LatestVersion,
+		Alias:           "renamed once",
+	}}, nil).Once()
+
+	c, w := newListContext(t, "")
+	listModels(deps)(c)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Second time round the alias is gone from the table; the cached page must
+	// not still be carrying it.
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
+
+	c, w = newListContext(t, "")
+	listModels(deps)(c)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	assert.NotContains(t, w.Body.String(), "renamed once")
+}

--- a/internal/routes/models/models.go
+++ b/internal/routes/models/models.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog/v2"
@@ -26,6 +27,9 @@ type Dependencies struct {
 	Storage     storage.Storage
 	TempDirFunc func() (string, error) // Function to get a temporary directory
 	AuthConfig  middleware.AuthConfig
+	// QueryCache holds recent listings from public registries. Nil disables
+	// caching.
+	QueryCache *model_registry.QueryCache
 }
 
 const modelReferencedByEndpointCode = "10131"
@@ -103,6 +107,12 @@ func RegisterModelsRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 	{
 		modelRegistries := workspaces.Group("/model_registries/:registry")
 		{
+			// Rewrites the registry's status, so it takes the registry's own update
+			// permission rather than a model-level one.
+			modelRegistries.POST("/retry_connection",
+				middleware.RequireWorkspacePermission("model_registry:update", permissionDeps),
+				retryConnection(deps))
+
 			models := modelRegistries.Group("/models")
 			{
 				// List all models in a registry
@@ -115,10 +125,8 @@ func RegisterModelsRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 					middleware.RequireWorkspacePermission("model:read", permissionDeps),
 					getModel(deps))
 
-				// Update a model's display metadata: its alias and the model info
-				// fields a user fills in by hand. Both are annotations on an
-				// existing model, so they reuse model:push rather than introducing
-				// a permission action of their own.
+				// Alias and hand-filled model info are annotations on an existing model, so
+				// they reuse model:push rather than adding a permission action.
 				models.PATCH("/:model",
 					middleware.RequireWorkspacePermission("model:push", permissionDeps),
 					patchModel(deps))
@@ -132,6 +140,11 @@ func RegisterModelsRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc,
 				models.POST("/:model/finalize",
 					middleware.RequireWorkspacePermission("model:push", permissionDeps),
 					finalizeModel(deps))
+
+				// Read a model's card, as markdown
+				models.GET("/:model/readme",
+					middleware.RequireWorkspacePermission("model:read", permissionDeps),
+					getModelReadme(deps))
 
 				// Download a model
 				models.GET("/:model/download",
@@ -196,6 +209,14 @@ func finalizeModel(deps *Dependencies) gin.HandlerFunc {
 		}
 		defer handle.client.Disconnect() //nolint:errcheck
 
+		// Finalizing is the tail of a push, so it is a write and is refused the same
+		// way.
+		if !registryAcceptsWrites(handle.registry) {
+			refuseReadOnlyRegistry(c, "Cannot finalize a model push")
+
+			return
+		}
+
 		modelVersion, err := handle.client.GetModelVersion(modelName, version)
 		if err != nil {
 			klog.Errorf("Failed to finalize model %s:%s: %v", modelName, version, err)
@@ -247,8 +268,9 @@ type registryHandle struct {
 	client   model_registry.ModelRegistry
 }
 
-// getModelRegistry retrieves and connects to a model registry
-func getModelRegistry(c *gin.Context, deps *Dependencies) (*registryHandle, error) {
+// findModelRegistry reads the stored registry the request names without
+// connecting to it, for handlers that need the row before deciding anything.
+func findModelRegistry(c *gin.Context, deps *Dependencies) (*v1.ModelRegistry, error) {
 	workspace := c.Param("workspace")
 	registryName := c.Param("registry")
 
@@ -275,8 +297,18 @@ func getModelRegistry(c *gin.Context, deps *Dependencies) (*registryHandle, erro
 		return nil, fmt.Errorf("model registry not found: %s/%s", workspace, registryName)
 	}
 
+	return &modelRegistries[0], nil
+}
+
+// getModelRegistry retrieves and connects to a model registry
+func getModelRegistry(c *gin.Context, deps *Dependencies) (*registryHandle, error) {
+	registry, err := findModelRegistry(c, deps)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create model registry client
-	modelRegistry, err := model_registry.NewModelRegistry(&modelRegistries[0])
+	modelRegistry, err := model_registry.NewModelRegistry(registry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create model registry client: %w", err)
 	}
@@ -286,7 +318,7 @@ func getModelRegistry(c *gin.Context, deps *Dependencies) (*registryHandle, erro
 		return nil, fmt.Errorf("failed to connect to model registry: %w", err)
 	}
 
-	return &registryHandle{registry: &modelRegistries[0], client: modelRegistry}, nil
+	return &registryHandle{registry: registry, client: modelRegistry}, nil
 }
 
 // listModels handles listing all models in a registry
@@ -316,18 +348,26 @@ func listModels(deps *Dependencies) gin.HandlerFunc {
 		}
 		defer handle.client.Disconnect() //nolint:errcheck
 
-		// List models
-		page, err := handle.client.ListModels(model_registry.ListOption{
+		// Public registries may answer from the cache; private ones are always read
+		// through.
+		page, meta, err := deps.QueryCache.ListModels(handle.registry, handle.client, model_registry.ListOption{
 			Search: search,
 			Offset: offset,
 			Limit:  limit,
 		})
 		if err != nil {
+			// Answered before the shared mapping to keep the wording existing callers
+			// assert on.
 			if errors.Is(err, model_registry.ErrNotSupported) {
 				c.JSON(http.StatusBadRequest, gin.H{
 					"message": fmt.Sprintf("This model registry cannot list models this way: %v", err),
+					"reason":  reasonNotSupported,
 				})
 
+				return
+			}
+
+			if respondRegistryError(c, "Failed to list models", err) {
 				return
 			}
 
@@ -355,7 +395,28 @@ func listModels(deps *Dependencies) gin.HandlerFunc {
 		// array. Wrapping the body in an envelope would break every existing
 		// caller for the sake of one number.
 		c.Header("Content-Range", contentRange(offset, len(page.Models), page.Total))
+		// How old the data is, so a client can show it.
+		setDataTimestamp(c, meta)
 		c.JSON(http.StatusOK, page.Models)
+	}
+}
+
+// Headers stating how old the data in the response is. A cached listing
+// describes the registry as of when it was fetched, not as of the request.
+const (
+	dataTimestampHeader = "X-Neutree-Data-Timestamp"
+	dataCachedHeader    = "X-Neutree-Data-Cached"
+)
+
+func setDataTimestamp(c *gin.Context, meta model_registry.QueryMeta) {
+	if meta.FetchedAt.IsZero() {
+		return
+	}
+
+	c.Header(dataTimestampHeader, meta.FetchedAt.UTC().Format(time.RFC3339))
+
+	if meta.Cached {
+		c.Header(dataCachedHeader, "true")
 	}
 }
 
@@ -379,9 +440,8 @@ func intQuery(c *gin.Context, name string) (int, bool) {
 	return value, true
 }
 
-// contentRange formats the PostgREST-style range header: "first-last/total",
-// with "*" in place of the range for an empty page and in place of the total
-// when the registry cannot count what matched.
+// contentRange formats the PostgREST-style range header "first-last/total",
+// with "*" for an empty page and for a total the registry cannot state.
 func contentRange(offset, returned int, total *int) string {
 	size := "*"
 	if total != nil {
@@ -421,6 +481,12 @@ func getModel(deps *Dependencies) gin.HandlerFunc {
 		// about itself.
 		modelVersion, err := handle.client.GetModelDetail(modelName, version)
 		if err != nil {
+			// A refusal from the registry is not a server fault; 500 would make a
+			// read-only or unauthenticated public registry look like a broken deployment.
+			if respondRegistryError(c, fmt.Sprintf("Failed to get model %s:%s", modelName, version), err) {
+				return
+			}
+
 			klog.Errorf("Failed to get model %s:%s: %v", modelName, version, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"message": fmt.Sprintf("Failed to get model %s:%s: %v", modelName, version, err),
@@ -462,6 +528,27 @@ func attachModelAlias(deps *Dependencies, handle *registryHandle,
 // uploadModel handles uploading a new model
 func uploadModel(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// This must stay ahead of MultipartReader. The handler answers with a chunked
+		// 200 and streams import progress as its body, so once it starts reading the
+		// body the status code is fixed and a refusal can only be reported inside a
+		// 200. Nothing in the body is needed to decide: workspace and registry are
+		// path parameters.
+		registry, err := findModelRegistry(c, deps)
+		if err != nil {
+			klog.Errorf("Failed to get model registry: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": err.Error(),
+			})
+
+			return
+		}
+
+		if !registryAcceptsWrites(registry) {
+			refuseReadOnlyRegistry(c, "Cannot upload a model")
+
+			return
+		}
+
 		mr, err := c.Request.MultipartReader()
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
@@ -708,6 +795,11 @@ func deleteModel(deps *Dependencies) gin.HandlerFunc {
 
 		// Delete the model
 		if err := handle.client.DeleteModel(modelName, version); err != nil {
+			// A registry with no delete operation is refusing, not failing.
+			if respondRegistryError(c, fmt.Sprintf("Failed to delete model %s:%s", modelName, version), err) {
+				return
+			}
+
 			klog.Errorf("Failed to delete model %s:%s: %v", modelName, version, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"message": fmt.Sprintf("Failed to delete model: %v", err),

--- a/internal/routes/models/models_test.go
+++ b/internal/routes/models/models_test.go
@@ -719,6 +719,17 @@ func TestUploadModel_InvalidName(t *testing.T) {
 		},
 	}
 
+	// The handler now reads the registry before the body, so that a push to a
+	// read-only registry is refused without uploading anything. The model name
+	// arrives *in* the body, so that check necessarily comes first and this test
+	// has to let it through. A writable registry keeps the name validation below
+	// as the thing under test.
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}}, nil)
+
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	assert.NoError(t, writer.WriteField("name", "Invalid_Name"))
@@ -749,7 +760,15 @@ func TestUploadModel_InvalidName(t *testing.T) {
 	assert.Contains(t, response["message"], "Invalid model name")
 	assert.Contains(t, response["message"], "model name must be lowercase")
 
-	mockStorage.AssertNotCalled(t, "ListModelRegistry", mock.Anything)
+	// This used to assert that storage was never consulted for a bad name. That
+	// property and "a read-only registry is refused before its body is read"
+	// cannot both hold: the name arrives in the body, so whichever check is meant
+	// to happen without reading the body has to come first. The registry check
+	// wins — it is the one that decides whether gigabytes get uploaded — and it
+	// costs one indexed lookup on a request that was going to make one anyway.
+	//
+	// What still holds, and is what this test is for, is that an invalid name is
+	// answered with its own 400 and never reaches the import.
 	mockModelRegistry.AssertNotCalled(t, "ImportModel", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 

--- a/internal/routes/models/readme.go
+++ b/internal/routes/models/readme.go
@@ -1,0 +1,85 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+const (
+	// readmeContentType is markdown, not HTML. The server returns what the registry
+	// stores and renders nothing: rendering it here would run whatever it contains
+	// in every client that displays the result.
+	readmeContentType = "text/markdown; charset=utf-8"
+	// readmeTruncatedHeader marks a card cut at model_registry.MaxReadmeBytes, so a
+	// client can tell it from one that simply ends there.
+	readmeTruncatedHeader = "X-Neutree-Content-Truncated"
+)
+
+// getModelReadme serves a model's README as stored.
+func getModelReadme(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		modelName := c.Param("model")
+
+		version := c.Query("version")
+		if version == "" {
+			version = v1.LatestVersion
+		}
+
+		handle, err := getModelRegistry(c, deps)
+		if err != nil {
+			klog.Errorf("Failed to get model registry: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": err.Error(),
+				"reason":  reasonUnavailable,
+			})
+
+			return
+		}
+		defer handle.client.Disconnect() //nolint:errcheck
+
+		readme, err := handle.client.GetReadme(modelName, version)
+		if err != nil {
+			respondReadmeError(c, modelName, version, err)
+
+			return
+		}
+
+		if readme.Truncated {
+			c.Header(readmeTruncatedHeader, "true")
+		}
+
+		c.Data(http.StatusOK, readmeContentType, []byte(readme.Content))
+	}
+}
+
+func respondReadmeError(c *gin.Context, modelName, version string, err error) {
+	context := fmt.Sprintf("Failed to read README of model %s:%s", modelName, version)
+
+	if errors.Is(err, model_registry.ErrNotFound) {
+		// Said in the model's own terms: "has no README" is a fact about the model,
+		// not something the user has to act on.
+		c.JSON(http.StatusNotFound, gin.H{
+			"message": fmt.Sprintf("Model %s:%s has no README", modelName, version),
+			"reason":  reasonNotFound,
+		})
+
+		return
+	}
+
+	if respondRegistryError(c, context, err) {
+		return
+	}
+
+	klog.Errorf("%s: %v", context, err)
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"message": fmt.Sprintf("%s: %v", context, err),
+		"reason":  reasonUnavailable,
+	})
+}

--- a/internal/routes/models/readme_test.go
+++ b/internal/routes/models/readme_test.go
@@ -1,0 +1,154 @@
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+func newReadmeContext(t *testing.T, rawQuery string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	url := "/api/v1/workspaces/default/model_registries/test-registry/models/qwen3/readme"
+	if rawQuery != "" {
+		url += "?" + rawQuery
+	}
+
+	c.Request = httptest.NewRequest(http.MethodGet, url, nil)
+	c.Params = []gin.Param{
+		{Key: "workspace", Value: "default"},
+		{Key: "registry", Value: "test-registry"},
+		{Key: "model", Value: "qwen3"},
+	}
+
+	return c, w
+}
+
+func TestGetModelReadme_ServesMarkdownVerbatim(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("GetReadme", "qwen3", "v1").
+		Return(&model_registry.Readme{Content: "# Qwen3\n\n<script>alert(1)</script>\n"}, nil)
+
+	c, w := newReadmeContext(t, "version=v1")
+	getModelReadme(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	// Markdown, byte for byte, and no rendering: a model card is content from
+	// outside this system, and turning it into HTML here would run it in every
+	// client that displays the result.
+	assert.Equal(t, "# Qwen3\n\n<script>alert(1)</script>\n", w.Body.String())
+	assert.Equal(t, readmeContentType, w.Header().Get("Content-Type"))
+	assert.Empty(t, w.Header().Get(readmeTruncatedHeader))
+
+	mockStorage.AssertExpectations(t)
+	mockRegistry.AssertExpectations(t)
+}
+
+func TestGetModelReadme_MarksTruncation(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.BentoMLModelRegistryType},
+	}}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("GetReadme", "qwen3", v1.LatestVersion).
+		Return(&model_registry.Readme{Content: "# Qwen3", Truncated: true}, nil)
+
+	c, w := newReadmeContext(t, "")
+	getModelReadme(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	// A document that ends abruptly has to be distinguishable from one written
+	// that way.
+	assert.Equal(t, "true", w.Header().Get(readmeTruncatedHeader))
+}
+
+// The three ways a card can fail to arrive need three different answers: one is
+// permanent for this registry kind, one is a fact about this model, and one is
+// worth retrying.
+func TestGetModelReadme_DistinguishesFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantReason string
+	}{
+		{
+			name:       "the model has no card",
+			err:        errors.Wrap(model_registry.ErrNotFound, "model qwen3:v1 has no README.md"),
+			wantStatus: http.StatusNotFound,
+			wantReason: reasonNotFound,
+		},
+		{
+			name:       "the registry does not serve cards",
+			err:        errors.Wrap(model_registry.ErrNotSupported, "operation not supported"),
+			wantStatus: http.StatusBadRequest,
+			wantReason: reasonNotSupported,
+		},
+		{
+			name:       "the registry could not be asked",
+			err:        errors.New("502 bad gateway"),
+			wantStatus: http.StatusInternalServerError,
+			wantReason: reasonUnavailable,
+		},
+		{
+			// Fixed by giving the registry a token, not by retrying and not by
+			// changing the request.
+			name:       "the registry rejected our credentials",
+			err:        errors.Wrap(model_registry.ErrUnauthorized, "a token is required"),
+			wantStatus: http.StatusBadRequest,
+			wantReason: reasonUnauthorized,
+		},
+		{
+			// Nothing is wrong; come back later. Passed through as itself so a
+			// client does not have to parse prose to know that.
+			name:       "the registry is throttling us",
+			err:        errors.Wrap(model_registry.ErrRateLimited, "429 Too Many Requests"),
+			wantStatus: http.StatusTooManyRequests,
+			wantReason: reasonRateLimited,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage, mockRegistry := setupMocks(t)
+			mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+				ID:       7,
+				Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+				Spec:     &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
+			}}, nil)
+			mockRegistry.On("Connect").Return(nil)
+			mockRegistry.On("Disconnect").Return(nil)
+			mockRegistry.On("GetReadme", "qwen3", v1.LatestVersion).
+				Return((*model_registry.Readme)(nil), tt.err)
+
+			c, w := newReadmeContext(t, "")
+			getModelReadme(&Dependencies{Storage: mockStorage})(c)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			assert.Contains(t, w.Body.String(), tt.wantReason)
+		})
+	}
+}

--- a/internal/routes/models/retry.go
+++ b/internal/routes/models/retry.go
@@ -1,0 +1,102 @@
+package models
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+// retryConnectionResponse is the outcome of the check that was just run. An
+// unreachable registry answers 200 with phase Failed: the check ran and produced
+// an answer, and the answer is the payload.
+type retryConnectionResponse struct {
+	Phase              v1.ModelRegistryPhase `json:"phase"`
+	ErrorMessage       string                `json:"error_message,omitempty"`
+	LastCheckedAt      string                `json:"last_checked_at,omitempty"`
+	LastTransitionTime string                `json:"last_transition_time,omitempty"`
+}
+
+// retryConnection checks a registry now and reports what it found.
+//
+// It does not unblock anything: a Failed registry is disconnected and
+// reconnected on every reconcile anyway. What it adds is an immediate answer, a
+// recorded check time, and — the part nothing else does — invalidation of the
+// cached query results, without which a refreshed status would sit next to
+// listings fetched before the fix.
+//
+// The check runs in this process, which is not the one that reconciles the
+// registry, so the two can disagree and the next reconcile wins. That also means
+// this process must be able to do what the check requires — for an NFS registry,
+// mount — or every healthy NFS registry is reported Failed here and that verdict
+// written back.
+func retryConnection(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		registry, err := findModelRegistry(c, deps)
+		if err != nil {
+			klog.Errorf("Failed to get model registry: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": err.Error(),
+			})
+
+			return
+		}
+
+		// Dropped before the check, so a listing that arrives while a slow check runs
+		// already misses the cache.
+		deps.QueryCache.Invalidate(registry)
+
+		checkErr := checkModelRegistry(registry)
+
+		phase := v1.ModelRegistryPhaseCONNECTED
+		errMessage := ""
+
+		if checkErr != nil {
+			phase = v1.ModelRegistryPhaseFAILED
+			errMessage = checkErr.Error()
+
+			klog.Warningf("Model registry %s/%s failed an on-demand connection check: %v",
+				registry.Metadata.Workspace, registry.Metadata.Name, checkErr)
+		}
+
+		status := model_registry.NextStatus(registry.Status, phase, errMessage, time.Now())
+
+		// Best effort: the caller is owed the answer even if it cannot be recorded, and
+		// the reconcile writes the same conclusion shortly after.
+		if err := deps.Storage.UpdateModelRegistry(strconv.Itoa(registry.ID),
+			&v1.ModelRegistry{Status: status}); err != nil {
+			klog.Errorf("Failed to record connection check of model registry %s/%s: %v",
+				registry.Metadata.Workspace, registry.Metadata.Name, err)
+		}
+
+		c.JSON(http.StatusOK, retryConnectionResponse{
+			Phase:              status.Phase,
+			ErrorMessage:       status.ErrorMessage,
+			LastCheckedAt:      status.LastCheckedAt,
+			LastTransitionTime: status.LastTransitionTime,
+		})
+	}
+}
+
+// checkModelRegistry attaches to the registry, asks whether it is usable, and
+// lets go. A configuration too broken to build a client from is a failed check,
+// not a separate error: the user sees the same "this registry does not work".
+func checkModelRegistry(registry *v1.ModelRegistry) error {
+	client, err := model_registry.NewModelRegistry(registry)
+	if err != nil {
+		return err
+	}
+
+	if err = client.Connect(); err != nil {
+		return err
+	}
+
+	defer client.Disconnect() //nolint:errcheck
+
+	return client.HealthyCheck()
+}

--- a/internal/routes/models/retry_test.go
+++ b/internal/routes/models/retry_test.go
@@ -1,0 +1,163 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+func newRetryContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	c.Request = httptest.NewRequest(http.MethodPost,
+		"/api/v1/workspaces/default/model_registries/public-hugging-face/retry_connection", nil)
+	c.Params = []gin.Param{
+		{Key: "workspace", Value: "default"},
+		{Key: "registry", Value: "public-hugging-face"},
+	}
+
+	return c, w
+}
+
+func failedPublicRegistry() v1.ModelRegistry {
+	return v1.ModelRegistry{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "public-hugging-face", Workspace: "default"},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.HuggingFaceModelRegistryType,
+			Url:  "https://huggingface.co",
+		},
+		Status: &v1.ModelRegistryStatus{
+			Phase:              v1.ModelRegistryPhaseFAILED,
+			ErrorMessage:       "invalid Hugging Face API token",
+			LastTransitionTime: "2026-08-01T00:00:00Z",
+			Stats:              &v1.ModelRegistryStats{ModelCount: 0},
+		},
+	}
+}
+
+func TestRetryConnection_RecordsASuccessfulCheck(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{failedPublicRegistry()}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("HealthyCheck").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+
+	var written *v1.ModelRegistryStatus
+
+	mockStorage.On("UpdateModelRegistry", "7", mock.Anything).Run(func(args mock.Arguments) {
+		obj, _ := args.Get(1).(*v1.ModelRegistry)
+		written = obj.Status
+	}).Return(nil)
+
+	c, w := newRetryContext(t)
+	retryConnection(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var body retryConnectionResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, v1.ModelRegistryPhaseCONNECTED, body.Phase)
+	assert.Empty(t, body.ErrorMessage)
+	assert.NotEmpty(t, body.LastCheckedAt)
+
+	require.NotNil(t, written)
+	assert.Equal(t, v1.ModelRegistryPhaseCONNECTED, written.Phase)
+	// Failed to Connected is a real transition, so this one does move.
+	assert.NotEqual(t, "2026-08-01T00:00:00Z", written.LastTransitionTime)
+	// The counters are not this path's to recompute, and PostgREST would null
+	// them if they were left out.
+	assert.NotNil(t, written.Stats)
+
+	mockStorage.AssertExpectations(t)
+	mockRegistry.AssertExpectations(t)
+}
+
+// The check ran and produced an answer, so the request succeeded. The answer is
+// the payload.
+func TestRetryConnection_ReportsAFailedCheckAsData(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{failedPublicRegistry()}, nil)
+	mockRegistry.On("Connect").Return(assert.AnError)
+	mockStorage.On("UpdateModelRegistry", "7", mock.Anything).Return(nil)
+
+	c, w := newRetryContext(t)
+	retryConnection(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body retryConnectionResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, v1.ModelRegistryPhaseFAILED, body.Phase)
+	assert.NotEmpty(t, body.ErrorMessage)
+	assert.NotEmpty(t, body.LastCheckedAt)
+
+	mockRegistry.AssertExpectations(t)
+}
+
+// This is the part nothing else does. Without it the status would go green while
+// the listing beside it replayed results from before the fix, which reads as the
+// retry not having worked.
+func TestRetryConnection_DropsTheCachedResults(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	registry := failedPublicRegistry()
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{registry}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("HealthyCheck").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("ListModels", mock.Anything).
+		Return(&model_registry.ModelPage{Models: []v1.GeneralModel{{Name: "qwen/qwen3"}}}, nil)
+	mockStorage.On("UpdateModelRegistry", "7", mock.Anything).Return(nil)
+
+	cache := model_registry.NewQueryCache(0)
+	deps := &Dependencies{Storage: mockStorage, QueryCache: cache}
+
+	// Prime the cache, then confirm it is being used before asserting that the
+	// retry clears it — an empty cache would pass the final assertion for the
+	// wrong reason.
+	_, _, err := cache.ListModels(&registry, mockRegistry, model_registry.ListOption{Search: "qwen"})
+	require.NoError(t, err)
+	_, _, err = cache.ListModels(&registry, mockRegistry, model_registry.ListOption{Search: "qwen"})
+	require.NoError(t, err)
+	mockRegistry.AssertNumberOfCalls(t, "ListModels", 1)
+
+	c, _ := newRetryContext(t)
+	retryConnection(deps)(c)
+
+	_, _, err = cache.ListModels(&registry, mockRegistry, model_registry.ListOption{Search: "qwen"})
+	require.NoError(t, err)
+	mockRegistry.AssertNumberOfCalls(t, "ListModels", 2)
+}
+
+// A registry that cannot be recorded has still been checked, and the caller is
+// owed the answer.
+func TestRetryConnection_AnswersEvenIfTheStatusCannotBeStored(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{failedPublicRegistry()}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("HealthyCheck").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockStorage.On("UpdateModelRegistry", "7", mock.Anything).Return(assert.AnError)
+
+	c, w := newRetryContext(t)
+	retryConnection(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body retryConnectionResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, v1.ModelRegistryPhaseCONNECTED, body.Phase)
+}

--- a/internal/routes/models/routing_test.go
+++ b/internal/routes/models/routing_test.go
@@ -1,0 +1,210 @@
+package models
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+	"github.com/neutree-ai/neutree/internal/routes"
+)
+
+// newRoutedEngine registers the real routes on an engine configured as production
+// configures it. These tests must go through the router rather than calling
+// handlers: the defect they cover was a request that reached no handler.
+func newRoutedEngine(t *testing.T, deps *Dependencies) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	routes.ConfigureEngine(engine)
+
+	authenticated := []gin.HandlerFunc{func(c *gin.Context) { c.Set("user_id", "test-user") }}
+	RegisterModelsRoutes(&engine.RouterGroup, authenticated, deps)
+
+	return engine
+}
+
+// modelRegistryFixture wires storage and a registry client that record which model
+// name the handler was given.
+func modelRegistryFixture(t *testing.T, registryType v1.ModelRegistryType) (*Dependencies, *string) {
+	t.Helper()
+
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: registryType},
+	}}, nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+
+	var seen string
+
+	mockRegistry.On("GetModelDetail", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			seen, _ = args.Get(0).(string)
+		}).Return(&v1.ModelVersion{Name: v1.LatestVersion}, nil)
+
+	mockRegistry.On("GetReadme", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			seen, _ = args.Get(0).(string)
+		}).Return(&model_registry.Readme{Content: "# card"}, nil)
+
+	// Permission checks are not what these tests are about.
+	mockStorage.On("CallDatabaseFunction", "has_permission", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			result, ok := args.Get(2).(*bool)
+			if ok {
+				*result = true
+			}
+		}).Return(nil)
+
+	return &Dependencies{Storage: mockStorage}, &seen
+}
+
+// Every model on the hub is named "org/model": the client encodes the slash, the
+// router keeps it encoded long enough to match, and the handler gets it decoded.
+func TestRouting_PublicModelNameWithASlash(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		wantModel string
+	}{
+		{
+			name:      "detail",
+			path:      "/workspaces/default/model_registries/test-registry/models/Qwen%2FQwen3-8B",
+			wantModel: "Qwen/Qwen3-8B",
+		},
+		{
+			name:      "readme",
+			path:      "/workspaces/default/model_registries/test-registry/models/Qwen%2FQwen3-8B/readme",
+			wantModel: "Qwen/Qwen3-8B",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps, seen := modelRegistryFixture(t, v1.HuggingFaceModelRegistryType)
+			engine := newRoutedEngine(t, deps)
+
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, httptest.NewRequest(http.MethodGet, tt.path, nil))
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			assert.Equal(t, tt.wantModel, *seen,
+				"the handler must receive the name decoded, not the escaped form")
+		})
+	}
+}
+
+// The regression is a framework-level 404 — gin answering before any handler runs.
+// Asserting "not 404" alone would also pass if the route were deleted, so this
+// pins the old failure too.
+func TestRouting_EncodedNameIsNotAFrameworkNotFound(t *testing.T) {
+	deps, _ := modelRegistryFixture(t, v1.HuggingFaceModelRegistryType)
+
+	unconfigured := gin.New()
+	authenticated := []gin.HandlerFunc{func(c *gin.Context) { c.Set("user_id", "test-user") }}
+	RegisterModelsRoutes(&unconfigured.RouterGroup, authenticated, deps)
+
+	path := "/workspaces/default/model_registries/test-registry/models/Qwen%2FQwen3-8B"
+
+	w := httptest.NewRecorder()
+	unconfigured.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+
+	// Without the setting, this is the bug: gin's own 404, no handler, no JSON.
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "404 page not found")
+
+	// With it, the same request is served. Same engine construction as production.
+	configured := newRoutedEngine(t, deps)
+
+	w = httptest.NewRecorder()
+	configured.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// Private model names are validated to [a-z0-9._-] and never need escaping, so
+// their URLs must route exactly as before.
+func TestRouting_PrivateModelNamesAreUnaffected(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "detail",
+			path: "/workspaces/default/model_registries/test-registry/models/qwen2.5-0.5b-instruct",
+		},
+		{
+			name: "readme",
+			path: "/workspaces/default/model_registries/test-registry/models/qwen2.5-0.5b-instruct/readme",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps, seen := modelRegistryFixture(t, v1.BentoMLModelRegistryType)
+			engine := newRoutedEngine(t, deps)
+
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, httptest.NewRequest(http.MethodGet, tt.path, nil))
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			assert.Equal(t, "qwen2.5-0.5b-instruct", *seen)
+		})
+	}
+}
+
+// The listing route shares the prefix and must not be shadowed by a model name
+// spanning what looks like two segments.
+func TestRouting_ListingStillResolves(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
+	}}, nil)
+	mockStorage.On("ListModelAlias", mock.Anything).Return([]v1.ModelAlias{}, nil)
+	mockStorage.On("CallDatabaseFunction", "has_permission", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			result, ok := args.Get(2).(*bool)
+			if ok {
+				*result = true
+			}
+		}).Return(nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("ListModels", mock.Anything).
+		Return(&model_registry.ModelPage{Models: []v1.GeneralModel{}}, nil)
+
+	engine := newRoutedEngine(t, &Dependencies{Storage: mockStorage})
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest(http.MethodGet,
+		"/workspaces/default/model_registries/test-registry/models?search=qwen", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// A literal slash is a different URL and matches no route. Left as a 404: making
+// the router guess how many trailing segments belong to a name would be ambiguous
+// against /readme and /download.
+func TestRouting_UnencodedSlashIsStillNotFound(t *testing.T) {
+	deps, _ := modelRegistryFixture(t, v1.HuggingFaceModelRegistryType)
+	engine := newRoutedEngine(t, deps)
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, httptest.NewRequest(http.MethodGet,
+		"/workspaces/default/model_registries/test-registry/models/Qwen/Qwen3-8B", nil))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/routes/models/write_paths_test.go
+++ b/internal/routes/models/write_paths_test.go
@@ -1,0 +1,188 @@
+package models
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry"
+)
+
+// countingReader records how much of a request body was consumed, so that
+// "refused before the upload" is asserted rather than assumed.
+type countingReader struct {
+	reader io.Reader
+	read   int
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	r.read += n
+
+	return n, err
+}
+
+// modelUploadBody builds a push the way the CLI sends one: metadata parts first,
+// then the model payload.
+func modelUploadBody(t *testing.T) (*countingReader, string) {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	writer := multipart.NewWriter(&buf)
+	require.NoError(t, writer.WriteField("name", "qwen3"))
+	require.NoError(t, writer.WriteField("version", "v1"))
+	require.NoError(t, writer.WriteField("model_size", "1048576"))
+
+	part, err := writer.CreateFormFile("model", "model.bentomodel")
+	require.NoError(t, err)
+	_, err = part.Write(bytes.Repeat([]byte("x"), 1<<20))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return &countingReader{reader: &buf}, writer.FormDataContentType()
+}
+
+func newUploadContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder, *countingReader) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	body, contentType := modelUploadBody(t)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost,
+		"/api/v1/workspaces/default/model_registries/test-registry/models", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	c.Params = []gin.Param{
+		{Key: "workspace", Value: "default"},
+		{Key: "registry", Value: "test-registry"},
+	}
+
+	return c, w, body
+}
+
+func registryRowOfType(registryType v1.ModelRegistryType) []v1.ModelRegistry {
+	return []v1.ModelRegistry{{
+		ID:       7,
+		Metadata: &v1.Metadata{Name: "test-registry", Workspace: "default"},
+		Spec:     &v1.ModelRegistrySpec{Type: registryType, Url: "https://huggingface.co"},
+	}}
+}
+
+// A push to a public registry must be refused with a status code, which is only
+// possible while nothing has been committed to the response.
+func TestUploadModel_PublicRegistryRefusedBeforeTheBodyIsRead(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).
+		Return(registryRowOfType(v1.HuggingFaceModelRegistryType), nil)
+
+	c, w, body := newUploadContext(t)
+	uploadModel(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), reasonNotSupported)
+
+	// No chunked framing and a JSON body, i.e. the response was not already open.
+	assert.Empty(t, w.Header().Get("Transfer-Encoding"))
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+
+	// The point of the whole change.
+	assert.Zero(t, body.read, "the request body must not be read before the registry is refused")
+	mockRegistry.AssertNotCalled(t, "ImportModel", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockRegistry.AssertNotCalled(t, "Connect")
+}
+
+// The guard keys off the registry, so the private path has to be shown still
+// importing — otherwise "refuses public registries" could pass by refusing all.
+func TestUploadModel_PrivateRegistryStillUploads(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).
+		Return(registryRowOfType(v1.BentoMLModelRegistryType), nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+
+	imported := false
+
+	mockRegistry.On("ImportModel", mock.Anything, "qwen3", "v1", mock.Anything).
+		Run(func(args mock.Arguments) {
+			// Drain the payload the way the real import does, so the body is genuinely
+			// consumed on this path.
+			reader, _ := args.Get(0).(io.Reader)
+			if reader != nil {
+				_, _ = io.Copy(io.Discard, reader)
+			}
+
+			imported = true
+		}).Return(nil)
+
+	c, w, body := newUploadContext(t)
+	uploadModel(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, imported, "a private registry must still receive the upload")
+	assert.Contains(t, w.Body.String(), "Success: Model imported successfully")
+	assert.Positive(t, body.read, "the private path does read the body")
+}
+
+// Deleting from a public registry is a refusal, not a server fault. The private
+// path is covered by TestDeleteModel_Success.
+func TestDeleteModel_PublicRegistryRefusalIsABadRequest(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).
+		Return(registryRowOfType(v1.HuggingFaceModelRegistryType), nil)
+	mockStorage.On("ListEndpoint", mock.Anything).Return([]v1.Endpoint{}, nil)
+	mockStorage.On("ListModelCatalog", mock.Anything).Return([]v1.ModelCatalog{}, nil).Maybe()
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+	mockRegistry.On("GetModelVersion", mock.Anything, mock.Anything).
+		Return(nil, errors.Wrap(model_registry.ErrNotSupported, "hugging face")).Maybe()
+	mockRegistry.On("DeleteModel", "qwen3", v1.LatestVersion).
+		Return(errors.Wrap(model_registry.ErrNotSupported, "hugging face"))
+
+	c, w := createMockContext("default", "test-registry", "qwen3", "")
+	deleteModel(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), reasonNotSupported)
+}
+
+// Finalizing is a write and is refused the same way, before the registry is asked
+// anything.
+func TestFinalizeModel_PublicRegistryIsRefused(t *testing.T) {
+	mockStorage, mockRegistry := setupMocks(t)
+	mockStorage.On("ListModelRegistry", mock.Anything).
+		Return(registryRowOfType(v1.HuggingFaceModelRegistryType), nil)
+	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
+
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost,
+		"/api/v1/workspaces/default/model_registries/test-registry/models/qwen3/finalize",
+		bytes.NewBufferString(`{"version":"v1"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = []gin.Param{
+		{Key: "workspace", Value: "default"},
+		{Key: "registry", Value: "test-registry"},
+		{Key: "model", Value: "qwen3"},
+	}
+
+	finalizeModel(&Dependencies{Storage: mockStorage})(c)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), reasonNotSupported)
+	mockRegistry.AssertNotCalled(t, "GetModelVersion", mock.Anything, mock.Anything)
+}

--- a/internal/routes/proxies/builtin_model_registry.go
+++ b/internal/routes/proxies/builtin_model_registry.go
@@ -1,0 +1,265 @@
+package proxies
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"k8s.io/klog/v2"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/middleware"
+	"github.com/neutree-ai/neutree/internal/utils/request"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// builtinRegistryImmutableCode marks an edit refused outright, as opposed to one
+// blocked by an existing reference.
+const (
+	builtinRegistryImmutableCode = "10132"
+	// credentialsPermission is what "administrators only" resolves to here. There
+	// is no admin flag to test: the preset admin role holds every permission action,
+	// and this is the one model_registry action the preset workspace-user role does
+	// not get. Gating on it keeps the rule in the permission system rather than
+	// hard-coding a role name.
+	credentialsPermission = "model_registry:read-credentials"
+)
+
+// builtinModelRegistryGuard refuses edits that a built-in registry cannot
+// meaningfully take, and stops the marker that identifies one from being set or
+// removed by hand.
+//
+// Deleting a built-in registry, changing its type, or changing its address are
+// all undone by the next reconcile, so they are refused with an explanation
+// rather than silently reverted. The address in particular is owned by the
+// deployment configuration: an operator who edits values.yaml has to see it take
+// effect, which it cannot if the API also lets it be edited out from under them.
+//
+// Credentials are the exception and belong to the user, so they stay editable —
+// by someone trusted with them. Everything else about the registry is
+// unaffected.
+func builtinModelRegistryGuard(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodPatch {
+			c.Next()
+
+			return
+		}
+
+		bodyCtx, err := request.ExtractBody(c)
+		if err != nil {
+			c.Next()
+
+			return
+		}
+
+		request.RestoreBody(c, bodyCtx.BodyBytes)
+
+		workspace, name, err := request.ExtractResourceIdentifiers(bodyCtx.BodyMap)
+		if err != nil {
+			// Same fallthrough as the deletion validation: a body this cannot identify is
+			// one PostgREST will reject or apply on its own terms.
+			klog.V(4).Infof("Could not extract model registry identifiers: %v, skipping built-in checks", err)
+			c.Next()
+
+			return
+		}
+
+		stored, err := findStoredModelRegistry(deps.Storage, workspace, name)
+		if err != nil {
+			klog.Errorf("Failed to look up model registry %s/%s: %v", workspace, name, err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"message": fmt.Sprintf("failed to look up model registry: %v", err),
+			})
+			c.Abort()
+
+			return
+		}
+
+		if builtinAnnotationChanged(bodyCtx.BodyMap, stored) {
+			abortBuiltinRegistry(c, workspace, name,
+				"the "+v1.BuiltinAnnotationKey+" annotation identifies a registry the control plane owns "+
+					"and cannot be set or removed by hand")
+
+			return
+		}
+
+		if stored == nil || stored.Metadata == nil || !v1.IsBuiltin(stored.Metadata.Annotations) {
+			c.Next()
+
+			return
+		}
+
+		if request.IsSoftDeleteRequest(bodyCtx.BodyMap) {
+			abortBuiltinRegistry(c, workspace, name,
+				"a built-in model registry cannot be deleted; turn off the built-in public model registries "+
+					"option to stop it being provisioned")
+
+			return
+		}
+
+		if !guardBuiltinRegistrySpec(c, deps, bodyCtx.BodyMap, stored, workspace, name) {
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// guardBuiltinRegistrySpec checks the spec changes in a patch of a built-in
+// registry, answering the request itself when it refuses one, and reports
+// whether the request may continue.
+func guardBuiltinRegistrySpec(c *gin.Context, deps *Dependencies, bodyMap map[string]interface{},
+	stored *v1.ModelRegistry, workspace, name string) bool {
+	spec, ok := bodyMap["spec"].(map[string]interface{})
+	if !ok {
+		return true
+	}
+
+	if stringFieldChanged(spec, "type", string(stored.Spec.Type)) {
+		abortBuiltinRegistry(c, workspace, name,
+			"a built-in model registry's type cannot be changed")
+
+		return false
+	}
+
+	if stringFieldChanged(spec, "url", storedURL(stored)) {
+		abortBuiltinRegistry(c, workspace, name,
+			"the address of a built-in model registry comes from this deployment's configuration "+
+				"(--hugging-face-endpoint); change it there, since the reconcile restores it otherwise")
+
+		return false
+	}
+
+	if !stringFieldChanged(spec, "credentials", storedCredentials(stored)) {
+		return true
+	}
+
+	allowed, err := middleware.CheckWorkspacePermission(deps.Storage, c.GetString("user_id"),
+		workspace, credentialsPermission)
+	if err != nil {
+		klog.Errorf("Failed to check permission %s: %v", credentialsPermission, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"message": fmt.Sprintf("failed to check permissions: %v", err),
+		})
+		c.Abort()
+
+		return false
+	}
+
+	if !allowed {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error":    "insufficient permissions",
+			"required": credentialsPermission,
+			"message": fmt.Sprintf("the credentials of built-in model registry '%s/%s' "+
+				"can only be changed by an administrator", workspace, name),
+		})
+		c.Abort()
+
+		return false
+	}
+
+	return true
+}
+
+// stringFieldChanged reports whether a patch body sets this field to something
+// other than what is stored. A field the body does not mention is not a change:
+// PostgREST leaves unmentioned columns alone.
+func stringFieldChanged(spec map[string]interface{}, field, current string) bool {
+	raw, present := spec[field]
+	if !present {
+		return false
+	}
+
+	value, ok := raw.(string)
+	if !ok {
+		return false
+	}
+
+	return value != current
+}
+
+func storedURL(stored *v1.ModelRegistry) string {
+	if stored.Spec == nil {
+		return ""
+	}
+
+	return stored.Spec.Url
+}
+
+func storedCredentials(stored *v1.ModelRegistry) string {
+	if stored.Spec == nil {
+		return ""
+	}
+
+	return stored.Spec.Credentials
+}
+
+func abortBuiltinRegistry(c *gin.Context, workspace, name, hint string) {
+	c.Header("X-Powered-By", "Neutree")
+	c.JSON(http.StatusBadRequest, gin.H{
+		"code":    builtinRegistryImmutableCode,
+		"message": fmt.Sprintf("cannot modify built-in model registry '%s/%s'", workspace, name),
+		"hint":    hint,
+	})
+	c.Abort()
+}
+
+// findStoredModelRegistry returns the registry a patch is aimed at, or nil when
+// there is none.
+func findStoredModelRegistry(s storage.Storage, workspace, name string) (*v1.ModelRegistry, error) {
+	registries, err := s.ListModelRegistry(storage.ListOption{
+		Filters: []storage.Filter{
+			{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
+			{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(name)},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(registries) == 0 {
+		return nil, nil
+	}
+
+	return &registries[0], nil
+}
+
+// builtinAnnotationChanged reports whether a patch adds or removes the built-in
+// marker.
+//
+// The marker is an identity, and identity must not be self-service in either
+// direction. Adding it to a user's own registry would hand it to the control
+// plane, which would then reconcile its address to the configured one; removing
+// it from a built-in registry would leave a row that provisioning no longer
+// recognises and this guard no longer protects.
+//
+// A patch that leaves the marker as it already is passes: PostgREST replaces the
+// whole metadata composite, so a client resending the object it just read must
+// not be refused for including it.
+func builtinAnnotationChanged(bodyMap map[string]interface{}, stored *v1.ModelRegistry) bool {
+	metadata, ok := bodyMap["metadata"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	annotations, present := metadata["annotations"]
+	if !present {
+		return false
+	}
+
+	wanted := false
+
+	if set, ok := annotations.(map[string]interface{}); ok {
+		value, _ := set[v1.BuiltinAnnotationKey].(string)
+		wanted = value == v1.BuiltinAnnotationValue
+	}
+
+	current := false
+	if stored != nil && stored.Metadata != nil {
+		current = v1.IsBuiltin(stored.Metadata.Annotations)
+	}
+
+	return wanted != current
+}

--- a/internal/routes/proxies/builtin_model_registry_test.go
+++ b/internal/routes/proxies/builtin_model_registry_test.go
@@ -1,0 +1,288 @@
+package proxies
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+func builtinRegistryRow(builtin bool) v1.ModelRegistry {
+	annotations := map[string]string{}
+	if builtin {
+		annotations = v1.WithBuiltinAnnotation(nil)
+	}
+
+	return v1.ModelRegistry{
+		ID: 4,
+		Metadata: &v1.Metadata{
+			Name:        "public-hugging-face",
+			Workspace:   "default",
+			Annotations: annotations,
+		},
+		Spec: &v1.ModelRegistrySpec{
+			Type:        v1.HuggingFaceModelRegistryType,
+			Url:         "https://huggingface.co",
+			Credentials: "hf_stored",
+		},
+	}
+}
+
+// runGuard drives the middleware over one PATCH body and reports whether the
+// request was allowed through.
+func runGuard(t *testing.T, storage *storagemocks.MockStorage, body map[string]interface{},
+	userID string) (*httptest.ResponseRecorder, bool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/model_registries", bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("user_id", userID)
+
+	passed := false
+
+	builtinModelRegistryGuard(&Dependencies{Storage: storage})(c)
+
+	// gin's Next() is a no-op on a context built this way, so "was it allowed
+	// through" is read off the abort flag rather than by chaining a handler.
+	if !c.IsAborted() {
+		passed = true
+	}
+
+	return w, passed
+}
+
+func patchBody(spec map[string]interface{}, deletionTimestamp string) map[string]interface{} {
+	metadata := map[string]interface{}{"workspace": "default", "name": "public-hugging-face"}
+	if deletionTimestamp != "" {
+		metadata["deletion_timestamp"] = deletionTimestamp
+	}
+
+	body := map[string]interface{}{"metadata": metadata}
+	if spec != nil {
+		body["spec"] = spec
+	}
+
+	return body
+}
+
+// The control plane provisions it back on the next reconcile, so allowing the
+// delete would make it flicker rather than remove it.
+func TestBuiltinModelRegistryGuard_RefusesDeletion(t *testing.T) {
+	storage := &storagemocks.MockStorage{}
+	storage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{builtinRegistryRow(true)}, nil)
+
+	w, passed := runGuard(t, storage, patchBody(nil, "2026-08-05T00:00:00Z"), "user-1")
+
+	assert.False(t, passed)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), builtinRegistryImmutableCode)
+}
+
+// A different type under a name that says otherwise, undone by the next
+// reconcile.
+func TestBuiltinModelRegistryGuard_RefusesTypeChange(t *testing.T) {
+	storage := &storagemocks.MockStorage{}
+	storage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{builtinRegistryRow(true)}, nil)
+
+	w, passed := runGuard(t, storage, patchBody(map[string]interface{}{
+		"type": string(v1.BentoMLModelRegistryType),
+	}, ""), "user-1")
+
+	assert.False(t, passed)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "type cannot be changed")
+}
+
+// The address is owned by the deployment configuration, so editing it through the
+// API is refused outright rather than accepted and reconciled away.
+func TestBuiltinModelRegistryGuard_RefusesAddressChange(t *testing.T) {
+	storage := &storagemocks.MockStorage{}
+	storage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{builtinRegistryRow(true)}, nil)
+
+	w, passed := runGuard(t, storage, patchBody(map[string]interface{}{
+		"url": "https://hf-mirror.example",
+	}, ""), "admin")
+
+	assert.False(t, passed)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), builtinRegistryImmutableCode)
+	assert.Contains(t, w.Body.String(), "hugging-face-endpoint")
+	// Refused for everyone, so it is not a permission question and none is asked.
+	storage.AssertNotCalled(t, "CallDatabaseFunction", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// Credentials are the user's, so they stay editable — by someone trusted with
+// them.
+func TestBuiltinModelRegistryGuard_CredentialsNeedThePermission(t *testing.T) {
+	tests := []struct {
+		name string
+		spec map[string]interface{}
+	}{
+		{name: "credentials", spec: map[string]interface{}{"credentials": "hf_new"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" refused without it", func(t *testing.T) {
+			storage := &storagemocks.MockStorage{}
+			storage.On("ListModelRegistry", mock.Anything).
+				Return([]v1.ModelRegistry{builtinRegistryRow(true)}, nil)
+			storage.On("CallDatabaseFunction", "has_permission", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					result, ok := args.Get(2).(*bool)
+					if ok {
+						*result = false
+					}
+				}).Return(nil)
+
+			w, passed := runGuard(t, storage, patchBody(tt.spec, ""), "user-1")
+
+			assert.False(t, passed)
+			assert.Equal(t, http.StatusForbidden, w.Code)
+			assert.Contains(t, w.Body.String(), credentialsPermission)
+		})
+
+		t.Run(tt.name+" allowed with it", func(t *testing.T) {
+			storage := &storagemocks.MockStorage{}
+			storage.On("ListModelRegistry", mock.Anything).
+				Return([]v1.ModelRegistry{builtinRegistryRow(true)}, nil)
+			storage.On("CallDatabaseFunction", "has_permission", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					result, ok := args.Get(2).(*bool)
+					if ok {
+						*result = true
+					}
+				}).Return(nil)
+
+			_, passed := runGuard(t, storage, patchBody(tt.spec, ""), "admin")
+
+			assert.True(t, passed)
+		})
+	}
+}
+
+// A patch that mentions the fields without changing them is not a change, and a
+// patch that touches something else entirely was never this guard's business.
+func TestBuiltinModelRegistryGuard_LetsUnchangedAndUnrelatedEditsThrough(t *testing.T) {
+	tests := []struct {
+		name string
+		body map[string]interface{}
+	}{
+		{
+			name: "same values resent",
+			body: patchBody(map[string]interface{}{
+				"url":         "https://huggingface.co",
+				"credentials": "hf_stored",
+				"type":        string(v1.HuggingFaceModelRegistryType),
+			}, ""),
+		},
+		{
+			name: "labels only",
+			body: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"workspace": "default",
+					"name":      "public-hugging-face",
+					"labels":    map[string]interface{}{"team": "platform"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := &storagemocks.MockStorage{}
+			storage.On("ListModelRegistry", mock.Anything).
+				Return([]v1.ModelRegistry{builtinRegistryRow(true)}, nil)
+
+			_, passed := runGuard(t, storage, tt.body, "user-1")
+
+			assert.True(t, passed)
+			storage.AssertNotCalled(t, "CallDatabaseFunction", mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// None of this applies to a registry a user created, whatever it is called.
+func TestBuiltinModelRegistryGuard_IgnoresUserRegistries(t *testing.T) {
+	storage := &storagemocks.MockStorage{}
+	storage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{builtinRegistryRow(false)}, nil)
+
+	_, passed := runGuard(t, storage, patchBody(map[string]interface{}{
+		"type": string(v1.BentoMLModelRegistryType),
+		"url":  "nfs://server/models",
+	}, "2026-08-05T00:00:00Z"), "user-1")
+
+	assert.True(t, passed)
+}
+
+// The marker is an identity: neither adding it to a user's registry nor removing
+// it from a built-in one may be done through the API.
+func TestBuiltinModelRegistryGuard_RefusesAnnotationChanges(t *testing.T) {
+	tests := []struct {
+		name    string
+		builtin bool
+		set     map[string]interface{}
+	}{
+		{
+			name:    "adding it to a user registry",
+			builtin: false,
+			set:     map[string]interface{}{v1.BuiltinAnnotationKey: v1.BuiltinAnnotationValue},
+		},
+		{
+			name:    "removing it from a built-in registry",
+			builtin: true,
+			set:     map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := &storagemocks.MockStorage{}
+			storage.On("ListModelRegistry", mock.Anything).
+				Return([]v1.ModelRegistry{builtinRegistryRow(tt.builtin)}, nil)
+
+			body := patchBody(nil, "")
+			metadata, _ := body["metadata"].(map[string]interface{})
+			metadata["annotations"] = tt.set
+
+			w, passed := runGuard(t, storage, body, "admin")
+
+			assert.False(t, passed)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), v1.BuiltinAnnotationKey)
+		})
+	}
+}
+
+// A client that read the object and sends it back unchanged must not be refused:
+// PostgREST replaces the whole metadata composite, so the marker travels with
+// every such write.
+func TestBuiltinModelRegistryGuard_AllowsResendingTheAnnotationUnchanged(t *testing.T) {
+	storage := &storagemocks.MockStorage{}
+	storage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{builtinRegistryRow(true)}, nil)
+
+	body := patchBody(nil, "")
+	metadata, _ := body["metadata"].(map[string]interface{})
+	metadata["annotations"] = map[string]interface{}{
+		v1.BuiltinAnnotationKey: v1.BuiltinAnnotationValue,
+		"team":                  "platform",
+	}
+
+	_, passed := runGuard(t, storage, body, "user-1")
+
+	assert.True(t, passed)
+}

--- a/internal/routes/proxies/model_registry_proxy.go
+++ b/internal/routes/proxies/model_registry_proxy.go
@@ -44,5 +44,8 @@ func RegisterModelRegistryRoutes(group *gin.RouterGroup, middlewares []gin.Handl
 
 	proxyGroup.GET("", handler)
 	proxyGroup.POST("", handler)
-	proxyGroup.PATCH("", deletionValidation, handler)
+	// The built-in guard runs first: a delete aimed at a built-in registry is
+	// refused outright, rather than being told which endpoints are in the way of
+	// something that was never going to be allowed.
+	proxyGroup.PATCH("", builtinModelRegistryGuard(deps), deletionValidation, handler)
 }

--- a/internal/routes/proxies/path_escaping_test.go
+++ b/internal/routes/proxies/path_escaping_test.go
@@ -1,0 +1,208 @@
+package proxies
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/neutree-ai/neutree/internal/routes"
+)
+
+// The proxy routes forward a caller-supplied path to the Ray dashboard, Ray Serve
+// and the Kubernetes API, so what routes.ConfigureEngine does to that path is part
+// of this API's contract with those upstreams.
+
+// upstreamRecorder answers every request and records the path it was asked for.
+type upstreamRecorder struct {
+	server      *httptest.Server
+	requestURI  string
+	decodedPath string
+}
+
+func newUpstreamRecorder(t *testing.T) *upstreamRecorder {
+	t.Helper()
+
+	recorder := &upstreamRecorder{}
+	recorder.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RequestURI is the raw request line, the only place the escaping the upstream
+		// receives is visible.
+		recorder.requestURI = r.RequestURI
+		recorder.decodedPath = r.URL.Path
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Cleanup(recorder.server.Close)
+
+	return recorder
+}
+
+// newProxyServer serves a wildcard proxy route shaped like the real ones over a
+// real listener. httputil.ReverseProxy needs a ResponseWriter implementing
+// http.CloseNotifier, which httptest.ResponseRecorder is not.
+//
+// It reproduces the handler body rather than calling handleServeProxy,
+// handleRayDashboardProxy or handleKubernetesProxy: each looks up a cluster
+// first, and the two lines under test are identical in all three.
+func newProxyServer(t *testing.T, upstreamURL string, configured bool) *httptest.Server {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	if configured {
+		routes.ConfigureEngine(engine)
+	}
+
+	engine.Any("/proxy/:workspace/:name/*path", func(c *gin.Context) {
+		path := c.Param("path")
+		if path != "" && path[0] == '/' {
+			path = path[1:]
+		}
+
+		CreateProxyHandler(upstreamURL, path, nil)(c)
+	})
+
+	server := httptest.NewServer(engine)
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// getRaw sends a request whose path keeps the escaping exactly as written.
+func getRaw(t *testing.T, rawURL string) *http.Response {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { resp.Body.Close() })
+
+	return resp
+}
+
+// What a proxied path turns into on the wire, and which cases
+// routes.ConfigureEngine changes. Every case runs through an engine with the
+// setting and one without, so a change in blast radius fails here.
+func TestProxyPathEscaping(t *testing.T) {
+	tests := []struct {
+		name string
+		// requestPath is written with the escaping the client sends.
+		requestPath string
+		wantStatus  int
+		// wantUpstreamURI is the raw request line the upstream receives. Empty when
+		// the request never reaches it.
+		wantUpstreamURI string
+		// differs records whether the setting changed this case.
+		differs bool
+		note    string
+	}{
+		{
+			name:            "plain path",
+			requestPath:     "/proxy/default/cluster/api/version",
+			wantStatus:      http.StatusOK,
+			wantUpstreamURI: "/api/version",
+		},
+		{
+			name:        "encoded slash",
+			requestPath: "/proxy/default/cluster/logs/worker%2Fout",
+			wantStatus:  http.StatusOK,
+			// A real separator either way: the proxy assigns req.URL.Path and never RawPath,
+			// so the wire form is derived from the decoded path.
+			wantUpstreamURI: "/logs/worker/out",
+		},
+		{
+			name:        "double-encoded slash",
+			requestPath: "/proxy/default/cluster/logs/a%252Fb",
+			wantStatus:  http.StatusOK,
+			// Decoded twice — once by the router, once when CreateProxyHandler re-parses the
+			// parameter into a URL. Pre-existing.
+			wantUpstreamURI: "/logs/a/b",
+		},
+		{
+			name:        "encoded percent",
+			requestPath: "/proxy/default/cluster/logs/a%25b",
+			// A lone "%" reaches url.Parse as an invalid escape. Pre-existing, and recorded
+			// so it is not later blamed on the setting.
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:        "encoded plus",
+			requestPath: "/proxy/default/cluster/logs/a%2Bb",
+			wantStatus:  http.StatusOK,
+			// A literal "+" is a legal path character and needs no escaping.
+			wantUpstreamURI: "/logs/a+b",
+		},
+		{
+			name:        "literal plus, no other escape",
+			requestPath: "/proxy/default/cluster/logs/a+b",
+			wantStatus:  http.StatusOK,
+			// RawPath is only populated when a URL's escaped and decoded forms differ, so a
+			// path with no escapes never engages the setting at all.
+			wantUpstreamURI: "/logs/a+b",
+		},
+		{
+			name:        "literal plus alongside an escape",
+			requestPath: "/proxy/default/cluster/logs/a+b%2Fc",
+			wantStatus:  http.StatusOK,
+			// The one divergence, and it needs both an escape (to populate RawPath) and a
+			// literal "+" (which QueryUnescape reads as a space).
+			wantUpstreamURI: "/logs/a%20b/c",
+			differs:         true,
+			note:            "known divergence introduced by routes.ConfigureEngine",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configured := newUpstreamRecorder(t)
+			configuredResp := getRaw(t, newProxyServer(t, configured.server.URL, true).URL+tt.requestPath)
+
+			require.Equal(t, tt.wantStatus, configuredResp.StatusCode)
+			assert.Equal(t, tt.wantUpstreamURI, configured.requestURI, tt.note)
+
+			before := newUpstreamRecorder(t)
+			beforeResp := getRaw(t, newProxyServer(t, before.server.URL, false).URL+tt.requestPath)
+
+			if tt.differs {
+				assert.NotEqual(t, before.requestURI, configured.requestURI,
+					"this case is recorded as changed by the setting; it did not change")
+
+				return
+			}
+
+			assert.Equal(t, before.requestURI, configured.requestURI,
+				"the setting must not change what this proxied path becomes")
+			assert.Equal(t, beforeResp.StatusCode, configuredResp.StatusCode)
+		})
+	}
+}
+
+// The single-segment proxy route, which has no cluster lookup in front of it and
+// so can be driven exactly as it is registered. An encoded slash inside an RPC
+// name used to make the request one segment too long and miss the route
+// entirely; now it routes and the name is passed through decoded.
+func TestPostgrestRPCProxyRoutesAnEncodedSlash(t *testing.T) {
+	upstream := newUpstreamRecorder(t)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	routes.ConfigureEngine(engine)
+	RegisterPostgrestRPCProxyRoutes(&engine.RouterGroup, nil, &Dependencies{
+		StorageAccessURL: upstream.server.URL,
+	})
+
+	server := httptest.NewServer(engine)
+	t.Cleanup(server.Close)
+
+	resp := getRaw(t, server.URL+"/rpc/get_workspace_models")
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "/rpc/get_workspace_models", upstream.requestURI)
+}

--- a/internal/routes/proxies/workspace_proxy.go
+++ b/internal/routes/proxies/workspace_proxy.go
@@ -2,6 +2,7 @@ package proxies
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
@@ -9,6 +10,52 @@ import (
 	"github.com/neutree-ai/neutree/internal/middleware"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
+
+// userModelRegistryCount counts the model registries in a workspace that would
+// keep a user from deleting it: the ones they created.
+//
+// Registries the control plane provisions are excluded. They exist in every
+// workspace whenever the built-in public registries option is on, and the API
+// refuses to delete them, so counting them would make every workspace
+// permanently undeletable. The built-in engines are excluded from this check the
+// same way — by not being counted at all — and this keeps the two consistent.
+//
+// Registries already marked for deletion are excluded for the same reason the
+// model deletion path excludes soft-deleted endpoints: an object on its way out
+// must not block the removal that releases it.
+//
+// Counted in Go rather than through a filter because the marker is a JSON key
+// containing a dot and a slash, which a PostgREST column expression cannot
+// address without quoting rules this codebase does not otherwise rely on.
+func userModelRegistryCount(s storage.Storage, workspace string) (int, error) {
+	registries, err := s.ListModelRegistry(storage.ListOption{
+		Filters: []storage.Filter{
+			{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to count %s: %w", storage.MODEL_REGISTRY_TABLE, err)
+	}
+
+	count := 0
+
+	for i := range registries {
+		metadata := registries[i].Metadata
+		if metadata == nil {
+			count++
+
+			continue
+		}
+
+		if v1.IsBuiltin(metadata.Annotations) || metadata.DeletionTimestamp != "" {
+			continue
+		}
+
+		count++
+	}
+
+	return count, nil
+}
 
 func validateWorkspaceDeletion(s storage.Storage) middleware.DeletionValidatorFunc {
 	return func(workspace, name string) error {
@@ -33,6 +80,13 @@ func validateWorkspaceDeletion(s storage.Storage) middleware.DeletionValidatorFu
 
 			counts[table] = count
 		}
+
+		registries, err := userModelRegistryCount(s, name)
+		if err != nil {
+			return err
+		}
+
+		counts[storage.MODEL_REGISTRY_TABLE] = registries
 
 		count, err := s.Count(storage.ROLE_ASSIGNMENT_TABLE, []storage.Filter{
 			{Column: "spec->>workspace", Operator: "eq", Value: name},

--- a/internal/routes/proxies/workspace_proxy_test.go
+++ b/internal/routes/proxies/workspace_proxy_test.go
@@ -1,139 +1,87 @@
 package proxies
 
 import (
-	"errors"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
-	"github.com/neutree-ai/neutree/internal/middleware"
-	"github.com/neutree-ai/neutree/pkg/storage"
-	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
-func TestValidateWorkspaceDeletion(t *testing.T) {
+func registryIn(workspace, name string, builtin bool, deletionTimestamp string) v1.ModelRegistry {
+	annotations := map[string]string{}
+	if builtin {
+		annotations = v1.WithBuiltinAnnotation(nil)
+	}
+
+	return v1.ModelRegistry{
+		ID: 1,
+		Metadata: &v1.Metadata{
+			Name:              name,
+			Workspace:         workspace,
+			Annotations:       annotations,
+			DeletionTimestamp: deletionTimestamp,
+		},
+		Spec: &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
+	}
+}
+
+// A workspace with nothing but the registry the control plane put there must
+// still be deletable. Counting that registry would make every workspace
+// permanently undeletable once the built-in option is on, because the API also
+// refuses to delete it.
+func TestUserModelRegistryCount_IgnoresControlPlaneOwnedRegistries(t *testing.T) {
 	tests := []struct {
-		name          string
-		workspace     string
-		workspaceName string
-		counts        map[string]int
-		queryError    error
-		expectError   bool
-		expectedCode  string
-		expectedHints []string
+		name       string
+		registries []v1.ModelRegistry
+		want       int
 	}{
 		{
-			name:          "no dependencies - deletion allowed",
-			workspace:     "",
-			workspaceName: "default",
-			counts: map[string]int{
-				storage.ENDPOINT_TABLE:        0,
-				storage.CLUSTERS_TABLE:        0,
-				storage.MODEL_REGISTRY_TABLE:  0,
-				storage.IMAGE_REGISTRY_TABLE:  0,
-				storage.MODEL_CATALOG_TABLE:   0,
-				storage.ROLE_TABLE:            0,
-				storage.API_KEY_TABLE:         0,
-				storage.ROLE_ASSIGNMENT_TABLE: 0,
-			},
-			queryError:  nil,
-			expectError: false,
+			name:       "only the built-in one",
+			registries: []v1.ModelRegistry{registryIn("default", "public-hugging-face", true, "")},
+			want:       0,
 		},
 		{
-			name:          "has dependencies - deletion blocked",
-			workspace:     "",
-			workspaceName: "default",
-			counts: map[string]int{
-				storage.ENDPOINT_TABLE:        2,
-				storage.CLUSTERS_TABLE:        1,
-				storage.MODEL_REGISTRY_TABLE:  0,
-				storage.IMAGE_REGISTRY_TABLE:  0,
-				storage.MODEL_CATALOG_TABLE:   0,
-				storage.ROLE_TABLE:            3,
-				storage.API_KEY_TABLE:         0,
-				storage.ROLE_ASSIGNMENT_TABLE: 0,
+			name: "a user registry blocks",
+			registries: []v1.ModelRegistry{
+				registryIn("default", "public-hugging-face", true, ""),
+				registryIn("default", "mine", false, ""),
 			},
-			queryError:   nil,
-			expectError:  true,
-			expectedCode: "10125",
-			expectedHints: []string{
-				storage.ENDPOINT_TABLE + ": 2",
-				storage.CLUSTERS_TABLE + ": 1",
-				storage.ROLE_TABLE + ": 3",
-			},
+			want: 1,
 		},
 		{
-			name:          "query error",
-			workspace:     "",
-			workspaceName: "default",
-			counts:        map[string]int{},
-			queryError:    errors.New("database error"),
-			expectError:   true,
+			// On its way out already; it must not block the deletion that releases it.
+			name:       "a soft-deleted user registry does not block",
+			registries: []v1.ModelRegistry{registryIn("default", "mine", false, "2026-08-11T00:00:00Z")},
+			want:       0,
+		},
+		{
+			name:       "nothing at all",
+			registries: []v1.ModelRegistry{},
+			want:       0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockStorage := storageMocks.NewMockStorage(t)
+			storage := &storagemocks.MockStorage{}
+			storage.On("ListModelRegistry", mock.Anything).Return(tt.registries, nil)
 
-			// Mock Count calls for all tables
-			tables := []string{
-				storage.ENDPOINT_TABLE,
-				storage.CLUSTERS_TABLE,
-				storage.MODEL_REGISTRY_TABLE,
-				storage.IMAGE_REGISTRY_TABLE,
-				storage.MODEL_CATALOG_TABLE,
-				storage.ROLE_TABLE,
-				storage.API_KEY_TABLE,
-			}
-
-			for _, table := range tables {
-				count := tt.counts[table]
-				mockStorage.On("Count",
-					table,
-					[]storage.Filter{
-						{Column: "metadata->>workspace", Operator: "eq", Value: tt.workspaceName},
-					},
-				).Return(count, tt.queryError).Maybe()
-
-				// If there's a query error, we might not get to all tables
-				if tt.queryError != nil {
-					break
-				}
-			}
-
-			// Mock Count call for role_assignment_table (different filter)
-			if tt.queryError == nil {
-				count := tt.counts[storage.ROLE_ASSIGNMENT_TABLE]
-				mockStorage.On("Count",
-					storage.ROLE_ASSIGNMENT_TABLE,
-					[]storage.Filter{
-						{Column: "spec->>workspace", Operator: "eq", Value: tt.workspaceName},
-					},
-				).Return(count, tt.queryError)
-			}
-
-			validator := validateWorkspaceDeletion(mockStorage)
-			err := validator(tt.workspace, tt.workspaceName)
-
-			if tt.expectError {
-				assert.Error(t, err)
-
-				if tt.queryError == nil {
-					deletionErr, ok := err.(*middleware.DeletionError)
-					assert.True(t, ok, "error should be DeletionError")
-					if ok {
-						assert.Equal(t, tt.expectedCode, deletionErr.Code)
-						for _, hint := range tt.expectedHints {
-							assert.Contains(t, deletionErr.Hint, hint)
-						}
-					}
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-
-			mockStorage.AssertExpectations(t)
+			count, err := userModelRegistryCount(storage, "default")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, count)
 		})
 	}
+}
+
+func TestUserModelRegistryCount_ReportsStorageFailures(t *testing.T) {
+	storage := &storagemocks.MockStorage{}
+	storage.On("ListModelRegistry", mock.Anything).Return(nil, errors.New("boom"))
+
+	_, err := userModelRegistryCount(storage, "default")
+	assert.Error(t, err)
 }

--- a/internal/routes/router.go
+++ b/internal/routes/router.go
@@ -1,0 +1,33 @@
+// Package routes holds configuration shared by the whole API router.
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// ConfigureEngine applies the router settings the API depends on.
+//
+// UseRawPath matches routes against URL.RawPath — the escaped form — so a
+// percent-encoded separator stays encoded while the route is chosen. The model
+// routes require it: a public registry names its models "org/model", and
+// matching against the already-decoded URL.Path gives such a request one path
+// segment too many, so it matches no route and never reaches a handler.
+// Captured parameters are still unescaped afterwards, so handlers receive
+// "org/model".
+//
+// gin leaves RawPath empty unless a URL actually contains a percent-escape, and
+// every resource name in this API is validated to a character set that needs no
+// escaping. The routes that see any difference are therefore the model detail
+// and README routes, and the proxy routes' caller-supplied *path.
+//
+// On those proxy routes one case diverges: in a URL that carries an escape, a
+// literal '+' in a captured parameter is unescaped to a space, so a proxied
+// /logs/a+b%2Fc reaches the upstream as /logs/a%20b/c. TestProxyPathEscaping
+// pins this and the cases that do not change.
+//
+// Setting UnescapePathValues = false instead does not preserve escaping through
+// the proxies: CreateProxyHandlerWithTransport re-parses the path into a URL and
+// assigns only req.URL.Path, so the escaping is dropped on the way out anyway.
+func ConfigureEngine(engine *gin.Engine) {
+	engine.UseRawPath = true
+}


### PR DESCRIPTION
## What

NEU-624. Hugging Face provider enhancement, registry availability status and built-in registry provisioning: model detail parsed from `config.json`, typed errors for the refusals a user can act on, a reachability state with a check time that actually moves, a cache in front of the hub, a built-in registry provisioned only when the deployment asks for it, and a README endpoint.

Rebased onto `main` now that NEU-620 has merged (`c112235`), so **CI runs and is green**. It was previously stacked on `neu-620-model-metadata-registry-api`.

> **Rebase note.** Replayed with `git rebase --onto origin/main afdd1003`, squashed to a single commit first (this PR is squash-merged, so the intermediate history bought nothing and made 18 rounds of conflict resolution where one would do). Six files conflicted, all in `internal/model_registry/`, and the cause is worth recording: **the squashed NEU-620 that landed on main dropped `GetReadme` entirely** — interface, both implementations, mocks and tests. My changes to it were therefore "modified vs deleted", which resolves to *deleted* unless you notice. `internal/model_registry/file_based.go` was hand-merged against PR #526 (NFS mount-read validation, which lands in the same file and the same reconcile), and git had silently taken main's side for the `os` import and the `readmeFileName` const there; both restored.
>
> Two behavioural interactions with #526, not mechanical conflicts: it made the reconcile `Connect()` on **every** pass rather than only out of `Pending`/`Failed`, so two of my status tests needed the new call in their expectations; and its restructured `sync` body now sits under my status-write `defer`, which is orthogonal to it and unchanged.
>
> Equivalence checked three ways, not by eye: (1) the net-diff file list is identical before and after (48 files); (2) an **independent reconstruction** — 3-way applying the pre-rebase net diff onto `main` and resolving the same six files the same way — produced a tree *byte-identical* to the rebase result; (3) per file, only five differ from my pre-rebase content and each delta is exactly main's own change. `make mockgen` then produced no diff, which independently confirms the mock resolution.

> **Ticket note.** This was first written against NEU-649, which turned out to be a duplicate of NEU-624 (raised from a JQL query that covered NEU-618's subtasks but not NEU-623's). NEU-624 is the requirement-side ticket and wins wherever the two differ. One place they contradicted each other, and the history shows it: NEU-649 asked for the built-in registry to be withdrawn when the switch is turned off, and NEU-624 says *"关闭开关后不再供应，已供应的不自动删除"*. Withdrawal — and the endpoint reference check added to it in review — is removed. Commits `7e554be`..`cff2e1d` implemented it; `9048cb7` onwards takes it back out.

## 1. Hugging Face provider

**`GetModelDetail`** fetches one file — `config.json` — and nothing else. That yields the architecture, layer and head counts, KV heads, `head_dim`, `max_position_embeddings`, dtype, expert counts and quantization width: everything the resource estimate needs, a few kilobytes next to a checkpoint measured in gigabytes. The weights are never downloaded.

The parsing is not a second implementation. `modelmeta.Parse` was split so that the config half is `modelmeta.ParseConfig([]byte)`, used by both the private path (reading the file from disk) and the public one (reading it over HTTP). Same file, same meaning, same parser, same provenance rules — including "never guess from the name".

`parameter_count` is the one field the public path cannot establish and reports in `missing_fields`: it is a sum over the safetensors headers, which live in the weight files. A repository with no `config.json` is a normal answer, not a failure — plenty of things on the Hub are not transformers checkpoints — and yields a model whose every field is missing.

`parameter_count` **is** established, from the Hub's own tally of the safetensors headers (`?expand[]=safetensors`) — the same sum the private path computes by reading those headers itself, which is why it is recorded as `auto` rather than as an estimate. It is a second call, made only on the detail path (never on a listing, which pays no parsing cost), and treated as optional: a hub that is slow, throttling, or simply does not report it — anything not stored as safetensors — leaves the field in `missing_fields` and the detail view is served anyway. A page that fails outright because a secondary metadata call timed out would be a worse answer than a page with one field marked unknown.

**Error mapping.** Two typed errors, because the three refusals a user can act on were previously indistinguishable from "it broke":

| condition | error | HTTP | why it is separate |
|---|---|---|---|
| 401 / 403 | `ErrUnauthorized` | 400 `registry_unauthorized` | needs a token, or a better one. Retrying never helps. The message says which of the two, based on whether a token is configured. |
| 429 | `ErrRateLimited` | 429 `rate_limited` | nothing is wrong; come back later |
| transport / timeout | unchanged | 500 `unavailable` | the shared client's 300s timeout still applies |

429s are retried inline, three attempts, exponential backoff from 300ms, honouring the hub's `Retry-After` where it sends one, capped at 2s — the budget is what somebody waiting on an HTTP handler will tolerate, not what a background job would. Past that the answer is the typed error, which is actionable.

Applied to the listing and token-validation paths too, so a rate-limited or unauthenticated registry now says so everywhere instead of only where the code happened to be new.

**Listing offset/total is not implemented.** NEU-624 §1 asks for it, but that line predates the implementation and was overtaken by it: the Hub's pagination is an opaque cursor that cannot express "start at row N", and its `skip` parameter is deprecated and fails past a few thousand rows. NEU-620 established that on the base branch, where `offset > 0` is refused with `ErrNotSupported` rather than silently serving page 1 forever. Confirmed with the requirement owner; the ticket is being corrected rather than the code.

## 1b. Public model names route correctly

Every model on the Hub is named `org/model`. A client percent-encodes that slash, but gin routes on `URL.Path`, which the standard library has already decoded — so `%2F` is a separator again by the time the router sees it, the request has one segment too many, and it is answered with gin's own plain-text 404 before any handler runs. Model detail and README were unusable for every public model that is not a bare name.

Fixed by routing on the escaped path: `routes.ConfigureEngine` sets `UseRawPath`, and gin unescapes the captured parameters afterwards, so handlers still receive `org/model`. It is exported and called from the engine factory rather than set there, so the tests drive the same configuration production does.

What this changes, per registry kind:

| | before | after |
|---|---|---|
| private (`[a-z0-9._-]`, never needs escaping — `v1.ValidateModelName`) | routed on a path with no escapes | **byte-identical**: `RawPath` is empty for those URLs, so the router takes exactly the same branch |
| public (`org/model`, encoded by the client) | framework 404, no handler | routed, handler receives the decoded name |
| any URL, literal unencoded slash | 404 | 404, unchanged — encoding is the client's side of the contract |

Tested through the real router rather than by calling handlers, since the failure was that no handler ran. `routing_test.go` covers the encoded name on both detail and README, private names unaffected, the listing route not shadowed, an unencoded slash still 404 — and, so it cannot pass for the wrong reason, that without the setting the same request produces the old `404 page not found`.

### Blast radius of the setting

`UseRawPath` is engine-wide, so it lives in `internal/routes` (`routes.ConfigureEngine`) rather than beside the model routes, and the analysis covers the whole router rather than the routes that motivated it.

It is inert for any URL with no percent-escapes — gin only consults `RawPath` when the escaped and decoded forms differ — which covers every resource route in the API, since workspace, cluster, registry and model names are all validated to character sets in which nothing needs escaping. Two families of route can carry escapes: the model detail/README routes, and the proxy routes that forward a caller-supplied `*path` to the Ray dashboard, Ray Serve and the Kubernetes API.

`TestProxyPathEscaping` runs seven cases through the router **twice — with the setting and without it** — and asserts which ones differ, so this is measured rather than argued:

| proxied path | reaches upstream as | changed by the setting |
|---|---|---|
| `/api/version` | `/api/version` | no |
| `/logs/worker%2Fout` | `/logs/worker/out` | no |
| `/logs/a%252Fb` | `/logs/a/b` | no |
| `/logs/a%25b` | 500 (pre-existing) | no |
| `/logs/a%2Bb` | `/logs/a+b` | no |
| `/logs/a+b` | `/logs/a+b` | no |
| `/logs/a+b%2Fc` | `/logs/a%20b/c` (was `/logs/a+b/c`) | **yes** |

Writing the test corrected three things I had asserted from reading the code:

- **A literal `+` on its own is not affected.** `RawPath` is only populated when a URL's escaped and decoded forms differ, so a path whose only notable character is `+` has no `RawPath` and never engages the setting at all. The divergence needs *both* a `+` and an escape elsewhere in the URL — that is the last row, and it is the only changed case in the table.
- **`%252F` already reaches the upstream as a plain `/`**, with or without the setting, because `CreateProxyHandlerWithTransport` interpolates the parameter into a URL string, re-parses it, and assigns only `req.URL.Path`.
- **A lone `%` already yields a 500** for the same reason. Pre-existing, now pinned so a later reader does not attribute it to this change.

That last point also disposes of the `UnescapePathValues = false` alternative: it would avoid the `+` divergence, but it could not preserve escaping through the proxy either, because the escaping is dropped by that handler's re-parse regardless. Preserving it is a change to `CreateProxyHandlerWithTransport`, not to this switch. `internal/routes/proxies` had no test touching path escaping before this.

## 2. "Last checked" is now separate from "last changed"

`status.last_transition_time` answers *when did the phase change*. A registry reachable for three days still reports the moment it first connected, so it cannot be shown as a check time — and the reconcile's write-back condition made this worse in two ways: it skipped the write whenever phase and *error presence* were unchanged, so

- a healthy registry's status was never rewritten at all, and
- a failing registry kept displaying its **first** failure reason, because "error present" → "error present" counted as no change even when the reason had become something else.

Added `status.last_checked_at` (migration `084`), and moved the write-back policy into one place, `internal/model_registry/status.go`, shared by the reconcile and by the new retry endpoint:

- `NextStatus` — carries `last_transition_time` forward when the phase is unchanged, always stamps `last_checked_at`, always carries `stats` forward (PostgREST replaces a composite column whole).
- `NeedsStatusWrite` — writes when the phase changed, when the error **text** changed, when statistics were refreshed, or when the recorded check time is older than `DefaultCheckedAtWriteInterval` (1 min).

The interval exists because the reconcile runs every 10s: without it, every registry would produce a status write six times a minute saying nothing. The cost is that the displayed check time trails reality by up to a minute. Overridable per-controller via `ModelRegistryControllerOption.CheckedAtWriteInterval`.

Deletion is explicitly *not* a check — `syncDeletion` carries the old `last_checked_at` over rather than stamping it.

## 3. "Retry connection" — what it does and does not do

The ticket asked me to confirm the current behaviour before designing this. Confirmed: `model_registry_controller.go` already disconnects and reconnects a `Failed` registry on **every** reconcile, so the connection is retried within the sync interval regardless. A button presented as *the* way to recover would be a lie.

`POST /api/v1/workspaces/:workspace/model_registries/:registry/retry_connection` is therefore scoped to the three things that are genuinely not otherwise available:

1. it answers, so someone who has just fixed a mirror address learns the outcome from the click;
2. **it invalidates the cached query results for that registry** — this is the part nothing else does. Without it the status goes green while the listing beside it replays pre-fix results, which reads as the retry having failed;
3. it records the check, so `last_checked_at` moves when a person checks and not only when the reconcile does.

Failure is data: an unreachable registry answers `200` with `phase: Failed` and the reason, following the `test_connectivity` precedent in `external_endpoint_proxy.go`. Permission is `model_registry:update` (no new permission action).

Three caveats, all documented at the handler:

- the check runs in `neutree-api`, which is not the process that reconciles the registry. They can genuinely disagree (different containers), and when they do the next reconcile overwrites this. That is the right resolution — the reconciling process's reachability is the one that decides whether models can be served.
- a disagreement is tolerable, but a process that *cannot perform the check at all* is not: for a private NFS registry the check mounts, so this depends on the API process being able to mount NFS, exactly as the reconciling one does. Otherwise every healthy NFS registry would be reported Failed here and that verdict written back. Both deployments give it the privileges and the `mount.nfs` binary, and the model listing handlers next to this one already rely on it since they connect the same way. Now stated explicitly rather than assumed.
- both processes now write the status column. Both go through `NextStatus`, so a lost update costs at most one carried-forward `stats` generation.

## 4. Query cache

`internal/model_registry/query_cache.go`. In-process, capped at 512 entries (the search term is user input, so the key space is unbounded).

TTL is **5 minutes by default and configurable** via `--public-registry-query-cache-ttl` on `neutree-api`. I had 1 minute and have taken the review's number: browsing a hub — searching, paging back and forth, opening something and coming back — should be one round of queries rather than one per interaction, and staleness inside the window is bounded where it matters, because "retry connection" drops the entries so nobody who has just fixed something has to wait it out.

- **Key** = workspace + registry name + row id + URL + SHA-256 prefix of the credential, then search/offset/limit. Credentials are in the key because a hub shows a different catalogue to different callers — gated repositories appear only for a token that may see them. Digested, not stored: a map key is the kind of thing that ends up in a heap dump. The URL is in the key so repointing at another mirror starts from an empty cache.
  - This rests on `Spec.Credentials` still carrying a value at this point. It is tagged `api:"-"`, but that tag is applied by the client-facing resource proxy on the way out to a caller, not by the storage read this object came from — `newHuggingFace` already depends on the same thing for its token. Were that to change, every scope would fingerprint as `anonymous` and one caller's view of a gated repository would be served to another, with `registryScope` still reading exactly as it does now. The invariant is written into the code where it would be broken.
- **Public registries only.** A private registry is a local tree — cheap to list, and a model pushed a second ago has to appear at once.
- **Errors are never cached**; a hub that refused this request may answer the next one.
- **Served pages are deep copies.** The list handler decorates models with aliases in place, and a shared page would leak one request's decorations into the next. There is a regression test for exactly this.
- Nothing is persisted and no full catalogue is synced, per the Story's "no full sync".

No cache library exists in the repo and none was added. Multi-replica deployments get one cache per replica; invalidation reaches the replica that served the request, and the rest self-correct within the TTL. Called out rather than solved — a shared cache is new infrastructure for entries worth less than a minute.

## 5. Built-in registry: provisioning and the switch

Follows the built-in **engines** pattern (`internal/engine/builtin.go` + `workspace_controller.syncWorkspaceEngine`), which is the repo's existing answer to "the control plane provisions this into every workspace":

- `internal/model_registry/builtin.go` declares the registry; `controllers/workspace_model_registry.go` reconciles it per workspace.
- Off by default. Enabled and pointed at a mirror by two `neutree-core` flags: `--enable-builtin-public-model-registries`, `--hugging-face-endpoint`. Plumbed through Helm (`publicModelRegistries.enabled` / `.huggingFace.url`) and through Compose (`neutree-cli launch neutree-core --enable-public-model-registries --hugging-face-endpoint`). When off, no argument is emitted at all.
- **The switch governs provisioning only.** Turning it off stops the control plane putting registries there; registries already provisioned stay until a person removes them (NEU-624 acceptance: *已供应的不自动删除*). With it off, nothing is even looked up.
- The `neutree.ai/builtin` annotation is what tells a provisioned registry from a user's. Provisioning never adopts a registry that merely shares the name, and the API keys off the same annotation for the guard below.
- A registry pointed at a new mirror keeps any credentials a user attached to it.

**Edits refused on a built-in registry** (`internal/routes/proxies/builtin_model_registry.go`, on the PATCH path ahead of the existing deletion validation):

| edit | answer | why |
|---|---|---|
| soft delete | 400 `10132` | the control plane provisions it back on the next reconcile, so allowing it makes the registry flicker rather than removing it. The hint says which option to turn off instead. |
| change `spec.type` | 400 `10132` | a different kind of registry under a name that says otherwise, undone on the next reconcile |
| change `spec.url` / `spec.credentials` | allowed for `model_registry:read-credentials`, else 403 | legitimately operator business — an air-gapped site pointing at its own mirror, or attaching a token |
| anything else | unchanged | |

"Administrators only" resolves to `model_registry:read-credentials` rather than a role-name check: the preset admin role holds every permission action, this is the action that already means "trusted with this registry's credentials", and it is the one `model_registry` action the preset workspace-user role is *not* granted. No new permission action, no migration, and the rule stays in the permission system instead of being hard-coded. A patch that mentions these fields without changing their values is not a change and is not gated.
- Credentials a user attached to the built-in registry are carried forward when the URL is re-pointed.
- The sync walks the *names* the control plane may provision rather than listing the workspace's registries, so a deployment with the option off does not scan somebody's registry list every sync interval.

## 6. Public / private is stated by the server

Migration `084` adds a PostgREST **computed field** `api.visibility(api.model_registries)` returning `public` / `private`, mirrored in Go by `v1.VisibilityForModelRegistryType` (one rule, two call sites, same file comment on both).

A computed field rather than a stored column because it is derived: storing it would need a trigger to keep it true, and it would appear in write payloads that clients round-trip back. It can be selected (`?select=*,visibility`) and filtered (`?visibility=eq.public`) but never written — which also means **a client must ask for it**; PostgREST leaves computed fields out of `select=*`. That is the contract for the CLI (NEU-625) and UI (NEU-626).

**Verified against a live PostgREST** (read-only, nothing mutated): `visibility` comes back `private` / `public` per registry under `?select=*,visibility`, is absent from a bare `select=*`, filters correctly in both directions, and a write is rejected with `PGRST204 Could not find the 'visibility' column` — which is what proves it is a computed field and not a column a client could round-trip back.

**The migration was renumbered `083` → `084`**: `#544` took `083` on main while this branch was open. git does not report that as a conflict, since the filenames differ, but golang-migrate refuses a source directory holding two migrations with the same version — so it would have failed at deploy time and not before. Renamed both halves, plus the two references in `db/dbtest/model_registry_stats_test.go` and the "current highest number" line in `contributing/database.md` that `#544` had just bumped. `084` is `max + 1`, not the lowest unused number: golang-migrate applies in ascending order and skips versions below the database's current one, so anything below `083` would never run on an already-migrated deployment. `up` / `down 1` / `up` was exercised against a real PostgreSQL 15 with the pinned golang-migrate, checking that both the attribute and the function disappear on the way down and return on the way up — an unpaired `down` being the failure a renumber invites.

## 7. README

`GET .../models/:model/readme?version=` returns the markdown as stored, `Content-Type: text/markdown`, never rendered — a model card is content from outside this system, and rendering it server-side would run it in every client that displays the result.

- The size cap moved into the registry layer: `GetReadme` now returns `*Readme{Content, Truncated}` instead of a `string`, and both implementations stop reading at `MaxReadmeBytes` (1 MiB) rather than reading the file and trimming afterwards. Truncation is signalled by `X-Neutree-Content-Truncated: true` and the cut lands on a rune boundary. **This changes an interface introduced on the base branch** — flagged for review.
- The ways a card can fail to arrive are kept distinct, with a machine-readable `reason`: `404 not_found` (registry answered, no card), `400 not_supported` (this registry kind serves no cards), `400 registry_unauthorized`, `429 rate_limited`, `500 unavailable` (could not ask).

## 8. Responses say how old the data is

A listing served from cache describes the hub as of when it was fetched, not as of when it was asked for. `X-Neutree-Data-Timestamp` carries that moment and `X-Neutree-Data-Cached` says the answer was reused, so a client can show it rather than having to infer it. The body stays a bare array — same reason as `Content-Range`.

`GetReadme` is implemented for Hugging Face too (one `GET .../resolve/<rev>/README.md`, no checkpoint download).

## 9. Write paths refuse in one shape, and early enough to matter

The read paths already answered a registry's refusal with `respondRegistryError`. The write paths did not, so a public registry produced two different wrong answers:

- **`deleteModel` answered `500`.** It now goes through `respondRegistryError`, so a refusal is a `400 not_supported` with the same body shape as everywhere else.
- **`uploadModel` had already committed a chunked `200`** before the refusal surfaced from `ImportModel`, so a push to a read-only registry was answered `200` with a body reading `Error: …` — after the entire archive had been streamed.

For upload the fix is not a better error path, because **once the response headers are out the status code cannot change**. The question is *when the decision happens*. It can happen before anything is committed: the workspace and registry are path parameters, so the registry row can be read from storage before `MultipartReader` is ever called. `uploadModel` now refuses there, with a real `400`, having read none of the body.

The predicate is the registry's visibility, not a trial call: a public registry is read-only by definition and every write on it wraps `ErrNotSupported`. Deciding from the stored row is what makes it knowable in advance; the per-operation `ErrNotSupported` stays as the backstop.

`finalizeModel` is the tail of a push and had the same `500`-instead-of-`400` shape, so it is guarded the same way.

Worth being precise about what this does and does not buy: the server now refuses before reading the body, but a client that has already begun streaming may still see a write error rather than the `400`, because that is a property of the client, not of this handler. Not uploading at all is the client's half, and NEU-625 (#546) does it CLI-side by rejecting before packaging. No protocol change was made to manufacture a status code.

One ordering consequence, deliberate: the registry lookup now precedes model-name validation, because the name arrives *in* the body and the whole point is to decide without reading it. An invalid name is still its own `400` and still never reaches the import.

## 10. Follow-ups from human review

- **Workspace deletion no longer deadlocks.** `validateWorkspaceDeletion` counted every model registry in a workspace; provisioning one into each workspace and refusing to delete it made `totalCount > 0` permanent, so no workspace could ever be deleted with the built-in option on. It now counts only user-created registries — `neutree.ai/builtin` excluded, matching how `ENGINE_TABLE` is excluded from that list entirely — and soft-deleted ones are skipped for the same reason the model deletion path skips soft-deleted endpoints. Workspace teardown removes the provisioned registries (`DeleteWorkspaceModelRegistry`) so excluding them from the count cannot strand them.
- **`latest` is the version name everywhere.** `GetModelDetail` reported the hub's `main` while listings report `latest`, so a version taken from a listing did not resolve in a detail lookup. `main` is now confined to the request URL (`revision`); callers always see `latest`.
- **A built-in registry's address is owned by the deployment configuration.** Editing it through the API used to be accepted and then silently reverted by the next reconcile. It is now refused, naming `--hugging-face-endpoint` as where the value comes from. Credentials remain the user's and stay editable under `model_registry:read-credentials`.
- **The `neutree.ai/builtin` marker cannot be set or removed through the API.** It is the identity the provisioning, the write guard and the workspace deletion count all key off. Adding it to a user's registry would hand that registry to the control plane; removing it from a built-in one would strand it. Resending it unchanged still passes, since PostgREST replaces the whole metadata composite.

## Incidental

- `getModel` mapped every registry error to `500`, including `ErrNotSupported`; a read-only public registry therefore looked like a broken deployment. Now `400` / `404` / `500`, matching what `patchModel` already did.
- `getModelRegistry` split so a handler can read the stored registry without connecting to it (`findModelRegistry`).
- `internal/routes/engine.go` is named `router.go`. In this repo "engine" consistently means the inference engine (`api/v1/engine_types.go`, `internal/engine/`, the `release-engine-image-*` workflows), and files under `internal/routes/` are named for their resource — so `engine.go` read as "routes for the engine resource". The exported `ConfigureEngine` keeps its name because its argument is a `*gin.Engine`; say the word if you would rather it changed too.

## 9. Write paths answer with the same shape as read paths

Found by the NEU-625 session against a running deployment, and folded in here rather than fixed there, because this PR introduced `respondRegistryError` and had only wired it into the read paths. A second refusal shape for writes is exactly what that helper exists to prevent.

| path | before | now |
|---|---|---|
| `DELETE .../models/:model` | `500` — a refusal reported as a server fault | `400` `not_supported`, via `respondRegistryError` |
| `POST .../models` (upload) | chunked `200` already committed, then `Error:` in the body — and only *after* the whole archive had been streamed | `400` `not_supported`, decided before the body is read |
| `POST .../models/:model/finalize` | `500` | `400` `not_supported` — same defect, found while fixing the other two |

**Upload is a "when", not a "how".** Once the chunked `200` is out there is no status code left to change, so no amount of error handling in `ImportModel`'s return path can produce a `400`. The fix is that the decision moves earlier: the workspace and registry are path parameters, so the registry row can be read from storage before `MultipartReader` is called at all, and a registry with no write operations is refused there. `registryAcceptsWrites` derives that from the visibility rule this PR already centralises; the per-operation `ErrNotSupported` stays as the backstop for anything not knowable in advance.

`TestUploadModel_PublicRegistryRefusedBeforeTheBodyIsRead` asserts it the only way that means anything: the request body is wrapped in a counting reader and the assertion is that **zero bytes were read**, alongside no chunked framing and a JSON body. The private path is covered too, so "refuses public registries" cannot pass by refusing everything.

**One deliberate ordering change.** The registry is now consulted before the model name is validated, because the name arrives *in* the body — the two properties "reject a bad name without touching storage" and "reject a read-only registry without reading the body" cannot both hold. `TestUploadModel_InvalidName` pinned the first; it now pins the second, with the trade-off written into the test. An invalid name still gets its own `400` and still never reaches the import.

Server-side only. The CLI already refuses both before packaging and before the delete prompt — that is NEU-625 / #546, deliberately not duplicated here.

## Not in scope

Importing public models into a private registry; aliases/editing on public models; ModelScope (NEU-627). No write path exists on a public registry — every write operation still returns `ErrNotSupported`, now surfaced as a `400` rather than a `500` (§9), and `offset > 0` is still refused exactly as the base branch left it.

## Existing tests I had to change

Three, each because the behaviour it pinned is what this ticket changes:

- `TestModelRegistryController_Sync_PublicRegistryHasNoStats` asserted "nothing measured → nothing written". A check time is now something to write. It still asserts no `stats` block.
- `TestHuggingFace_UnsupportedOperationsAreTyped` no longer lists `GetModelDetail` and `GetReadme`, which are implemented. Everything else in it is untouched, including the assertion pinning the "operation not supported for Hugging Face registry" wording — now made against an operation that is still refused.
- `TestUploadModel_InvalidName` used to assert that storage was never consulted for a bad model name. That property and "a read-only registry is refused before its body is read" cannot both hold, since the name arrives in the body. The registry check wins — it is the one that decides whether gigabytes get uploaded. The test still asserts the invalid name gets its own `400` and never reaches the import.

`TestListModels_OffsetRefusedByRegistry` asserts on the exact refusal wording, so the listing handler keeps its own sentence for `ErrNotSupported` instead of taking the shared one.

Three more needed mocks after workspace teardown began listing registries: `TestForceDelete_WorkspaceController` and the three deletion cases in `TestWorkspaceController_Sync_Deletion`.

`make mockgen` also rewrites `internal/accelerator/mocks/mock_manager.go` — that drift is pre-existing (it reproduces on the base branch) and is **not** included here.

## What I ran, and what it said

In a `golang:1.23` sandbox, at the current head: `go build ./...` clean; `golangci-lint run --fast=false` clean — run without `--fix`, the way CI's action does, since `make lint` carries `--fix` and would report a green it had just created; `go test` over every package except `tests/e2e`, `db/dbtest` and `mocks` passes apart from the pre-existing failures below. `git status` after the gate is clean except for `internal/routes/logs/trace_store_test.go`, which `gofmt -l` also flags on a pristine `main` checkout.

Three failures, none from this branch, all reproduced on a clean checkout of `main` @ `3b7e65b`: `TestClusterController_Sync_PendingOrNoStatus` and `TestNewObsCollectConfigManager` fail there identically, and `TestServerMetricsDoesNotBlockOnSlowAllocationProvider` is a timing flake that passes in isolation on both. All three pass in CI.

Migration `084` has `db/dbtest` coverage. It adds a fifth attribute to `api.model_registry_status`, which broke two existing NEU-619 dbtests that build that composite with a positional `ROW(...)` literal; both are fixed. One of them exists to pin "a partial PATCH nulls the whole composite", so it now asserts that for `last_checked_at` as well — the invariant `NextStatus`'s carry-forward exists for — and the other asserts the check time advances across a real reconcile. `up` / `down 1` / `up` was exercised against a real PostgreSQL with the pinned golang-migrate version.
