### PR TITLE
feat: validate cluster credential rotation

### DIFF
--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -247,16 +247,26 @@ func clusterPatchIsSoftDelete(body []byte) (bool, error) {
 }
 
 type clusterPatchConfigurationUpdate struct {
-	imageRegistry    string
-	imageRegistrySet bool
-	kubeconfig       string
-	kubeconfigSet    bool
-	sshPrivateKey    string
-	sshPrivateKeySet bool
+	imageRegistry           string
+	imageRegistrySet        bool
+	configCleared           bool
+	kubernetesConfigCleared bool
+	kubeconfig              string
+	kubeconfigSet           bool
+	sshConfigCleared        bool
+	sshAuthCleared          bool
+	sshPrivateKey           string
+	sshPrivateKeySet        bool
 }
 
 func (u clusterPatchConfigurationUpdate) hasChanges() bool {
-	return u.imageRegistrySet || u.kubeconfigSet || u.sshPrivateKeySet
+	return u.imageRegistrySet ||
+		u.configCleared ||
+		u.kubernetesConfigCleared ||
+		u.kubeconfigSet ||
+		u.sshConfigCleared ||
+		u.sshAuthCleared ||
+		u.sshPrivateKeySet
 }
 
 func parseClusterPatchConfigurationUpdate(body []byte) (clusterPatchConfigurationUpdate, error) {
@@ -289,48 +299,66 @@ func parseClusterPatchConfigurationUpdate(body []byte) (clusterPatchConfiguratio
 		return update, nil
 	}
 
+	if isJSONNull(configRaw) {
+		update.configCleared = true
+		return update, nil
+	}
+
 	var config map[string]json.RawMessage
 	if err := json.Unmarshal(configRaw, &config); err != nil {
 		return clusterPatchConfigurationUpdate{}, err
 	}
 
 	if kubernetesConfigRaw, ok := config["kubernetes_config"]; ok {
-		var kubernetesConfig map[string]json.RawMessage
-		if err := json.Unmarshal(kubernetesConfigRaw, &kubernetesConfig); err != nil {
-			return clusterPatchConfigurationUpdate{}, err
-		}
-
-		if kubeconfigRaw, ok := kubernetesConfig["kubeconfig"]; ok {
-			if err := json.Unmarshal(kubeconfigRaw, &update.kubeconfig); err != nil {
+		if isJSONNull(kubernetesConfigRaw) {
+			update.kubernetesConfigCleared = true
+		} else {
+			var kubernetesConfig map[string]json.RawMessage
+			if err := json.Unmarshal(kubernetesConfigRaw, &kubernetesConfig); err != nil {
 				return clusterPatchConfigurationUpdate{}, err
 			}
 
-			update.kubeconfigSet = true
+			if kubeconfigRaw, ok := kubernetesConfig["kubeconfig"]; ok {
+				if err := json.Unmarshal(kubeconfigRaw, &update.kubeconfig); err != nil {
+					return clusterPatchConfigurationUpdate{}, err
+				}
+
+				update.kubeconfigSet = true
+			}
 		}
 	}
 
 	if sshConfigRaw, ok := config["ssh_config"]; ok {
-		var sshConfig map[string]json.RawMessage
-		if err := json.Unmarshal(sshConfigRaw, &sshConfig); err != nil {
-			return clusterPatchConfigurationUpdate{}, err
-		}
-
-		authRaw, ok := sshConfig["auth"]
-		if !ok {
-			return update, nil
-		}
-
-		var auth map[string]json.RawMessage
-		if err := json.Unmarshal(authRaw, &auth); err != nil {
-			return clusterPatchConfigurationUpdate{}, err
-		}
-
-		if sshPrivateKeyRaw, ok := auth["ssh_private_key"]; ok {
-			if err := json.Unmarshal(sshPrivateKeyRaw, &update.sshPrivateKey); err != nil {
+		if isJSONNull(sshConfigRaw) {
+			update.sshConfigCleared = true
+		} else {
+			var sshConfig map[string]json.RawMessage
+			if err := json.Unmarshal(sshConfigRaw, &sshConfig); err != nil {
 				return clusterPatchConfigurationUpdate{}, err
 			}
 
-			update.sshPrivateKeySet = true
+			authRaw, ok := sshConfig["auth"]
+			if !ok {
+				return update, nil
+			}
+
+			if isJSONNull(authRaw) {
+				update.sshAuthCleared = true
+				return update, nil
+			}
+
+			var auth map[string]json.RawMessage
+			if err := json.Unmarshal(authRaw, &auth); err != nil {
+				return clusterPatchConfigurationUpdate{}, err
+			}
+
+			if sshPrivateKeyRaw, ok := auth["ssh_private_key"]; ok {
+				if err := json.Unmarshal(sshPrivateKeyRaw, &update.sshPrivateKey); err != nil {
+					return clusterPatchConfigurationUpdate{}, err
+				}
+
+				update.sshPrivateKeySet = true
+			}
 		}
 	}
 
@@ -342,46 +370,70 @@ func validateClusterConfigurationUpdate(current *v1.Cluster, update clusterPatch
 		return nil
 	}
 
+	if update.configCleared {
+		return errors.New("config cannot be cleared after cluster initialization")
+	}
+
 	if update.imageRegistrySet && update.imageRegistry != current.Spec.ImageRegistry {
 		return errors.New("image registry cannot be changed after cluster initialization")
 	}
 
-	if current.Spec.Type == v1.KubernetesClusterType && update.kubeconfigSet {
-		if strings.TrimSpace(update.kubeconfig) == "" {
-			return errors.New("kubeconfig cannot be empty for an initialized cluster")
+	if current.Spec.Type == v1.KubernetesClusterType {
+		if update.kubernetesConfigCleared {
+			return errors.New("kubernetes_config cannot be cleared for an initialized cluster")
 		}
 
-		currentKubeconfig, err := util.GetKubeConfigFromCluster(current)
-		if err != nil {
-			return fmt.Errorf("failed to read current kubeconfig: %w", err)
-		}
+		if update.kubeconfigSet {
+			if strings.TrimSpace(update.kubeconfig) == "" {
+				return errors.New("kubeconfig cannot be empty for an initialized cluster")
+			}
 
-		currentAPIServer, err := util.GetApiServerUrlFromDecodedKubeConfig(currentKubeconfig)
-		if err != nil {
-			return fmt.Errorf("failed to parse current kubeconfig: %w", err)
-		}
+			currentKubeconfig, err := util.GetKubeConfigFromCluster(current)
+			if err != nil {
+				return fmt.Errorf("failed to read current kubeconfig: %w", err)
+			}
 
-		updatedAPIServer, err := util.GetApiServerUrlFromKubeConfig(update.kubeconfig)
-		if err != nil {
-			return fmt.Errorf("failed to parse updated kubeconfig: %w", err)
-		}
+			currentAPIServer, err := util.GetApiServerUrlFromDecodedKubeConfig(currentKubeconfig)
+			if err != nil {
+				return fmt.Errorf("failed to parse current kubeconfig: %w", err)
+			}
 
-		if currentAPIServer != updatedAPIServer {
-			return errors.New("kubeconfig must reference the current Kubernetes API server")
+			updatedAPIServer, err := util.GetApiServerUrlFromKubeConfig(update.kubeconfig)
+			if err != nil {
+				return fmt.Errorf("failed to parse updated kubeconfig: %w", err)
+			}
+
+			if currentAPIServer != updatedAPIServer {
+				return errors.New("kubeconfig must reference the current Kubernetes API server")
+			}
 		}
 	}
 
-	if current.Spec.Type == v1.SSHClusterType && update.sshPrivateKeySet {
-		if strings.TrimSpace(update.sshPrivateKey) == "" {
-			return errors.New("SSH private key cannot be empty for an initialized cluster")
+	if current.Spec.Type == v1.SSHClusterType {
+		if update.sshConfigCleared {
+			return errors.New("ssh_config cannot be cleared for an initialized cluster")
 		}
 
-		if _, err := base64.StdEncoding.DecodeString(update.sshPrivateKey); err != nil {
-			return fmt.Errorf("SSH private key must be base64 encoded: %w", err)
+		if update.sshAuthCleared {
+			return errors.New("SSH auth cannot be cleared for an initialized cluster")
+		}
+
+		if update.sshPrivateKeySet {
+			if strings.TrimSpace(update.sshPrivateKey) == "" {
+				return errors.New("SSH private key cannot be empty for an initialized cluster")
+			}
+
+			if _, err := base64.StdEncoding.DecodeString(update.sshPrivateKey); err != nil {
+				return fmt.Errorf("SSH private key must be base64 encoded: %w", err)
+			}
 		}
 	}
 
 	return nil
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
 }
 
 func clusterConfigurationUpdateError(err error) *validationError {

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -171,15 +171,7 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		configurationUpdate, err := parseClusterPatchConfigurationUpdate(body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		if !hasVersion && !configurationUpdate.hasChanges() {
+		if !hasVersion {
 			c.Next()
 			return
 		}
@@ -192,17 +184,7 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		var (
-			current       *v1.Cluster
-			validationErr *validationError
-		)
-
-		if hasVersion {
-			current, validationErr = resolveClusterForVersionUpdate(s, patch, c.Request.URL.Query())
-		} else {
-			current, validationErr = resolveClusterForConfigurationUpdate(s, patch, c.Request.URL.Query())
-		}
-
+		current, validationErr := resolveClusterForVersionUpdate(s, patch, c.Request.URL.Query())
 		if validationErr != nil {
 			c.JSON(http.StatusBadRequest, validationErr)
 			c.Abort()
@@ -210,20 +192,89 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		if hasVersion {
-			if err := validateClusterVersionNotDowngrade(current, desiredVersion); err != nil {
-				c.JSON(http.StatusBadRequest, &validationError{
-					Code:    "10212",
-					Message: "invalid cluster version update",
-					Hint:    err.Error(),
-				})
-				c.Abort()
+		if err := validateClusterVersionNotDowngrade(current, desiredVersion); err != nil {
+			c.JSON(http.StatusBadRequest, &validationError{
+				Code:    "10212",
+				Message: "invalid cluster version update",
+				Hint:    err.Error(),
+			})
+			c.Abort()
 
-				return
-			}
+			return
 		}
 
-		if err := validateClusterConfigurationUpdate(current, configurationUpdate); err != nil {
+		c.Next()
+	}
+}
+
+func validateClusterConfigurationUpdate(s storage.Storage) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodPatch {
+			c.Next()
+			return
+		}
+
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+			c.Abort()
+
+			return
+		}
+
+		c.Request.Body.Close()
+		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+		c.Request.ContentLength = int64(len(body))
+		c.Request.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+		if len(bytes.TrimSpace(body)) == 0 {
+			c.Next()
+			return
+		}
+
+		isSoftDelete, err := clusterPatchIsSoftDelete(body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+			c.Abort()
+
+			return
+		}
+
+		if isSoftDelete {
+			c.Next()
+			return
+		}
+
+		configurationUpdate, err := parseClusterPatchConfigurationUpdate(body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+			c.Abort()
+
+			return
+		}
+
+		if !configurationUpdate.hasChanges() {
+			c.Next()
+			return
+		}
+
+		var patch v1.Cluster
+		if err := json.Unmarshal(body, &patch); err != nil {
+			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+			c.Abort()
+
+			return
+		}
+
+		current, validationErr := resolveClusterForConfigurationUpdate(s, patch, c.Request.URL.Query())
+		if validationErr != nil {
+			c.JSON(http.StatusBadRequest, validationErr)
+			c.Abort()
+
+			return
+		}
+
+		if err := validateInitializedClusterConfigurationUpdate(current, configurationUpdate); err != nil {
 			c.JSON(http.StatusBadRequest, clusterConfigurationUpdateError(err))
 			c.Abort()
 
@@ -365,7 +416,7 @@ func parseClusterPatchConfigurationUpdate(body []byte) (clusterPatchConfiguratio
 	return update, nil
 }
 
-func validateClusterConfigurationUpdate(current *v1.Cluster, update clusterPatchConfigurationUpdate) error {
+func validateInitializedClusterConfigurationUpdate(current *v1.Cluster, update clusterPatchConfigurationUpdate) error {
 	if current == nil || current.Spec == nil || !current.IsInitialized() {
 		return nil
 	}
@@ -848,8 +899,9 @@ func RegisterClusterRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc
 	handler := CreateStructProxyHandler[v1.Cluster](deps, storage.CLUSTERS_TABLE)
 	acceleratorVirtualizationValidation := validateClusterAcceleratorVirtualization(deps.Storage)
 	versionUpdateValidation := validateClusterVersionUpdate(deps.Storage)
+	configurationUpdateValidation := validateClusterConfigurationUpdate(deps.Storage)
 
 	proxyGroup.GET("", handler)
 	proxyGroup.POST("", acceleratorVirtualizationValidation, handler)
-	proxyGroup.PATCH("", deletionValidation, versionUpdateValidation, acceleratorVirtualizationValidation, handler)
+	proxyGroup.PATCH("", deletionValidation, versionUpdateValidation, configurationUpdateValidation, acceleratorVirtualizationValidation, handler)
 }

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -41,6 +41,165 @@ func validateClusterDeletion(s storage.Storage) middleware.DeletionValidatorFunc
 	}
 }
 
+type clusterValidationOperation string
+
+const (
+	clusterValidationCreate     clusterValidationOperation = "create"
+	clusterValidationPatch      clusterValidationOperation = "patch"
+	clusterValidationSoftDelete clusterValidationOperation = "soft_delete"
+)
+
+// ValidationInput contains the original request data shared by Cluster validators.
+type ValidationInput[T any] struct {
+	Method      string
+	Body        []byte
+	RawPayload  map[string]json.RawMessage
+	Patch       T
+	QueryParams url.Values
+	Operation   clusterValidationOperation
+}
+
+func validateClusterRequest(s storage.Storage) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
+			c.Next()
+
+			return
+		}
+
+		input, validationErr := readClusterValidationInput(c)
+		if validationErr != nil {
+			c.JSON(http.StatusBadRequest, validationErr)
+			c.Abort()
+
+			return
+		}
+
+		if input.Operation == clusterValidationSoftDelete {
+			if err := validateClusterSoftDelete(s, input); err != nil {
+				writeClusterDeletionError(c, err)
+
+				return
+			}
+
+			c.Next()
+
+			return
+		}
+
+		if input.Operation == clusterValidationPatch {
+			if validationErr := validateClusterVersionUpdateInput(s, input); validationErr != nil {
+				c.JSON(http.StatusBadRequest, validationErr)
+				c.Abort()
+
+				return
+			}
+
+			if validationErr := validateClusterConfigurationUpdateInput(s, input); validationErr != nil {
+				c.JSON(http.StatusBadRequest, validationErr)
+				c.Abort()
+
+				return
+			}
+		}
+
+		if validationErr := validateClusterAcceleratorVirtualizationInput(s, input); validationErr != nil {
+			c.JSON(http.StatusBadRequest, validationErr)
+			c.Abort()
+
+			return
+		}
+
+		c.Next()
+	}
+}
+
+func readClusterValidationInput(c *gin.Context) (*ValidationInput[v1.Cluster], *validationError) {
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return nil, invalidClusterPayloadError(err)
+	}
+
+	if err := c.Request.Body.Close(); err != nil {
+		return nil, invalidClusterPayloadError(err)
+	}
+
+	c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	c.Request.ContentLength = int64(len(body))
+	c.Request.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	input := &ValidationInput[v1.Cluster]{
+		Method:      c.Request.Method,
+		Body:        body,
+		QueryParams: c.Request.URL.Query(),
+		Operation:   clusterValidationCreate,
+	}
+	if c.Request.Method == http.MethodPatch {
+		input.Operation = clusterValidationPatch
+	}
+
+	if len(bytes.TrimSpace(body)) == 0 {
+		return input, nil
+	}
+
+	if err := json.Unmarshal(body, &input.RawPayload); err != nil {
+		return nil, invalidClusterPayloadError(err)
+	}
+
+	if input.Operation == clusterValidationPatch {
+		isSoftDelete, err := clusterPatchIsSoftDelete(input.RawPayload)
+		if err != nil {
+			return nil, invalidClusterPayloadError(err)
+		}
+
+		if isSoftDelete {
+			input.Operation = clusterValidationSoftDelete
+			if metadataRaw, ok := input.RawPayload["metadata"]; ok {
+				if err := json.Unmarshal(metadataRaw, &input.Patch.Metadata); err != nil {
+					return nil, invalidClusterPayloadError(err)
+				}
+			}
+
+			return input, nil
+		}
+	}
+
+	if err := json.Unmarshal(body, &input.Patch); err != nil {
+		return nil, invalidClusterPayloadError(err)
+	}
+
+	return input, nil
+}
+
+func validateClusterSoftDelete(s storage.Storage, input *ValidationInput[v1.Cluster]) error {
+	if input.Patch.Metadata == nil || input.Patch.Metadata.Name == "" {
+		return nil
+	}
+
+	return validateClusterDeletion(s)(input.Patch.Metadata.Workspace, input.Patch.Metadata.Name)
+}
+
+func writeClusterDeletionError(c *gin.Context, err error) {
+	deletionErr, ok := err.(*middleware.DeletionError)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"code":    "500",
+			"message": fmt.Sprintf("Failed to validate deletion: %v", err),
+		})
+		c.Abort()
+
+		return
+	}
+
+	c.Header("X-Powered-By", "Neutree")
+	c.JSON(http.StatusBadRequest, gin.H{
+		"code":    deletionErr.Code,
+		"message": deletionErr.Message,
+		"hint":    deletionErr.Hint,
+	})
+	c.Abort()
+}
+
 func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
@@ -48,76 +207,25 @@ func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc
 			return
 		}
 
-		body, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, &validationError{
-				Code:    "10209",
-				Message: "invalid cluster payload",
-				Hint:    err.Error(),
-			})
-			c.Abort()
-
-			return
-		}
-
-		c.Request.Body = io.NopCloser(bytes.NewReader(body))
-
-		if len(bytes.TrimSpace(body)) == 0 {
-			c.Next()
-			return
-		}
-
-		if c.Request.Method == http.MethodPatch {
-			isSoftDelete, err := clusterPatchIsSoftDelete(body)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-				c.Abort()
-
-				return
-			}
-
-			if isSoftDelete {
-				c.Next()
-				return
-			}
-		}
-
-		if validationErr := validateClusterAcceleratorVirtualizationBody(body); validationErr != nil {
+		input, validationErr := readClusterValidationInput(c)
+		if validationErr != nil {
 			c.JSON(http.StatusBadRequest, validationErr)
 			c.Abort()
 
 			return
 		}
 
-		if c.Request.Method == http.MethodPatch {
-			disableRequested, err := clusterAcceleratorVirtualizationDisableRequested(body)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-				c.Abort()
+		if input.Operation == clusterValidationSoftDelete {
+			c.Next()
 
-				return
-			}
+			return
+		}
 
-			if !disableRequested {
-				c.Next()
-				return
-			}
+		if validationErr := validateClusterAcceleratorVirtualizationInput(s, input); validationErr != nil {
+			c.JSON(http.StatusBadRequest, validationErr)
+			c.Abort()
 
-			var cluster v1.Cluster
-			if err := json.Unmarshal(body, &cluster); err != nil {
-				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-				c.Abort()
-
-				return
-			}
-
-			if validationErr := validateClusterAcceleratorVirtualizationDisable(
-				s, cluster, c.Request.URL.Query()); validationErr != nil {
-				c.JSON(http.StatusBadRequest, validationErr)
-				c.Abort()
-
-				return
-			}
+			return
 		}
 
 		c.Next()
@@ -131,59 +239,7 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		body, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		c.Request.Body.Close()
-		c.Request.Body = io.NopCloser(bytes.NewReader(body))
-		c.Request.ContentLength = int64(len(body))
-		c.Request.Header.Set("Content-Length", strconv.Itoa(len(body)))
-
-		if len(bytes.TrimSpace(body)) == 0 {
-			c.Next()
-			return
-		}
-
-		isSoftDelete, err := clusterPatchIsSoftDelete(body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		if isSoftDelete {
-			c.Next()
-			return
-		}
-
-		desiredVersion, hasVersion, err := clusterPatchDesiredVersion(body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		if !hasVersion {
-			c.Next()
-			return
-		}
-
-		var patch v1.Cluster
-		if err := json.Unmarshal(body, &patch); err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		current, validationErr := resolveClusterForVersionUpdate(s, patch, c.Request.URL.Query())
+		input, validationErr := readClusterValidationInput(c)
 		if validationErr != nil {
 			c.JSON(http.StatusBadRequest, validationErr)
 			c.Abort()
@@ -191,15 +247,13 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		if err := validateClusterVersionNotDowngrade(current, desiredVersion); err != nil {
-			c.JSON(http.StatusBadRequest, &validationError{
-				Code:    "10212",
-				Message: "invalid cluster version update",
-				Hint:    err.Error(),
-			})
-			c.Abort()
+		if input.Operation != clusterValidationSoftDelete {
+			if validationErr := validateClusterVersionUpdateInput(s, input); validationErr != nil {
+				c.JSON(http.StatusBadRequest, validationErr)
+				c.Abort()
 
-			return
+				return
+			}
 		}
 
 		c.Next()
@@ -213,59 +267,7 @@ func validateClusterConfigurationUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		body, err := io.ReadAll(c.Request.Body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		c.Request.Body.Close()
-		c.Request.Body = io.NopCloser(bytes.NewReader(body))
-		c.Request.ContentLength = int64(len(body))
-		c.Request.Header.Set("Content-Length", strconv.Itoa(len(body)))
-
-		if len(bytes.TrimSpace(body)) == 0 {
-			c.Next()
-			return
-		}
-
-		isSoftDelete, err := clusterPatchIsSoftDelete(body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		if isSoftDelete {
-			c.Next()
-			return
-		}
-
-		configurationUpdate, err := parseClusterPatchConfigurationUpdate(body)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		if !configurationUpdate.hasChanges() {
-			c.Next()
-			return
-		}
-
-		var patch v1.Cluster
-		if err := json.Unmarshal(body, &patch); err != nil {
-			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-			c.Abort()
-
-			return
-		}
-
-		current, validationErr := resolveClusterForConfigurationUpdate(s, patch, c.Request.URL.Query())
+		input, validationErr := readClusterValidationInput(c)
 		if validationErr != nil {
 			c.JSON(http.StatusBadRequest, validationErr)
 			c.Abort()
@@ -273,27 +275,31 @@ func validateClusterConfigurationUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		if err := validateInitializedClusterConfigurationUpdate(current, configurationUpdate); err != nil {
-			c.JSON(http.StatusBadRequest, clusterConfigurationUpdateError(err))
-			c.Abort()
+		if input.Operation != clusterValidationSoftDelete {
+			if validationErr := validateClusterConfigurationUpdateInput(s, input); validationErr != nil {
+				c.JSON(http.StatusBadRequest, validationErr)
+				c.Abort()
 
-			return
+				return
+			}
 		}
 
 		c.Next()
 	}
 }
 
-func clusterPatchIsSoftDelete(body []byte) (bool, error) {
-	var payload struct {
-		Metadata *v1.Metadata `json:"metadata"`
+func clusterPatchIsSoftDelete(payload map[string]json.RawMessage) (bool, error) {
+	metadataRaw, ok := payload["metadata"]
+	if !ok {
+		return false, nil
 	}
 
-	if err := json.Unmarshal(body, &payload); err != nil {
+	var metadata v1.Metadata
+	if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
 		return false, err
 	}
 
-	return payload.Metadata != nil && payload.Metadata.DeletionTimestamp != "", nil
+	return metadata.DeletionTimestamp != "", nil
 }
 
 type clusterPatchConfigurationUpdate struct {
@@ -325,6 +331,10 @@ func parseClusterPatchConfigurationUpdate(body []byte) (clusterPatchConfiguratio
 		return clusterPatchConfigurationUpdate{}, err
 	}
 
+	return parseClusterPatchConfigurationUpdatePayload(payload)
+}
+
+func parseClusterPatchConfigurationUpdatePayload(payload map[string]json.RawMessage) (clusterPatchConfigurationUpdate, error) {
 	specRaw, ok := payload["spec"]
 	if !ok {
 		return clusterPatchConfigurationUpdate{}, nil
@@ -486,12 +496,55 @@ func clusterConfigurationUpdateError(err error) *validationError {
 	}
 }
 
-func clusterPatchDesiredVersion(body []byte) (string, bool, error) {
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return "", false, err
+func validateClusterVersionUpdateInput(
+	s storage.Storage, input *ValidationInput[v1.Cluster],
+) *validationError {
+	desiredVersion, hasVersion, err := clusterPatchDesiredVersionPayload(input.RawPayload)
+	if err != nil {
+		return invalidClusterPayloadError(err)
 	}
 
+	if !hasVersion {
+		return nil
+	}
+
+	current, validationErr := resolveClusterForVersionUpdate(s, input.Patch, input.QueryParams)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	if err := validateClusterVersionNotDowngrade(current, desiredVersion); err != nil {
+		return clusterVersionUpdateError(err)
+	}
+
+	return nil
+}
+
+func validateClusterConfigurationUpdateInput(
+	s storage.Storage, input *ValidationInput[v1.Cluster],
+) *validationError {
+	configurationUpdate, err := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
+	if err != nil {
+		return invalidClusterPayloadError(err)
+	}
+
+	if !configurationUpdate.hasChanges() {
+		return nil
+	}
+
+	current, validationErr := resolveClusterForConfigurationUpdate(s, input.Patch, input.QueryParams)
+	if validationErr != nil {
+		return validationErr
+	}
+
+	if err := validateInitializedClusterConfigurationUpdate(current, configurationUpdate); err != nil {
+		return clusterConfigurationUpdateError(err)
+	}
+
+	return nil
+}
+
+func clusterPatchDesiredVersionPayload(payload map[string]json.RawMessage) (string, bool, error) {
 	specRaw, ok := payload["spec"]
 	if !ok {
 		return "", false, nil
@@ -518,32 +571,38 @@ func clusterPatchDesiredVersion(body []byte) (string, bool, error) {
 func resolveClusterForVersionUpdate(
 	s storage.Storage, patch v1.Cluster, queryParams url.Values,
 ) (*v1.Cluster, *validationError) {
-	return resolveClusterForPatchUpdate(
-		s,
-		patch,
-		queryParams,
-		"10212",
-		"failed to validate cluster version update",
-		"cluster identity is required when updating spec.version",
-	)
+	filters := clusterPatchUpdateFilters(patch, queryParams)
+	if len(filters) == 0 {
+		return nil, clusterVersionUpdateResolutionError(
+			errors.New("cluster identity is required when updating spec.version"))
+	}
+
+	current, err := resolveClusterForPatchUpdate(s, filters)
+	if err != nil {
+		return nil, clusterVersionUpdateResolutionError(err)
+	}
+
+	return current, nil
 }
 
 func resolveClusterForConfigurationUpdate(
 	s storage.Storage, patch v1.Cluster, queryParams url.Values,
 ) (*v1.Cluster, *validationError) {
-	return resolveClusterForPatchUpdate(
-		s,
-		patch,
-		queryParams,
-		"10209",
-		"failed to validate cluster configuration update",
-		"cluster identity is required when updating cluster configuration",
-	)
+	filters := clusterPatchUpdateFilters(patch, queryParams)
+	if len(filters) == 0 {
+		return nil, clusterConfigurationUpdateResolutionError(
+			errors.New("cluster identity is required when updating cluster configuration"))
+	}
+
+	current, err := resolveClusterForPatchUpdate(s, filters)
+	if err != nil {
+		return nil, clusterConfigurationUpdateResolutionError(err)
+	}
+
+	return current, nil
 }
 
-func resolveClusterForPatchUpdate(
-	s storage.Storage, patch v1.Cluster, queryParams url.Values, code, message, identityHint string,
-) (*v1.Cluster, *validationError) {
+func clusterPatchUpdateFilters(patch v1.Cluster, queryParams url.Values) []storage.Filter {
 	filters := queryParamsToFilters(queryParams)
 	if len(filters) == 0 && patch.Metadata != nil && patch.Metadata.Workspace != "" && patch.Metadata.Name != "" {
 		filters = []storage.Filter{
@@ -552,41 +611,49 @@ func resolveClusterForPatchUpdate(
 		}
 	}
 
-	if len(filters) == 0 {
-		return nil, &validationError{
-			Code:    code,
-			Message: message,
-			Hint:    identityHint,
-		}
-	}
+	return filters
+}
 
+func resolveClusterForPatchUpdate(s storage.Storage, filters []storage.Filter) (*v1.Cluster, error) {
 	clusters, err := s.ListCluster(storage.ListOption{Filters: filters})
 	if err != nil {
-		return nil, &validationError{
-			Code:    code,
-			Message: message,
-			Hint:    err.Error(),
-		}
+		return nil, err
 	}
 
 	if len(clusters) != 1 {
-		return nil, &validationError{
-			Code:    code,
-			Message: message,
-			Hint:    fmt.Sprintf("expected exactly one cluster from patch filters, got %d", len(clusters)),
-		}
+		return nil, fmt.Errorf("expected exactly one cluster from patch filters, got %d", len(clusters))
 	}
 
 	current := &clusters[0]
 	if current.Spec == nil {
-		return nil, &validationError{
-			Code:    code,
-			Message: message,
-			Hint:    "current cluster spec is required",
-		}
+		return nil, errors.New("current cluster spec is required")
 	}
 
 	return current, nil
+}
+
+func clusterVersionUpdateError(err error) *validationError {
+	return &validationError{
+		Code:    "10212",
+		Message: "invalid cluster version update",
+		Hint:    err.Error(),
+	}
+}
+
+func clusterVersionUpdateResolutionError(err error) *validationError {
+	return &validationError{
+		Code:    "10212",
+		Message: "failed to validate cluster version update",
+		Hint:    err.Error(),
+	}
+}
+
+func clusterConfigurationUpdateResolutionError(err error) *validationError {
+	return &validationError{
+		Code:    "10209",
+		Message: "failed to validate cluster configuration update",
+		Hint:    err.Error(),
+	}
 }
 
 func validateClusterVersionNotDowngrade(current *v1.Cluster, desiredVersion string) error {
@@ -650,6 +717,10 @@ func clusterAcceleratorVirtualizationDisableRequested(body []byte) (bool, error)
 		return false, err
 	}
 
+	return clusterAcceleratorVirtualizationDisableRequestedPayload(payload)
+}
+
+func clusterAcceleratorVirtualizationDisableRequestedPayload(payload map[string]json.RawMessage) (bool, error) {
 	specRaw, ok := payload["spec"]
 	if !ok {
 		return false, nil
@@ -803,6 +874,29 @@ func resolveClusterIdentityFromPatchFilters(s storage.Storage, filters []storage
 	return resolved.Metadata.Workspace, resolved.Metadata.Name, nil
 }
 
+func validateClusterAcceleratorVirtualizationInput(
+	s storage.Storage, input *ValidationInput[v1.Cluster],
+) *validationError {
+	if validationErr := validateClusterAcceleratorVirtualizationCluster(input.Patch); validationErr != nil {
+		return validationErr
+	}
+
+	if input.Operation != clusterValidationPatch {
+		return nil
+	}
+
+	disableRequested, err := clusterAcceleratorVirtualizationDisableRequestedPayload(input.RawPayload)
+	if err != nil {
+		return invalidClusterPayloadError(err)
+	}
+
+	if !disableRequested {
+		return nil
+	}
+
+	return validateClusterAcceleratorVirtualizationDisable(s, input.Patch, input.QueryParams)
+}
+
 func validateClusterAcceleratorVirtualizationBody(body []byte) *validationError {
 	var cluster v1.Cluster
 	decoder := json.NewDecoder(bytes.NewReader(body))
@@ -812,11 +906,13 @@ func validateClusterAcceleratorVirtualizationBody(body []byte) *validationError 
 	}
 
 	if cluster.GetDeletionTimestamp() != "" {
-		// Soft delete PATCH reuses the same route but should not be blocked by
-		// accelerator virtualization validation.
 		return nil
 	}
 
+	return validateClusterAcceleratorVirtualizationCluster(cluster)
+}
+
+func validateClusterAcceleratorVirtualizationCluster(cluster v1.Cluster) *validationError {
 	if cluster.Spec == nil || cluster.Spec.AcceleratorVirtualization == nil {
 		return nil
 	}
@@ -883,16 +979,10 @@ func RegisterClusterRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc
 	proxyGroup := group.Group("/clusters")
 	proxyGroup.Use(middlewares...)
 
-	deletionValidation := middleware.DeletionValidation(
-		storage.CLUSTERS_TABLE,
-		validateClusterDeletion(deps.Storage),
-	)
 	handler := CreateStructProxyHandler[v1.Cluster](deps, storage.CLUSTERS_TABLE)
-	acceleratorVirtualizationValidation := validateClusterAcceleratorVirtualization(deps.Storage)
-	versionUpdateValidation := validateClusterVersionUpdate(deps.Storage)
-	configurationUpdateValidation := validateClusterConfigurationUpdate(deps.Storage)
+	validation := validateClusterRequest(deps.Storage)
 
 	proxyGroup.GET("", handler)
-	proxyGroup.POST("", acceleratorVirtualizationValidation, handler)
-	proxyGroup.PATCH("", deletionValidation, versionUpdateValidation, configurationUpdateValidation, acceleratorVirtualizationValidation, handler)
+	proxyGroup.POST("", validation, handler)
+	proxyGroup.PATCH("", validation, handler)
 }

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 
 	mastermindssemver "github.com/Masterminds/semver/v3"
 	"github.com/gin-gonic/gin"
@@ -434,11 +433,7 @@ func validateInitializedClusterConfigurationUpdate(current *v1.Cluster, update c
 			return errors.New("kubernetes_config cannot be cleared for an initialized cluster")
 		}
 
-		if update.kubeconfigSet {
-			if strings.TrimSpace(update.kubeconfig) == "" {
-				return errors.New("kubeconfig cannot be empty for an initialized cluster")
-			}
-
+		if update.kubeconfigSet && update.kubeconfig != "" {
 			currentKubeconfig, err := util.GetKubeConfigFromCluster(current)
 			if err != nil {
 				return fmt.Errorf("failed to read current kubeconfig: %w", err)
@@ -470,10 +465,6 @@ func validateInitializedClusterConfigurationUpdate(current *v1.Cluster, update c
 		}
 
 		if update.sshPrivateKeySet {
-			if strings.TrimSpace(update.sshPrivateKey) == "" {
-				return errors.New("SSH private key cannot be empty for an initialized cluster")
-			}
-
 			if _, err := base64.StdEncoding.DecodeString(update.sshPrivateKey); err != nil {
 				return fmt.Errorf("SSH private key must be base64 encoded: %w", err)
 			}

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -192,13 +192,17 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		var current *v1.Cluster
-		var validationErr *validationError
+		var (
+			current       *v1.Cluster
+			validationErr *validationError
+		)
+
 		if hasVersion {
 			current, validationErr = resolveClusterForVersionUpdate(s, patch, c.Request.URL.Query())
 		} else {
 			current, validationErr = resolveClusterForConfigurationUpdate(s, patch, c.Request.URL.Query())
 		}
+
 		if validationErr != nil {
 			c.JSON(http.StatusBadRequest, validationErr)
 			c.Abort()
@@ -234,6 +238,7 @@ func clusterPatchIsSoftDelete(body []byte) (bool, error) {
 	var payload struct {
 		Metadata *v1.Metadata `json:"metadata"`
 	}
+
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return false, err
 	}
@@ -419,13 +424,27 @@ func clusterPatchDesiredVersion(body []byte) (string, bool, error) {
 func resolveClusterForVersionUpdate(
 	s storage.Storage, patch v1.Cluster, queryParams url.Values,
 ) (*v1.Cluster, *validationError) {
-	return resolveClusterForPatchUpdate(s, patch, queryParams, "10212", "failed to validate cluster version update", "cluster identity is required when updating spec.version")
+	return resolveClusterForPatchUpdate(
+		s,
+		patch,
+		queryParams,
+		"10212",
+		"failed to validate cluster version update",
+		"cluster identity is required when updating spec.version",
+	)
 }
 
 func resolveClusterForConfigurationUpdate(
 	s storage.Storage, patch v1.Cluster, queryParams url.Values,
 ) (*v1.Cluster, *validationError) {
-	return resolveClusterForPatchUpdate(s, patch, queryParams, "10209", "failed to validate cluster configuration update", "cluster identity is required when updating cluster configuration")
+	return resolveClusterForPatchUpdate(
+		s,
+		patch,
+		queryParams,
+		"10209",
+		"failed to validate cluster configuration update",
+		"cluster identity is required when updating cluster configuration",
+	)
 }
 
 func resolveClusterForPatchUpdate(

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 
 	mastermindssemver "github.com/Masterminds/semver/v3"
@@ -203,12 +204,11 @@ func prepareClusterValidationInput(
 		return clusterPatchValidationPreparationError(input, err)
 	}
 
-	newCluster, err := mergeClusterPatchForValidation(current, input.Body)
+	newCluster, err := buildPostgrestClusterPatchValidationNew(current, input.Body)
 	if err != nil {
 		return invalidClusterPayloadError(err)
 	}
 
-	preserveMaskedClusterPatchCredentials(current, newCluster, input.RawPayload)
 	input.Current = current
 	input.New = newCluster
 
@@ -236,12 +236,12 @@ func clusterPatchValidationPreparationError(
 		return clusterConfigurationUpdateResolutionError(err)
 	}
 
-	disableRequested, acceleratorErr := clusterAcceleratorVirtualizationDisableRequestedPayload(input.RawPayload)
+	acceleratorVirtualizationMayDisable, acceleratorErr := clusterAcceleratorVirtualizationMayDisablePayload(input.RawPayload)
 	if acceleratorErr != nil {
 		return invalidClusterPayloadError(acceleratorErr)
 	}
 
-	if disableRequested {
+	if acceleratorVirtualizationMayDisable {
 		return clusterAcceleratorVirtualizationResolutionError(err)
 	}
 
@@ -269,12 +269,12 @@ func clusterPatchValidationIdentityError(input *ValidationInput[v1.Cluster]) *va
 			errors.New("cluster identity is required when updating cluster configuration"))
 	}
 
-	disableRequested, acceleratorErr := clusterAcceleratorVirtualizationDisableRequestedPayload(input.RawPayload)
+	acceleratorVirtualizationMayDisable, acceleratorErr := clusterAcceleratorVirtualizationMayDisablePayload(input.RawPayload)
 	if acceleratorErr != nil {
 		return invalidClusterPayloadError(acceleratorErr)
 	}
 
-	if disableRequested {
+	if acceleratorVirtualizationMayDisable {
 		return clusterAcceleratorVirtualizationResolutionError(
 			errors.New("cluster identity is required when disabling accelerator virtualization"))
 	}
@@ -283,109 +283,60 @@ func clusterPatchValidationIdentityError(input *ValidationInput[v1.Cluster]) *va
 		errors.New("cluster identity is required when patching a cluster"))
 }
 
-func mergeClusterPatchForValidation(current *v1.Cluster, body []byte) (*v1.Cluster, error) {
-	patch := json.RawMessage(body)
-	if len(bytes.TrimSpace(patch)) == 0 {
-		patch = json.RawMessage(`{}`)
+// buildPostgrestClusterPatchValidationNew mirrors the resource proxy before it
+// forwards a PATCH: masked leaves are backfilled, then supplied row columns
+// replace their current values. A supplied spec therefore replaces the whole
+// PostgreSQL composite rather than recursively merging its attributes.
+func buildPostgrestClusterPatchValidationNew(current *v1.Cluster, body []byte) (*v1.Cluster, error) {
+	if current == nil {
+		return nil, errors.New("current cluster is required")
+	}
+
+	currentBody, err := json.Marshal(current)
+	if err != nil {
+		return nil, fmt.Errorf("marshal current cluster: %w", err)
+	}
+
+	var currentPayload map[string]interface{}
+	if err := json.Unmarshal(currentBody, &currentPayload); err != nil {
+		return nil, fmt.Errorf("decode current cluster: %w", err)
+	}
+
+	if len(bytes.TrimSpace(body)) == 0 {
+		body = []byte(`{}`)
+	}
+
+	filteredBody, err := filterPayloadToTopLevelFields(
+		body,
+		extractTopLevelJSONFields(reflect.TypeOf(v1.Cluster{})),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("filter cluster patch payload: %w", err)
+	}
+
+	var patchPayload map[string]interface{}
+	if err := json.Unmarshal(filteredBody, &patchPayload); err != nil {
+		return nil, fmt.Errorf("decode cluster patch payload: %w", err)
+	}
+
+	tagConfig := extractStructTagConfig(reflect.TypeOf(v1.Cluster{}))
+	mergeExcludedFields(patchPayload, currentPayload, tagConfig.excludeFields, tagConfig.arrayMergeKeys)
+
+	for field, value := range patchPayload {
+		currentPayload[field] = value
+	}
+
+	nextBody, err := json.Marshal(currentPayload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal patched cluster: %w", err)
 	}
 
 	var next v1.Cluster
-	if err := util.JsonMerge(current, patch, &next); err != nil {
-		return nil, fmt.Errorf("merge cluster patch for validation: %w", err)
+	if err := json.Unmarshal(nextBody, &next); err != nil {
+		return nil, fmt.Errorf("decode patched cluster: %w", err)
 	}
 
 	return &next, nil
-}
-
-func preserveMaskedClusterPatchCredentials(
-	current, next *v1.Cluster, payload map[string]json.RawMessage,
-) {
-	if current == nil || current.Spec == nil || next == nil || next.Spec == nil {
-		return
-	}
-
-	specRaw, ok := payload["spec"]
-	if !ok {
-		return
-	}
-
-	var spec map[string]json.RawMessage
-	if err := json.Unmarshal(specRaw, &spec); err != nil {
-		return
-	}
-
-	configRaw, ok := spec["config"]
-	if !ok || isJSONNull(configRaw) {
-		return
-	}
-
-	var config map[string]json.RawMessage
-	if err := json.Unmarshal(configRaw, &config); err != nil {
-		return
-	}
-
-	preserveMaskedKubeconfig(current, next, config)
-	preserveMaskedSSHPrivateKey(current, next, config)
-}
-
-func preserveMaskedKubeconfig(current, next *v1.Cluster, config map[string]json.RawMessage) {
-	kubernetesConfigRaw, ok := config["kubernetes_config"]
-	if !ok || isJSONNull(kubernetesConfigRaw) {
-		return
-	}
-
-	var kubernetesConfig map[string]json.RawMessage
-	if err := json.Unmarshal(kubernetesConfigRaw, &kubernetesConfig); err != nil {
-		return
-	}
-
-	kubeconfigRaw, ok := kubernetesConfig["kubeconfig"]
-	if !ok || !isJSONEmptyOrNullString(kubeconfigRaw) || current.Spec.Config == nil ||
-		current.Spec.Config.KubernetesConfig == nil || next.Spec.Config == nil || next.Spec.Config.KubernetesConfig == nil {
-		return
-	}
-
-	next.Spec.Config.KubernetesConfig.Kubeconfig = current.Spec.Config.KubernetesConfig.Kubeconfig
-}
-
-func preserveMaskedSSHPrivateKey(current, next *v1.Cluster, config map[string]json.RawMessage) {
-	sshConfigRaw, ok := config["ssh_config"]
-	if !ok || isJSONNull(sshConfigRaw) {
-		return
-	}
-
-	var sshConfig map[string]json.RawMessage
-	if err := json.Unmarshal(sshConfigRaw, &sshConfig); err != nil {
-		return
-	}
-
-	authRaw, ok := sshConfig["auth"]
-	if !ok || isJSONNull(authRaw) {
-		return
-	}
-
-	var auth map[string]json.RawMessage
-	if err := json.Unmarshal(authRaw, &auth); err != nil {
-		return
-	}
-
-	privateKeyRaw, ok := auth["ssh_private_key"]
-	if !ok || !isJSONEmptyOrNullString(privateKeyRaw) || current.Spec.Config == nil ||
-		current.Spec.Config.SSHConfig == nil || next.Spec.Config == nil || next.Spec.Config.SSHConfig == nil {
-		return
-	}
-
-	next.Spec.Config.SSHConfig.Auth.SSHPrivateKey = current.Spec.Config.SSHConfig.Auth.SSHPrivateKey
-}
-
-func isJSONEmptyOrNullString(raw json.RawMessage) bool {
-	if isJSONNull(raw) {
-		return true
-	}
-
-	var value string
-
-	return json.Unmarshal(raw, &value) == nil && value == ""
 }
 
 func validateClusterSoftDelete(s storage.Storage, input *ValidationInput[v1.Cluster]) error {
@@ -439,15 +390,7 @@ func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc
 		}
 
 		if input.Operation == clusterValidationPatch {
-			updated, err := clusterAcceleratorVirtualizationUpdatedPayload(input.RawPayload)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-				c.Abort()
-
-				return
-			}
-
-			if !updated {
+			if _, updatesSpec := input.RawPayload["spec"]; !updatesSpec {
 				c.Next()
 
 				return
@@ -969,16 +912,9 @@ func currentClusterSpecVersionBaseline(current *v1.Cluster) (string, error) {
 	return baseline, nil
 }
 
-func clusterAcceleratorVirtualizationDisableRequested(body []byte) (bool, error) {
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return false, err
-	}
-
-	return clusterAcceleratorVirtualizationDisableRequestedPayload(payload)
-}
-
-func clusterAcceleratorVirtualizationDisableRequestedPayload(payload map[string]json.RawMessage) (bool, error) {
+// clusterAcceleratorVirtualizationMayDisablePayload preserves the legacy error
+// contract when Current/New cannot be built because the PATCH target is unknown.
+func clusterAcceleratorVirtualizationMayDisablePayload(payload map[string]json.RawMessage) (bool, error) {
 	specRaw, ok := payload["spec"]
 	if !ok {
 		return false, nil
@@ -1001,9 +937,6 @@ func clusterAcceleratorVirtualizationDisableRequestedPayload(payload map[string]
 
 	enabledRaw, ok := acceleratorVirtualization["enabled"]
 	if !ok {
-		// The CLI decodes YAML into Cluster and re-marshals JSON before PATCH.
-		// enabled:false is omitted by the API struct tag, yielding
-		// "accelerator_virtualization": {}, which still clears the enabled flag.
 		return true, nil
 	}
 
@@ -1013,22 +946,6 @@ func clusterAcceleratorVirtualizationDisableRequestedPayload(payload map[string]
 	}
 
 	return !enabled, nil
-}
-
-func clusterAcceleratorVirtualizationUpdatedPayload(payload map[string]json.RawMessage) (bool, error) {
-	specRaw, ok := payload["spec"]
-	if !ok {
-		return false, nil
-	}
-
-	var spec map[string]json.RawMessage
-	if err := json.Unmarshal(specRaw, &spec); err != nil {
-		return false, err
-	}
-
-	_, updated := spec["accelerator_virtualization"]
-
-	return updated, nil
 }
 
 func clusterEndpointReferenceFilters(workspace, name string) []storage.Filter {
@@ -1203,20 +1120,13 @@ func validateClusterAcceleratorVirtualizationInput(
 		return nil
 	}
 
-	disableRequested, err := clusterAcceleratorVirtualizationDisableRequestedPayload(input.RawPayload)
-	if err != nil {
-		return invalidClusterPayloadError(err)
-	}
-
-	if !disableRequested {
+	if input.Current == nil || input.New == nil ||
+		!input.Current.Spec.AcceleratorVirtualizationEnabled() ||
+		input.New.Spec.AcceleratorVirtualizationEnabled() {
 		return nil
 	}
 
-	if input.Current != nil {
-		return validateClusterAcceleratorVirtualizationDisableForCurrent(s, input.Current, input.Patch)
-	}
-
-	return validateClusterAcceleratorVirtualizationDisable(s, input.Patch, input.QueryParams)
+	return validateClusterAcceleratorVirtualizationDisableForCurrent(s, input.Current, input.Patch)
 }
 
 func validateClusterAcceleratorVirtualizationBody(body []byte) *validationError {

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -2,6 +2,7 @@ package proxies
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	mastermindssemver "github.com/Masterminds/semver/v3"
 	"github.com/gin-gonic/gin"
@@ -17,6 +19,7 @@ import (
 	clustervalidation "github.com/neutree-ai/neutree/internal/cluster/validation"
 	"github.com/neutree-ai/neutree/internal/middleware"
 	"github.com/neutree-ai/neutree/internal/semver"
+	"github.com/neutree-ai/neutree/internal/util"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
@@ -63,6 +66,21 @@ func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc
 		if len(bytes.TrimSpace(body)) == 0 {
 			c.Next()
 			return
+		}
+
+		if c.Request.Method == http.MethodPatch {
+			isSoftDelete, err := clusterPatchIsSoftDelete(body)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+				c.Abort()
+
+				return
+			}
+
+			if isSoftDelete {
+				c.Next()
+				return
+			}
 		}
 
 		if validationErr := validateClusterAcceleratorVirtualizationBody(body); validationErr != nil {
@@ -132,6 +150,19 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
+		isSoftDelete, err := clusterPatchIsSoftDelete(body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+			c.Abort()
+
+			return
+		}
+
+		if isSoftDelete {
+			c.Next()
+			return
+		}
+
 		desiredVersion, hasVersion, err := clusterPatchDesiredVersion(body)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
@@ -140,7 +171,15 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		if !hasVersion {
+		configurationUpdate, err := parseClusterPatchConfigurationUpdate(body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+			c.Abort()
+
+			return
+		}
+
+		if !hasVersion && !configurationUpdate.hasChanges() {
 			c.Next()
 			return
 		}
@@ -153,12 +192,13 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		if patch.GetDeletionTimestamp() != "" {
-			c.Next()
-			return
+		var current *v1.Cluster
+		var validationErr *validationError
+		if hasVersion {
+			current, validationErr = resolveClusterForVersionUpdate(s, patch, c.Request.URL.Query())
+		} else {
+			current, validationErr = resolveClusterForConfigurationUpdate(s, patch, c.Request.URL.Query())
 		}
-
-		current, validationErr := resolveClusterForVersionUpdate(s, patch, c.Request.URL.Query())
 		if validationErr != nil {
 			c.JSON(http.StatusBadRequest, validationErr)
 			c.Abort()
@@ -166,18 +206,184 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
-		if err := validateClusterVersionNotDowngrade(current, desiredVersion); err != nil {
-			c.JSON(http.StatusBadRequest, &validationError{
-				Code:    "10212",
-				Message: "invalid cluster version update",
-				Hint:    err.Error(),
-			})
+		if hasVersion {
+			if err := validateClusterVersionNotDowngrade(current, desiredVersion); err != nil {
+				c.JSON(http.StatusBadRequest, &validationError{
+					Code:    "10212",
+					Message: "invalid cluster version update",
+					Hint:    err.Error(),
+				})
+				c.Abort()
+
+				return
+			}
+		}
+
+		if err := validateClusterConfigurationUpdate(current, configurationUpdate); err != nil {
+			c.JSON(http.StatusBadRequest, clusterConfigurationUpdateError(err))
 			c.Abort()
 
 			return
 		}
 
 		c.Next()
+	}
+}
+
+func clusterPatchIsSoftDelete(body []byte) (bool, error) {
+	var payload struct {
+		Metadata *v1.Metadata `json:"metadata"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false, err
+	}
+
+	return payload.Metadata != nil && payload.Metadata.DeletionTimestamp != "", nil
+}
+
+type clusterPatchConfigurationUpdate struct {
+	imageRegistry    string
+	imageRegistrySet bool
+	kubeconfig       string
+	kubeconfigSet    bool
+	sshPrivateKey    string
+	sshPrivateKeySet bool
+}
+
+func (u clusterPatchConfigurationUpdate) hasChanges() bool {
+	return u.imageRegistrySet || u.kubeconfigSet || u.sshPrivateKeySet
+}
+
+func parseClusterPatchConfigurationUpdate(body []byte) (clusterPatchConfigurationUpdate, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return clusterPatchConfigurationUpdate{}, err
+	}
+
+	specRaw, ok := payload["spec"]
+	if !ok {
+		return clusterPatchConfigurationUpdate{}, nil
+	}
+
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
+		return clusterPatchConfigurationUpdate{}, err
+	}
+
+	update := clusterPatchConfigurationUpdate{}
+	if imageRegistryRaw, ok := spec["image_registry"]; ok {
+		if err := json.Unmarshal(imageRegistryRaw, &update.imageRegistry); err != nil {
+			return clusterPatchConfigurationUpdate{}, err
+		}
+
+		update.imageRegistrySet = true
+	}
+
+	configRaw, ok := spec["config"]
+	if !ok {
+		return update, nil
+	}
+
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(configRaw, &config); err != nil {
+		return clusterPatchConfigurationUpdate{}, err
+	}
+
+	if kubernetesConfigRaw, ok := config["kubernetes_config"]; ok {
+		var kubernetesConfig map[string]json.RawMessage
+		if err := json.Unmarshal(kubernetesConfigRaw, &kubernetesConfig); err != nil {
+			return clusterPatchConfigurationUpdate{}, err
+		}
+
+		if kubeconfigRaw, ok := kubernetesConfig["kubeconfig"]; ok {
+			if err := json.Unmarshal(kubeconfigRaw, &update.kubeconfig); err != nil {
+				return clusterPatchConfigurationUpdate{}, err
+			}
+
+			update.kubeconfigSet = true
+		}
+	}
+
+	if sshConfigRaw, ok := config["ssh_config"]; ok {
+		var sshConfig map[string]json.RawMessage
+		if err := json.Unmarshal(sshConfigRaw, &sshConfig); err != nil {
+			return clusterPatchConfigurationUpdate{}, err
+		}
+
+		authRaw, ok := sshConfig["auth"]
+		if !ok {
+			return update, nil
+		}
+
+		var auth map[string]json.RawMessage
+		if err := json.Unmarshal(authRaw, &auth); err != nil {
+			return clusterPatchConfigurationUpdate{}, err
+		}
+
+		if sshPrivateKeyRaw, ok := auth["ssh_private_key"]; ok {
+			if err := json.Unmarshal(sshPrivateKeyRaw, &update.sshPrivateKey); err != nil {
+				return clusterPatchConfigurationUpdate{}, err
+			}
+
+			update.sshPrivateKeySet = true
+		}
+	}
+
+	return update, nil
+}
+
+func validateClusterConfigurationUpdate(current *v1.Cluster, update clusterPatchConfigurationUpdate) error {
+	if current == nil || current.Spec == nil || !current.IsInitialized() {
+		return nil
+	}
+
+	if update.imageRegistrySet && update.imageRegistry != current.Spec.ImageRegistry {
+		return errors.New("image registry cannot be changed after cluster initialization")
+	}
+
+	if current.Spec.Type == v1.KubernetesClusterType && update.kubeconfigSet {
+		if strings.TrimSpace(update.kubeconfig) == "" {
+			return errors.New("kubeconfig cannot be empty for an initialized cluster")
+		}
+
+		currentKubeconfig, err := util.GetKubeConfigFromCluster(current)
+		if err != nil {
+			return fmt.Errorf("failed to read current kubeconfig: %w", err)
+		}
+
+		currentAPIServer, err := util.GetApiServerUrlFromDecodedKubeConfig(currentKubeconfig)
+		if err != nil {
+			return fmt.Errorf("failed to parse current kubeconfig: %w", err)
+		}
+
+		updatedAPIServer, err := util.GetApiServerUrlFromKubeConfig(update.kubeconfig)
+		if err != nil {
+			return fmt.Errorf("failed to parse updated kubeconfig: %w", err)
+		}
+
+		if currentAPIServer != updatedAPIServer {
+			return errors.New("kubeconfig must reference the current Kubernetes API server")
+		}
+	}
+
+	if current.Spec.Type == v1.SSHClusterType && update.sshPrivateKeySet {
+		if strings.TrimSpace(update.sshPrivateKey) == "" {
+			return errors.New("SSH private key cannot be empty for an initialized cluster")
+		}
+
+		if _, err := base64.StdEncoding.DecodeString(update.sshPrivateKey); err != nil {
+			return fmt.Errorf("SSH private key must be base64 encoded: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func clusterConfigurationUpdateError(err error) *validationError {
+	return &validationError{
+		Code:    "10209",
+		Message: "invalid cluster configuration update",
+		Hint:    err.Error(),
 	}
 }
 
@@ -213,6 +419,18 @@ func clusterPatchDesiredVersion(body []byte) (string, bool, error) {
 func resolveClusterForVersionUpdate(
 	s storage.Storage, patch v1.Cluster, queryParams url.Values,
 ) (*v1.Cluster, *validationError) {
+	return resolveClusterForPatchUpdate(s, patch, queryParams, "10212", "failed to validate cluster version update", "cluster identity is required when updating spec.version")
+}
+
+func resolveClusterForConfigurationUpdate(
+	s storage.Storage, patch v1.Cluster, queryParams url.Values,
+) (*v1.Cluster, *validationError) {
+	return resolveClusterForPatchUpdate(s, patch, queryParams, "10209", "failed to validate cluster configuration update", "cluster identity is required when updating cluster configuration")
+}
+
+func resolveClusterForPatchUpdate(
+	s storage.Storage, patch v1.Cluster, queryParams url.Values, code, message, identityHint string,
+) (*v1.Cluster, *validationError) {
 	filters := queryParamsToFilters(queryParams)
 	if len(filters) == 0 && patch.Metadata != nil && patch.Metadata.Workspace != "" && patch.Metadata.Name != "" {
 		filters = []storage.Filter{
@@ -223,25 +441,25 @@ func resolveClusterForVersionUpdate(
 
 	if len(filters) == 0 {
 		return nil, &validationError{
-			Code:    "10212",
-			Message: "failed to validate cluster version update",
-			Hint:    "cluster identity is required when updating spec.version",
+			Code:    code,
+			Message: message,
+			Hint:    identityHint,
 		}
 	}
 
 	clusters, err := s.ListCluster(storage.ListOption{Filters: filters})
 	if err != nil {
 		return nil, &validationError{
-			Code:    "10212",
-			Message: "failed to validate cluster version update",
+			Code:    code,
+			Message: message,
 			Hint:    err.Error(),
 		}
 	}
 
 	if len(clusters) != 1 {
 		return nil, &validationError{
-			Code:    "10212",
-			Message: "failed to validate cluster version update",
+			Code:    code,
+			Message: message,
 			Hint:    fmt.Sprintf("expected exactly one cluster from patch filters, got %d", len(clusters)),
 		}
 	}
@@ -249,8 +467,8 @@ func resolveClusterForVersionUpdate(
 	current := &clusters[0]
 	if current.Spec == nil {
 		return nil, &validationError{
-			Code:    "10212",
-			Message: "failed to validate cluster version update",
+			Code:    code,
+			Message: message,
 			Hint:    "current cluster spec is required",
 		}
 	}

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -55,6 +55,8 @@ type ValidationInput[T any] struct {
 	Body        []byte
 	RawPayload  map[string]json.RawMessage
 	Patch       T
+	Current     *T
+	New         *T
 	QueryParams url.Values
 	Operation   clusterValidationOperation
 }
@@ -87,15 +89,22 @@ func validateClusterRequest(s storage.Storage) gin.HandlerFunc {
 			return
 		}
 
+		if validationErr := prepareClusterValidationInput(s, input); validationErr != nil {
+			c.JSON(http.StatusBadRequest, validationErr)
+			c.Abort()
+
+			return
+		}
+
 		if input.Operation == clusterValidationPatch {
-			if validationErr := validateClusterVersionUpdateInput(s, input); validationErr != nil {
+			if validationErr := validateClusterVersionUpdateInput(input); validationErr != nil {
 				c.JSON(http.StatusBadRequest, validationErr)
 				c.Abort()
 
 				return
 			}
 
-			if validationErr := validateClusterConfigurationUpdateInput(s, input); validationErr != nil {
+			if validationErr := validateClusterConfigurationUpdateInput(input); validationErr != nil {
 				c.JSON(http.StatusBadRequest, validationErr)
 				c.Abort()
 
@@ -171,6 +180,214 @@ func readClusterValidationInput(c *gin.Context) (*ValidationInput[v1.Cluster], *
 	return input, nil
 }
 
+func prepareClusterValidationInput(
+	s storage.Storage, input *ValidationInput[v1.Cluster],
+) *validationError {
+	if input.Operation == clusterValidationSoftDelete {
+		return nil
+	}
+
+	if input.Operation == clusterValidationCreate {
+		input.New = &input.Patch
+
+		return nil
+	}
+
+	filters := clusterPatchUpdateFilters(input.Patch, input.QueryParams)
+	if len(filters) == 0 {
+		return clusterPatchValidationIdentityError(input)
+	}
+
+	current, err := resolveClusterForPatchUpdate(s, filters)
+	if err != nil {
+		return clusterPatchValidationPreparationError(input, err)
+	}
+
+	newCluster, err := mergeClusterPatchForValidation(current, input.Body)
+	if err != nil {
+		return invalidClusterPayloadError(err)
+	}
+
+	preserveMaskedClusterPatchCredentials(current, newCluster, input.RawPayload)
+	input.Current = current
+	input.New = newCluster
+
+	return nil
+}
+
+func clusterPatchValidationPreparationError(
+	input *ValidationInput[v1.Cluster], err error,
+) *validationError {
+	hasVersion, versionErr := clusterPatchDesiredVersionPayload(input.RawPayload)
+	if versionErr != nil {
+		return invalidClusterPayloadError(versionErr)
+	}
+
+	if hasVersion {
+		return clusterVersionUpdateResolutionError(err)
+	}
+
+	configurationUpdate, configurationErr := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
+	if configurationErr != nil {
+		return invalidClusterPayloadError(configurationErr)
+	}
+
+	if configurationUpdate.hasChanges() {
+		return clusterConfigurationUpdateResolutionError(err)
+	}
+
+	disableRequested, acceleratorErr := clusterAcceleratorVirtualizationDisableRequestedPayload(input.RawPayload)
+	if acceleratorErr != nil {
+		return invalidClusterPayloadError(acceleratorErr)
+	}
+
+	if disableRequested {
+		return clusterAcceleratorVirtualizationResolutionError(err)
+	}
+
+	return clusterPatchValidationResolutionError(err)
+}
+
+func clusterPatchValidationIdentityError(input *ValidationInput[v1.Cluster]) *validationError {
+	hasVersion, versionErr := clusterPatchDesiredVersionPayload(input.RawPayload)
+	if versionErr != nil {
+		return invalidClusterPayloadError(versionErr)
+	}
+
+	if hasVersion {
+		return clusterVersionUpdateResolutionError(
+			errors.New("cluster identity is required when updating spec.version"))
+	}
+
+	configurationUpdate, configurationErr := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
+	if configurationErr != nil {
+		return invalidClusterPayloadError(configurationErr)
+	}
+
+	if configurationUpdate.hasChanges() {
+		return clusterConfigurationUpdateResolutionError(
+			errors.New("cluster identity is required when updating cluster configuration"))
+	}
+
+	disableRequested, acceleratorErr := clusterAcceleratorVirtualizationDisableRequestedPayload(input.RawPayload)
+	if acceleratorErr != nil {
+		return invalidClusterPayloadError(acceleratorErr)
+	}
+
+	if disableRequested {
+		return clusterAcceleratorVirtualizationResolutionError(
+			errors.New("cluster identity is required when disabling accelerator virtualization"))
+	}
+
+	return clusterPatchValidationResolutionError(
+		errors.New("cluster identity is required when patching a cluster"))
+}
+
+func mergeClusterPatchForValidation(current *v1.Cluster, body []byte) (*v1.Cluster, error) {
+	patch := json.RawMessage(body)
+	if len(bytes.TrimSpace(patch)) == 0 {
+		patch = json.RawMessage(`{}`)
+	}
+
+	var next v1.Cluster
+	if err := util.JsonMerge(current, patch, &next); err != nil {
+		return nil, fmt.Errorf("merge cluster patch for validation: %w", err)
+	}
+
+	return &next, nil
+}
+
+func preserveMaskedClusterPatchCredentials(
+	current, next *v1.Cluster, payload map[string]json.RawMessage,
+) {
+	if current == nil || current.Spec == nil || next == nil || next.Spec == nil {
+		return
+	}
+
+	specRaw, ok := payload["spec"]
+	if !ok {
+		return
+	}
+
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
+		return
+	}
+
+	configRaw, ok := spec["config"]
+	if !ok || isJSONNull(configRaw) {
+		return
+	}
+
+	var config map[string]json.RawMessage
+	if err := json.Unmarshal(configRaw, &config); err != nil {
+		return
+	}
+
+	preserveMaskedKubeconfig(current, next, config)
+	preserveMaskedSSHPrivateKey(current, next, config)
+}
+
+func preserveMaskedKubeconfig(current, next *v1.Cluster, config map[string]json.RawMessage) {
+	kubernetesConfigRaw, ok := config["kubernetes_config"]
+	if !ok || isJSONNull(kubernetesConfigRaw) {
+		return
+	}
+
+	var kubernetesConfig map[string]json.RawMessage
+	if err := json.Unmarshal(kubernetesConfigRaw, &kubernetesConfig); err != nil {
+		return
+	}
+
+	kubeconfigRaw, ok := kubernetesConfig["kubeconfig"]
+	if !ok || !isJSONEmptyOrNullString(kubeconfigRaw) || current.Spec.Config == nil ||
+		current.Spec.Config.KubernetesConfig == nil || next.Spec.Config == nil || next.Spec.Config.KubernetesConfig == nil {
+		return
+	}
+
+	next.Spec.Config.KubernetesConfig.Kubeconfig = current.Spec.Config.KubernetesConfig.Kubeconfig
+}
+
+func preserveMaskedSSHPrivateKey(current, next *v1.Cluster, config map[string]json.RawMessage) {
+	sshConfigRaw, ok := config["ssh_config"]
+	if !ok || isJSONNull(sshConfigRaw) {
+		return
+	}
+
+	var sshConfig map[string]json.RawMessage
+	if err := json.Unmarshal(sshConfigRaw, &sshConfig); err != nil {
+		return
+	}
+
+	authRaw, ok := sshConfig["auth"]
+	if !ok || isJSONNull(authRaw) {
+		return
+	}
+
+	var auth map[string]json.RawMessage
+	if err := json.Unmarshal(authRaw, &auth); err != nil {
+		return
+	}
+
+	privateKeyRaw, ok := auth["ssh_private_key"]
+	if !ok || !isJSONEmptyOrNullString(privateKeyRaw) || current.Spec.Config == nil ||
+		current.Spec.Config.SSHConfig == nil || next.Spec.Config == nil || next.Spec.Config.SSHConfig == nil {
+		return
+	}
+
+	next.Spec.Config.SSHConfig.Auth.SSHPrivateKey = current.Spec.Config.SSHConfig.Auth.SSHPrivateKey
+}
+
+func isJSONEmptyOrNullString(raw json.RawMessage) bool {
+	if isJSONNull(raw) {
+		return true
+	}
+
+	var value string
+
+	return json.Unmarshal(raw, &value) == nil && value == ""
+}
+
 func validateClusterSoftDelete(s storage.Storage, input *ValidationInput[v1.Cluster]) error {
 	if input.Patch.Metadata == nil || input.Patch.Metadata.Name == "" {
 		return nil
@@ -221,6 +438,29 @@ func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc
 			return
 		}
 
+		if input.Operation == clusterValidationPatch {
+			updated, err := clusterAcceleratorVirtualizationUpdatedPayload(input.RawPayload)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+				c.Abort()
+
+				return
+			}
+
+			if !updated {
+				c.Next()
+
+				return
+			}
+		}
+
+		if validationErr := prepareClusterValidationInput(s, input); validationErr != nil {
+			c.JSON(http.StatusBadRequest, validationErr)
+			c.Abort()
+
+			return
+		}
+
 		if validationErr := validateClusterAcceleratorVirtualizationInput(s, input); validationErr != nil {
 			c.JSON(http.StatusBadRequest, validationErr)
 			c.Abort()
@@ -248,7 +488,28 @@ func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
 		}
 
 		if input.Operation != clusterValidationSoftDelete {
-			if validationErr := validateClusterVersionUpdateInput(s, input); validationErr != nil {
+			hasVersion, err := clusterPatchDesiredVersionPayload(input.RawPayload)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+				c.Abort()
+
+				return
+			}
+
+			if !hasVersion {
+				c.Next()
+
+				return
+			}
+
+			if validationErr := prepareClusterValidationInput(s, input); validationErr != nil {
+				c.JSON(http.StatusBadRequest, validationErr)
+				c.Abort()
+
+				return
+			}
+
+			if validationErr := validateClusterVersionUpdateInput(input); validationErr != nil {
 				c.JSON(http.StatusBadRequest, validationErr)
 				c.Abort()
 
@@ -276,7 +537,28 @@ func validateClusterConfigurationUpdate(s storage.Storage) gin.HandlerFunc {
 		}
 
 		if input.Operation != clusterValidationSoftDelete {
-			if validationErr := validateClusterConfigurationUpdateInput(s, input); validationErr != nil {
+			configurationUpdate, err := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
+				c.Abort()
+
+				return
+			}
+
+			if !configurationUpdate.hasChanges() {
+				c.Next()
+
+				return
+			}
+
+			if validationErr := prepareClusterValidationInput(s, input); validationErr != nil {
+				c.JSON(http.StatusBadRequest, validationErr)
+				c.Abort()
+
+				return
+			}
+
+			if validationErr := validateClusterConfigurationUpdateInput(input); validationErr != nil {
 				c.JSON(http.StatusBadRequest, validationErr)
 				c.Abort()
 
@@ -425,8 +707,10 @@ func parseClusterPatchConfigurationUpdatePayload(payload map[string]json.RawMess
 	return update, nil
 }
 
-func validateInitializedClusterConfigurationUpdate(current *v1.Cluster, update clusterPatchConfigurationUpdate) error {
-	if current == nil || current.Spec == nil || !current.IsInitialized() {
+func validateInitializedClusterConfigurationUpdate(
+	current, next *v1.Cluster, update clusterPatchConfigurationUpdate,
+) error {
+	if current == nil || current.Spec == nil || next == nil || next.Spec == nil || !current.IsInitialized() {
 		return nil
 	}
 
@@ -434,7 +718,7 @@ func validateInitializedClusterConfigurationUpdate(current *v1.Cluster, update c
 		return errors.New("config cannot be cleared after cluster initialization")
 	}
 
-	if update.imageRegistrySet && update.imageRegistry != current.Spec.ImageRegistry {
+	if update.imageRegistrySet && next.Spec.ImageRegistry != current.Spec.ImageRegistry {
 		return errors.New("image registry cannot be changed after cluster initialization")
 	}
 
@@ -454,7 +738,13 @@ func validateInitializedClusterConfigurationUpdate(current *v1.Cluster, update c
 				return fmt.Errorf("failed to parse current kubeconfig: %w", err)
 			}
 
-			updatedAPIServer, err := util.GetApiServerUrlFromKubeConfig(update.kubeconfig)
+			if next.Spec.Config == nil || next.Spec.Config.KubernetesConfig == nil {
+				return errors.New("updated Kubernetes config is required")
+			}
+
+			updatedKubeconfig := next.Spec.Config.KubernetesConfig.Kubeconfig
+
+			updatedAPIServer, err := util.GetApiServerUrlFromKubeConfig(updatedKubeconfig)
 			if err != nil {
 				return fmt.Errorf("failed to parse updated kubeconfig: %w", err)
 			}
@@ -496,10 +786,8 @@ func clusterConfigurationUpdateError(err error) *validationError {
 	}
 }
 
-func validateClusterVersionUpdateInput(
-	s storage.Storage, input *ValidationInput[v1.Cluster],
-) *validationError {
-	desiredVersion, hasVersion, err := clusterPatchDesiredVersionPayload(input.RawPayload)
+func validateClusterVersionUpdateInput(input *ValidationInput[v1.Cluster]) *validationError {
+	hasVersion, err := clusterPatchDesiredVersionPayload(input.RawPayload)
 	if err != nil {
 		return invalidClusterPayloadError(err)
 	}
@@ -508,21 +796,18 @@ func validateClusterVersionUpdateInput(
 		return nil
 	}
 
-	current, validationErr := resolveClusterForVersionUpdate(s, input.Patch, input.QueryParams)
-	if validationErr != nil {
-		return validationErr
+	if input.Current == nil || input.New == nil {
+		return clusterPatchValidationResolutionError(errors.New("cluster validation objects are required"))
 	}
 
-	if err := validateClusterVersionNotDowngrade(current, desiredVersion); err != nil {
+	if err := validateClusterVersionNotDowngrade(input.Current, input.New.GetVersion()); err != nil {
 		return clusterVersionUpdateError(err)
 	}
 
 	return nil
 }
 
-func validateClusterConfigurationUpdateInput(
-	s storage.Storage, input *ValidationInput[v1.Cluster],
-) *validationError {
+func validateClusterConfigurationUpdateInput(input *ValidationInput[v1.Cluster]) *validationError {
 	configurationUpdate, err := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
 	if err != nil {
 		return invalidClusterPayloadError(err)
@@ -532,74 +817,39 @@ func validateClusterConfigurationUpdateInput(
 		return nil
 	}
 
-	current, validationErr := resolveClusterForConfigurationUpdate(s, input.Patch, input.QueryParams)
-	if validationErr != nil {
-		return validationErr
+	if input.Current == nil || input.New == nil {
+		return clusterPatchValidationResolutionError(errors.New("cluster validation objects are required"))
 	}
 
-	if err := validateInitializedClusterConfigurationUpdate(current, configurationUpdate); err != nil {
+	if err := validateInitializedClusterConfigurationUpdate(input.Current, input.New, configurationUpdate); err != nil {
 		return clusterConfigurationUpdateError(err)
 	}
 
 	return nil
 }
 
-func clusterPatchDesiredVersionPayload(payload map[string]json.RawMessage) (string, bool, error) {
+func clusterPatchDesiredVersionPayload(payload map[string]json.RawMessage) (bool, error) {
 	specRaw, ok := payload["spec"]
 	if !ok {
-		return "", false, nil
+		return false, nil
 	}
 
 	var spec map[string]json.RawMessage
 	if err := json.Unmarshal(specRaw, &spec); err != nil {
-		return "", false, err
+		return false, err
 	}
 
 	versionRaw, ok := spec["version"]
 	if !ok {
-		return "", false, nil
+		return false, nil
 	}
 
 	var version string
 	if err := json.Unmarshal(versionRaw, &version); err != nil {
-		return "", false, err
+		return false, err
 	}
 
-	return version, true, nil
-}
-
-func resolveClusterForVersionUpdate(
-	s storage.Storage, patch v1.Cluster, queryParams url.Values,
-) (*v1.Cluster, *validationError) {
-	filters := clusterPatchUpdateFilters(patch, queryParams)
-	if len(filters) == 0 {
-		return nil, clusterVersionUpdateResolutionError(
-			errors.New("cluster identity is required when updating spec.version"))
-	}
-
-	current, err := resolveClusterForPatchUpdate(s, filters)
-	if err != nil {
-		return nil, clusterVersionUpdateResolutionError(err)
-	}
-
-	return current, nil
-}
-
-func resolveClusterForConfigurationUpdate(
-	s storage.Storage, patch v1.Cluster, queryParams url.Values,
-) (*v1.Cluster, *validationError) {
-	filters := clusterPatchUpdateFilters(patch, queryParams)
-	if len(filters) == 0 {
-		return nil, clusterConfigurationUpdateResolutionError(
-			errors.New("cluster identity is required when updating cluster configuration"))
-	}
-
-	current, err := resolveClusterForPatchUpdate(s, filters)
-	if err != nil {
-		return nil, clusterConfigurationUpdateResolutionError(err)
-	}
-
-	return current, nil
+	return true, nil
 }
 
 func clusterPatchUpdateFilters(patch v1.Cluster, queryParams url.Values) []storage.Filter {
@@ -636,6 +886,14 @@ func clusterVersionUpdateError(err error) *validationError {
 	return &validationError{
 		Code:    "10212",
 		Message: "invalid cluster version update",
+		Hint:    err.Error(),
+	}
+}
+
+func clusterPatchValidationResolutionError(err error) *validationError {
+	return &validationError{
+		Code:    "10209",
+		Message: "failed to prepare cluster patch validation",
 		Hint:    err.Error(),
 	}
 }
@@ -757,6 +1015,22 @@ func clusterAcceleratorVirtualizationDisableRequestedPayload(payload map[string]
 	return !enabled, nil
 }
 
+func clusterAcceleratorVirtualizationUpdatedPayload(payload map[string]json.RawMessage) (bool, error) {
+	specRaw, ok := payload["spec"]
+	if !ok {
+		return false, nil
+	}
+
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
+		return false, err
+	}
+
+	_, updated := spec["accelerator_virtualization"]
+
+	return updated, nil
+}
+
 func clusterEndpointReferenceFilters(workspace, name string) []storage.Filter {
 	return []storage.Filter{
 		{Column: "metadata->>workspace", Operator: "eq", Value: workspace},
@@ -777,6 +1051,12 @@ func validateClusterAcceleratorVirtualizationDisable(
 		return validationErr
 	}
 
+	return validateClusterAcceleratorVirtualizationDisableForIdentity(s, workspace, name)
+}
+
+func validateClusterAcceleratorVirtualizationDisableForIdentity(
+	s storage.Storage, workspace, name string,
+) *validationError {
 	endpoints, err := s.ListEndpoint(storage.ListOption{Filters: clusterEndpointReferenceFilters(workspace, name)})
 	if err != nil {
 		return &validationError{
@@ -808,6 +1088,39 @@ func validateClusterAcceleratorVirtualizationDisable(
 	}
 
 	return nil
+}
+
+func validateClusterAcceleratorVirtualizationDisableForCurrent(
+	s storage.Storage, current *v1.Cluster, patch v1.Cluster,
+) *validationError {
+	if current == nil || current.Metadata == nil || current.Metadata.Workspace == "" || current.Metadata.Name == "" {
+		return &validationError{
+			Code:    "10209",
+			Message: "failed to validate cluster accelerator virtualization",
+			Hint:    "cluster identity is required when disabling accelerator virtualization",
+		}
+	}
+
+	if patch.Metadata != nil &&
+		((patch.Metadata.Workspace != "" && patch.Metadata.Workspace != current.Metadata.Workspace) ||
+			(patch.Metadata.Name != "" && patch.Metadata.Name != current.Metadata.Name)) {
+		return &validationError{
+			Code:    "10209",
+			Message: "failed to validate cluster accelerator virtualization",
+			Hint:    "cluster metadata in patch body does not match patch target",
+		}
+	}
+
+	return validateClusterAcceleratorVirtualizationDisableForIdentity(
+		s, current.Metadata.Workspace, current.Metadata.Name)
+}
+
+func clusterAcceleratorVirtualizationResolutionError(err error) *validationError {
+	return &validationError{
+		Code:    "10209",
+		Message: "failed to validate cluster accelerator virtualization",
+		Hint:    err.Error(),
+	}
 }
 
 func resolveClusterIdentityForAcceleratorVirtualizationDisable(
@@ -877,7 +1190,12 @@ func resolveClusterIdentityFromPatchFilters(s storage.Storage, filters []storage
 func validateClusterAcceleratorVirtualizationInput(
 	s storage.Storage, input *ValidationInput[v1.Cluster],
 ) *validationError {
-	if validationErr := validateClusterAcceleratorVirtualizationCluster(input.Patch); validationErr != nil {
+	cluster := input.Patch
+	if input.New != nil {
+		cluster = *input.New
+	}
+
+	if validationErr := validateClusterAcceleratorVirtualizationCluster(cluster); validationErr != nil {
 		return validationErr
 	}
 
@@ -892,6 +1210,10 @@ func validateClusterAcceleratorVirtualizationInput(
 
 	if !disableRequested {
 		return nil
+	}
+
+	if input.Current != nil {
+		return validateClusterAcceleratorVirtualizationDisableForCurrent(s, input.Current, input.Patch)
 	}
 
 	return validateClusterAcceleratorVirtualizationDisable(s, input.Patch, input.QueryParams)

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -1,7 +1,9 @@
 package proxies
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -507,6 +509,256 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	t.Run("rejects image registry switch for initialized cluster before proxy handler", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{
+			{
+				Spec:   &v1.ClusterSpec{ImageRegistry: "current-registry"},
+				Status: &v1.ClusterStatus{Initialized: true},
+			},
+		}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"image_registry": "replacement-registry"}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "image registry")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("allows kubeconfig rotation for the same Kubernetes API server", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				Type: v1.KubernetesClusterType,
+				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+					Kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "old-token"),
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		body := fmt.Sprintf(`{"spec":{"config":{"kubernetes_config":{"kubeconfig":%q}}}}`,
+			testEncodedKubeconfig("https://api.example.test:6443", "rotated-token"))
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("rejects kubeconfig rotation for a different Kubernetes API server", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				Type: v1.KubernetesClusterType,
+				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+					Kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "old-token"),
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		body := fmt.Sprintf(`{"spec":{"config":{"kubernetes_config":{"kubeconfig":%q}}}}`,
+			testEncodedKubeconfig("https://other-api.example.test:6443", "rotated-token"))
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "current Kubernetes API server")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("allows SSH private key rotation for an initialized cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				Type: v1.SSHClusterType,
+				Config: &v1.ClusterConfig{SSHConfig: &v1.RaySSHProvisionClusterConfig{
+					Auth: v1.Auth{SSHPrivateKey: "old-private-key"},
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		body := fmt.Sprintf(`{"spec":{"config":{"ssh_config":{"auth":{"ssh_private_key":%q}}}}}`,
+			base64.StdEncoding.EncodeToString([]byte("rotated-private-key")))
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("rejects empty SSH private key for an initialized cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"config": {"ssh_config": {"auth": {"ssh_private_key": " "}}}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "SSH private key cannot be empty")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("rejects malformed SSH private key for an initialized cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"config": {"ssh_config": {"auth": {"ssh_private_key": "invalid-base64"}}}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "SSH private key must be base64 encoded")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("allows image registry change before cluster initialization", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec:   &v1.ClusterSpec{ImageRegistry: "current-registry"},
+			Status: &v1.ClusterStatus{Initialized: false},
+		}}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"image_registry": "replacement-registry"}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("skips malformed configuration validation for a soft delete patch", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"metadata": {"deletion_timestamp": "2026-08-07T00:00:00Z"},
+			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
 	t.Run("rejects SSH static flow downgrade before proxy handler", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
@@ -641,6 +893,69 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
+}
+
+func TestRegisterClusterRoutesSoftDeleteBypassesMalformedGuardedConfig(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockStorage := storageMocks.NewMockStorage(t)
+	mockStorage.On("Count", storage.ENDPOINT_TABLE, clusterEndpointReferenceFilters("default", "cluster")).Return(0, nil).Once()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/clusters", r.URL.Path)
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{
+			"metadata": {"workspace": "default", "name": "cluster", "deletion_timestamp": "2026-08-07T00:00:00Z"},
+			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+		}`, string(body))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	RegisterClusterRoutes(router.Group("/api/v1"), nil, &Dependencies{
+		Storage:          mockStorage,
+		StorageAccessURL: upstream.URL,
+	})
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/clusters?id=eq.1", strings.NewReader(`{
+		"metadata": {"workspace": "default", "name": "cluster", "deletion_timestamp": "2026-08-07T00:00:00Z"},
+		"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := newCloseNotifyRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+	mockStorage.AssertExpectations(t)
+	mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+}
+
+func testEncodedKubeconfig(server, token string) string {
+	content := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: primary
+  cluster:
+    server: %s
+contexts:
+- name: primary
+  context:
+    cluster: primary
+    user: primary
+current-context: primary
+users:
+- name: primary
+  user:
+    token: %s
+`, server, token)
+
+	return base64.StdEncoding.EncodeToString([]byte(content))
 }
 
 type trackingReadCloser struct {

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -504,6 +504,28 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 	})
+
+	t.Run("allows soft delete without validating guarded configuration", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterAcceleratorVirtualization(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"metadata": {"deletion_timestamp": "2026-08-10T00:00:00Z"},
+			"spec": {"accelerator_virtualization": {"enabled": false}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
 }
 
 func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
@@ -612,6 +634,42 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 	})
 
+	t.Run("rejects clearing config on an initialized Kubernetes cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				Type: v1.KubernetesClusterType,
+				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+					Kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "old-token"),
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"config": null}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "config cannot be cleared")
+		mockStorage.AssertExpectations(t)
+	})
+
 	t.Run("allows SSH private key rotation for an initialized cluster", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
@@ -705,6 +763,42 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
 		assert.Contains(t, recorder.Body.String(), "SSH private key must be base64 encoded")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("rejects clearing SSH auth on an initialized cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				Type: v1.SSHClusterType,
+				Config: &v1.ClusterConfig{SSHConfig: &v1.RaySSHProvisionClusterConfig{
+					Auth: v1.Auth{SSHPrivateKey: base64.StdEncoding.EncodeToString([]byte("old-private-key"))},
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil)
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"config": {"ssh_config": {"auth": null}}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "SSH auth cannot be cleared")
 		mockStorage.AssertExpectations(t)
 	})
 
@@ -956,6 +1050,269 @@ users:
 `, server, token)
 
 	return base64.StdEncoding.EncodeToString([]byte(content))
+}
+
+func TestParseClusterPatchConfigurationUpdate(t *testing.T) {
+	t.Run("tracks supported configuration fields", func(t *testing.T) {
+		update, err := parseClusterPatchConfigurationUpdate([]byte(`{
+			"spec": {
+				"image_registry": "registry.example.test",
+				"config": {
+					"kubernetes_config": {"kubeconfig": "new-kubeconfig"},
+					"ssh_config": {"auth": {"ssh_private_key": "new-private-key"}}
+				}
+			}
+		}`))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "registry.example.test", update.imageRegistry)
+		assert.True(t, update.imageRegistrySet)
+		assert.Equal(t, "new-kubeconfig", update.kubeconfig)
+		assert.True(t, update.kubeconfigSet)
+		assert.Equal(t, "new-private-key", update.sshPrivateKey)
+		assert.True(t, update.sshPrivateKeySet)
+		assert.True(t, update.hasChanges())
+	})
+
+	t.Run("does not treat omitted configuration fields as updates", func(t *testing.T) {
+		update, err := parseClusterPatchConfigurationUpdate([]byte(`{
+			"spec": {"config": {"ssh_config": {}}}
+		}`))
+
+		assert.NoError(t, err)
+		assert.False(t, update.hasChanges())
+	})
+
+	t.Run("tracks cleared nested configuration", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			body   string
+			assert func(*testing.T, clusterPatchConfigurationUpdate)
+		}{
+			{
+				name: "entire config",
+				body: `{"spec": {"config": null}}`,
+				assert: func(t *testing.T, update clusterPatchConfigurationUpdate) {
+					assert.True(t, update.configCleared)
+				},
+			},
+			{
+				name: "Kubernetes config",
+				body: `{"spec": {"config": {"kubernetes_config": null}}}`,
+				assert: func(t *testing.T, update clusterPatchConfigurationUpdate) {
+					assert.True(t, update.kubernetesConfigCleared)
+				},
+			},
+			{
+				name: "SSH config",
+				body: `{"spec": {"config": {"ssh_config": null}}}`,
+				assert: func(t *testing.T, update clusterPatchConfigurationUpdate) {
+					assert.True(t, update.sshConfigCleared)
+				},
+			},
+			{
+				name: "SSH auth",
+				body: `{"spec": {"config": {"ssh_config": {"auth": null}}}}`,
+				assert: func(t *testing.T, update clusterPatchConfigurationUpdate) {
+					assert.True(t, update.sshAuthCleared)
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				update, err := parseClusterPatchConfigurationUpdate([]byte(tt.body))
+
+				assert.NoError(t, err)
+				assert.True(t, update.hasChanges())
+				tt.assert(t, update)
+			})
+		}
+	})
+
+	for _, body := range []string{
+		`{`,
+		`{"spec": []}`,
+		`{"spec": {"image_registry": []}}`,
+		`{"spec": {"config": []}}`,
+		`{"spec": {"config": {"kubernetes_config": []}}}`,
+		`{"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}}`,
+		`{"spec": {"config": {"ssh_config": []}}}`,
+		`{"spec": {"config": {"ssh_config": {"auth": []}}}}`,
+		`{"spec": {"config": {"ssh_config": {"auth": {"ssh_private_key": []}}}}}`,
+	} {
+		_, err := parseClusterPatchConfigurationUpdate([]byte(body))
+		assert.Error(t, err, body)
+	}
+}
+
+func TestValidateClusterConfigurationUpdate(t *testing.T) {
+	initializedKubernetesCluster := func(kubeconfig string) *v1.Cluster {
+		return &v1.Cluster{
+			Spec: &v1.ClusterSpec{
+				Type: v1.KubernetesClusterType,
+				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+					Kubeconfig: kubeconfig,
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}
+	}
+
+	t.Run("allows uninitialized clusters", func(t *testing.T) {
+		err := validateClusterConfigurationUpdate(&v1.Cluster{
+			Spec:   &v1.ClusterSpec{ImageRegistry: "current"},
+			Status: &v1.ClusterStatus{Initialized: false},
+		}, clusterPatchConfigurationUpdate{imageRegistry: "replacement", imageRegistrySet: true})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("allows an unchanged image registry", func(t *testing.T) {
+		err := validateClusterConfigurationUpdate(&v1.Cluster{
+			Spec:   &v1.ClusterSpec{ImageRegistry: "current"},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}, clusterPatchConfigurationUpdate{imageRegistry: "current", imageRegistrySet: true})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects unusable Kubernetes credential rotations", func(t *testing.T) {
+		validCurrent := testEncodedKubeconfig("https://api.example.test:6443", "old-token")
+		tests := []struct {
+			name       string
+			current    *v1.Cluster
+			kubeconfig string
+			hint       string
+		}{
+			{
+				name:       "empty updated kubeconfig",
+				current:    initializedKubernetesCluster(validCurrent),
+				kubeconfig: " ",
+				hint:       "kubeconfig cannot be empty",
+			},
+			{
+				name:       "missing current Kubernetes config",
+				current:    &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.KubernetesClusterType}, Status: &v1.ClusterStatus{Initialized: true}},
+				kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
+				hint:       "failed to read current kubeconfig",
+			},
+			{
+				name:       "invalid updated kubeconfig",
+				current:    initializedKubernetesCluster(validCurrent),
+				kubeconfig: "not-base64",
+				hint:       "failed to parse updated kubeconfig",
+			},
+			{
+				name:       "different Kubernetes API server",
+				current:    initializedKubernetesCluster(validCurrent),
+				kubeconfig: testEncodedKubeconfig("https://other-api.example.test:6443", "new-token"),
+				hint:       "current Kubernetes API server",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := validateClusterConfigurationUpdate(tt.current, clusterPatchConfigurationUpdate{
+					kubeconfig:    tt.kubeconfig,
+					kubeconfigSet: true,
+				})
+
+				assert.ErrorContains(t, err, tt.hint)
+			})
+		}
+	})
+
+	t.Run("allows same-host Kubernetes credential rotation", func(t *testing.T) {
+		err := validateClusterConfigurationUpdate(
+			initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token")),
+			clusterPatchConfigurationUpdate{
+				kubeconfig:    testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
+				kubeconfigSet: true,
+			},
+		)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("validates SSH private-key rotations", func(t *testing.T) {
+		cluster := &v1.Cluster{
+			Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}
+
+		for _, tt := range []struct {
+			name string
+			key  string
+			hint string
+		}{
+			{name: "empty private key", key: " ", hint: "SSH private key cannot be empty"},
+			{name: "invalid base64", key: "not-base64", hint: "SSH private key must be base64 encoded"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				err := validateClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
+					sshPrivateKey:    tt.key,
+					sshPrivateKeySet: true,
+				})
+
+				assert.ErrorContains(t, err, tt.hint)
+			})
+		}
+
+		err := validateClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
+			sshPrivateKey:    base64.StdEncoding.EncodeToString([]byte("rotated-private-key")),
+			sshPrivateKeySet: true,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects cleared initialized configurations", func(t *testing.T) {
+		kubernetesCluster := initializedKubernetesCluster(
+			testEncodedKubeconfig("https://api.example.test:6443", "old-token"),
+		)
+		sshCluster := &v1.Cluster{
+			Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}
+
+		for _, tt := range []struct {
+			name    string
+			cluster *v1.Cluster
+			update  clusterPatchConfigurationUpdate
+			hint    string
+		}{
+			{
+				name:    "entire config",
+				cluster: kubernetesCluster,
+				update:  clusterPatchConfigurationUpdate{configCleared: true},
+				hint:    "config cannot be cleared",
+			},
+			{
+				name:    "Kubernetes config",
+				cluster: kubernetesCluster,
+				update:  clusterPatchConfigurationUpdate{kubernetesConfigCleared: true},
+				hint:    "kubernetes_config cannot be cleared",
+			},
+			{
+				name:    "SSH config",
+				cluster: sshCluster,
+				update:  clusterPatchConfigurationUpdate{sshConfigCleared: true},
+				hint:    "ssh_config cannot be cleared",
+			},
+			{
+				name:    "SSH auth",
+				cluster: sshCluster,
+				update:  clusterPatchConfigurationUpdate{sshAuthCleared: true},
+				hint:    "SSH auth cannot be cleared",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				err := validateClusterConfigurationUpdate(tt.cluster, tt.update)
+
+				assert.ErrorContains(t, err, tt.hint)
+			})
+		}
+	})
 }
 
 type trackingReadCloser struct {

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -531,6 +531,27 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	t.Run("skips configuration validation for non-PATCH requests", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.POST("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/clusters", strings.NewReader(`{
+			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
 	t.Run("rejects image registry switch for initialized cluster before proxy handler", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
@@ -1389,6 +1410,12 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 				current:    &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.KubernetesClusterType}, Status: &v1.ClusterStatus{Initialized: true}},
 				kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
 				hint:       "failed to read current kubeconfig",
+			},
+			{
+				name:       "invalid current Kubernetes config",
+				current:    initializedKubernetesCluster(base64.StdEncoding.EncodeToString([]byte("not a kubeconfig"))),
+				kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
+				hint:       "failed to parse current kubeconfig",
 			},
 			{
 				name:       "invalid updated kubeconfig",

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -751,190 +751,103 @@ func TestValidateClusterAcceleratorVirtualizationDisableForCurrent(t *testing.T)
 }
 
 func TestValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
-	t.Run("allows Kubernetes cluster to enable accelerator virtualization", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"version": "v1.1.0",
-				"accelerator_virtualization": {
-					"enabled": true,
-					"config_patch": {"devicePlugin": {"nvidiaDriverRoot": "/run/nvidia/driver"}}
-				}
+	tests := []struct {
+		name        string
+		body        string
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name: "allows Kubernetes cluster to enable accelerator virtualization",
+			body: `{"spec":{"type":"kubernetes","version":"v1.1.0","accelerator_virtualization":{"enabled":true,"config_patch":{"devicePlugin":{"nvidiaDriverRoot":"/run/nvidia/driver"}}}}}`,
+		},
+		{
+			name: "allows Kubernetes nightly cluster with minimum base version to enable accelerator virtualization",
+			body: `{"spec":{"type":"kubernetes","version":"v1.1.0-nightly-20260603","accelerator_virtualization":{"enabled":true}}}`,
+		},
+		{
+			name:        "rejects Kubernetes cluster below minimum version enabling accelerator virtualization",
+			body:        `{"spec":{"type":"kubernetes","version":"v1.0.9","accelerator_virtualization":{"enabled":true}}}`,
+			wantCode:    "10208",
+			wantMessage: "requires cluster version >= v1.1.0",
+		},
+		{
+			name:        "rejects Kubernetes cluster missing version enabling accelerator virtualization",
+			body:        `{"spec":{"type":"kubernetes","accelerator_virtualization":{"enabled":true}}}`,
+			wantCode:    "10208",
+			wantMessage: "requires cluster version >= v1.1.0",
+		},
+		{
+			name:        "rejects invalid cluster version enabling accelerator virtualization",
+			body:        `{"spec":{"type":"kubernetes","version":"nightly","accelerator_virtualization":{"enabled":true}}}`,
+			wantCode:    "10209",
+			wantMessage: "invalid cluster version",
+		},
+		{
+			name:     "rejects SSH cluster enabling accelerator virtualization",
+			body:     `{"spec":{"type":"ssh","accelerator_virtualization":{"enabled":true}}}`,
+			wantCode: "10208",
+		},
+		{
+			name:        "rejects non-bool enabled",
+			body:        `{"spec":{"type":"kubernetes","version":"v1.1.0","accelerator_virtualization":{"enabled":"true"}}}`,
+			wantCode:    "10209",
+			wantMessage: "invalid cluster payload",
+		},
+		{
+			name:        "rejects non-object config_patch",
+			body:        `{"spec":{"type":"kubernetes","version":"v1.1.0","accelerator_virtualization":{"enabled":true,"config_patch":["invalid"]}}}`,
+			wantCode:    "10209",
+			wantMessage: "invalid cluster payload",
+		},
+		{
+			name: "skips accelerator virtualization validation for soft delete patch",
+			body: `{"metadata":{"name":"cluster","workspace":"default","deletion_timestamp":"2026-06-10T00:00:00Z"},"spec":{"type":"ssh","accelerator_virtualization":{"enabled":true}}}`,
+		},
+		{
+			name:        "rejects unsupported config patch key",
+			body:        `{"spec":{"type":"kubernetes","version":"v1.1.0","accelerator_virtualization":{"enabled":true,"config_patch":{"dra":{"enabled":true}}}}}`,
+			wantCode:    "10210",
+			wantMessage: "unsupported",
+		},
+		{
+			name:        "rejects MIG virtualization config patch",
+			body:        `{"spec":{"type":"kubernetes","version":"v1.1.0","accelerator_virtualization":{"enabled":true,"config_patch":{"devicePlugin":{"migStrategy":"mixed"}}}}}`,
+			wantCode:    "10210",
+			wantMessage: "MIG",
+		},
+		{
+			name:        "rejects partial patch missing cluster type and version",
+			body:        `{"metadata":{"name":"cluster","workspace":"default"},"spec":{"accelerator_virtualization":{"enabled":true}}}`,
+			wantCode:    "10208",
+			wantMessage: "only supported for Kubernetes",
+		},
+		{
+			name:        "rejects partial patch missing cluster version",
+			body:        `{"metadata":{"name":"cluster","workspace":"default"},"spec":{"type":"kubernetes","accelerator_virtualization":{"enabled":true}}}`,
+			wantCode:    "10208",
+			wantMessage: "requires cluster version >= v1.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateClusterAcceleratorVirtualizationBody([]byte(tt.body))
+			if tt.wantCode == "" {
+				assert.Nil(t, err)
+
+				return
 			}
-		}`))
 
-		assert.Nil(t, err)
-	})
-
-	t.Run("allows Kubernetes nightly cluster with minimum base version to enable accelerator virtualization", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"version": "v1.1.0-nightly-20260603",
-				"accelerator_virtualization": {"enabled": true}
+			if !assert.NotNil(t, err) {
+				return
 			}
-		}`))
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("rejects Kubernetes cluster below minimum version enabling accelerator virtualization", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"version": "v1.0.9",
-				"accelerator_virtualization": {"enabled": true}
+			assert.Equal(t, tt.wantCode, err.Code)
+			if tt.wantMessage != "" {
+				assert.Contains(t, err.Message, tt.wantMessage)
 			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10208", err.Code)
-		assert.Contains(t, err.Message, "requires cluster version >= v1.1.0")
-	})
-
-	t.Run("rejects Kubernetes cluster missing version enabling accelerator virtualization", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"accelerator_virtualization": {"enabled": true}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10208", err.Code)
-		assert.Contains(t, err.Message, "requires cluster version >= v1.1.0")
-	})
-
-	t.Run("rejects invalid cluster version enabling accelerator virtualization", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"version": "nightly",
-				"accelerator_virtualization": {"enabled": true}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10209", err.Code)
-		assert.Equal(t, "invalid cluster version", err.Message)
-	})
-
-	t.Run("rejects SSH cluster enabling accelerator virtualization", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "ssh",
-				"accelerator_virtualization": {"enabled": true}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10208", err.Code)
-	})
-
-	t.Run("rejects non-bool enabled", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"version": "v1.1.0",
-				"accelerator_virtualization": {"enabled": "true"}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10209", err.Code)
-		assert.Equal(t, "invalid cluster payload", err.Message)
-	})
-
-	t.Run("rejects non-object config_patch", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"version": "v1.1.0",
-				"accelerator_virtualization": {"enabled": true, "config_patch": ["invalid"]}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10209", err.Code)
-		assert.Equal(t, "invalid cluster payload", err.Message)
-	})
-
-	t.Run("skips accelerator virtualization validation for soft delete patch", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {
-				"name": "cluster",
-				"workspace": "default",
-				"deletion_timestamp": "2026-06-10T00:00:00Z"
-			},
-			"spec": {
-				"type": "ssh",
-				"accelerator_virtualization": {"enabled": true}
-			}
-		}`))
-
-		assert.Nil(t, err)
-	})
-
-	t.Run("rejects unsupported config patch key", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"version": "v1.1.0",
-				"accelerator_virtualization": {
-					"enabled": true,
-					"config_patch": {"dra": {"enabled": true}}
-				}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10210", err.Code)
-		assert.Contains(t, err.Message, "unsupported")
-	})
-
-	t.Run("rejects MIG virtualization config patch", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"spec": {
-				"type": "kubernetes",
-				"version": "v1.1.0",
-				"accelerator_virtualization": {
-					"enabled": true,
-					"config_patch": {"devicePlugin": {"migStrategy": "mixed"}}
-				}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10210", err.Code)
-		assert.Contains(t, err.Message, "MIG")
-	})
-
-	t.Run("rejects partial patch missing cluster type and version", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "cluster", "workspace": "default"},
-			"spec": {
-				"accelerator_virtualization": {"enabled": true}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10208", err.Code)
-		assert.Contains(t, err.Message, "only supported for Kubernetes")
-	})
-
-	t.Run("rejects partial patch missing cluster version", func(t *testing.T) {
-		err := validateClusterAcceleratorVirtualizationBody([]byte(`{
-			"metadata": {"name": "cluster", "workspace": "default"},
-			"spec": {
-				"type": "kubernetes",
-				"accelerator_virtualization": {"enabled": true}
-			}
-		}`))
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10208", err.Code)
-		assert.Contains(t, err.Message, "requires cluster version >= v1.1.0")
-	})
+		})
+	}
 }
 
 func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
@@ -957,144 +870,121 @@ func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
 		},
 	}
 
-	t.Run("rejects disabling when vGPU endpoint references cluster", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		cluster := v1.Cluster{
-			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
-			Spec: &v1.ClusterSpec{
+	cluster := func(name string, acceleratorVirtualization *v1.AcceleratorVirtualizationSpec) v1.Cluster {
+		return v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: name},
+			Spec:     &v1.ClusterSpec{AcceleratorVirtualization: acceleratorVirtualization},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		patch           v1.Cluster
+		query           url.Values
+		resolved        *v1.Cluster
+		endpoints       []v1.Endpoint
+		endpointErr     error
+		lookupEndpoints bool
+		wantCode        string
+		wantMessage     string
+		wantHint        string
+	}{
+		{
+			name:            "rejects disabling when vGPU endpoint references cluster",
+			patch:           cluster("gpu-cluster", &v1.AcceleratorVirtualizationSpec{Enabled: false}),
+			endpoints:       []v1.Endpoint{vGPUEndpoint},
+			lookupEndpoints: true,
+			wantCode:        "10211",
+			wantMessage:     "cannot disable accelerator virtualization",
+			wantHint:        "1 vGPU endpoint(s) still reference this cluster",
+		},
+		{
+			name:            "allows disabling when only non-vGPU endpoint references cluster",
+			patch:           cluster("gpu-cluster", &v1.AcceleratorVirtualizationSpec{Enabled: false}),
+			endpoints:       []v1.Endpoint{nonVGPUEndpoint},
+			lookupEndpoints: true,
+		},
+		{
+			name: "resolves cluster identity from patch query filters",
+			patch: v1.Cluster{Spec: &v1.ClusterSpec{
 				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
+			}},
+			query: url.Values{
+				"metadata->>workspace": {"eq.default"},
+				"metadata->>name":      {"eq.gpu-cluster"},
 			},
-		}
-		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
-
-		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
-			Return([]v1.Endpoint{vGPUEndpoint}, nil)
-
-		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, cluster, nil)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10211", err.Code)
-		assert.Contains(t, err.Message, "cannot disable accelerator virtualization")
-		assert.Contains(t, err.Hint, "1 vGPU endpoint(s) still reference this cluster")
-		mockStorage.AssertExpectations(t)
-	})
-
-	t.Run("allows disabling when only non-vGPU endpoint references cluster", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		cluster := v1.Cluster{
-			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
-			Spec: &v1.ClusterSpec{
-				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
+			resolved:        &v1.Cluster{Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"}},
+			endpoints:       []v1.Endpoint{vGPUEndpoint},
+			lookupEndpoints: true,
+			wantCode:        "10211",
+			wantHint:        "1 vGPU endpoint(s) still reference this cluster",
+		},
+		{
+			name:  "rejects mismatched patch body identity and query target",
+			patch: cluster("body-cluster", &v1.AcceleratorVirtualizationSpec{Enabled: false}),
+			query: url.Values{
+				"id": {"eq.1"},
 			},
-		}
-		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
+			resolved: &v1.Cluster{Metadata: &v1.Metadata{Workspace: "default", Name: "query-cluster"}},
+			wantCode: "10209",
+			wantHint: "does not match patch target",
+		},
+		{
+			name:            "returns validation error when endpoint lookup fails",
+			patch:           cluster("gpu-cluster", &v1.AcceleratorVirtualizationSpec{Enabled: false}),
+			endpointErr:     errors.New("database error"),
+			lookupEndpoints: true,
+			wantCode:        "10209",
+			wantHint:        "database error",
+		},
+		{
+			name:            "rejects clearing accelerator virtualization with null while vGPU endpoint references cluster",
+			patch:           cluster("gpu-cluster", nil),
+			endpoints:       []v1.Endpoint{vGPUEndpoint},
+			lookupEndpoints: true,
+			wantCode:        "10211",
+			wantHint:        "1 vGPU endpoint(s) still reference this cluster",
+		},
+	}
 
-		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
-			Return([]v1.Endpoint{nonVGPUEndpoint}, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := storageMocks.NewMockStorage(t)
+			if tt.resolved != nil {
+				mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+					return sameFilters(opt.Filters, queryParamsToFilters(tt.query))
+				})).Return([]v1.Cluster{*tt.resolved}, nil).Once()
+			}
 
-		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, cluster, nil)
+			if tt.lookupEndpoints {
+				identity := tt.patch.Metadata
+				if tt.resolved != nil {
+					identity = tt.resolved.Metadata
+				}
+				mockStorage.On("ListEndpoint", storage.ListOption{
+					Filters: clusterEndpointReferenceFilters(identity.Workspace, identity.Name),
+				}).Return(tt.endpoints, tt.endpointErr).Once()
+			}
 
-		assert.Nil(t, err)
-		mockStorage.AssertExpectations(t)
-	})
+			err := validateClusterAcceleratorVirtualizationDisable(mockStorage, tt.patch, tt.query)
+			if tt.wantCode == "" {
+				assert.Nil(t, err)
+			} else if assert.NotNil(t, err) {
+				assert.Equal(t, tt.wantCode, err.Code)
+				if tt.wantMessage != "" {
+					assert.Contains(t, err.Message, tt.wantMessage)
+				}
+				if tt.wantHint != "" {
+					assert.Contains(t, err.Hint, tt.wantHint)
+				}
+			}
 
-	t.Run("resolves cluster identity from patch query filters", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		clusterPatch := v1.Cluster{
-			Spec: &v1.ClusterSpec{
-				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
-			},
-		}
-		query := url.Values{
-			"metadata->>workspace": []string{"eq.default"},
-			"metadata->>name":      []string{"eq.gpu-cluster"},
-		}
-		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
-
-		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
-			return sameFilters(opt.Filters, queryParamsToFilters(query))
-		})).Return([]v1.Cluster{
-			{Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"}},
-		}, nil)
-		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
-			Return([]v1.Endpoint{vGPUEndpoint}, nil)
-
-		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, clusterPatch, query)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10211", err.Code)
-		assert.Contains(t, err.Hint, "1 vGPU endpoint(s) still reference this cluster")
-		mockStorage.AssertExpectations(t)
-	})
-
-	t.Run("rejects mismatched patch body identity and query target", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		clusterPatch := v1.Cluster{
-			Metadata: &v1.Metadata{Workspace: "default", Name: "body-cluster"},
-			Spec: &v1.ClusterSpec{
-				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
-			},
-		}
-		query := url.Values{
-			"id": []string{"eq.1"},
-		}
-
-		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
-			return sameFilters(opt.Filters, queryParamsToFilters(query))
-		})).Return([]v1.Cluster{
-			{Metadata: &v1.Metadata{Workspace: "default", Name: "query-cluster"}},
-		}, nil)
-
-		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, clusterPatch, query)
-
-		if assert.NotNil(t, err) {
-			assert.Equal(t, "10209", err.Code)
-			assert.Contains(t, err.Hint, "does not match patch target")
-		}
-		mockStorage.AssertExpectations(t)
-		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
-	})
-
-	t.Run("returns validation error when endpoint lookup fails", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		cluster := v1.Cluster{
-			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
-			Spec: &v1.ClusterSpec{
-				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{Enabled: false},
-			},
-		}
-		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
-
-		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
-			Return(nil, errors.New("database error"))
-
-		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, cluster, nil)
-
-		assert.NotNil(t, err)
-		assert.Equal(t, "10209", err.Code)
-		assert.Contains(t, err.Hint, "database error")
-		mockStorage.AssertExpectations(t)
-	})
-
-	t.Run("rejects clearing accelerator virtualization with null while vGPU endpoint references cluster", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		cluster := v1.Cluster{
-			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
-			Spec:     &v1.ClusterSpec{AcceleratorVirtualization: nil},
-		}
-		expectedEndpointFilters := clusterEndpointReferenceFilters("default", "gpu-cluster")
-
-		mockStorage.On("ListEndpoint", storage.ListOption{Filters: expectedEndpointFilters}).
-			Return([]v1.Endpoint{vGPUEndpoint}, nil)
-
-		err := validateClusterAcceleratorVirtualizationDisable(mockStorage, cluster, nil)
-
-		if assert.NotNil(t, err) {
-			assert.Equal(t, "10211", err.Code)
-			assert.Contains(t, err.Hint, "1 vGPU endpoint(s) still reference this cluster")
-		}
-		mockStorage.AssertExpectations(t)
-	})
+			mockStorage.AssertExpectations(t)
+			if !tt.lookupEndpoints {
+				mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+			}
+		})
+	}
 }
 
 func TestPrepareClusterValidationInput(t *testing.T) {
@@ -1128,100 +1018,134 @@ func TestPrepareClusterValidationInput(t *testing.T) {
 		return input
 	}
 
-	t.Run("creates a separate New cluster from a whole spec replacement and preserves an empty kubeconfig", func(t *testing.T) {
-		current := v1.Cluster{
-			Metadata: &v1.Metadata{Workspace: "default", Name: "kubernetes"},
+	sshCluster := func() v1.Cluster {
+		return v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "ssh"},
 			Spec: &v1.ClusterSpec{
-				Type:          v1.KubernetesClusterType,
-				ImageRegistry: "current-registry",
-				Version:       "v1.0.0",
-				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
-					Kubeconfig: "current-kubeconfig",
+				Type: v1.SSHClusterType,
+				Config: &v1.ClusterConfig{SSHConfig: &v1.RaySSHProvisionClusterConfig{
+					Auth: v1.Auth{SSHPrivateKey: "current-private-key"},
 				}},
 			},
 		}
-
-		input := prepare(t, current, `{
-			"spec": {
-				"version": "v1.1.0",
-				"config": {"kubernetes_config": {"kubeconfig": ""}}
-			}
-		}`)
-
-		assert.Equal(t, &current, input.Current)
-		assert.NotSame(t, input.Current, input.New)
-		assert.Equal(t, "v1.0.0", input.Current.Spec.Version)
-		assert.Equal(t, "current-kubeconfig", input.Current.Spec.Config.KubernetesConfig.Kubeconfig)
-		assert.Empty(t, input.New.Spec.Type)
-		assert.Empty(t, input.New.Spec.ImageRegistry)
-		assert.Equal(t, "v1.1.0", input.New.Spec.Version)
-		assert.Equal(t, "current-kubeconfig", input.New.Spec.Config.KubernetesConfig.Kubeconfig)
-	})
-
-	for _, tt := range []struct {
-		name string
-		raw  string
-	}{
-		{name: "empty", raw: `""`},
-		{name: "null", raw: "null"},
-	} {
-		t.Run("preserves SSH private key "+tt.name, func(t *testing.T) {
-			current := v1.Cluster{
-				Metadata: &v1.Metadata{Workspace: "default", Name: "ssh"},
-				Spec: &v1.ClusterSpec{
-					Type: v1.SSHClusterType,
-					Config: &v1.ClusterConfig{SSHConfig: &v1.RaySSHProvisionClusterConfig{
-						Auth: v1.Auth{SSHPrivateKey: "current-private-key"},
-					}},
-				},
-			}
-
-			input := prepare(t, current, `{
-				"spec": {"config": {"ssh_config": {"auth": {"ssh_private_key": `+tt.raw+`}}}}
-			}`)
-
-			assert.Equal(t, "current-private-key", input.Current.Spec.Config.SSHConfig.Auth.SSHPrivateKey)
-			assert.Equal(t, "current-private-key", input.New.Spec.Config.SSHConfig.Auth.SSHPrivateKey)
-		})
 	}
 
-	t.Run("retains an explicit config null in the raw update for configuration validation", func(t *testing.T) {
-		current := v1.Cluster{
-			Metadata: &v1.Metadata{Workspace: "default", Name: "kubernetes"},
-			Spec: &v1.ClusterSpec{
-				Type:   v1.KubernetesClusterType,
-				Config: &v1.ClusterConfig{},
+	tests := []struct {
+		name    string
+		current v1.Cluster
+		body    string
+		assert  func(*testing.T, *ValidationInput[v1.Cluster])
+	}{
+		{
+			name: "creates a separate New cluster from a whole spec replacement and preserves an empty kubeconfig",
+			current: v1.Cluster{
+				Metadata: &v1.Metadata{Workspace: "default", Name: "kubernetes"},
+				Spec: &v1.ClusterSpec{
+					Type:          v1.KubernetesClusterType,
+					ImageRegistry: "current-registry",
+					Version:       "v1.0.0",
+					Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+						Kubeconfig: "current-kubeconfig",
+					}},
+				},
 			},
-		}
-		input := prepare(t, current, `{"spec": {"config": null}}`)
-
-		update, err := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
-		assert.NoError(t, err)
-		assert.True(t, update.configCleared)
-	})
-}
-
-func TestBuildPostgrestClusterPatchValidationNew(t *testing.T) {
-	current := &v1.Cluster{
-		Spec: &v1.ClusterSpec{
-			Type:          v1.KubernetesClusterType,
-			ImageRegistry: "current-registry",
-			Version:       "v1.0.0",
+			body: `{"spec":{"version":"v1.1.0","config":{"kubernetes_config":{"kubeconfig":""}}}}`,
+			assert: func(t *testing.T, input *ValidationInput[v1.Cluster]) {
+				assert.NotSame(t, input.Current, input.New)
+				assert.Equal(t, "v1.0.0", input.Current.Spec.Version)
+				assert.Equal(t, "current-kubeconfig", input.Current.Spec.Config.KubernetesConfig.Kubeconfig)
+				assert.Empty(t, input.New.Spec.Type)
+				assert.Empty(t, input.New.Spec.ImageRegistry)
+				assert.Equal(t, "v1.1.0", input.New.Spec.Version)
+				assert.Equal(t, "current-kubeconfig", input.New.Spec.Config.KubernetesConfig.Kubeconfig)
+			},
+		},
+		{
+			name:    "preserves an empty SSH private key",
+			current: sshCluster(),
+			body:    `{"spec":{"config":{"ssh_config":{"auth":{"ssh_private_key":""}}}}}`,
+			assert: func(t *testing.T, input *ValidationInput[v1.Cluster]) {
+				assert.Equal(t, "current-private-key", input.Current.Spec.Config.SSHConfig.Auth.SSHPrivateKey)
+				assert.Equal(t, "current-private-key", input.New.Spec.Config.SSHConfig.Auth.SSHPrivateKey)
+			},
+		},
+		{
+			name:    "preserves a null SSH private key",
+			current: sshCluster(),
+			body:    `{"spec":{"config":{"ssh_config":{"auth":{"ssh_private_key":null}}}}}`,
+			assert: func(t *testing.T, input *ValidationInput[v1.Cluster]) {
+				assert.Equal(t, "current-private-key", input.Current.Spec.Config.SSHConfig.Auth.SSHPrivateKey)
+				assert.Equal(t, "current-private-key", input.New.Spec.Config.SSHConfig.Auth.SSHPrivateKey)
+			},
+		},
+		{
+			name: "retains an explicit config null in the raw update for configuration validation",
+			current: v1.Cluster{
+				Metadata: &v1.Metadata{Workspace: "default", Name: "kubernetes"},
+				Spec:     &v1.ClusterSpec{Type: v1.KubernetesClusterType, Config: &v1.ClusterConfig{}},
+			},
+			body: `{"spec":{"config":null}}`,
+			assert: func(t *testing.T, input *ValidationInput[v1.Cluster]) {
+				update, err := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
+				assert.NoError(t, err)
+				assert.True(t, update.configCleared)
+			},
 		},
 	}
 
-	next, err := buildPostgrestClusterPatchValidationNew(current, []byte(`{
-		"spec": {"version": "v1.1.0"}
-	}`))
-	assert.NoError(t, err)
-	assert.NotSame(t, current, next)
-	assert.Equal(t, "v1.0.0", current.Spec.Version)
-	assert.Equal(t, "v1.1.0", next.Spec.Version)
-	assert.Empty(t, next.Spec.Type)
-	assert.Empty(t, next.Spec.ImageRegistry)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := prepare(t, tt.current, tt.body)
+			assert.Equal(t, &tt.current, input.Current)
+			tt.assert(t, input)
+		})
+	}
+}
 
