### PR TITLE
fix: reject revoked API keys on the control plane (NEU-600)

### DIFF
--- a/cmd/neutree-api/app/factory.go
+++ b/cmd/neutree-api/app/factory.go
@@ -145,7 +145,8 @@ type MiddlewareFactory func(deps *MiddlewareOptions) gin.HandlerFunc
 func CommonMiddlewareFactory(register MiddlewareRegisterFunc) MiddlewareFactory {
 	return func(deps *MiddlewareOptions) gin.HandlerFunc {
 		return register(middleware.Dependencies{
-			Config: deps.Config.AuthConfig,
+			Config:  deps.Config.AuthConfig,
+			Storage: deps.Config.Storage,
 		})
 	}
 }

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -14,11 +14,20 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
+	"k8s.io/klog/v2"
+
+	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 type Dependencies struct {
-	Config AuthConfig
+	Config  AuthConfig
+	Storage storage.Storage
 }
+
+// errAPIKeyStateUnknown marks a failure to determine whether an API key is still
+// valid, as opposed to having determined that it is not. Authentication fails
+// closed either way; the distinction only decides the status code the caller sees.
+var errAPIKeyStateUnknown = errors.New("failed to verify API key")
 
 // AuthConfig holds the configuration for JWT authentication
 type AuthConfig struct {
@@ -66,13 +75,25 @@ func Auth(deps Dependencies) gin.HandlerFunc {
 			parsedInfo, err = parseBearerToken(deps.Config, authHeader)
 			is_api_key = false
 		case strings.HasPrefix(authHeader, "sk_"):
-			parsedInfo, err = parseApiKey(authHeader, deps.Config)
+			parsedInfo, err = parseApiKey(authHeader, deps.Config, deps.Storage)
 			is_api_key = true
 		default:
 			err = errors.New("invalid Authorization header format")
 		}
 
 		if err != nil {
+			// Why the key was refused stays server-side when the cause is a storage
+			// failure: the detail describes control-plane internals, not the request.
+			if errors.Is(err, errAPIKeyStateUnknown) {
+				klog.Errorf("Failed to verify API key: %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": errAPIKeyStateUnknown.Error(),
+				})
+				c.Abort()
+
+				return
+			}
+
 			c.JSON(http.StatusUnauthorized, gin.H{
 				"error": err.Error(),
 			})
@@ -135,9 +156,13 @@ func parseBearerToken(config AuthConfig, authHeader string) (*ParsedInfo, error)
 	}, nil
 }
 
