### PR TITLE
feat: publish offline package images as multiarch

### DIFF
--- a/cmd/neutree-cli/app/cmd/packageimport/cluster.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/cluster.go
@@ -46,6 +46,7 @@ metadata:
 images:
   - image_name: "neutree/neutree-serve"
     tag: "v1.0.0"
+    platform: "linux/amd64"
     image_file: "images/all-images.tar"
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,8 +72,9 @@ func runClusterImport(opts *ClusterImportOptions) error {
 
 	// Prepare import options
 	importOpts := &packageimport.ImportOptions{
-		PackagePath: opts.packagePath,
-		ExtractPath: opts.extractPath,
+		PackagePath:                 opts.packagePath,
+		ExtractPath:                 opts.extractPath,
+		EnableMultiArchRegistryPush: true,
 	}
 
 	// if not importLocal, set registry info

--- a/cmd/neutree-cli/app/cmd/packageimport/controlplane.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/controlplane.go
@@ -46,6 +46,7 @@ metadata:
 images:
   - image_name: "neutree/neutree-api"
     tag: "v1.0.0"
+    platform: "linux/amd64"
     image_file: "images/all-images.tar"
 
 Note: This command does not require API connection and can run standalone.
@@ -74,9 +75,10 @@ func runControlPlaneImport(opts *ControlPlaneImportOptions) error {
 
 	// Prepare import options
 	importOpts := &packageimport.ImportOptions{
-		PackagePath: opts.packagePath,
-		Workspace:   workspace,
-		ExtractPath: opts.extractPath,
+		PackagePath:                 opts.packagePath,
+		Workspace:                   workspace,
+		ExtractPath:                 opts.extractPath,
+		EnableMultiArchRegistryPush: true,
 	}
 
 	// if not importLocal, set registry info

--- a/internal/cli/packageimport/image_pusher.go
+++ b/internal/cli/packageimport/image_pusher.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 )
@@ -65,23 +67,43 @@ func (p *ImagePusher) loadImages(ctx context.Context, manifest *PackageManifest,
 }
 
 func (p *ImagePusher) PushImagesToMirrorRegistry(ctx context.Context,
-	mirrorRegistry string, registryAuth string, manifest *PackageManifest) ([]string, error) {
+	mirrorRegistry string, registryAuth string, manifest *PackageManifest, multiArch bool,
+	registryUsername, registryPassword string) ([]string, error) {
 	klog.Infof("Pushing images to mirror registry: %s", mirrorRegistry)
 
 	// Load and push images
-	return p.pushImages(ctx, mirrorRegistry, registryAuth, manifest)
+	return p.pushImages(ctx, mirrorRegistry, registryAuth, manifest, multiArch, registryUsername, registryPassword)
 }
 
 // loadAndPushImages is the internal implementation that loads and pushes images
 func (p *ImagePusher) pushImages(ctx context.Context, mirrorRegistry string, registryAuth string,
-	manifest *PackageManifest) ([]string, error) {
+	manifest *PackageManifest, multiArch bool, registryUsername, registryPassword string) ([]string, error) {
 	var pushedImages []string
 	var errs []error
 
 	for _, imgSpec := range manifest.Images {
 		// Build the original and target image references
 		originalImage := fmt.Sprintf("%s:%s", imgSpec.ImageName, imgSpec.Tag)
-		targetImage := p.buildTargetImage(mirrorRegistry, imgSpec)
+		logicalTarget := p.buildTargetImage(mirrorRegistry, imgSpec)
+		targetImage := logicalTarget
+		var platform v1.Platform
+		useMultiArch := imageUsesMultiArchPush(multiArch, imgSpec.Platform)
+
+		if useMultiArch {
+			var err error
+
+			platform, err = multiArchPlatform(imgSpec.Platform)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "image %s:%s", imgSpec.ImageName, imgSpec.Tag))
+				continue
+			}
+
+			targetImage, err = multiArchChildTarget(logicalTarget, platform)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+		}
 
 		// Tag the image with the target registry
 		klog.Infof("Tagging image %s as %s", originalImage, targetImage)
@@ -99,8 +121,27 @@ func (p *ImagePusher) pushImages(ctx context.Context, mirrorRegistry string, reg
 			continue
 		}
 