-	_, err = buildPostgrestClusterPatchValidationNew(current, []byte(`[`))
-	assert.Error(t, err)
+func TestBuildPostgrestClusterPatchValidationNew(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+		assert  func(*testing.T, *v1.Cluster, *v1.Cluster)
+	}{
+		{
+			name: "replaces a supplied spec composite without mutating Current",
+			body: `{"spec":{"version":"v1.1.0"}}`,
+			assert: func(t *testing.T, current, next *v1.Cluster) {
+				assert.NotSame(t, current, next)
+				assert.Equal(t, "v1.0.0", current.Spec.Version)
+				assert.Equal(t, "v1.1.0", next.Spec.Version)
+				assert.Empty(t, next.Spec.Type)
+				assert.Empty(t, next.Spec.ImageRegistry)
+			},
+		},
+		{
+			name:    "rejects malformed PATCH payloads",
+			body:    `[`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := &v1.Cluster{Spec: &v1.ClusterSpec{
+				Type:          v1.KubernetesClusterType,
+				ImageRegistry: "current-registry",
+				Version:       "v1.0.0",
+			}}
+
+			next, err := buildPostgrestClusterPatchValidationNew(current, []byte(tt.body))
+			if tt.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			assert.NoError(t, err)
+			tt.assert(t, current, next)
+		})
+	}
 }
 
 func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