-func parseApiKey(authHeader string, config AuthConfig) (*ParsedInfo, error) {
+func parseApiKey(authHeader string, config AuthConfig, store storage.Storage) (*ParsedInfo, error) {
 	payload, err := parseSelfContainedAPIKey(authHeader, config.JwtSecret)
 	if err != nil {
+		return nil, err
+	}
+
+	if err = verifyAPIKeyNotRevoked(store, payload.KeyID); err != nil {
 		return nil, err
 	}
 
@@ -145,6 +170,45 @@ func parseApiKey(authHeader string, config AuthConfig) (*ParsedInfo, error) {
 		UserID: payload.UserID,
 		KeyID:  &payload.KeyID,
 	}, nil
+}
+
+// verifyAPIKeyNotRevoked confirms the key backing a self-contained token is still
+// live.
+//
+// The signature proves who issued the token and the embedded expiry bounds its
+// natural lifetime, but neither says anything about whether the key has since been
+// revoked: deleting or disabling a key only changes database and gateway state. So
+// without this read a deleted or disabled key keeps working against the control
+// plane until its own expiry, and keys created without expires_in never expire at
+// all (NEU-600).
+//
+// Identity still comes from the signed payload — this read only establishes
+// liveness, so it queries by primary key and no field of the returned row is
+// trusted for identity. Any failure to reach the store denies the request: a
+// revocation check that fails open is not a revocation check.
+func verifyAPIKeyNotRevoked(store storage.Storage, keyID string) error {
+	if store == nil {
+		return fmt.Errorf("%w: no storage configured", errAPIKeyStateUnknown)
+	}
+
+	apiKey, err := store.GetApiKey(keyID)
+	if err != nil {
+		if errors.Is(err, storage.ErrResourceNotFound) {
+			return errors.New("API key has been revoked")
+		}
+
+		return fmt.Errorf("%w: %s", errAPIKeyStateUnknown, err.Error())
+	}
+
+	if apiKey.Metadata != nil && apiKey.Metadata.DeletionTimestamp != "" {
+		return errors.New("API key has been revoked")
+	}
+
+	if apiKey.Spec != nil && apiKey.Spec.Limits != nil && apiKey.Spec.Limits.Disabled {
+		return errors.New("API key is disabled")
+	}
+
+	return nil
 }
 
 func parseSelfContainedAPIKey(apiKey string, jwtSecret string) (*SelfContainedPayload, error) {

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,6 +17,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
 // Helper function to create a test self-contained API key
@@ -111,9 +116,27 @@ func TestAuth(t *testing.T) {
 		JwtSecret: jwtSecret,
 	}
 
+	const (
+		testUserID = "12345678-1234-1234-1234-123456789abc"
+		testKeyID  = "87654321-4321-4321-4321-abcdef123456"
+	)
+
+	// liveKey is the stored row of a key that has not been revoked.
+	liveKey := func() *storagemocks.MockStorage {
+		s := &storagemocks.MockStorage{}
+		s.On("GetApiKey", testKeyID).Return(&v1.ApiKey{
+			ID:       testKeyID,
+			Metadata: &v1.Metadata{Name: "live"},
+			Spec:     &v1.ApiKeySpec{},
+		}, nil)
+
+		return s
+	}
+
 	tests := []struct {
 		name                 string
 		setupAuth            func() string
+		setupStorage         func() *storagemocks.MockStorage
 		expectedStatus       int
 		expectUserID         string
 		expectPostgrestToken bool
@@ -141,16 +164,88 @@ func TestAuth(t *testing.T) {
 			name: "Valid self-contained API key",
 			setupAuth: func() string {
 				apiKey, _ := createTestAPIKey(
-					"12345678-1234-1234-1234-123456789abc",
-					"87654321-4321-4321-4321-abcdef123456",
+					testUserID,
+					testKeyID,
 					jwtSecret,
 					0, // Never expires
 				)
 				return apiKey
 			},
+			setupStorage:         liveKey,
 			expectedStatus:       http.StatusOK,
-			expectUserID:         "12345678-1234-1234-1234-123456789abc",
+			expectUserID:         testUserID,
 			expectPostgrestToken: true, // API keys should generate postgrest_token
+		},
+		{
+			// NEU-600: a cryptographically valid key whose row is gone must not
+			// authenticate, otherwise deleting a key never revokes it.
+			name: "Deleted API key is rejected",
+			setupAuth: func() string {
+				apiKey, _ := createTestAPIKey(testUserID, testKeyID, jwtSecret, 0)
+				return apiKey
+			},
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", testKeyID).Return(nil, storage.ErrResourceNotFound)
+
+				return s
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "API key pending deletion is rejected",
+			setupAuth: func() string {
+				apiKey, _ := createTestAPIKey(testUserID, testKeyID, jwtSecret, 0)
+				return apiKey
+			},
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", testKeyID).Return(&v1.ApiKey{
+					ID: testKeyID,
+					Metadata: &v1.Metadata{
+						Name:              "deleting",
+						DeletionTimestamp: "2026-08-05T07:20:48Z",
+					},
+					Spec: &v1.ApiKeySpec{},
+				}, nil)
+
+				return s
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "Disabled API key is rejected",
+			setupAuth: func() string {
+				apiKey, _ := createTestAPIKey(testUserID, testKeyID, jwtSecret, 0)
+				return apiKey
+			},
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", testKeyID).Return(&v1.ApiKey{
+					ID:       testKeyID,
+					Metadata: &v1.Metadata{Name: "disabled"},
+					Spec:     &v1.ApiKeySpec{Limits: &v1.ApiKeyLimits{Disabled: true}},
+				}, nil)
+
+				return s
+			},
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			// Fail closed: an unreachable store must deny rather than grant, and
+			// says so with a server error so it is not mistaken for a bad key.
+			name: "Unreachable storage denies the request",
+			setupAuth: func() string {
+				apiKey, _ := createTestAPIKey(testUserID, testKeyID, jwtSecret, 0)
+				return apiKey
+			},
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", testKeyID).Return(nil, assert.AnError)
+
+				return s
+			},
+			expectedStatus: http.StatusInternalServerError,
 		},
 		{
 			name: "Invalid API Key format",
@@ -177,9 +272,17 @@ func TestAuth(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Left as a nil interface when the case has no storage, so that a
+			// typed-nil mock never reaches the middleware.
+			var store storage.Storage
+			if tt.setupStorage != nil {
+				store = tt.setupStorage()
+			}
+
 			r := gin.New()
 			r.Use(Auth(Dependencies{
-				Config: config,
+				Config:  config,
+				Storage: store,
 			}))
 			r.GET("/test", func(c *gin.Context) {
 				userID, _ := GetUserID(c)
@@ -282,6 +385,105 @@ func TestParseBearerToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVerifyAPIKeyNotRevoked(t *testing.T) {
+	const keyID = "87654321-4321-4321-4321-abcdef123456"
+
+	tests := []struct {
+		name         string
+		setupStorage func() *storagemocks.MockStorage
+		wantErr      bool
+		wantUnknown  bool
+	}{
+		{
+			name: "live key passes",
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", keyID).Return(&v1.ApiKey{ID: keyID, Spec: &v1.ApiKeySpec{}}, nil)
+
+				return s
+			},
+		},
+		{
+			name: "key without limits passes",
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", keyID).Return(&v1.ApiKey{ID: keyID}, nil)
+
+				return s
+			},
+		},
+		{
+			name: "missing row is a revocation",
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", keyID).Return(nil, storage.ErrResourceNotFound)
+
+				return s
+			},
+			wantErr: true,
+		},
+		{
+			name: "deletion timestamp is a revocation",
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", keyID).Return(&v1.ApiKey{
+					ID:       keyID,
+					Metadata: &v1.Metadata{DeletionTimestamp: "2026-08-05T07:20:48Z"},
+				}, nil)
+
+				return s
+			},
+			wantErr: true,
+		},
+		{
+			name: "disabled is a revocation",
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", keyID).Return(&v1.ApiKey{
+					ID:   keyID,
+					Spec: &v1.ApiKeySpec{Limits: &v1.ApiKeyLimits{Disabled: true}},
+				}, nil)
+
+				return s
+			},
+			wantErr: true,
+		},
+		{
+			name: "storage failure is reported as unknown, not as a valid key",
+			setupStorage: func() *storagemocks.MockStorage {
+				s := &storagemocks.MockStorage{}
+				s.On("GetApiKey", keyID).Return(nil, assert.AnError)
+
+				return s
+			},
+			wantErr:     true,
+			wantUnknown: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyAPIKeyNotRevoked(tt.setupStorage(), keyID)
+
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+
+			assert.Error(t, err)
+			assert.Equal(t, tt.wantUnknown, errors.Is(err, errAPIKeyStateUnknown))
+		})
+	}
+}
+
+// A missing storage dependency must deny rather than skip the check.
+func TestVerifyAPIKeyNotRevokedWithoutStorage(t *testing.T) {
+	err := verifyAPIKeyNotRevoked(nil, "87654321-4321-4321-4321-abcdef123456")
+
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, errAPIKeyStateUnknown))
 }
 
 func TestParseSelfContainedAPIKey(t *testing.T) {

--- a/internal/routes/auth/auth.go
+++ b/internal/routes/auth/auth.go
@@ -29,7 +29,8 @@ type Dependencies struct {
 // RegisterAuthRoutes registers authentication-related routes
 func RegisterAuthRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc, deps *Dependencies) {
 	authMiddleware := middleware.Auth(middleware.Dependencies{
-		Config: deps.AuthConfig,
+		Config:  deps.AuthConfig,
+		Storage: deps.Storage,
 	})
 
 	authGroup := group.Group("/auth")


### PR DESCRIPTION
## Issue

NEU-600

## Summary

Control-plane authentication accepted any self-contained API key whose signature and embedded expiry checked out, and then trusted the payload outright. Neither of those facts says anything about whether the key is still valid: deleting or disabling a key changes only database and gateway state, and the middleware read neither. So a deleted or disabled key kept working against every control-plane route, in the original user's permission scope, for as long as its own expiry allowed — and a key created without `expires_in` never expires at all. Deleting the gateway consumer stopped inference, which is why this stayed hidden; the control plane went on signing PostgREST tokens for the same key.

This adds the missing check: after the signature and expiry checks pass, read the key row by primary key and refuse a key that is absent, pending deletion, or disabled.

The check does not weaken what self-contained keys bought. Identity still comes from the signed payload, so the read establishes liveness only and no field of the returned row is trusted for identity — the query is by primary key, not the by-secret lookup that self-contained keys replaced. Being able to sign PostgREST tokens without a lookup, the other thing that change bought, is untouched.

## Changes

- `internal/middleware/auth.go`: `Dependencies` takes a `Storage`; `parseApiKey` calls `verifyAPIKeyNotRevoked` after parsing. Absent row, non-empty `metadata.deletion_timestamp`, or `spec.limits.disabled` all deny with 401.
- `internal/middleware/auth.go`: a storage failure denies with 500 and logs the cause rather than returning it, since the detail describes control-plane internals rather than the request. Failing open was not an option: a revocation check that fails open is not a revocation check.
- `cmd/neutree-api/app/factory.go`, `internal/routes/auth/auth.go`: pass the existing storage handle through to the middleware. Both construction sites are covered; there are no others.
- Tests: end-to-end through the middleware for live, deleted, pending-deletion, disabled, and unreachable-storage keys, plus direct coverage of the check including the missing-dependency case.

## Design notes

**Where the check lives.** The middleware is the only place that covers every route an API key can reach. Two cheaper placements were considered and rejected for incomplete coverage: a PostgREST `db-pre-request` hook (no Go changes, immediate, but blind to `serve-proxy`, `k8s-proxy`, `system`, `endpoint-logs`, `clusters`) and folding the predicate into `has_permission` (covers only `models`, `credentials`, `ai-traces`, and needs both editions changed). Partial coverage of a security boundary is not worth the saving.

**Cost.** A primary-key read on API-key requests only. The `rest/*` routes already proxy to PostgREST and `models` / `credentials` / `ai-traces` already call `has_permission`, so for those this is a second round trip rather than a first; the remainder go from none to one. Inference is unaffected — the gateway validates against its own key-auth credential and never enters this path.

**No cache, deliberately.** Revocation takes effect immediately and there is no staleness window to define or test. Control-plane API-key traffic is CLI and automation; the UI uses bearer sessions. If measurement later shows a hot path, a short-TTL positive cache belongs in the same function — at which point the TTL becomes a documented revocation window and needs active invalidation plus fail-closed behaviour.

**Not in scope.** A default expiry bound for new keys, which is orthogonal and being discussed separately.

## Test Plan

- [x] Unit: `go test ./internal/middleware/... ./internal/routes/... ./cmd/neutree-api/...` — all pass.
- [x] Lint: `golangci-lint run` via the pre-commit gate — clean.
- [ ] E2E: needs a real run before release. The matrix is create → 200, disable → deny, re-enable → 200, delete → control plane and gateway both deny, run once with and once without `expires_in`, plus a storage-unavailable case for fail-closed. `serve-proxy` needs explicit coverage — earlier evidence had that route returning 401 at every stage, so it has never actually been exercised.
- [ ] DB integration (`make db-test`): not affected — no schema change.

Enterprise needs its own verification rather than inference from community results: the authentication path is shared, but enterprise carries additional RLS.

## Risk & Rollback

No schema change, no key-format change; existing keys keep working. Behaviour change is the intended one: deleted and disabled keys now fail control-plane authentication where they previously succeeded. Anything relying on a deleted key continuing to work was relying on the defect.

The new failure mode is that control-plane API-key authentication now depends on storage being reachable, and denies with 500 when it is not. Bearer sessions are unaffected. This is the deliberate trade — the alternative grants access to revoked keys whenever the database is down.

Rollback is a plain revert.
