### PR TITLE
fix: keep Kubernetes collectors without remote write

### DIFF
--- a/internal/cluster/component/metrics/manifests.go
+++ b/internal/cluster/component/metrics/manifests.go
@@ -17,6 +17,7 @@ const (
 )
 
 var metricsManifestTemplate = `
+{{ if .EnableVMAgent }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -103,6 +104,7 @@ roleRef:
   kind: ClusterRole
   name: vmagent-node-reader-{{ .HashSuffix }}
   apiGroup: rbac.authorization.k8s.io
+{{ end }}
 {{ if .EnableKubeStateMetrics }}
 ---
 apiVersion: v1
@@ -465,6 +467,7 @@ spec:
 {{ .Volumes | toYaml | indent 6 }}
 {{ end }}
 {{ end }}
+{{ if .EnableVMAgent }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -527,6 +530,7 @@ spec:
       - name: vmagent-config
         configMap:
           name: vmagent-config
+{{ end }}
 `
 
 // MetricsManifestVariables holds the variables for rendering metrics manifests
@@ -559,6 +563,7 @@ type MetricsManifestVariables struct {
 	EnableNodeExporter               bool
 	EnableExternalDCGMScrape         bool
 	AcceleratorExporters             []metricsAcceleratorExporter
+	EnableVMAgent                    bool
 	VMAgentConfig                    string
 }
 