@@ -2238,204 +2162,140 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 		return &next
 	}
 
-	t.Run("allows uninitialized clusters", func(t *testing.T) {
-		current := &v1.Cluster{
-			Spec:   &v1.ClusterSpec{ImageRegistry: "current"},
-			Status: &v1.ClusterStatus{Initialized: false},
-		}
-		update := clusterPatchConfigurationUpdate{imageRegistry: "replacement", imageRegistrySet: true}
-		err := validateInitializedClusterConfigurationUpdate(current, updatedCluster(t, current, update), update)
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("allows an unchanged image registry", func(t *testing.T) {
-		current := &v1.Cluster{
-			Spec:   &v1.ClusterSpec{ImageRegistry: "current"},
-			Status: &v1.ClusterStatus{Initialized: true},
-		}
-		update := clusterPatchConfigurationUpdate{imageRegistry: "current", imageRegistrySet: true}
-		err := validateInitializedClusterConfigurationUpdate(current, updatedCluster(t, current, update), update)
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("rejects unusable Kubernetes credential rotations", func(t *testing.T) {
-		validCurrent := testEncodedKubeconfig("https://api.example.test:6443", "old-token")
-		tests := []struct {
-			name       string
-			current    *v1.Cluster
-			kubeconfig string
-			hint       string
-		}{
-			{
-				name:       "blank updated kubeconfig",
-				current:    initializedKubernetesCluster(validCurrent),
-				kubeconfig: " ",
-				hint:       "failed to parse updated kubeconfig",
-			},
-			{
-				name:       "missing current Kubernetes config",
-				current:    &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.KubernetesClusterType}, Status: &v1.ClusterStatus{Initialized: true}},
-				kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
-				hint:       "failed to read current kubeconfig",
-			},
-			{
-				name:       "invalid current Kubernetes config",
-				current:    initializedKubernetesCluster(base64.StdEncoding.EncodeToString([]byte("not a kubeconfig"))),
-				kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
-				hint:       "failed to parse current kubeconfig",
-			},
-			{
-				name:       "invalid updated kubeconfig",
-				current:    initializedKubernetesCluster(validCurrent),
-				kubeconfig: "not-base64",
-				hint:       "failed to parse updated kubeconfig",
-			},
-			{
-				name:       "different Kubernetes API server",
-				current:    initializedKubernetesCluster(validCurrent),
-				kubeconfig: testEncodedKubeconfig("https://other-api.example.test:6443", "new-token"),
-				hint:       "current Kubernetes API server",
-			},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				update := clusterPatchConfigurationUpdate{
-					kubeconfig:    tt.kubeconfig,
-					kubeconfigSet: true,
-				}
-				err := validateInitializedClusterConfigurationUpdate(
-					tt.current,
-					updatedCluster(t, tt.current, update),
-					update,
-				)
-
-				assert.ErrorContains(t, err, tt.hint)
-			})
-		}
-	})
-
-	t.Run("allows same-host Kubernetes credential rotation", func(t *testing.T) {
-		current := initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token"))
-		update := clusterPatchConfigurationUpdate{
-			kubeconfig:    testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
-			kubeconfigSet: true,
-		}
-		err := validateInitializedClusterConfigurationUpdate(
-			current,
-			updatedCluster(t, current, update),
-			update,
-		)
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("allows empty Kubernetes credential backfill", func(t *testing.T) {
-		current := initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token"))
-		update := clusterPatchConfigurationUpdate{kubeconfigSet: true}
-		err := validateInitializedClusterConfigurationUpdate(
-			current,
-			updatedCluster(t, current, update),
-			update,
-		)
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("validates SSH private-key rotations", func(t *testing.T) {
-		cluster := &v1.Cluster{
+	validKubeconfig := testEncodedKubeconfig("https://api.example.test:6443", "old-token")
+	initializedSSHCluster := func() *v1.Cluster {
+		return &v1.Cluster{
 			Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
 			Status: &v1.ClusterStatus{Initialized: true},
 		}
+	}
 
-		for _, tt := range []struct {
-			name string
-			key  string
-			hint string
-		}{
-			{name: "blank private key", key: " ", hint: "SSH private key must be base64 encoded"},
-			{name: "invalid base64", key: "not-base64", hint: "SSH private key must be base64 encoded"},
-		} {
-			t.Run(tt.name, func(t *testing.T) {
-				update := clusterPatchConfigurationUpdate{
-					sshPrivateKey:    tt.key,
-					sshPrivateKeySet: true,
-				}
-				err := validateInitializedClusterConfigurationUpdate(
-					cluster,
-					updatedCluster(t, cluster, update),
-					update,
-				)
+	tests := []struct {
+		name            string
+		current         *v1.Cluster
+		update          clusterPatchConfigurationUpdate
+		wantErrContains string
+	}{
+		{
+			name:    "allows image registry changes before initialization",
+			current: &v1.Cluster{Spec: &v1.ClusterSpec{ImageRegistry: "current"}, Status: &v1.ClusterStatus{Initialized: false}},
+			update:  clusterPatchConfigurationUpdate{imageRegistry: "replacement", imageRegistrySet: true},
+		},
+		{
+			name:    "allows an unchanged image registry",
+			current: &v1.Cluster{Spec: &v1.ClusterSpec{ImageRegistry: "current"}, Status: &v1.ClusterStatus{Initialized: true}},
+			update:  clusterPatchConfigurationUpdate{imageRegistry: "current", imageRegistrySet: true},
+		},
+		{
+			name:            "rejects image registry changes after initialization",
+			current:         &v1.Cluster{Spec: &v1.ClusterSpec{ImageRegistry: "current"}, Status: &v1.ClusterStatus{Initialized: true}},
+			update:          clusterPatchConfigurationUpdate{imageRegistry: "replacement", imageRegistrySet: true},
+			wantErrContains: "image registry cannot be changed",
+		},
+		{
+			name:            "rejects a blank updated kubeconfig",
+			current:         initializedKubernetesCluster(validKubeconfig),
+			update:          clusterPatchConfigurationUpdate{kubeconfig: " ", kubeconfigSet: true},
+			wantErrContains: "failed to parse updated kubeconfig",
+		},
+		{
+			name:            "rejects a missing current Kubernetes config",
+			current:         &v1.Cluster{Spec: &v1.ClusterSpec{Type: v1.KubernetesClusterType}, Status: &v1.ClusterStatus{Initialized: true}},
+			update:          clusterPatchConfigurationUpdate{kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "new-token"), kubeconfigSet: true},
+			wantErrContains: "failed to read current kubeconfig",
+		},
+		{
+			name:            "rejects an invalid current kubeconfig",
+			current:         initializedKubernetesCluster(base64.StdEncoding.EncodeToString([]byte("not a kubeconfig"))),
+			update:          clusterPatchConfigurationUpdate{kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "new-token"), kubeconfigSet: true},
+			wantErrContains: "failed to parse current kubeconfig",
+		},
+		{
+			name:            "rejects an invalid updated kubeconfig",
+			current:         initializedKubernetesCluster(validKubeconfig),
+			update:          clusterPatchConfigurationUpdate{kubeconfig: "not-base64", kubeconfigSet: true},
+			wantErrContains: "failed to parse updated kubeconfig",
+		},
+		{
+			name:            "rejects a kubeconfig for a different Kubernetes API server",
+			current:         initializedKubernetesCluster(validKubeconfig),
+			update:          clusterPatchConfigurationUpdate{kubeconfig: testEncodedKubeconfig("https://other-api.example.test:6443", "new-token"), kubeconfigSet: true},
+			wantErrContains: "current Kubernetes API server",
+		},
+		{
+			name:    "allows same-host Kubernetes credential rotation",
+			current: initializedKubernetesCluster(validKubeconfig),
+			update:  clusterPatchConfigurationUpdate{kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "new-token"), kubeconfigSet: true},
+		},
+		{
+			name:    "allows empty Kubernetes credential backfill",
+			current: initializedKubernetesCluster(validKubeconfig),
+			update:  clusterPatchConfigurationUpdate{kubeconfigSet: true},
+		},
+		{
+			name:            "rejects a blank SSH private key",
+			current:         initializedSSHCluster(),
+			update:          clusterPatchConfigurationUpdate{sshPrivateKey: " ", sshPrivateKeySet: true},
+			wantErrContains: "SSH private key must be base64 encoded",
+		},
+		{
+			name:            "rejects an invalid SSH private key",
+			current:         initializedSSHCluster(),
+			update:          clusterPatchConfigurationUpdate{sshPrivateKey: "not-base64", sshPrivateKeySet: true},
+			wantErrContains: "SSH private key must be base64 encoded",
+		},
+		{
+			name:    "allows an SSH private key rotation",
+			current: initializedSSHCluster(),
+			update:  clusterPatchConfigurationUpdate{sshPrivateKey: base64.StdEncoding.EncodeToString([]byte("rotated-private-key")), sshPrivateKeySet: true},
+		},
+		{
+			name:    "allows an empty SSH private key backfill",
+			current: initializedSSHCluster(),
+			update:  clusterPatchConfigurationUpdate{sshPrivateKeySet: true},
+		},
+		{
+			name:            "rejects clearing the entire config",
+			current:         initializedKubernetesCluster(validKubeconfig),
+			update:          clusterPatchConfigurationUpdate{configCleared: true},
+			wantErrContains: "config cannot be cleared",
+		},
+		{
+			name:            "rejects clearing Kubernetes config",
+			current:         initializedKubernetesCluster(validKubeconfig),
+			update:          clusterPatchConfigurationUpdate{kubernetesConfigCleared: true},
+			wantErrContains: "kubernetes_config cannot be cleared",
+		},
+		{
+			name:            "rejects clearing SSH config",
+			current:         initializedSSHCluster(),
+			update:          clusterPatchConfigurationUpdate{sshConfigCleared: true},
+			wantErrContains: "ssh_config cannot be cleared",
+		},
+		{
+			name:            "rejects clearing SSH auth",
+			current:         initializedSSHCluster(),
+			update:          clusterPatchConfigurationUpdate{sshAuthCleared: true},
+			wantErrContains: "SSH auth cannot be cleared",
+		},
+	}
 
-				assert.ErrorContains(t, err, tt.hint)
-			})
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInitializedClusterConfigurationUpdate(
+				tt.current,
+				updatedCluster(t, tt.current, tt.update),
+				tt.update,
+			)
 
-		update := clusterPatchConfigurationUpdate{
-			sshPrivateKey:    base64.StdEncoding.EncodeToString([]byte("rotated-private-key")),
-			sshPrivateKeySet: true,
-		}
-		err := validateInitializedClusterConfigurationUpdate(cluster, updatedCluster(t, cluster, update), update)
-		assert.NoError(t, err)
+			if tt.wantErrContains == "" {
+				assert.NoError(t, err)
 
-		update = clusterPatchConfigurationUpdate{sshPrivateKeySet: true}
-		err = validateInitializedClusterConfigurationUpdate(cluster, updatedCluster(t, cluster, update), update)
-		assert.NoError(t, err)
-	})
-
-	t.Run("rejects cleared initialized configurations", func(t *testing.T) {
-		kubernetesCluster := initializedKubernetesCluster(
-			testEncodedKubeconfig("https://api.example.test:6443", "old-token"),
-		)
-		sshCluster := &v1.Cluster{
-			Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
-			Status: &v1.ClusterStatus{Initialized: true},
-		}
-
-		for _, tt := range []struct {
-			name    string
-			cluster *v1.Cluster
-			update  clusterPatchConfigurationUpdate
-			hint    string
-		}{
-			{
-				name:    "entire config",
-				cluster: kubernetesCluster,
-				update:  clusterPatchConfigurationUpdate{configCleared: true},
-				hint:    "config cannot be cleared",
-			},
-			{
-				name:    "Kubernetes config",
-				cluster: kubernetesCluster,
-				update:  clusterPatchConfigurationUpdate{kubernetesConfigCleared: true},
-				hint:    "kubernetes_config cannot be cleared",
-			},
-			{
-				name:    "SSH config",
-				cluster: sshCluster,
-				update:  clusterPatchConfigurationUpdate{sshConfigCleared: true},
-				hint:    "ssh_config cannot be cleared",
-			},
-			{
-				name:    "SSH auth",
-				cluster: sshCluster,
-				update:  clusterPatchConfigurationUpdate{sshAuthCleared: true},
-				hint:    "SSH auth cannot be cleared",
-			},
-		} {
-			t.Run(tt.name, func(t *testing.T) {
-				err := validateInitializedClusterConfigurationUpdate(
-					tt.cluster,
-					updatedCluster(t, tt.cluster, tt.update),
-					tt.update,
-				)
-
-				assert.ErrorContains(t, err, tt.hint)
-			})
-		}
-	})
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErrContains)
+		})
+	}
 }
 
 type trackingReadCloser struct {

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -96,6 +96,141 @@ func TestValidateClusterDeletion(t *testing.T) {
 	}
 }
 