-		pushedImages = append(pushedImages, targetImage)
-		klog.Infof("Successfully pushed image: %s", targetImage)
+		if useMultiArch {
+			logicalRef, err := name.NewTag(logicalTarget)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "failed to parse logical image"))
+				continue
+			}
+
+			childRef, err := name.NewTag(targetImage)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "failed to parse child image"))
+				continue
+			}
+
+			if err := publishMultiArchIndex(ctx, logicalRef, childRef, platform, registryUsername, registryPassword); err != nil {
+				errs = append(errs, errors.Wrapf(err, "failed to publish multi-architecture index"))
+				continue
+			}
+		}
+
+		pushedImages = append(pushedImages, logicalTarget)
+		klog.Infof("Successfully pushed image: %s", logicalTarget)
 	}
 
 	if len(errs) > 0 {
@@ -108,6 +149,10 @@ func (p *ImagePusher) pushImages(ctx context.Context, mirrorRegistry string, reg
 	}
 
 	return pushedImages, nil
+}
+
+func imageUsesMultiArchPush(enabled bool, platform string) bool {
+	return enabled && platform != ""
 }
 
 // buildTargetImage builds the target image reference with registry and repo

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -239,7 +239,8 @@ func (i *Importer) pushImages(ctx context.Context, opts *ImportOptions, manifest
 		return nil, errors.Wrap(err, "failed to build image prefix")
 	}
 
-	pushedImages, err := imagePusher.PushImagesToMirrorRegistry(ctx, imagePrefix, registryAuth, manifest)
+	pushedImages, err := imagePusher.PushImagesToMirrorRegistry(ctx, imagePrefix, registryAuth, manifest,
+		opts.EnableMultiArchRegistryPush, opts.RegistryUser, opts.RegistryPassword)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to push images to mirror registry")
 	}