--- a/internal/cluster/component/metrics/metrics_apply.go
+++ b/internal/cluster/component/metrics/metrics_apply.go
@@ -15,6 +15,7 @@ import (
 // GetMetricsResources returns all Kubernetes resources for the metrics component.
 func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructured.UnstructuredList, error) {
 	variables := m.buildManifestVariables()
+	variables.EnableVMAgent = util.IsHTTPOrHTTPSURL(m.metricsRemoteWriteURL)
 
 	enableKubeStateMetrics, err := m.supportsKubeStateMetrics()
 	if err != nil {
@@ -46,12 +47,18 @@ func (m *MetricsComponent) GetMetricsResources(ctx context.Context) (*unstructur
 
 	variables.NeutreeNodeAgentMetricsEnv = nodeAgentEnvFromAcceleratorExporters(acceleratorExporters)
 
-	vmagentConfig, err := renderKubernetesVMAgentConfig(variables)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to render vmagent config for cluster %s", m.cluster.Metadata.Name)
+	if variables.EnableVMAgent {
+		vmagentConfig, err := renderKubernetesVMAgentConfig(variables)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to render vmagent config for cluster %s", m.cluster.Metadata.Name)
+		}
+
+		variables.VMAgentConfig = vmagentConfig
 	}
 
-	variables.VMAgentConfig = vmagentConfig
+	if !variables.EnableVMAgent && !variables.EnableKubeStateMetrics && !variables.EnableNodeExporter && len(variables.AcceleratorExporters) == 0 {
+		return &unstructured.UnstructuredList{}, nil
+	}
 
 	objs, err := util.RenderKubernetesManifest(metricsManifestTemplate, variables)
 	if err != nil {

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -95,9 +95,10 @@ func TestBuildVMAgentDeployment(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -127,15 +128,62 @@ func TestBuildVMAgentDeployment(t *testing.T) {
 	t.Fatalf("vmagent deployment not found in resources")
 }
 
+func TestBuildMetricsResourcesWithoutValidRemoteWriteOmitsVMAgentAndKeepsLocalCollectors(t *testing.T) {
+	for _, remoteWriteURL := range []string{"", "invalid-url"} {
+		t.Run("remote write URL="+remoteWriteURL, func(t *testing.T) {
+			metricsCmpt := &MetricsComponent{
+				cluster: &v1.Cluster{
+					Metadata: &v1.Metadata{Name: "test-cluster", Workspace: "test-workspace"},
+					Spec:     &v1.ClusterSpec{Version: "v1.1.0"},
+				},
+				namespace:             "test-namespace",
+				imagePrefix:           "test-image-prefix",
+				imagePullSecret:       "test-image-pull-secret",
+				metricsRemoteWriteURL: remoteWriteURL,
+			}
+
+			objs, err := metricsCmpt.GetMetricsResources(context.Background())
+			assert.NilError(t, err)
+
+			for _, obj := range objs.Items {
+				assert.Assert(t, obj.GetLabels()["app"] != "vmagent", "unexpected vmagent resource %s/%s", obj.GetKind(), obj.GetName())
+			}
+
+			findMetricsDaemonSet(t, objs, "neutree-node-exporter")
+			findMetricsDaemonSet(t, objs, "neutree-node-agent")
+			findMetricsDeployment(t, objs, "neutree-kube-state-metrics")
+		})
+	}
+}
+
+func TestBuildMetricsResourcesWithoutRequiredCollectorsReturnsEmptyList(t *testing.T) {
+	for _, remoteWriteURL := range []string{"", "invalid-url"} {
+		t.Run("remote write URL="+remoteWriteURL, func(t *testing.T) {
+			metricsCmpt := &MetricsComponent{
+				cluster: &v1.Cluster{
+					Metadata: &v1.Metadata{Name: "test-cluster", Workspace: "test-workspace"},
+					Spec:     &v1.ClusterSpec{Version: "v1.0.0"},
+				},
+				metricsRemoteWriteURL: remoteWriteURL,
+			}
+
+			objs, err := metricsCmpt.GetMetricsResources(context.Background())
+			assert.NilError(t, err)
+			assert.Equal(t, 0, len(objs.Items))
+		})
+	}
+}
+
 func TestBuildMetricsResourcesWithNumericClusterMetadata(t *testing.T) {
 	metricsCmpt := &MetricsComponent{
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{Name: "123", Workspace: "456"},
 			Spec:     &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -168,9 +216,10 @@ func TestBuildVMAgentConfigIncludesHAMiMonitorScrape(t *testing.T) {
 				},
 			},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -205,9 +254,10 @@ func TestBuildVMAgentConfigNormalizesSGLangMetricNames(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -252,9 +302,10 @@ func TestBuildMetricsResourcesSkipsKubeStateMetricsBeforeV110(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.0.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -285,9 +336,10 @@ func TestBuildVMAgentConfigSkipsHAMiMonitorScrapeWhenAcceleratorVirtualizationDi
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -320,9 +372,10 @@ func TestBuildVMAgentConfigIncludesHAMiMonitorScrapeBeforeV110WhenAcceleratorVir
 				},
 			},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -452,10 +505,11 @@ func TestBuildMetricsResourcesRewritesImagesByRegistry(t *testing.T) {
 					},
 					Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 				},
-				namespace:       "test-namespace",
-				imagePrefix:     tt.imagePrefix,
-				imagePullSecret: "test-image-pull-secret",
-				acceleratorMgr:  accelerator.NewManager(gin.New()),
+				namespace:             "test-namespace",
+				imagePrefix:           tt.imagePrefix,
+				imagePullSecret:       "test-image-pull-secret",
+				metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+				acceleratorMgr:        accelerator.NewManager(gin.New()),
 				ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
 					"nvidia.com/gpu.present": "true",
 				})).Build(),
@@ -493,9 +547,10 @@ func TestBuildMetricsResourcesIncludesNodeExporterDaemonSet(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -536,9 +591,10 @@ func TestBuildMetricsResourcesIncludesNodeAgentDaemonSet(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v9.9.9"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())
@@ -590,10 +646,11 @@ func TestBuildMetricsResourcesDoesNotSupportManagedExportersBeforeV110(t *testin
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.0.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  accelerator.NewManager(gin.New()),
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
 			"nvidia.com/gpu.present": "true",
 		})).Build(),
@@ -637,10 +694,11 @@ func TestBuildMetricsResourcesUsesExternalDCGMScrapeWhenConfigured(t *testing.T)
 				},
 			},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  accelerator.NewManager(gin.New()),
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
 			"nvidia.com/gpu.present": "true",
 		})).Build(),