+func TestValidateClusterRequestMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("dispatches POST to accelerator virtualization validation", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.POST("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/clusters", strings.NewReader(`{
+			"spec": {
+				"type": "ssh",
+				"accelerator_virtualization": {"enabled": true}
+			}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10208"`)
+		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
+	t.Run("dispatches normal PATCH to configuration validation", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec:   &v1.ClusterSpec{ImageRegistry: "current-registry"},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"image_registry": "replacement-registry"}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "image registry cannot be changed")
+		mockStorage.AssertExpectations(t)
+		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
+	t.Run("dispatches soft delete to deletion validation and restores the body", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On(
+			"Count",
+			storage.ENDPOINT_TABLE,
+			clusterEndpointReferenceFilters("default", "cluster"),
+		).Return(0, nil).Once()
+
+		body := `{
+			"metadata": {
+				"workspace": "default",
+				"name": "cluster",
+				"deletion_timestamp": "2026-08-10T00:00:00Z"
+			},
+			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+		}`
+		originalBody := &trackingReadCloser{Reader: strings.NewReader(body)}
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+
+			restoredBody, err := io.ReadAll(c.Request.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, body, string(restoredBody))
+			assert.Equal(t, int64(len(body)), c.Request.ContentLength)
+			assert.Equal(t, strconv.Itoa(len(body)), c.Request.Header.Get("Content-Length"))
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", nil)
+		req.Body = originalBody
+		req.ContentLength = 0
+		req.Header.Set("Content-Length", "0")
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.True(t, originalBody.closed)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertExpectations(t)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
+	t.Run("rejects malformed PATCH before any validator lookup", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "invalid cluster payload")
+		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+}
+
 func TestValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
 	t.Run("allows Kubernetes cluster to enable accelerator virtualization", func(t *testing.T) {
 		err := validateClusterAcceleratorVirtualizationBody([]byte(`{

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -2,6 +2,7 @@ package proxies
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -243,6 +244,77 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 	})
 
+	t.Run("resolves the current cluster once for all normal PATCH validators", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				ImageRegistry: "current-registry",
+				Version:       "v1.0.0",
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			body, err := io.ReadAll(c.Request.Body)
+			assert.NoError(t, err)
+			assert.JSONEq(t, `{
+				"spec": {"version": "v1.1.0", "image_registry": "current-registry"}
+			}`, string(body))
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"version": "v1.1.0", "image_registry": "current-registry"}
+		}`)))
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertExpectations(t)
+		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
+	t.Run("keeps a masked kubeconfig null in the forwarded PATCH body", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				Type: v1.KubernetesClusterType,
+				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+					Kubeconfig: "current-kubeconfig",
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil).Once()
+
+		body := `{"spec":{"config":{"kubernetes_config":{"kubeconfig":null}}}}`
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			forwardedBody, err := io.ReadAll(c.Request.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, body, string(forwardedBody))
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body)))
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertExpectations(t)
+	})
+
 	t.Run("dispatches soft delete to deletion validation and restores the body", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		mockStorage.On(
@@ -357,7 +429,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
-	t.Run("reports a fixed version resolution error when PATCH has no identity", func(t *testing.T) {
+	t.Run("preserves the version resolution error when PATCH has no identity", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
@@ -377,11 +449,11 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10212"`)
 		assert.Contains(t, recorder.Body.String(), "failed to validate cluster version update")
-		assert.Contains(t, recorder.Body.String(), "cluster identity is required")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required when updating spec.version")
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
-	t.Run("reports a fixed version resolution error when the current cluster lookup fails", func(t *testing.T) {
+	t.Run("preserves the version resolution error when the current cluster lookup fails", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
 		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
@@ -405,11 +477,12 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10212"`)
+		assert.Contains(t, recorder.Body.String(), "failed to validate cluster version update")
 		assert.Contains(t, recorder.Body.String(), "read cluster failed")
 		mockStorage.AssertExpectations(t)
 	})
 
-	t.Run("reports a fixed configuration resolution error when PATCH has no identity", func(t *testing.T) {
+	t.Run("preserves the configuration resolution error when PATCH has no identity", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
@@ -429,8 +502,79 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
 		assert.Contains(t, recorder.Body.String(), "failed to validate cluster configuration update")
-		assert.Contains(t, recorder.Body.String(), "cluster identity is required")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required when updating cluster configuration")
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("uses the generic preparation error for an unrelated PATCH without identity", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"metadata": {"name": "cluster"}
+		}`)))
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required when patching a cluster")
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("preserves the accelerator virtualization identity error when PATCH has no identity", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"spec": {"accelerator_virtualization": {}}
+		}`)))
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "failed to validate cluster accelerator virtualization")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required when disabling accelerator virtualization")
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("preserves the accelerator virtualization resolution error when the current cluster lookup fails", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return(nil, errors.New("read cluster failed")).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"accelerator_virtualization": {}}
+		}`)))
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "failed to validate cluster accelerator virtualization")
+		assert.Contains(t, recorder.Body.String(), "read cluster failed")
+		mockStorage.AssertExpectations(t)
 	})
 
 	t.Run("reports a fixed configuration resolution error when the target is ambiguous", func(t *testing.T) {
@@ -468,6 +612,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 			return sameFilters(opt.Filters, queryParamsToFilters(query))
 		})).Return([]v1.Cluster{{
 			Metadata: &v1.Metadata{Workspace: "default", Name: "cluster"},
+			Spec:     &v1.ClusterSpec{},
 		}}, nil).Once()
 		mockStorage.On(
 			"ListEndpoint",
@@ -523,6 +668,20 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 	})
+}
+
+func TestValidateClusterAcceleratorVirtualizationDisableForCurrent(t *testing.T) {
+	mockStorage := storageMocks.NewMockStorage(t)
+	current := &v1.Cluster{Metadata: &v1.Metadata{Workspace: "default", Name: "cluster"}}
+	patch := v1.Cluster{Metadata: &v1.Metadata{Workspace: "default", Name: "other-cluster"}}
+
+	validationErr := validateClusterAcceleratorVirtualizationDisableForCurrent(mockStorage, current, patch)
+
+	assert.NotNil(t, validationErr)
+	assert.Equal(t, "10209", validationErr.Code)
+	assert.Equal(t, "failed to validate cluster accelerator virtualization", validationErr.Message)
+	assert.Equal(t, "cluster metadata in patch body does not match patch target", validationErr.Hint)
+	mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 }
 
 func TestValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
@@ -872,11 +1031,135 @@ func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
 	})
 }
 
+func TestPrepareClusterValidationInput(t *testing.T) {
+	prepare := func(t *testing.T, current v1.Cluster, body string) *ValidationInput[v1.Cluster] {
+		t.Helper()
+
+		var payload map[string]json.RawMessage
+		assert.NoError(t, json.Unmarshal([]byte(body), &payload))
+
+		var patch v1.Cluster
+		assert.NoError(t, json.Unmarshal([]byte(body), &patch))
+
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(url.Values{"id": []string{"eq.1"}}))
+		})).Return([]v1.Cluster{current}, nil).Once()
+
+		input := &ValidationInput[v1.Cluster]{
+			Method:      http.MethodPatch,
+			Body:        []byte(body),
+			RawPayload:  payload,
+			Patch:       patch,
+			QueryParams: url.Values{"id": []string{"eq.1"}},
+			Operation:   clusterValidationPatch,
+		}
+
+		validationErr := prepareClusterValidationInput(mockStorage, input)
+		assert.Nil(t, validationErr)
+		mockStorage.AssertExpectations(t)
+
+		return input
+	}
+
+	t.Run("creates a separate New cluster and preserves an empty kubeconfig", func(t *testing.T) {
+		current := v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "kubernetes"},
+			Spec: &v1.ClusterSpec{
+				Type:    v1.KubernetesClusterType,
+				Version: "v1.0.0",
+				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+					Kubeconfig: "current-kubeconfig",
+				}},
+			},
+		}
+
+		input := prepare(t, current, `{
+			"spec": {
+				"version": "v1.1.0",
+				"config": {"kubernetes_config": {"kubeconfig": ""}}
+			}
+		}`)
+
+		assert.Equal(t, &current, input.Current)
+		assert.NotSame(t, input.Current, input.New)
+		assert.Equal(t, "v1.0.0", input.Current.Spec.Version)
+		assert.Equal(t, "current-kubeconfig", input.Current.Spec.Config.KubernetesConfig.Kubeconfig)
+		assert.Equal(t, "v1.1.0", input.New.Spec.Version)
+		assert.Equal(t, "current-kubeconfig", input.New.Spec.Config.KubernetesConfig.Kubeconfig)
+	})
+
+	for _, tt := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty", raw: `""`},
+		{name: "null", raw: "null"},
+	} {
+		t.Run("preserves SSH private key "+tt.name, func(t *testing.T) {
+			current := v1.Cluster{
+				Metadata: &v1.Metadata{Workspace: "default", Name: "ssh"},
+				Spec: &v1.ClusterSpec{
+					Type: v1.SSHClusterType,
+					Config: &v1.ClusterConfig{SSHConfig: &v1.RaySSHProvisionClusterConfig{
+						Auth: v1.Auth{SSHPrivateKey: "current-private-key"},
+					}},
+				},
+			}
+
+			input := prepare(t, current, `{
+				"spec": {"config": {"ssh_config": {"auth": {"ssh_private_key": `+tt.raw+`}}}}
+			}`)
+
+			assert.Equal(t, "current-private-key", input.Current.Spec.Config.SSHConfig.Auth.SSHPrivateKey)
+			assert.Equal(t, "current-private-key", input.New.Spec.Config.SSHConfig.Auth.SSHPrivateKey)
+		})
+	}
+
+	t.Run("retains an explicit config null in New for configuration validation", func(t *testing.T) {
+		current := v1.Cluster{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "kubernetes"},
+			Spec: &v1.ClusterSpec{
+				Type:   v1.KubernetesClusterType,
+				Config: &v1.ClusterConfig{},
+			},
+		}
+		input := prepare(t, current, `{"spec": {"config": null}}`)
+
+		assert.Nil(t, input.New.Spec.Config)
+		update, err := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
+		assert.NoError(t, err)
+		assert.True(t, update.configCleared)
+	})
+}
+
+func TestMergeClusterPatchForValidation(t *testing.T) {
+	current := &v1.Cluster{
+		Spec: &v1.ClusterSpec{
+			Type:          v1.KubernetesClusterType,
+			ImageRegistry: "current-registry",
+			Version:       "v1.0.0",
+		},
+	}
+
+	next, err := mergeClusterPatchForValidation(current, nil)
+	assert.NoError(t, err)
+	assert.NotSame(t, current, next)
+	assert.Equal(t, current, next)
+
+	_, err = mergeClusterPatchForValidation(current, []byte(`[`))
+	assert.Error(t, err)
+}
+
 func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("rejects disable patch before proxy handler when vGPU endpoint references cluster", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListCluster", mock.Anything).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec:     &v1.ClusterSpec{},
+		}}, nil).Once()
 		mockStorage.On("ListEndpoint", storage.ListOption{
 			Filters: clusterEndpointReferenceFilters("default", "gpu-cluster"),
 		}).Return([]v1.Endpoint{
@@ -931,6 +1214,7 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 
 		assert.True(t, proxyCalled)
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 	})
 
@@ -1444,7 +1728,7 @@ func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("allows configuration-only patch without storage lookup", func(t *testing.T) {
+	t.Run("skips version validation for a configuration-only patch", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
@@ -1801,21 +2085,63 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 			Status: &v1.ClusterStatus{Initialized: true},
 		}
 	}
+	updatedCluster := func(t *testing.T, current *v1.Cluster, update clusterPatchConfigurationUpdate) *v1.Cluster {
+		t.Helper()
+
+		data, err := json.Marshal(current)
+		assert.NoError(t, err)
+
+		var next v1.Cluster
+		assert.NoError(t, json.Unmarshal(data, &next))
+		if next.Spec == nil {
+			next.Spec = &v1.ClusterSpec{}
+		}
+
+		if update.imageRegistrySet {
+			next.Spec.ImageRegistry = update.imageRegistry
+		}
+
+		if update.kubeconfigSet {
+			if next.Spec.Config == nil {
+				next.Spec.Config = &v1.ClusterConfig{}
+			}
+			if next.Spec.Config.KubernetesConfig == nil {
+				next.Spec.Config.KubernetesConfig = &v1.KubernetesClusterConfig{}
+			}
+			next.Spec.Config.KubernetesConfig.Kubeconfig = update.kubeconfig
+		}
+
+		if update.sshPrivateKeySet {
+			if next.Spec.Config == nil {
+				next.Spec.Config = &v1.ClusterConfig{}
+			}
+			if next.Spec.Config.SSHConfig == nil {
+				next.Spec.Config.SSHConfig = &v1.RaySSHProvisionClusterConfig{}
+			}
+			next.Spec.Config.SSHConfig.Auth.SSHPrivateKey = update.sshPrivateKey
+		}
+
+		return &next
+	}
 
 	t.Run("allows uninitialized clusters", func(t *testing.T) {
-		err := validateInitializedClusterConfigurationUpdate(&v1.Cluster{
+		current := &v1.Cluster{
 			Spec:   &v1.ClusterSpec{ImageRegistry: "current"},
 			Status: &v1.ClusterStatus{Initialized: false},
-		}, clusterPatchConfigurationUpdate{imageRegistry: "replacement", imageRegistrySet: true})
+		}
+		update := clusterPatchConfigurationUpdate{imageRegistry: "replacement", imageRegistrySet: true}
+		err := validateInitializedClusterConfigurationUpdate(current, updatedCluster(t, current, update), update)
 
 		assert.NoError(t, err)
 	})
 
 	t.Run("allows an unchanged image registry", func(t *testing.T) {
-		err := validateInitializedClusterConfigurationUpdate(&v1.Cluster{
+		current := &v1.Cluster{
 			Spec:   &v1.ClusterSpec{ImageRegistry: "current"},
 			Status: &v1.ClusterStatus{Initialized: true},
-		}, clusterPatchConfigurationUpdate{imageRegistry: "current", imageRegistrySet: true})
+		}
+		update := clusterPatchConfigurationUpdate{imageRegistry: "current", imageRegistrySet: true}
+		err := validateInitializedClusterConfigurationUpdate(current, updatedCluster(t, current, update), update)
 
 		assert.NoError(t, err)
 	})
@@ -1862,10 +2188,15 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				err := validateInitializedClusterConfigurationUpdate(tt.current, clusterPatchConfigurationUpdate{
+				update := clusterPatchConfigurationUpdate{
 					kubeconfig:    tt.kubeconfig,
 					kubeconfigSet: true,
-				})
+				}
+				err := validateInitializedClusterConfigurationUpdate(
+					tt.current,
+					updatedCluster(t, tt.current, update),
+					update,
+				)
 
 				assert.ErrorContains(t, err, tt.hint)
 			})
@@ -1873,21 +2204,27 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 	})
 
 	t.Run("allows same-host Kubernetes credential rotation", func(t *testing.T) {
+		current := initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token"))
+		update := clusterPatchConfigurationUpdate{
+			kubeconfig:    testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
+			kubeconfigSet: true,
+		}
 		err := validateInitializedClusterConfigurationUpdate(
-			initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token")),
-			clusterPatchConfigurationUpdate{
-				kubeconfig:    testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
-				kubeconfigSet: true,
-			},
+			current,
+			updatedCluster(t, current, update),
+			update,
 		)
 
 		assert.NoError(t, err)
 	})
 
 	t.Run("allows empty Kubernetes credential backfill", func(t *testing.T) {
+		current := initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token"))
+		update := clusterPatchConfigurationUpdate{kubeconfigSet: true}
 		err := validateInitializedClusterConfigurationUpdate(
-			initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token")),
-			clusterPatchConfigurationUpdate{kubeconfigSet: true},
+			current,
+			updatedCluster(t, current, update),
+			update,
 		)
 
 		assert.NoError(t, err)
@@ -1908,24 +2245,29 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 			{name: "invalid base64", key: "not-base64", hint: "SSH private key must be base64 encoded"},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				err := validateInitializedClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
+				update := clusterPatchConfigurationUpdate{
 					sshPrivateKey:    tt.key,
 					sshPrivateKeySet: true,
-				})
+				}
+				err := validateInitializedClusterConfigurationUpdate(
+					cluster,
+					updatedCluster(t, cluster, update),
+					update,
+				)
 
 				assert.ErrorContains(t, err, tt.hint)
 			})
 		}
 
-		err := validateInitializedClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
+		update := clusterPatchConfigurationUpdate{
 			sshPrivateKey:    base64.StdEncoding.EncodeToString([]byte("rotated-private-key")),
 			sshPrivateKeySet: true,
-		})
+		}
+		err := validateInitializedClusterConfigurationUpdate(cluster, updatedCluster(t, cluster, update), update)
 		assert.NoError(t, err)
 
-		err = validateInitializedClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
-			sshPrivateKeySet: true,
-		})
+		update = clusterPatchConfigurationUpdate{sshPrivateKeySet: true}
+		err = validateInitializedClusterConfigurationUpdate(cluster, updatedCluster(t, cluster, update), update)
 		assert.NoError(t, err)
 	})
 
@@ -1970,7 +2312,11 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				err := validateInitializedClusterConfigurationUpdate(tt.cluster, tt.update)
+				err := validateInitializedClusterConfigurationUpdate(
+					tt.cluster,
+					updatedCluster(t, tt.cluster, tt.update),
+					tt.update,
+				)
 
 				assert.ErrorContains(t, err, tt.hint)
 			})

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -528,7 +528,7 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 	})
 }
 
-func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
+func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("rejects image registry switch for initialized cluster before proxy handler", func(t *testing.T) {
@@ -545,7 +545,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -581,7 +581,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -615,7 +615,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -651,7 +651,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -687,7 +687,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -716,7 +716,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -747,7 +747,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -783,7 +783,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -814,7 +814,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -835,7 +835,7 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -850,6 +850,89 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		assert.True(t, proxyCalled)
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("restores request body and content length", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		body := `{"metadata":{"name":"cluster"}}`
+		originalBody := &trackingReadCloser{Reader: strings.NewReader(body)}
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+			restoredBody, err := io.ReadAll(c.Request.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, body, string(restoredBody))
+			assert.Equal(t, int64(len(body)), c.Request.ContentLength)
+			assert.Equal(t, strconv.Itoa(len(body)), c.Request.Header.Get("Content-Length"))
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", nil)
+		req.Body = originalBody
+		req.ContentLength = 0
+		req.Header.Set("Content-Length", "0")
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, originalBody.closed)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+}
+
+func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("allows configuration-only patch without storage lookup", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"config": {"kubernetes_config": {"kubeconfig": "updated-kubeconfig"}}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("rejects malformed configuration before resolving version update", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH(
+			"/clusters",
+			validateClusterVersionUpdate(mockStorage),
+			validateClusterConfigurationUpdate(mockStorage),
+			func(c *gin.Context) {
+				proxyCalled = true
+				c.Status(http.StatusNoContent)
+			},
+		)
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {
+				"version": "v1.2.0",
+				"config": {"kubernetes_config": {"kubeconfig": []}}
+			}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "invalid cluster payload")
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
@@ -1146,7 +1229,7 @@ func TestParseClusterPatchConfigurationUpdate(t *testing.T) {
 	}
 }
 
-func TestValidateClusterConfigurationUpdate(t *testing.T) {
+func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 	initializedKubernetesCluster := func(kubeconfig string) *v1.Cluster {
 		return &v1.Cluster{
 			Spec: &v1.ClusterSpec{
@@ -1160,7 +1243,7 @@ func TestValidateClusterConfigurationUpdate(t *testing.T) {
 	}
 
 	t.Run("allows uninitialized clusters", func(t *testing.T) {
-		err := validateClusterConfigurationUpdate(&v1.Cluster{
+		err := validateInitializedClusterConfigurationUpdate(&v1.Cluster{
 			Spec:   &v1.ClusterSpec{ImageRegistry: "current"},
 			Status: &v1.ClusterStatus{Initialized: false},
 		}, clusterPatchConfigurationUpdate{imageRegistry: "replacement", imageRegistrySet: true})
@@ -1169,7 +1252,7 @@ func TestValidateClusterConfigurationUpdate(t *testing.T) {
 	})
 
 	t.Run("allows an unchanged image registry", func(t *testing.T) {
-		err := validateClusterConfigurationUpdate(&v1.Cluster{
+		err := validateInitializedClusterConfigurationUpdate(&v1.Cluster{
 			Spec:   &v1.ClusterSpec{ImageRegistry: "current"},
 			Status: &v1.ClusterStatus{Initialized: true},
 		}, clusterPatchConfigurationUpdate{imageRegistry: "current", imageRegistrySet: true})
@@ -1213,7 +1296,7 @@ func TestValidateClusterConfigurationUpdate(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				err := validateClusterConfigurationUpdate(tt.current, clusterPatchConfigurationUpdate{
+				err := validateInitializedClusterConfigurationUpdate(tt.current, clusterPatchConfigurationUpdate{
 					kubeconfig:    tt.kubeconfig,
 					kubeconfigSet: true,
 				})
@@ -1224,7 +1307,7 @@ func TestValidateClusterConfigurationUpdate(t *testing.T) {
 	})
 
 	t.Run("allows same-host Kubernetes credential rotation", func(t *testing.T) {
-		err := validateClusterConfigurationUpdate(
+		err := validateInitializedClusterConfigurationUpdate(
 			initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token")),
 			clusterPatchConfigurationUpdate{
 				kubeconfig:    testEncodedKubeconfig("https://api.example.test:6443", "new-token"),
@@ -1250,7 +1333,7 @@ func TestValidateClusterConfigurationUpdate(t *testing.T) {
 			{name: "invalid base64", key: "not-base64", hint: "SSH private key must be base64 encoded"},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				err := validateClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
+				err := validateInitializedClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
 					sshPrivateKey:    tt.key,
 					sshPrivateKeySet: true,
 				})
@@ -1259,7 +1342,7 @@ func TestValidateClusterConfigurationUpdate(t *testing.T) {
 			})
 		}
 
-		err := validateClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
+		err := validateInitializedClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
 			sshPrivateKey:    base64.StdEncoding.EncodeToString([]byte("rotated-private-key")),
 			sshPrivateKeySet: true,
 		})
@@ -1307,7 +1390,7 @@ func TestValidateClusterConfigurationUpdate(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				err := validateClusterConfigurationUpdate(tt.cluster, tt.update)
+				err := validateInitializedClusterConfigurationUpdate(tt.cluster, tt.update)
 
 				assert.ErrorContains(t, err, tt.hint)
 			})

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -95,6 +95,181 @@ func TestValidateClusterDeletion(t *testing.T) {
 			mockStorage.AssertExpectations(t)
 		})
 	}
+
+}
+
+func TestValidateClusterSoftDelete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name            string
+		path            string
+		body            string
+		endpointCount   int
+		countError      error
+		expectCount     bool
+		expectProxy     bool
+		expectPoweredBy bool
+		expectedStatus  int
+		expectedCode    string
+		expectedHint    string
+	}{
+		{
+			name: "allows incomplete identity",
+			path: "/clusters",
+			body: `{
+				"metadata": {"deletion_timestamp": "2026-08-10T00:00:00Z"}
+			}`,
+			expectProxy:    true,
+			expectedStatus: http.StatusNoContent,
+		},
+		{
+			name: "bypasses malformed guarded configuration",
+			path: "/clusters?id=eq.1",
+			body: `{
+				"metadata": {
+					"workspace": "default",
+					"name": "cluster",
+					"deletion_timestamp": "2026-08-10T00:00:00Z"
+				},
+				"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+			}`,
+			endpointCount:  0,
+			expectCount:    true,
+			expectProxy:    true,
+			expectedStatus: http.StatusNoContent,
+		},
+		{
+			name: "rejects referenced cluster",
+			path: "/clusters",
+			body: `{
+				"metadata": {
+					"workspace": "default",
+					"name": "cluster",
+					"deletion_timestamp": "2026-08-10T00:00:00Z"
+				}
+			}`,
+			endpointCount:   1,
+			expectCount:     true,
+			expectedStatus:  http.StatusBadRequest,
+			expectedCode:    "10126",
+			expectedHint:    "1 endpoint(s) still reference this cluster",
+			expectPoweredBy: true,
+		},
+		{
+			name: "returns internal error when dependency lookup fails",
+			path: "/clusters",
+			body: `{
+				"metadata": {
+					"workspace": "default",
+					"name": "cluster",
+					"deletion_timestamp": "2026-08-10T00:00:00Z"
+				}
+			}`,
+			countError:     errors.New("count endpoints failed"),
+			expectCount:    true,
+			expectedStatus: http.StatusInternalServerError,
+			expectedCode:   "500",
+			expectedHint:   "Failed to validate deletion",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStorage := storageMocks.NewMockStorage(t)
+			if tt.expectCount {
+				mockStorage.On(
+					"Count",
+					storage.ENDPOINT_TABLE,
+					clusterEndpointReferenceFilters("default", "cluster"),
+				).Return(tt.endpointCount, tt.countError).Once()
+			}
+
+			proxyCalled := false
+			router := gin.New()
+			router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+				proxyCalled = true
+
+				forwardedBody, err := io.ReadAll(c.Request.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.body, string(forwardedBody))
+				assert.Equal(t, int64(len(tt.body)), c.Request.ContentLength)
+				assert.Equal(t, strconv.Itoa(len(tt.body)), c.Request.Header.Get("Content-Length"))
+				c.Status(http.StatusNoContent)
+			})
+
+			originalBody := &trackingReadCloser{Reader: strings.NewReader(tt.body)}
+			req := httptest.NewRequest(http.MethodPatch, tt.path, nil)
+			req.Body = originalBody
+			req.ContentLength = 0
+			req.Header.Set("Content-Length", "0")
+			recorder := httptest.NewRecorder()
+
+			router.ServeHTTP(recorder, req)
+
+			assert.Equal(t, tt.expectProxy, proxyCalled)
+			assert.True(t, originalBody.closed)
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+			if tt.expectPoweredBy {
+				assert.Equal(t, "Neutree", recorder.Header().Get("X-Powered-By"))
+			}
+			if tt.expectedCode != "" {
+				assert.Contains(t, recorder.Body.String(), `"code":"`+tt.expectedCode+`"`)
+			}
+			if tt.expectedHint != "" {
+				assert.Contains(t, recorder.Body.String(), tt.expectedHint)
+			}
+			mockStorage.AssertExpectations(t)
+			if !tt.expectCount {
+				mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+			}
+			mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+			mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+		})
+	}
+
+	t.Run("forwards malformed guarded configuration through registered route", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On(
+			"Count",
+			storage.ENDPOINT_TABLE,
+			clusterEndpointReferenceFilters("default", "cluster"),
+		).Return(0, nil).Once()
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPatch, r.Method)
+			assert.Equal(t, "/clusters", r.URL.Path)
+
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.JSONEq(t, `{
+				"metadata": {"workspace": "default", "name": "cluster", "deletion_timestamp": "2026-08-07T00:00:00Z"},
+				"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+			}`, string(body))
+
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer upstream.Close()
+
+		router := gin.New()
+		RegisterClusterRoutes(router.Group("/api/v1"), nil, &Dependencies{
+			Storage:          mockStorage,
+			StorageAccessURL: upstream.URL,
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/api/v1/clusters?id=eq.1", strings.NewReader(`{
+			"metadata": {"workspace": "default", "name": "cluster", "deletion_timestamp": "2026-08-07T00:00:00Z"},
+			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+		}`))
+		req.Header.Set("Content-Type", "application/json")
+		recorder := newCloseNotifyRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
+		mockStorage.AssertExpectations(t)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
 }
 
 func TestValidateClusterRequestMiddleware(t *testing.T) {
@@ -183,29 +358,6 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10208"`)
-		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
-		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
-	})
-
-	t.Run("allows soft delete without a complete identity", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		proxyCalled := false
-		router := gin.New()
-		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
-			proxyCalled = true
-			c.Status(http.StatusNoContent)
-		})
-
-		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
-			"metadata": {"deletion_timestamp": "2026-08-10T00:00:00Z"}
-		}`))
-		recorder := httptest.NewRecorder()
-
-		router.ServeHTTP(recorder, req)
-
-		assert.True(t, proxyCalled)
-		assert.Equal(t, http.StatusNoContent, recorder.Code)
 		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
@@ -355,120 +507,6 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.True(t, proxyCalled)
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
 		mockStorage.AssertExpectations(t)
-	})
-
-	t.Run("dispatches soft delete to deletion validation and restores the body", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		mockStorage.On(
-			"Count",
-			storage.ENDPOINT_TABLE,
-			clusterEndpointReferenceFilters("default", "cluster"),
-		).Return(0, nil).Once()
-
-		body := `{
-			"metadata": {
-				"workspace": "default",
-				"name": "cluster",
-				"deletion_timestamp": "2026-08-10T00:00:00Z"
-			},
-			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
-		}`
-		originalBody := &trackingReadCloser{Reader: strings.NewReader(body)}
-		proxyCalled := false
-		router := gin.New()
-		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
-			proxyCalled = true
-
-			restoredBody, err := io.ReadAll(c.Request.Body)
-			assert.NoError(t, err)
-			assert.Equal(t, body, string(restoredBody))
-			assert.Equal(t, int64(len(body)), c.Request.ContentLength)
-			assert.Equal(t, strconv.Itoa(len(body)), c.Request.Header.Get("Content-Length"))
-			c.Status(http.StatusNoContent)
-		})
-
-		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", nil)
-		req.Body = originalBody
-		req.ContentLength = 0
-		req.Header.Set("Content-Length", "0")
-		recorder := httptest.NewRecorder()
-
-		router.ServeHTTP(recorder, req)
-
-		assert.True(t, proxyCalled)
-		assert.True(t, originalBody.closed)
-		assert.Equal(t, http.StatusNoContent, recorder.Code)
-		mockStorage.AssertExpectations(t)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
-		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
-	})
-
-	t.Run("writes deletion dependency validation errors", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		mockStorage.On(
-			"Count",
-			storage.ENDPOINT_TABLE,
-			clusterEndpointReferenceFilters("default", "cluster"),
-		).Return(1, nil).Once()
-
-		proxyCalled := false
-		router := gin.New()
-		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
-			proxyCalled = true
-			c.Status(http.StatusNoContent)
-		})
-
-		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
-			"metadata": {
-				"workspace": "default",
-				"name": "cluster",
-				"deletion_timestamp": "2026-08-10T00:00:00Z"
-			}
-		}`))
-		recorder := httptest.NewRecorder()
-
-		router.ServeHTTP(recorder, req)
-
-		assert.False(t, proxyCalled)
-		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		assert.Equal(t, "Neutree", recorder.Header().Get("X-Powered-By"))
-		assert.Contains(t, recorder.Body.String(), `"code":"10126"`)
-		mockStorage.AssertExpectations(t)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
-	})
-
-	t.Run("writes deletion storage errors", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		mockStorage.On(
-			"Count",
-			storage.ENDPOINT_TABLE,
-			clusterEndpointReferenceFilters("default", "cluster"),
-		).Return(0, errors.New("count endpoints failed")).Once()
-
-		proxyCalled := false
-		router := gin.New()
-		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
-			proxyCalled = true
-			c.Status(http.StatusNoContent)
-		})
-
-		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
-			"metadata": {
-				"workspace": "default",
-				"name": "cluster",
-				"deletion_timestamp": "2026-08-10T00:00:00Z"
-			}
-		}`))
-		recorder := httptest.NewRecorder()
-
-		router.ServeHTTP(recorder, req)
-
-		assert.False(t, proxyCalled)
-		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
-		assert.Contains(t, recorder.Body.String(), `"code":"500"`)
-		assert.Contains(t, recorder.Body.String(), "Failed to validate deletion")
-		mockStorage.AssertExpectations(t)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
 	t.Run("preserves the version resolution error when PATCH has no identity", func(t *testing.T) {
@@ -736,7 +774,14 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 	})
 }
 
-func TestValidateClusterAcceleratorVirtualizationDisableForCurrent(t *testing.T) {
+func TestValidateClusterAcceleratorVirtualization(t *testing.T) {
+	t.Run("body", testValidateClusterAcceleratorVirtualizationBody)
+	t.Run("disable for current", testValidateClusterAcceleratorVirtualizationDisableForCurrent)
+	t.Run("disable", testValidateClusterAcceleratorVirtualizationDisable)
+	t.Run("middleware", testValidateClusterAcceleratorVirtualizationMiddleware)
+}
+
+func testValidateClusterAcceleratorVirtualizationDisableForCurrent(t *testing.T) {
 	mockStorage := storageMocks.NewMockStorage(t)
 	current := &v1.Cluster{Metadata: &v1.Metadata{Workspace: "default", Name: "cluster"}}
 	patch := v1.Cluster{Metadata: &v1.Metadata{Workspace: "default", Name: "other-cluster"}}
@@ -750,7 +795,7 @@ func TestValidateClusterAcceleratorVirtualizationDisableForCurrent(t *testing.T)
 	mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 }
 
-func TestValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
+func testValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
 	tests := []struct {
 		name        string
 		body        string
@@ -850,7 +895,7 @@ func TestValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
 	}
 }
 
-func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
+func testValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
 	vGPUEndpoint := v1.Endpoint{
 		Spec: &v1.EndpointSpec{
 			Resources: &v1.ResourceSpec{
@@ -987,7 +1032,12 @@ func TestValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
 	}
 }
 
-func TestPrepareClusterValidationInput(t *testing.T) {
+func TestClusterValidationInput(t *testing.T) {
+	t.Run("prepare", testPrepareClusterValidationInput)
+	t.Run("build PostgREST PATCH New", testBuildPostgrestClusterPatchValidationNew)
+}
+
+func testPrepareClusterValidationInput(t *testing.T) {
 	prepare := func(t *testing.T, current v1.Cluster, body string) *ValidationInput[v1.Cluster] {
 		t.Helper()
 
@@ -1102,7 +1152,7 @@ func TestPrepareClusterValidationInput(t *testing.T) {
 	}
 }
 
-func TestBuildPostgrestClusterPatchValidationNew(t *testing.T) {
+func testBuildPostgrestClusterPatchValidationNew(t *testing.T) {
 	tests := []struct {
 		name    string
 		body    string
@@ -1148,7 +1198,7 @@ func TestBuildPostgrestClusterPatchValidationNew(t *testing.T) {
 	}
 }
 
-func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
+func testValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("rejects disable patch before proxy handler when vGPU endpoint references cluster", func(t *testing.T) {
@@ -1279,7 +1329,13 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 	})
 }
 
-func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
+func TestValidateClusterConfiguration(t *testing.T) {
+	t.Run("middleware", testValidateClusterConfigurationUpdateMiddleware)
+	t.Run("parse PATCH update", testParseClusterPatchConfigurationUpdate)
+	t.Run("initialized update", testValidateInitializedClusterConfigurationUpdate)
+}
+
+func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("skips configuration validation for non-PATCH requests", func(t *testing.T) {
@@ -1763,7 +1819,12 @@ func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 	})
 }
 
-func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
+func TestValidateClusterVersion(t *testing.T) {
+	t.Run("middleware", testValidateClusterVersionUpdateMiddleware)
+	t.Run("not downgrade", testValidateClusterVersionNotDowngrade)
+}
+
+func testValidateClusterVersionUpdateMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	t.Run("skips version validation for a configuration-only patch", func(t *testing.T) {
@@ -1954,47 +2015,6 @@ func TestValidateClusterVersionUpdateMiddleware(t *testing.T) {
 	})
 }
 
-func TestRegisterClusterRoutesSoftDeleteBypassesMalformedGuardedConfig(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	mockStorage := storageMocks.NewMockStorage(t)
-	mockStorage.On("Count", storage.ENDPOINT_TABLE, clusterEndpointReferenceFilters("default", "cluster")).Return(0, nil).Once()
-
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPatch, r.Method)
-		assert.Equal(t, "/clusters", r.URL.Path)
-
-		body, err := io.ReadAll(r.Body)
-		assert.NoError(t, err)
-		assert.JSONEq(t, `{
-			"metadata": {"workspace": "default", "name": "cluster", "deletion_timestamp": "2026-08-07T00:00:00Z"},
-			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
-		}`, string(body))
-
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer upstream.Close()
-
-	router := gin.New()
-	RegisterClusterRoutes(router.Group("/api/v1"), nil, &Dependencies{
-		Storage:          mockStorage,
-		StorageAccessURL: upstream.URL,
-	})
-
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/clusters?id=eq.1", strings.NewReader(`{
-		"metadata": {"workspace": "default", "name": "cluster", "deletion_timestamp": "2026-08-07T00:00:00Z"},
-		"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
-	}`))
-	req.Header.Set("Content-Type", "application/json")
-	recorder := newCloseNotifyRecorder()
-
-	router.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusNoContent, recorder.ResponseRecorder.Code)
-	mockStorage.AssertExpectations(t)
-	mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
-}
-
 func testEncodedKubeconfig(server, token string) string {
 	content := fmt.Sprintf(`apiVersion: v1
 kind: Config