--- a/internal/cli/packageimport/multiarch.go
+++ b/internal/cli/packageimport/multiarch.go
@@ -1,0 +1,184 @@
+package packageimport
+
+import (
+	"context"
+	stderrors "errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/match"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/pkg/errors"
+)
+
+func multiArchPlatform(value string) (v1.Platform, error) {
+	if value == "" {
+		return v1.Platform{}, errors.New("platform is required for multi-architecture package import")
+	}
+
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 || parts[0] != "linux" || (parts[1] != "amd64" && parts[1] != "arm64") {
+		return v1.Platform{}, errors.Errorf("unsupported platform %q for multi-architecture package import", value)
+	}
+
+	return v1.Platform{OS: parts[0], Architecture: parts[1]}, nil
+}
+
+func multiArchChildTarget(target string, platform v1.Platform) (string, error) {
+	tag, err := name.NewTag(target)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse target image %s", target)
+	}
+
+	parts := strings.Split(tag.Context().RepositoryStr(), "/")
+	parts[len(parts)-1] += "-" + platform.Architecture
+
+	return tag.Context().RegistryStr() + "/" + strings.Join(parts, "/") + ":" + tag.TagStr(), nil
+}
+
+func publishMultiArchIndex(ctx context.Context, logicalRef, childRef name.Tag, platform v1.Platform, username, password string) error {
+	remoteOptions := []remote.Option{
+		remote.WithContext(ctx),
+		remote.WithAuth(&authn.Basic{Username: username, Password: password}),
+	}
+
+	childImage, err := remote.Image(childRef, remoteOptions...)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read pushed child image %s", childRef.Name())
+	}
+
+	childPlatform, err := verifyImagePlatform(childImage, platform, childRef.Name())
+	if err != nil {
+		return err
+	}
+
+	base, err := existingIndex(logicalRef, remoteOptions...)
+	if err != nil {
+		return err
+	}
+
+	index := mutate.RemoveManifests(base, platformMatcher(platform))
+	index = mutate.AppendManifests(index, mutate.IndexAddendum{
+		Add:        childImage,
+		Descriptor: v1.Descriptor{Platform: &childPlatform},
+	})
+
+	if err := remote.WriteIndex(logicalRef, index, remoteOptions...); err != nil {
+		return errors.Wrapf(err, "failed to publish multi-architecture index %s", logicalRef.Name())
+	}
+
+	return verifyPublishedIndex(logicalRef, childImage, childPlatform, remoteOptions...)
+}
+
+func existingIndex(ref name.Tag, options ...remote.Option) (v1.ImageIndex, error) {
+	desc, err := remote.Get(ref, options...)
+	if err != nil {
+		if isRegistryNotFound(err) {
+			return empty.Index, nil
+		}
+
+		return nil, errors.Wrapf(err, "failed to read existing image %s", ref.Name())
+	}
+
+	if desc.MediaType.IsIndex() {
+		index, err := desc.ImageIndex()
+		return index, errors.Wrapf(err, "failed to read existing image index %s", ref.Name())
+	}
+
+	image, err := desc.Image()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read existing image manifest %s", ref.Name())
+	}
+
+	legacyPlatform, err := imagePlatform(image, ref.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	if legacyPlatform.OS != "linux" || (legacyPlatform.Architecture != "amd64" && legacyPlatform.Architecture != "arm64") {
+		return nil, errors.Errorf("existing image %s has unsupported platform %s/%s", ref.Name(), legacyPlatform.OS, legacyPlatform.Architecture)
+	}
+
+	return mutate.AppendManifests(empty.Index, mutate.IndexAddendum{
+		Add:        image,
+		Descriptor: v1.Descriptor{Platform: &legacyPlatform},
+	}), nil
+}
+
+func verifyImagePlatform(image v1.Image, expected v1.Platform, reference string) (v1.Platform, error) {
+	actual, err := imagePlatform(image, reference)
+	if err != nil {
+		return v1.Platform{}, err
+	}
+
+	if !actual.Satisfies(expected) {
+		return v1.Platform{}, errors.Errorf("pushed image %s has platform %s/%s, expected %s/%s", reference,
+			actual.OS, actual.Architecture, expected.OS, expected.Architecture)
+	}
+
+	return actual, nil
+}
+
+func platformMatcher(platform v1.Platform) match.Matcher {
+	return func(descriptor v1.Descriptor) bool {
+		return descriptor.Platform != nil && descriptor.Platform.Satisfies(platform)
+	}
+}
+
+func imagePlatform(image v1.Image, reference string) (v1.Platform, error) {
+	config, err := image.ConfigFile()
+	if err != nil {
+		return v1.Platform{}, errors.Wrapf(err, "failed to read image config for %s", reference)
+	}
+
+	if config == nil || config.Platform() == nil {
+		return v1.Platform{}, errors.Errorf("image %s does not declare a platform", reference)
+	}
+
+	return *config.Platform(), nil
+}
+
+func verifyPublishedIndex(ref name.Tag, child v1.Image, platform v1.Platform, options ...remote.Option) error {
+	desc, err := remote.Get(ref, options...)
+	if err != nil {
+		return errors.Wrapf(err, "failed to verify multi-architecture index %s", ref.Name())
+	}
+
+	if !desc.MediaType.IsIndex() {
+		return errors.Errorf("published image %s is not an OCI index", ref.Name())
+	}
+
+	index, err := desc.ImageIndex()
+	if err != nil {
+		return errors.Wrapf(err, "failed to read published index %s", ref.Name())
+	}
+
+	manifest, err := index.IndexManifest()
+	if err != nil {
+		return errors.Wrapf(err, "failed to read published index manifest %s", ref.Name())
+	}
+
+	childDigest, err := child.Digest()
+	if err != nil {
+		return errors.Wrapf(err, "failed to calculate child image digest for %s", ref.Name())
+	}
+
+	for _, descriptor := range manifest.Manifests {
+		if descriptor.Platform != nil && descriptor.Platform.Equals(platform) && descriptor.Digest == childDigest {
+			return nil
+		}
+	}
+
+	return errors.Errorf("published index %s does not contain %s/%s child digest %s", ref.Name(), platform.OS, platform.Architecture, childDigest)
+}
+
+func isRegistryNotFound(err error) bool {
+	var registryError *transport.Error
+	return stderrors.As(err, &registryError) && registryError.StatusCode == http.StatusNotFound
+}