@@ -866,10 +924,11 @@ func TestBuildMetricsResourcesIncludesAcceleratorExporterFromPluginProfile(t *te
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  accelerator.NewManager(gin.New()),
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("gpu-node", map[string]string{
 			"nvidia.com/gpu.present": "true",
 		})).Build(),
@@ -1093,10 +1152,11 @@ func TestBuildMetricsResourcesDoesNotParseDockerRunOptions(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
-		acceleratorMgr:  acceleratorMgr,
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+		acceleratorMgr:        acceleratorMgr,
 		ctrlClient: fake.NewClientBuilder().WithObjects(metricsTestNode("custom-node", map[string]string{
 			"accelerator.example.com/custom": "true",
 		})).Build(),
@@ -1337,9 +1397,10 @@ func TestBuildVMAgentConfigIncludesKubeStateMetricsScrape(t *testing.T) {
 			},
 			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
 		},
-		namespace:       "test-namespace",
-		imagePrefix:     "test-image-prefix",
-		imagePullSecret: "test-image-pull-secret",
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 	}
 
 	objs, err := metricsCmpt.GetMetricsResources(context.Background())

--- a/internal/cluster/component/metrics/metrics_status.go
+++ b/internal/cluster/component/metrics/metrics_status.go
@@ -15,6 +15,7 @@ import (
 
 // MetricsStatus represents the status of metrics component resources
 type MetricsStatus struct {
+	VMAgentRequired                       bool
 	DeploymentReady                       bool
 	NodeExporterRequired                  bool
 	NodeExporterDaemonSetReady            bool
@@ -40,13 +41,13 @@ type MetricsStatus struct {
 
 func (m MetricsStatus) String() string {
 	base := fmt.Sprintf(
-		"DeploymentReady: %v, PodsReady: %d/%d, NodeExporterDaemonSetReady: %v, "+
+		"VMAgentRequired: %v, DeploymentReady: %v, PodsReady: %d/%d, NodeExporterDaemonSetReady: %v, "+
 			"NodeExporterRequired: %v, NodeExporterPodsReady: %d/%d, NeutreeNodeAgentMetricsRequired: %v, "+
 			"NeutreeNodeAgentMetricsDaemonSetReady: %v, NeutreeNodeAgentMetricsPodsReady: %d/%d, KubeStateMetricsRequired: %v, "+
 			"KubeStateMetricsDeploymentReady: %v, KubeStateMetricsPodsReady: %d/%d, "+
 			"AcceleratorExporterRequired: %v, AcceleratorExporterDaemonSetsReady: %v, "+
 			"AcceleratorExporterPodsReady: %d/%d, Errors: %v",
-		m.DeploymentReady, m.PodsReady, m.TotalPods,
+		m.VMAgentRequired, m.DeploymentReady, m.PodsReady, m.TotalPods,
 		m.NodeExporterDaemonSetReady, m.NodeExporterRequired, m.NodeExporterPodsReady, m.NodeExporterTotalPods,
 		m.NeutreeNodeAgentMetricsRequired, m.NeutreeNodeAgentMetricsDaemonSetReady,
 		m.NeutreeNodeAgentMetricsPodsReady, m.NeutreeNodeAgentMetricsTotalPods,
@@ -64,7 +65,7 @@ func (m MetricsStatus) Ready() bool {
 		return false
 	}
 
-	return m.DeploymentReady &&
+	return (!m.VMAgentRequired || m.DeploymentReady) &&
 		(!m.NodeExporterRequired || m.NodeExporterDaemonSetReady) &&
 		(!m.NeutreeNodeAgentMetricsRequired || m.NeutreeNodeAgentMetricsDaemonSetReady) &&
 		(!m.KubeStateMetricsRequired || m.KubeStateMetricsDeploymentReady) &&
@@ -74,21 +75,23 @@ func (m MetricsStatus) Ready() bool {
 // CheckResourcesStatus checks the status of all metrics resources
 func (m *MetricsComponent) CheckResourcesStatus(ctx context.Context) (*MetricsStatus, error) {
 	status := &MetricsStatus{
-		Errors: []string{},
+		VMAgentRequired: util.IsHTTPOrHTTPSURL(m.metricsRemoteWriteURL),
+		Errors:          []string{},
 	}
 
-	// Check Deployment status
-	deploymentReady, podsReady, totalPods, err := m.checkDeploymentStatus(ctx)
-	if err != nil {
-		status.Errors = append(status.Errors, fmt.Sprintf("deployment check failed: %v", err))
-		status.Diagnostics = append(status.Diagnostics, component.DeploymentDiagnostics(ctx, m.ctrlClient, m.namespace, "vmagent", m.metricsPodLabels())...)
-	} else {
-		status.DeploymentReady = deploymentReady
-		status.PodsReady = podsReady
-		status.TotalPods = totalPods
-
-		if !deploymentReady {
+	if status.VMAgentRequired {
+		deploymentReady, podsReady, totalPods, err := m.checkDeploymentStatus(ctx)
+		if err != nil {
+			status.Errors = append(status.Errors, fmt.Sprintf("deployment check failed: %v", err))
 			status.Diagnostics = append(status.Diagnostics, component.DeploymentDiagnostics(ctx, m.ctrlClient, m.namespace, "vmagent", m.metricsPodLabels())...)
+		} else {
+			status.DeploymentReady = deploymentReady
+			status.PodsReady = podsReady
+			status.TotalPods = totalPods
+
+			if !deploymentReady {
+				status.Diagnostics = append(status.Diagnostics, component.DeploymentDiagnostics(ctx, m.ctrlClient, m.namespace, "vmagent", m.metricsPodLabels())...)
+			}
 		}
 	}
 

--- a/internal/cluster/component/metrics/metrics_status_test.go
+++ b/internal/cluster/component/metrics/metrics_status_test.go
@@ -185,8 +185,9 @@ func TestCheckResourcesStatusIncludesKubeStateMetrics(t *testing.T) {
 		Build()
 
 	metricsCmpt := &MetricsComponent{
-		ctrlClient: fakeClient,
-		namespace:  "default",
+		ctrlClient:            fakeClient,
+		namespace:             "default",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
 			Spec:     &v1.ClusterSpec{Version: "v1.1.0"},
@@ -207,6 +208,38 @@ func TestCheckResourcesStatusIncludesKubeStateMetrics(t *testing.T) {
 	assert.Equal(t, 1, status.KubeStateMetricsPodsReady)
 }
 
+func TestCheckResourcesStatusDoesNotRequireVMAgentWithoutValidRemoteWrite(t *testing.T) {
+	for _, remoteWriteURL := range []string{"", "invalid-url"} {
+		t.Run("remote write URL="+remoteWriteURL, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithObjects(
+					readyMetricsDeployment("neutree-kube-state-metrics"),
+					readyMetricsDaemonSet("neutree-node-exporter", 2),
+					readyMetricsDaemonSet("neutree-node-agent", 2),
+				).
+				Build()
+
+			metricsCmpt := &MetricsComponent{
+				ctrlClient:            fakeClient,
+				namespace:             "default",
+				metricsRemoteWriteURL: remoteWriteURL,
+				cluster: &v1.Cluster{
+					Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
+					Spec:     &v1.ClusterSpec{Version: "v1.1.0"},
+				},
+			}
+
+			status, err := metricsCmpt.CheckResourcesStatus(context.Background())
+
+			assert.NoError(t, err)
+			assert.True(t, status.Ready())
+			assert.False(t, status.VMAgentRequired)
+			assert.False(t, status.DeploymentReady)
+			assert.Empty(t, status.Errors)
+		})
+	}
+}
+
 func TestCheckResourcesStatusSkipsKubeStateMetricsBeforeV110(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().
 		WithObjects(
@@ -216,8 +249,9 @@ func TestCheckResourcesStatusSkipsKubeStateMetricsBeforeV110(t *testing.T) {
 		Build()
 
 	metricsCmpt := &MetricsComponent{
-		ctrlClient: fakeClient,
-		namespace:  "default",
+		ctrlClient:            fakeClient,
+		namespace:             "default",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
 			Spec:     &v1.ClusterSpec{Version: "v1.0.0"},
@@ -256,9 +290,10 @@ func TestCheckResourcesStatusIncludesAcceleratorExporterDaemonSet(t *testing.T) 
 		Build()
 
 	metricsCmpt := &MetricsComponent{
-		ctrlClient:     fakeClient,
-		namespace:      "default",
-		acceleratorMgr: accelerator.NewManager(gin.New()),
+		ctrlClient:            fakeClient,
+		namespace:             "default",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
 			Spec:     &v1.ClusterSpec{Version: "v1.1.0"},
@@ -295,9 +330,10 @@ func TestCheckResourcesStatusDoesNotRequireManagedAcceleratorExporterInExternalM
 		Build()
 
 	metricsCmpt := &MetricsComponent{
-		ctrlClient:     fakeClient,
-		namespace:      "default",
-		acceleratorMgr: accelerator.NewManager(gin.New()),
+		ctrlClient:            fakeClient,
+		namespace:             "default",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+		acceleratorMgr:        accelerator.NewManager(gin.New()),
 		cluster: &v1.Cluster{
 			Metadata: &v1.Metadata{Name: "test", Workspace: "default"},
 			Spec: &v1.ClusterSpec{

--- a/internal/cluster/kubernetes_cluster.go
+++ b/internal/cluster/kubernetes_cluster.go
@@ -209,15 +209,10 @@ func (c *NativeKubernetesClusterReconciler) ComputeAdditionalComponents(reconcil
 	reconcileComps := []component.Component{}
 	reconcileDeleteComps := []component.Component{}
 
-	// Only install metrics component when metrics remote write url is valid.
 	metricsComp := metrics.NewMetricsComponent(reconcileCtx.Cluster,
 		reconcileCtx.clusterNamespace, imagePrefix, ImagePullSecretName,
 		c.metricsRemoteWriteURL, *reconcileCtx.kubernetesClusterConfig, reconcileCtx.ctrClient, c.acceleratorMgr)
-	if util.IsHTTPOrHTTPSURL(c.metricsRemoteWriteURL) {
-		reconcileComps = append(reconcileComps, metricsComp)
-	} else {
-		reconcileDeleteComps = append(reconcileDeleteComps, metricsComp)
-	}
+	reconcileComps = append(reconcileComps, metricsComp)
 
 	hamiComp := hami.NewHAMiComponent(reconcileCtx.Cluster,
 		reconcileCtx.clusterNamespace, imagePrefix, ImagePullSecretName,

--- a/internal/cluster/kubernetes_cluster_test.go
+++ b/internal/cluster/kubernetes_cluster_test.go
@@ -589,14 +589,14 @@ func TestComputeAdditionalComponents_Metrics(t *testing.T) {
 		{
 			name:                   "URL without HTTP/HTTPS scheme for metrics",
 			metricsRemoteWriteURL:  "invalid-url",
-			expectedReconcileCount: 0,
-			expectedDeleteCount:    2,
+			expectedReconcileCount: 1,
+			expectedDeleteCount:    1,
 		},
 		{
 			name:                   "Empty URL for metrics",
 			metricsRemoteWriteURL:  "",
-			expectedReconcileCount: 0,
-			expectedDeleteCount:    2,
+			expectedReconcileCount: 1,
+			expectedDeleteCount:    1,
 		},
 	}
 
@@ -636,11 +636,11 @@ func TestComputeAdditionalComponents_HAMi(t *testing.T) {
 
 	reconcileComps, deleteComps := reconciler.ComputeAdditionalComponents(reconcileCtx, "test-prefix/")
 
-	if len(reconcileComps) != 1 {
-		t.Fatalf("expected accelerator virtualization component to be reconciled, got %d components", len(reconcileComps))
+	if len(reconcileComps) != 2 {
+		t.Fatalf("expected metrics and accelerator virtualization components to be reconciled, got %d components", len(reconcileComps))
 	}
-	if len(deleteComps) != 1 {
-		t.Fatalf("expected metrics component to be deleted when metrics URL is empty, got %d components", len(deleteComps))
+	if len(deleteComps) != 0 {
+		t.Fatalf("expected no component deletions when accelerator virtualization is enabled, got %d components", len(deleteComps))
 	}
 }
 

--- a/internal/deploy/kubernetes_deployer_test.go
+++ b/internal/deploy/kubernetes_deployer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,6 +66,31 @@ func TestKubernetesDeployer_Apply(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKubernetesDeployer_ApplyTransitionsToEmptyDesiredState(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	ctx := context.Background()
+	fakeClient := &fakeApplyClient{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	vmagent := createTestDeployment("vmagent", "default", 1)
+	initialObjects := &unstructured.UnstructuredList{Items: []unstructured.Unstructured{*vmagent}}
+	initial := NewKubernetesDeployer(fakeClient, "default", "test-cluster", "metrics").WithNewObjects(initialObjects)
+	count, err := initial.Apply(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	emptyObjects := &unstructured.UnstructuredList{}
+	transition := NewKubernetesDeployer(fakeClient, "default", "test-cluster", "metrics").WithNewObjects(emptyObjects)
+	count, err = transition.Apply(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.True(t, apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "vmagent"}, createTestDeployment("vmagent", "default", 1))))
+
+	count, err = NewKubernetesDeployer(fakeClient, "default", "test-cluster", "metrics").WithNewObjects(emptyObjects).Apply(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
 }
 
 func TestKubernetesDeployer_Delete(t *testing.T) {

--- a/internal/deploy/manifest_apply.go
+++ b/internal/deploy/manifest_apply.go
@@ -233,7 +233,7 @@ func (m *ManifestApply) ApplyManifests(
 		m.logger.Info("Deleting resource",
 			"kind", obj.GetKind(),
 			"name", obj.GetName(),
-			"namespace", m.namespace)
+			"namespace", obj.GetNamespace())
 
 		if err := m.ctrlClient.Delete(ctx, obj); err != nil {
 			if !apierrors.IsNotFound(err) {
@@ -242,7 +242,8 @@ func (m *ManifestApply) ApplyManifests(
 					"name", obj.GetName())
 
 				if deleteErr == nil {
-					deleteErr = errors.Wrapf(err, "failed to delete object %s/%s", obj.GetKind(), obj.GetName())
+					deleteErr = errors.Wrapf(err, "failed to delete object %s/%s/%s",
+						obj.GetKind(), obj.GetNamespace(), obj.GetName())
 				}
 			}
 		}

--- a/internal/deploy/manifest_apply.go
+++ b/internal/deploy/manifest_apply.go
@@ -226,6 +226,7 @@ func (m *ManifestApply) ApplyManifests(
 	}
 
 	deleteObjects := diff.DeletedObjects
+	var deleteErr error
 
 	for i := range deleteObjects {
 		obj := &deleteObjects[i]
@@ -239,9 +240,15 @@ func (m *ManifestApply) ApplyManifests(
 				klog.ErrorS(err, "Failed to delete resource",
 					"kind", obj.GetKind(),
 					"name", obj.GetName())
-				// Continue with other resources
+				if deleteErr == nil {
+					deleteErr = errors.Wrapf(err, "failed to delete object %s/%s", obj.GetKind(), obj.GetName())
+				}
 			}
 		}
+	}
+
+	if deleteErr != nil {
+		return 0, deleteErr
 	}
 
 	return len(objects) + len(deleteObjects), nil

--- a/internal/deploy/manifest_apply.go
+++ b/internal/deploy/manifest_apply.go
@@ -240,6 +240,7 @@ func (m *ManifestApply) ApplyManifests(
 				klog.ErrorS(err, "Failed to delete resource",
 					"kind", obj.GetKind(),
 					"name", obj.GetName())
+
 				if deleteErr == nil {
 					deleteErr = errors.Wrapf(err, "failed to delete object %s/%s", obj.GetKind(), obj.GetName())
 				}

--- a/internal/deploy/manifest_apply_test.go
+++ b/internal/deploy/manifest_apply_test.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,6 +28,18 @@ func newFakeClient(objs ...client.Object) client.Client {
 
 type fakeApplyClient struct {
 	client.Client
+}
+
+type failingDeleteClient struct {
+	client.Client
+}
+
+func (c *failingDeleteClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if obj.GetName() == "vmagent" {
+		return errors.New("vmagent deletion failed")
+	}
+
+	return c.Client.Delete(ctx, obj, opts...)
 }
 
 func (c *fakeApplyClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
@@ -338,6 +351,50 @@ func TestApplyManifests_NoChanges(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count)
+}
+
+func TestApplyManifests_RemovesVMAgentObjectsAndKeepsLocalMetricsObjects(t *testing.T) {
+	vmagent := createTestDeployment("vmagent", "test-ns", 1)
+	kubeStateMetrics := createTestDeployment("neutree-kube-state-metrics", "test-ns", 1)
+	nodeExporter := createTestService("neutree-node-exporter", "test-ns")
+
+	lastApplied := []unstructured.Unstructured{*vmagent, *kubeStateMetrics, *nodeExporter}
+	lastAppliedJSON, err := json.Marshal(lastApplied)
+	assert.NoError(t, err)
+
+	newObjects := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{*kubeStateMetrics, *nodeExporter},
+	}
+
+	fakeClient := newFakeClient(vmagent, kubeStateMetrics, nodeExporter)
+	ma := NewManifestApply(fakeClient, "test-ns").
+		WithLastAppliedConfig(string(lastAppliedJSON)).
+		WithNewObjects(newObjects).
+		WithLogger(klog.NewKlogr())
+
+	count, err := ma.ApplyManifests(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.True(t, apierrors.IsNotFound(fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "test-ns", Name: "vmagent"}, createTestDeployment("vmagent", "test-ns", 1))))
+	assert.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "test-ns", Name: "neutree-kube-state-metrics"}, createTestDeployment("neutree-kube-state-metrics", "test-ns", 1)))
+	assert.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "test-ns", Name: "neutree-node-exporter"}, createTestService("neutree-node-exporter", "test-ns")))
+}
+
+func TestApplyManifests_ReturnsDeletionFailure(t *testing.T) {
+	vmagent := createTestDeployment("vmagent", "test-ns", 1)
+	kubeStateMetrics := createTestDeployment("neutree-kube-state-metrics", "test-ns", 1)
+	lastAppliedJSON, err := json.Marshal([]unstructured.Unstructured{*vmagent, *kubeStateMetrics})
+	assert.NoError(t, err)
+
+	ma := NewManifestApply(&failingDeleteClient{Client: newFakeClient(vmagent, kubeStateMetrics)}, "test-ns").
+		WithLastAppliedConfig(string(lastAppliedJSON)).
+		WithNewObjects(&unstructured.UnstructuredList{Items: []unstructured.Unstructured{*kubeStateMetrics}}).
+		WithLogger(klog.NewKlogr())
+
+	_, err = ma.ApplyManifests(context.Background())
+
+	assert.ErrorContains(t, err, "vmagent deletion failed")
 }
 
 func TestApplyManifests_IgnoresLiveDeploymentDefaultedSpecFields(t *testing.T) {

--- a/internal/deploy/manifest_apply_test.go
+++ b/internal/deploy/manifest_apply_test.go
@@ -395,6 +395,7 @@ func TestApplyManifests_ReturnsDeletionFailure(t *testing.T) {
 	_, err = ma.ApplyManifests(context.Background())
 
 	assert.ErrorContains(t, err, "vmagent deletion failed")
+	assert.ErrorContains(t, err, "failed to delete object Deployment/test-ns/vmagent")
 }
 
 func TestApplyManifests_IgnoresLiveDeploymentDefaultedSpecFields(t *testing.T) {

--- a/internal/util/url_check.go
+++ b/internal/util/url_check.go
@@ -10,12 +10,12 @@ const (
 	SchemeHTTPS = "https"
 )
 
-// IsHTTPOrHTTPSURL returns true if s is a valid URL with scheme "http" or "https" and a non-empty host.
+// IsHTTPOrHTTPSURL returns true if s is a valid URL with scheme "http" or "https" and a non-empty hostname.
 func IsHTTPOrHTTPSURL(s string) bool {
 	u, err := url.Parse(strings.TrimSpace(s))
 	if err != nil {
 		return false
 	}
 
-	return (u.Scheme == SchemeHTTP || u.Scheme == SchemeHTTPS) && u.Host != ""
+	return (u.Scheme == SchemeHTTP || u.Scheme == SchemeHTTPS) && u.Hostname() != ""
 }

--- a/internal/util/url_check_test.go
+++ b/internal/util/url_check_test.go
@@ -9,11 +9,15 @@ func TestIsHTTPOrHTTPSURL(t *testing.T) {
 	}{
 		{"http://example.com", true},
 		{"https://example.com", true},
+		{"https://example.com:8428", true},
+		{"http://127.0.0.1:8428", true},
+		{"https://[::1]:8428", true},
 		{"ftp://example.com", false},
 		{"example.com", false},
 		{"", false},
 		{"   https://example.com   ", true},
 		{"http:/example.com", false},
+		{"http://:8428", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Issue

n/a

## Summary

Keep Kubernetes local metrics collectors available when the control plane has no valid metrics remote-write URL, matching StaticNode behavior.

## Changes

- Reconcile the Kubernetes metrics component for every remote-write value.
- Render and require vmagent only for valid HTTP(S) URLs while retaining local collectors and kube-state-metrics.
- Preserve cleanup retryability when deleting stale vmagent resources fails.
- Require a non-empty hostname for the shared HTTP(S) URL predicate.

## Test Plan

### Unit test

- `go test ./internal/util ./internal/cluster/staticcluster ./internal/cluster/component/metrics ./internal/cluster ./internal/deploy -count=1`
- `go vet ./internal/util ./internal/cluster/staticcluster ./internal/cluster/component/metrics ./internal/cluster ./internal/deploy`
- `git diff --check`

### DB test

- N/A: no database or migration changes.

### E2E test

- Manual Kubernetes validation used cluster version v1.1.0 with `router.access_mode=NodePort`.
- Valid HTTP remote-write URL: Cluster reached `Running`; vmagent, router, node-exporter, node-agent, and kube-state-metrics were ready.
- No remote-write URL: Cluster reached `Running`; only vmagent resources and RBAC were absent while local collectors and kube-state-metrics were ready.
- Invalid `invalid-url` and hostname-empty `http://:8428`: Clusters reached `Running`; only vmagent resources and RBAC were absent while local collectors and kube-state-metrics were ready.
- Node-agent health and metrics endpoints responded successfully in every case. Temporary Clusters, ImageRegistries, and namespaces were removed after validation.

## Risk & Rollback

This changes only metrics resource reconciliation and shared URL validation. Revert the feature commits in this PR to restore the former lifecycle.