@@ -2017,7 +2037,7 @@ users:
 	return base64.StdEncoding.EncodeToString([]byte(content))
 }
 
-func TestParseClusterPatchConfigurationUpdate(t *testing.T) {
+func testParseClusterPatchConfigurationUpdate(t *testing.T) {
 	t.Run("tracks supported configuration fields", func(t *testing.T) {
 		update, err := parseClusterPatchConfigurationUpdate([]byte(`{
 			"spec": {
@@ -2111,7 +2131,7 @@ func TestParseClusterPatchConfigurationUpdate(t *testing.T) {
 	}
 }
 
-func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
+func testValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 	initializedKubernetesCluster := func(kubeconfig string) *v1.Cluster {
 		return &v1.Cluster{
 			Spec: &v1.ClusterSpec{
@@ -2309,7 +2329,7 @@ func (r *trackingReadCloser) Close() error {
 	return nil
 }
 
-func TestValidateClusterVersionNotDowngrade(t *testing.T) {
+func testValidateClusterVersionNotDowngrade(t *testing.T) {
 	tests := []struct {
 		name            string
 		current         *v1.Cluster

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -244,6 +244,48 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 	})
 
+	t.Run("rejects a spec replacement that disables accelerator virtualization with vGPU endpoints", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec: &v1.ClusterSpec{
+				Type:    v1.KubernetesClusterType,
+				Version: "v1.0.0",
+				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{
+					Enabled: true,
+				},
+			},
+		}}, nil).Once()
+		mockStorage.On("ListEndpoint", storage.ListOption{
+			Filters: clusterEndpointReferenceFilters("default", "gpu-cluster"),
+		}).Return([]v1.Endpoint{{
+			Spec: &v1.EndpointSpec{Resources: &v1.ResourceSpec{Accelerator: map[string]string{
+				v1.AcceleratorVirtualizationMemoryMiBKey: "8192",
+			}}},
+		}}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+				"spec": {"version": "v1.1.0"}
+			}`)))
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10211"`)
+		assert.Contains(t, recorder.Body.String(), "vGPU endpoint(s) still reference this cluster")
+		mockStorage.AssertExpectations(t)
+	})
+
 	t.Run("resolves the current cluster once for all normal PATCH validators", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
@@ -550,6 +592,28 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
+	t.Run("uses the generic identity error for an accelerator virtualization enable PATCH", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"spec": {"accelerator_virtualization": {"enabled": true}}
+		}`)))
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required when patching a cluster")
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
 	t.Run("preserves the accelerator virtualization resolution error when the current cluster lookup fails", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
@@ -612,7 +676,9 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 			return sameFilters(opt.Filters, queryParamsToFilters(query))
 		})).Return([]v1.Cluster{{
 			Metadata: &v1.Metadata{Workspace: "default", Name: "cluster"},
-			Spec:     &v1.ClusterSpec{},
+			Spec: &v1.ClusterSpec{AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{
+				Enabled: true,
+			}},
 		}}, nil).Once()
 		mockStorage.On(
 			"ListEndpoint",
@@ -1062,12 +1128,13 @@ func TestPrepareClusterValidationInput(t *testing.T) {
 		return input
 	}
 
-	t.Run("creates a separate New cluster and preserves an empty kubeconfig", func(t *testing.T) {
+	t.Run("creates a separate New cluster from a whole spec replacement and preserves an empty kubeconfig", func(t *testing.T) {
 		current := v1.Cluster{
 			Metadata: &v1.Metadata{Workspace: "default", Name: "kubernetes"},
 			Spec: &v1.ClusterSpec{
-				Type:    v1.KubernetesClusterType,
-				Version: "v1.0.0",
+				Type:          v1.KubernetesClusterType,
+				ImageRegistry: "current-registry",
+				Version:       "v1.0.0",
 				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
 					Kubeconfig: "current-kubeconfig",
 				}},
@@ -1085,6 +1152,8 @@ func TestPrepareClusterValidationInput(t *testing.T) {
 		assert.NotSame(t, input.Current, input.New)
 		assert.Equal(t, "v1.0.0", input.Current.Spec.Version)
 		assert.Equal(t, "current-kubeconfig", input.Current.Spec.Config.KubernetesConfig.Kubeconfig)
+		assert.Empty(t, input.New.Spec.Type)
+		assert.Empty(t, input.New.Spec.ImageRegistry)
 		assert.Equal(t, "v1.1.0", input.New.Spec.Version)
 		assert.Equal(t, "current-kubeconfig", input.New.Spec.Config.KubernetesConfig.Kubeconfig)
 	})
@@ -1116,7 +1185,7 @@ func TestPrepareClusterValidationInput(t *testing.T) {
 		})
 	}
 
-	t.Run("retains an explicit config null in New for configuration validation", func(t *testing.T) {
+	t.Run("retains an explicit config null in the raw update for configuration validation", func(t *testing.T) {
 		current := v1.Cluster{
 			Metadata: &v1.Metadata{Workspace: "default", Name: "kubernetes"},
 			Spec: &v1.ClusterSpec{
@@ -1126,14 +1195,13 @@ func TestPrepareClusterValidationInput(t *testing.T) {
 		}
 		input := prepare(t, current, `{"spec": {"config": null}}`)
 
-		assert.Nil(t, input.New.Spec.Config)
 		update, err := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
 		assert.NoError(t, err)
 		assert.True(t, update.configCleared)
 	})
 }
 
-func TestMergeClusterPatchForValidation(t *testing.T) {
+func TestBuildPostgrestClusterPatchValidationNew(t *testing.T) {
 	current := &v1.Cluster{
 		Spec: &v1.ClusterSpec{
 			Type:          v1.KubernetesClusterType,
@@ -1142,12 +1210,17 @@ func TestMergeClusterPatchForValidation(t *testing.T) {
 		},
 	}
 
-	next, err := mergeClusterPatchForValidation(current, nil)
+	next, err := buildPostgrestClusterPatchValidationNew(current, []byte(`{
+		"spec": {"version": "v1.1.0"}
+	}`))
 	assert.NoError(t, err)
 	assert.NotSame(t, current, next)
-	assert.Equal(t, current, next)
+	assert.Equal(t, "v1.0.0", current.Spec.Version)
+	assert.Equal(t, "v1.1.0", next.Spec.Version)
+	assert.Empty(t, next.Spec.Type)
+	assert.Empty(t, next.Spec.ImageRegistry)
 
-	_, err = mergeClusterPatchForValidation(current, []byte(`[`))
+	_, err = buildPostgrestClusterPatchValidationNew(current, []byte(`[`))
 	assert.Error(t, err)
 }
 
@@ -1158,7 +1231,9 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		mockStorage.On("ListCluster", mock.Anything).Return([]v1.Cluster{{
 			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
-			Spec:     &v1.ClusterSpec{},
+			Spec: &v1.ClusterSpec{AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{
+				Enabled: true,
+			}},
 		}}, nil).Once()
 		mockStorage.On("ListEndpoint", storage.ListOption{
 			Filters: clusterEndpointReferenceFilters("default", "gpu-cluster"),
@@ -1189,6 +1264,45 @@ func TestValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
 		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10211"`)
+		assert.Contains(t, recorder.Body.String(), "vGPU endpoint(s) still reference this cluster")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("rejects a spec replacement that disables accelerator virtualization with vGPU endpoints", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListCluster", mock.Anything).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec: &v1.ClusterSpec{
+				Type:    v1.KubernetesClusterType,
+				Version: "v1.0.0",
+				AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{
+					Enabled: true,
+				},
+			},
+		}}, nil).Once()
+		mockStorage.On("ListEndpoint", storage.ListOption{
+			Filters: clusterEndpointReferenceFilters("default", "gpu-cluster"),
+		}).Return([]v1.Endpoint{{
+			Spec: &v1.EndpointSpec{Resources: &v1.ResourceSpec{Accelerator: map[string]string{
+				v1.AcceleratorVirtualizationMemoryMiBKey: "8192",
+			}}},
+		}}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterAcceleratorVirtualization(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"version": "v1.1.0"}
+		}`)))
 
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -2449,52 +2563,6 @@ func TestValidateClusterVersionNotDowngrade(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErrContains)
 		})
 	}
-}
-
-func TestClusterAcceleratorVirtualizationDisableRequested(t *testing.T) {
-	t.Run("true when payload explicitly sets enabled false", func(t *testing.T) {
-		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
-			"spec": {
-				"accelerator_virtualization": {"enabled": false}
-			}
-		}`))
-
-		assert.NoError(t, err)
-		assert.True(t, requested)
-	})
-
-	t.Run("true when enabled is omitted from accelerator virtualization patch", func(t *testing.T) {
-		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
-			"spec": {
-				"accelerator_virtualization": {"config_patch": {"devicePlugin": {}}}
-			}
-		}`))
-
-		assert.NoError(t, err)
-		assert.True(t, requested)
-	})
-
-	t.Run("true when accelerator virtualization patch is empty after omitempty marshal", func(t *testing.T) {
-		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
-			"spec": {
-				"accelerator_virtualization": {}
-			}
-		}`))
-
-		assert.NoError(t, err)
-		assert.True(t, requested)
-	})
-
-	t.Run("true when accelerator virtualization patch is null", func(t *testing.T) {
-		requested, err := clusterAcceleratorVirtualizationDisableRequested([]byte(`{
-			"spec": {
-				"accelerator_virtualization": null
-			}
-		}`))
-
-		assert.NoError(t, err)
-		assert.True(t, requested)
-	})
 }
 
 func sameFilters(actual, expected []storage.Filter) bool {

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -598,6 +598,43 @@ func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 	})
 