--- a/internal/cli/packageimport/multiarch_test.go
+++ b/internal/cli/packageimport/multiarch_test.go
@@ -1,0 +1,233 @@
+package packageimport
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiArchPlatform(t *testing.T) {
+	tests := []struct {
+		platform string
+		wantArch string
+		wantErr  string
+	}{
+		{platform: "linux/amd64", wantArch: "amd64"},
+		{platform: "linux/arm64", wantArch: "arm64"},
+		{platform: "", wantErr: "platform is required"},
+		{platform: "linux/arm/v7", wantErr: "unsupported platform"},
+		{platform: "windows/amd64", wantErr: "unsupported platform"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			platform, err := multiArchPlatform(tt.platform)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, "linux", platform.OS)
+			assert.Equal(t, tt.wantArch, platform.Architecture)
+		})
+	}
+}
+
+func TestImageUsesMultiArchPush(t *testing.T) {
+	assert.False(t, imageUsesMultiArchPush(false, "linux/amd64"))
+	assert.False(t, imageUsesMultiArchPush(true, ""))
+	assert.True(t, imageUsesMultiArchPush(true, "linux/amd64"))
+}
+
+func TestMultiArchChildTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		platform string
+		want     string
+	}{
+		{
+			name:     "nested repository appends architecture to final component",
+			target:   "registry.example.com/neutree/neutree-api:v1.2.0",
+			platform: "linux/amd64",
+			want:     "registry.example.com/neutree/neutree-api-amd64:v1.2.0",
+		},
+		{
+			name:     "repository tag is preserved for arm64",
+			target:   "registry.example.com/project/team/component:release-7",
+			platform: "linux/arm64",
+			want:     "registry.example.com/project/team/component-arm64:release-7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			platform, err := multiArchPlatform(tt.platform)
+			require.NoError(t, err)
+
+			got, err := multiArchChildTarget(tt.target, platform)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPublishMultiArchIndexMergesAndReplacesPlatform(t *testing.T) {
+	server := httptest.NewServer(registry.New())
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	logicalTarget := host + "/project/component:v1"
+	amd64Target := host + "/project/component-amd64:v1"
+	arm64Target := host + "/project/component-arm64:v1"
+	amd64 := v1.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := v1.Platform{OS: "linux", Architecture: "arm64"}
+
+	firstAMD64 := platformImage(t, amd64)
+	writeImage(t, amd64Target, firstAMD64)
+	require.NoError(t, publishMultiArchIndex(context.Background(), insecureTag(t, logicalTarget), insecureTag(t, amd64Target), amd64, "", ""))
+
+	arm64Image := platformImage(t, arm64)
+	writeImage(t, arm64Target, arm64Image)
+	require.NoError(t, publishMultiArchIndex(context.Background(), insecureTag(t, logicalTarget), insecureTag(t, arm64Target), arm64, "", ""))
+
+	replacementAMD64 := platformImage(t, amd64)
+	writeImage(t, amd64Target, replacementAMD64)
+	require.NoError(t, publishMultiArchIndex(context.Background(), insecureTag(t, logicalTarget), insecureTag(t, amd64Target), amd64, "", ""))
+
+	logicalRef, err := name.NewTag(logicalTarget, name.Insecure)
+	require.NoError(t, err)
+	index, err := remote.Index(logicalRef)
+	require.NoError(t, err)
+	manifest, err := index.IndexManifest()
+	require.NoError(t, err)
+	require.Len(t, manifest.Manifests, 2)
+
+	assertDescriptorDigest(t, manifest.Manifests, amd64, replacementAMD64)
+	assertDescriptorDigest(t, manifest.Manifests, arm64, arm64Image)
+}
+
+func TestPublishMultiArchIndexMigratesLegacyManifest(t *testing.T) {
+	server := httptest.NewServer(registry.New())
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	logicalTarget := host + "/project/component:v1"
+	amd64Target := host + "/project/component-amd64:v1"
+	amd64 := v1.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := v1.Platform{OS: "linux", Architecture: "arm64"}
+
+	legacyARM64 := platformImage(t, arm64)
+	writeImage(t, logicalTarget, legacyARM64)
+	amd64Image := platformImage(t, amd64)
+	writeImage(t, amd64Target, amd64Image)
+
+	require.NoError(t, publishMultiArchIndex(context.Background(), insecureTag(t, logicalTarget), insecureTag(t, amd64Target), amd64, "", ""))
+
+	logicalRef, err := name.NewTag(logicalTarget, name.Insecure)
+	require.NoError(t, err)
+	index, err := remote.Index(logicalRef)
+	require.NoError(t, err)
+	manifest, err := index.IndexManifest()
+	require.NoError(t, err)
+	require.Len(t, manifest.Manifests, 2)
+
+	assertDescriptorDigest(t, manifest.Manifests, amd64, amd64Image)
+	assertDescriptorDigest(t, manifest.Manifests, arm64, legacyARM64)
+}
+
+func TestPublishMultiArchIndexRejectsPlatformMismatch(t *testing.T) {
+	server := httptest.NewServer(registry.New())
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	logicalTarget := host + "/project/component:v1"
+	amd64Target := host + "/project/component-amd64:v1"
+	amd64 := v1.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := v1.Platform{OS: "linux", Architecture: "arm64"}
+
+	writeImage(t, amd64Target, platformImage(t, arm64))
+	err := publishMultiArchIndex(context.Background(), insecureTag(t, logicalTarget), insecureTag(t, amd64Target), amd64, "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has platform linux/arm64, expected linux/amd64")
+
+	logicalRef, err := name.NewTag(logicalTarget, name.Insecure)
+	require.NoError(t, err)
+	_, err = remote.Get(logicalRef)
+	assert.True(t, isRegistryNotFound(err))
+}
+
+func TestPublishMultiArchIndexAcceptsArm64Variant(t *testing.T) {
+	server := httptest.NewServer(registry.New())
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	logicalTarget := host + "/project/component:v1"
+	arm64Target := host + "/project/component-arm64:v1"
+	requested := v1.Platform{OS: "linux", Architecture: "arm64"}
+	actual := v1.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"}
+	image := platformImage(t, actual)
+	writeImage(t, arm64Target, image)
+
+	require.NoError(t, publishMultiArchIndex(context.Background(), insecureTag(t, logicalTarget), insecureTag(t, arm64Target), requested, "", ""))
+
+	logicalRef, err := name.NewTag(logicalTarget, name.Insecure)
+	require.NoError(t, err)
+	index, err := remote.Index(logicalRef)
+	require.NoError(t, err)
+	manifest, err := index.IndexManifest()
+	require.NoError(t, err)
+	require.Len(t, manifest.Manifests, 1)
+	assertDescriptorDigest(t, manifest.Manifests, actual, image)
+}
+
+func platformImage(t *testing.T, platform v1.Platform) v1.Image {
+	t.Helper()
+	image, err := random.Image(1024, 1)
+	require.NoError(t, err)
+	config, err := image.ConfigFile()
+	require.NoError(t, err)
+	config.OS = platform.OS
+	config.Architecture = platform.Architecture
+	config.Variant = platform.Variant
+	image, err = mutate.ConfigFile(image, config)
+	require.NoError(t, err)
+	return image
+}
+
+func writeImage(t *testing.T, target string, image v1.Image) {
+	t.Helper()
+	require.NoError(t, remote.Write(insecureTag(t, target), image))
+}
+
+func insecureTag(t *testing.T, target string) name.Tag {
+	t.Helper()
+	ref, err := name.NewTag(target, name.Insecure)
+	require.NoError(t, err)
+	return ref
+}
+
+func assertDescriptorDigest(t *testing.T, descriptors []v1.Descriptor, platform v1.Platform, image v1.Image) {
+	t.Helper()
+	want, err := image.Digest()
+	require.NoError(t, err)
+	for _, descriptor := range descriptors {
+		if descriptor.Platform != nil && descriptor.Platform.Equals(platform) {
+			assert.Equal(t, want, descriptor.Digest)
+			return
+		}
+	}
+	t.Fatalf("platform %s/%s descriptor not found", platform.OS, platform.Architecture)
+}

--- a/internal/cli/packageimport/types.go
+++ b/internal/cli/packageimport/types.go
@@ -100,6 +100,11 @@ type ImportOptions struct {
 
 	// ExtractPath is the path to extract the package to (temporary directory)
 	ExtractPath string
+
+	// EnableMultiArchRegistryPush publishes images that declare a platform as
+	// architecture-suffixed child repositories plus an OCI index at the logical tag.
+	// Images without a platform and Engine package imports preserve the existing path.
+	EnableMultiArchRegistryPush bool
 }
 
 // ImportResult contains the result of importing an engine version package


### PR DESCRIPTION
## Summary

- Publish control-plane and cluster package images to architecture-suffixed child repositories while retaining original package image names and tags.
- Merge child manifests into the original repository/tag as a multi-architecture index, including legacy single-manifest migration and platform verification.
- Keep registry HTTP and TLS configuration out of the index publisher; Docker daemon and deployment registry configuration remain the sole owners of that behavior.
- Keep engine package imports on the existing single-architecture Docker push path.

Design: http://gitlab.smartx.com/wei.huang/neutree-dev-docs/-/merge_requests/98

## Test Plan

### Unit test

- [x] `go test ./internal/cli/packageimport`
- [x] `go vet ./internal/cli/packageimport ./cmd/neutree-cli/app/cmd/packageimport`
- [x] CI-version `golangci-lint v1.64.6` for both affected packages.
- [x] Index creation, merge, same-platform replacement, legacy manifest migration, platform mismatch rejection, and arm64 variant acceptance.

### DB test

- [x] Not applicable: this change does not access or modify database state.

### E2E test

- [ ] Pending a paired-package registry environment reachable through the default `go-containerregistry` transport. HTTP/TLS exceptions are intentionally not configured by the CLI.
- [x] Manual testing is required because E2E cannot cover the current registry configuration.