+	t.Run("allows empty kubeconfig for an initialized Kubernetes cluster", func(t *testing.T) {
+		for _, kubeconfig := range []string{`""`, "null"} {
+			t.Run(kubeconfig, func(t *testing.T) {
+				mockStorage := storageMocks.NewMockStorage(t)
+				query := url.Values{"id": []string{"eq.1"}}
+				mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+					return sameFilters(opt.Filters, queryParamsToFilters(query))
+				})).Return([]v1.Cluster{{
+					Spec: &v1.ClusterSpec{
+						Type: v1.KubernetesClusterType,
+						Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+							Kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "old-token"),
+						}},
+					},
+					Status: &v1.ClusterStatus{Initialized: true},
+				}}, nil).Once()
+
+				proxyCalled := false
+				router := gin.New()
+				router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+					proxyCalled = true
+					c.Status(http.StatusNoContent)
+				})
+
+				body := fmt.Sprintf(`{"spec":{"config":{"kubernetes_config":{"kubeconfig":%s}}}}`, kubeconfig)
+				req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
+				recorder := httptest.NewRecorder()
+
+				router.ServeHTTP(recorder, req)
+
+				assert.True(t, proxyCalled)
+				assert.Equal(t, http.StatusNoContent, recorder.Code)
+				mockStorage.AssertExpectations(t)
+			})
+		}
+	})
+
 	t.Run("rejects kubeconfig rotation for a different Kubernetes API server", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
@@ -670,6 +707,42 @@ func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 	})
 
+	t.Run("rejects clearing Kubernetes config on an initialized cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				Type: v1.KubernetesClusterType,
+				Config: &v1.ClusterConfig{KubernetesConfig: &v1.KubernetesClusterConfig{
+					Kubeconfig: testEncodedKubeconfig("https://api.example.test:6443", "old-token"),
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"config": {"kubernetes_config": null}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "kubernetes_config cannot be cleared")
+		mockStorage.AssertExpectations(t)
+	})
+
 	t.Run("allows SSH private key rotation for an initialized cluster", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
@@ -704,35 +777,36 @@ func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 	})
 
-	t.Run("rejects empty SSH private key for an initialized cluster", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		query := url.Values{"id": []string{"eq.1"}}
-		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
-			return sameFilters(opt.Filters, queryParamsToFilters(query))
-		})).Return([]v1.Cluster{{
-			Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
-			Status: &v1.ClusterStatus{Initialized: true},
-		}}, nil)
+	t.Run("allows empty SSH private key for an initialized cluster", func(t *testing.T) {
+		for _, sshPrivateKey := range []string{`""`, "null"} {
+			t.Run(sshPrivateKey, func(t *testing.T) {
+				mockStorage := storageMocks.NewMockStorage(t)
+				query := url.Values{"id": []string{"eq.1"}}
+				mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+					return sameFilters(opt.Filters, queryParamsToFilters(query))
+				})).Return([]v1.Cluster{{
+					Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
+					Status: &v1.ClusterStatus{Initialized: true},
+				}}, nil).Once()
 
-		proxyCalled := false
-		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
-			proxyCalled = true
-			c.Status(http.StatusNoContent)
-		})
+				proxyCalled := false
+				router := gin.New()
+				router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+					proxyCalled = true
+					c.Status(http.StatusNoContent)
+				})
 
-		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"config": {"ssh_config": {"auth": {"ssh_private_key": " "}}}}
-		}`))
-		recorder := httptest.NewRecorder()
+				body := fmt.Sprintf(`{"spec":{"config":{"ssh_config":{"auth":{"ssh_private_key":%s}}}}}`, sshPrivateKey)
+				req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
+				recorder := httptest.NewRecorder()
 
-		router.ServeHTTP(recorder, req)
+				router.ServeHTTP(recorder, req)
 
-		assert.False(t, proxyCalled)
-		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
-		assert.Contains(t, recorder.Body.String(), "SSH private key cannot be empty")
-		mockStorage.AssertExpectations(t)
+				assert.True(t, proxyCalled)
+				assert.Equal(t, http.StatusNoContent, recorder.Code)
+				mockStorage.AssertExpectations(t)
+			})
+		}
 	})
 
 	t.Run("rejects malformed SSH private key for an initialized cluster", func(t *testing.T) {
@@ -799,6 +873,42 @@ func TestValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
 		assert.Contains(t, recorder.Body.String(), "SSH auth cannot be cleared")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("rejects clearing SSH config on an initialized cluster", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Spec: &v1.ClusterSpec{
+				Type: v1.SSHClusterType,
+				Config: &v1.ClusterConfig{SSHConfig: &v1.RaySSHProvisionClusterConfig{
+					Auth: v1.Auth{SSHPrivateKey: "old-private-key"},
+				}},
+			},
+			Status: &v1.ClusterStatus{Initialized: true},
+		}}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"config": {"ssh_config": null}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "ssh_config cannot be cleared")
 		mockStorage.AssertExpectations(t)
 	})
 
@@ -1269,10 +1379,10 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 			hint       string
 		}{
 			{
-				name:       "empty updated kubeconfig",
+				name:       "blank updated kubeconfig",
 				current:    initializedKubernetesCluster(validCurrent),
 				kubeconfig: " ",
-				hint:       "kubeconfig cannot be empty",
+				hint:       "failed to parse updated kubeconfig",
 			},
 			{
 				name:       "missing current Kubernetes config",
@@ -1318,6 +1428,15 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("allows empty Kubernetes credential backfill", func(t *testing.T) {
+		err := validateInitializedClusterConfigurationUpdate(
+			initializedKubernetesCluster(testEncodedKubeconfig("https://api.example.test:6443", "old-token")),
+			clusterPatchConfigurationUpdate{kubeconfigSet: true},
+		)
+
+		assert.NoError(t, err)
+	})
+
 	t.Run("validates SSH private-key rotations", func(t *testing.T) {
 		cluster := &v1.Cluster{
 			Spec:   &v1.ClusterSpec{Type: v1.SSHClusterType},
@@ -1329,7 +1448,7 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 			key  string
 			hint string
 		}{
-			{name: "empty private key", key: " ", hint: "SSH private key cannot be empty"},
+			{name: "blank private key", key: " ", hint: "SSH private key must be base64 encoded"},
 			{name: "invalid base64", key: "not-base64", hint: "SSH private key must be base64 encoded"},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
@@ -1344,6 +1463,11 @@ func TestValidateInitializedClusterConfigurationUpdate(t *testing.T) {
 
 		err := validateInitializedClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
 			sshPrivateKey:    base64.StdEncoding.EncodeToString([]byte("rotated-private-key")),
+			sshPrivateKeySet: true,
+		})
+		assert.NoError(t, err)
+
+		err = validateInitializedClusterConfigurationUpdate(cluster, clusterPatchConfigurationUpdate{
 			sshPrivateKeySet: true,
 		})
 		assert.NoError(t, err)

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -99,6 +99,67 @@ func TestValidateClusterDeletion(t *testing.T) {
 func TestValidateClusterRequestMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
+	t.Run("passes through non-mutating requests", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.GET("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/clusters", nil))
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
+	t.Run("allows an empty create body", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.POST("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/clusters", nil))
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
+	t.Run("rejects JSON that cannot be decoded as a cluster object", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`[]`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "invalid cluster payload")
+		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
 	t.Run("dispatches POST to accelerator virtualization validation", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
@@ -121,6 +182,29 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10208"`)
+		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
+	t.Run("allows soft delete without a complete identity", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"metadata": {"deletion_timestamp": "2026-08-10T00:00:00Z"}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.True(t, proxyCalled)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
 		mockStorage.AssertNotCalled(t, "Count", mock.Anything)
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
@@ -203,6 +287,216 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
+	})
+
+	t.Run("writes deletion dependency validation errors", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On(
+			"Count",
+			storage.ENDPOINT_TABLE,
+			clusterEndpointReferenceFilters("default", "cluster"),
+		).Return(1, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"metadata": {
+				"workspace": "default",
+				"name": "cluster",
+				"deletion_timestamp": "2026-08-10T00:00:00Z"
+			}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Equal(t, "Neutree", recorder.Header().Get("X-Powered-By"))
+		assert.Contains(t, recorder.Body.String(), `"code":"10126"`)
+		mockStorage.AssertExpectations(t)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("writes deletion storage errors", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On(
+			"Count",
+			storage.ENDPOINT_TABLE,
+			clusterEndpointReferenceFilters("default", "cluster"),
+		).Return(0, errors.New("count endpoints failed")).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"metadata": {
+				"workspace": "default",
+				"name": "cluster",
+				"deletion_timestamp": "2026-08-10T00:00:00Z"
+			}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"500"`)
+		assert.Contains(t, recorder.Body.String(), "Failed to validate deletion")
+		mockStorage.AssertExpectations(t)
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("reports a fixed version resolution error when PATCH has no identity", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"spec": {"version": "v1.2.0"}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10212"`)
+		assert.Contains(t, recorder.Body.String(), "failed to validate cluster version update")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required")
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("reports a fixed version resolution error when the current cluster lookup fails", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return(nil, errors.New("read cluster failed")).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"version": "v1.2.0"}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10212"`)
+		assert.Contains(t, recorder.Body.String(), "read cluster failed")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("reports a fixed configuration resolution error when PATCH has no identity", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(`{
+			"spec": {"image_registry": "replacement-registry"}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "failed to validate cluster configuration update")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required")
+		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+	})
+
+	t.Run("reports a fixed configuration resolution error when the target is ambiguous", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"image_registry": "replacement-registry"}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "expected exactly one cluster")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("dispatches accelerator virtualization disable checks after PATCH validators", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "cluster"},
+		}}, nil).Once()
+		mockStorage.On(
+			"ListEndpoint",
+			storage.ListOption{Filters: clusterEndpointReferenceFilters("default", "cluster")},
+		).Return([]v1.Endpoint{{
+			Spec: &v1.EndpointSpec{Resources: &v1.ResourceSpec{Accelerator: map[string]string{
+				v1.AcceleratorVirtualizationMemoryMiBKey: "8192",
+			}}},
+		}}, nil).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
+			"spec": {"accelerator_virtualization": {}}
+		}`))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"10211"`)
+		assert.Contains(t, recorder.Body.String(), "cannot disable accelerator virtualization")
+		mockStorage.AssertExpectations(t)
 	})
 
 	t.Run("rejects malformed PATCH before any validator lookup", func(t *testing.T) {

--- a/internal/routes/proxies/resource_proxy_test.go
+++ b/internal/routes/proxies/resource_proxy_test.go
@@ -568,6 +568,42 @@ func TestCreateStructProxyHandlerFiltersUnknownTopLevelFieldsAndInfersColumns(t 
 	assert.Equal(t, http.StatusOK, recorder.ResponseRecorder.Code)
 }
 
+func TestCreateStructProxyHandlerMasksClusterCredentials(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/clusters", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{
+				"metadata": {"name": "cluster", "workspace": "default"},
+				"spec": {
+					"config": {
+						"kubernetes_config": {"kubeconfig": "synthetic-kubeconfig"},
+						"ssh_config": {"auth": {"ssh_private_key": "synthetic-private-key"}}
+					}
+				}
+			}
+		]`))
+	}))
+	defer upstream.Close()
+
+	router := gin.New()
+	router.GET("/api/v1/clusters", CreateStructProxyHandler[v1.Cluster](&Dependencies{
+		StorageAccessURL: upstream.URL,
+	}, storage.CLUSTERS_TABLE))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/clusters?select=*", nil)
+	recorder := newCloseNotifyRecorder()
+	router.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusOK, recorder.ResponseRecorder.Code)
+	assert.NotContains(t, recorder.Body.String(), "synthetic-kubeconfig")
+	assert.NotContains(t, recorder.Body.String(), "synthetic-private-key")
+}
+
 func TestCreateStructProxyHandlerFiltersSoftDeletePayloadAndInfersColumns(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/routes/proxies/resource_proxy_test.go
+++ b/internal/routes/proxies/resource_proxy_test.go
@@ -824,24 +824,34 @@ func Test_mergeExcludedFields(t *testing.T) {
 		assert.Equal(t, "updated", target["spec"].(map[string]interface{})["type"])
 	})
 
-	t.Run("handle empty string as missing", func(t *testing.T) {
-		target := map[string]interface{}{
-			"spec": map[string]interface{}{
-				"credentials": "",
-			},
-		}
-		source := map[string]interface{}{
-			"spec": map[string]interface{}{
-				"credentials": "should_be_merged",
-			},
-		}
-		excludeFields := map[string]struct{}{
-			"spec.credentials": {},
-		}
+	t.Run("handle empty values as missing", func(t *testing.T) {
+		for _, tt := range []struct {
+			name       string
+			credential interface{}
+		}{
+			{name: "empty string", credential: ""},
+			{name: "nil", credential: nil},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				target := map[string]interface{}{
+					"spec": map[string]interface{}{
+						"credentials": tt.credential,
+					},
+				}
+				source := map[string]interface{}{
+					"spec": map[string]interface{}{
+						"credentials": "should_be_merged",
+					},
+				}
+				excludeFields := map[string]struct{}{
+					"spec.credentials": {},
+				}
 
-		mergeExcludedFields(target, source, excludeFields, nil)
+				mergeExcludedFields(target, source, excludeFields, nil)
 
-		assert.Equal(t, "should_be_merged", target["spec"].(map[string]interface{})["credentials"])
+				assert.Equal(t, "should_be_merged", target["spec"].(map[string]interface{})["credentials"])
+			})
+		}
 	})
 
 	t.Run("merge excluded field inside array elements", func(t *testing.T) {


### PR DESCRIPTION
## Issue

NEU-388

## Summary

Allow initialized Kubernetes and SSH Clusters to rotate masked credentials safely while keeping image-registry, Kubernetes API-server, version, soft-delete, and accelerator-virtualization validation on the unified Cluster POST/PATCH entry.

## Changes

- Build one validation-only `Current` / `New` object pair for each normal Cluster PATCH by resolving the target once and simulating the PostgREST row replacement shape used by the proxy.
- Preserve stored kubeconfig and SSH private-key values in validation-only `New` when the PATCH credential field is empty, `null`, or omitted; the forwarded PATCH body remains owned by the resource proxy.
- Dispatch unified Cluster validation in version, configuration, and accelerator-virtualization order while soft delete performs dependency validation only.
- Preserve fixed error contracts for version/configuration/vGPU failures and PATCH identity-resolution failures after middleware unification.
- Keep initialized Cluster safeguards: reject image-registry switches, cross-server kubeconfig changes, malformed non-empty SSH private keys, version downgrades, and vGPU-disabling spec replacements while referenced endpoints still exist.

## Test Plan

### Unit test

- `go test ./internal/routes/proxies ./internal/cluster -count=1`
- `go vet ./internal/routes/proxies ./internal/cluster`
- `git diff --check`
- PR CI for `b5b9a16d6de9152bfa1465118b97faf526a6cbec` passed: `pr-check`, `gateway-lua-test`, `codecov/patch`.

### DB test

- No DB migration, schema, or storage implementation changed.
- The mock API E2E runners asserted direct PostgreSQL persistence/no-op behavior for credential preservation, rejected updates, version state, vGPU state, soft-delete timestamps, and fixture cleanup.

### E2E test

- Hot-updated API/Core on `192.168.20.158` to git `b5b9a16d`; the control plane uses `registry.smtx.io/neutree-ai` images. Core was stopped only while isolated mock fixtures existed, then restored after every runner; final API health was `200`.
- `/var/tmp/neu388-e2e-1786420887/results.log`: `40 passed / 0 failed`.
  Covered credential rotation/preservation for empty, `null`, and omitted values; registry mutability; cross-server kubeconfig rejection; structural-clear rejection; and Base64 validation.
- `/var/tmp/neu388-current-e2e-1786421345/results.log`: `30 passed / 0 failed`.
  Covered GET credential masking, version downgrade rejection, PostgREST whole-`spec` vGPU disable detection, vGPU dependency handling, soft-delete dependencies and storage integrity, POST accelerator admission, malformed payload handling, and PATCH identity error routing.
- Total: `70 passed / 0 failed`; final audit confirmed API/Core are both `b5b9a16d`, stable with restart count `0`, and no test Endpoint/Cluster/ImageRegistry fixtures remain.
- Manual testing is not required.

## Risk & Rollback

No DB schema, controller reconcile loop, or UI workflow changed. Revert `b5b9a16d` (or the NEU-388 commit series) to restore the pre-unification Cluster validation path.
