### PR TITLE
feat(obs): scrape inference metrics by engine capability (NEU-636)

### DIFF
--- a/internal/cluster/component/metrics/inference_scrape.go
+++ b/internal/cluster/component/metrics/inference_scrape.go
@@ -1,0 +1,163 @@
+package metrics
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// The `neutree-inference` scrape job discovers inference pods by their
+// `app=inference` label and, historically, scraped every one of them on a fixed
+// :8000/metrics. Engine versions can now declare a metrics-export capability
+// (see api/v1/engine_types.go), and these rules turn those declarations into
+// relabel configuration.
+//
+// The filtering deliberately lives in the vmagent config rather than in pod
+// metadata. Encoding the decision as a pod label or annotation would change the
+// pod template, so upgrading Neutree would roll every inference deployment --
+// minutes of downtime per endpoint while models reload -- and would leave
+// already-running pods unfiltered until they happened to be redeployed. Pods
+// already carry `engine` and `engine_version` labels, which is enough to target
+// them from the config side with no pod change at all.
+//
+// Consistent with the capability protocol's forward-compatibility rule, this is
+// an exclusion list, not an allow list: an engine version that declares nothing
+// is absent from the rules and keeps being scraped exactly as before.
+
+// InferenceScrapeExclusion identifies an engine version that declared it does
+// not export metrics, so its pods are dropped from the inference job.
+type InferenceScrapeExclusion struct {
+	Engine  string
+	Version string
+}
+
+// InferenceScrapeOverride redirects the inference job to a non-default metrics
+// port or path for one engine version.
+type InferenceScrapeOverride struct {
+	Engine  string
+	Version string
+
+	// Port is set only when it differs from the job's default.
+	Port int
+
+	// Path is set only when it differs from the job's default.
+	Path string
+}
+
+// HasPort reports whether this override changes the scrape port.
+func (o InferenceScrapeOverride) HasPort() bool {
+	return o.Port != 0
+}
+
+// HasPath reports whether this override changes the metrics path.
+func (o InferenceScrapeOverride) HasPath() bool {
+	return o.Path != ""
+}
+
+// TargetRegex renders the regex matching this override's engine and version
+// against the `[engine, engine_version]` source labels, which relabel joins with
+// the default ";" separator. Engine names and versions carry regex
+// metacharacters ("v0.24.0"), so both halves are quoted.
+func (o InferenceScrapeOverride) TargetRegex() string {
+	return regexp.QuoteMeta(o.Engine) + ";" + regexp.QuoteMeta(o.Version)
+}
+
+// InferenceScrapeRules is the full set of inference-job adjustments derived from
+// the engines available to a cluster.
+type InferenceScrapeRules struct {
+	Exclusions []InferenceScrapeExclusion
+	Overrides  []InferenceScrapeOverride
+}
+
+// ExclusionRegex renders the alternation matching every excluded engine version
+// against the `[engine, engine_version]` source labels. Returns "" when nothing
+// is excluded, in which case the drop rule is omitted entirely rather than
+// emitted with an empty regex -- an empty regex is anchored and would match
+// every pod whose labels are also empty.
+func (r InferenceScrapeRules) ExclusionRegex() string {
+	if len(r.Exclusions) == 0 {
+		return ""
+	}
+
+	alternatives := make([]string, 0, len(r.Exclusions))
+	for _, e := range r.Exclusions {
+		alternatives = append(alternatives, regexp.QuoteMeta(e.Engine)+";"+regexp.QuoteMeta(e.Version))
+	}
+
+	return strings.Join(alternatives, "|")
+}
+
+// BuildInferenceScrapeRules derives the inference-job rules from the engines
+// registered in a workspace.
+//
+// Only declarations that differ from the job's defaults produce a rule, so a
+// cluster running nothing but engines that declare the defaults (or declare
+// nothing at all) renders byte-identical config to before this feature.
+func BuildInferenceScrapeRules(engines []v1.Engine, defaultPort int, defaultPath string) InferenceScrapeRules {
+	rules := InferenceScrapeRules{}
+
+	for i := range engines {
+		engine := engines[i]
+		if engine.Spec == nil || engine.Metadata == nil {
+			continue
+		}
+
+		for _, version := range engine.Spec.Versions {
+			if version == nil || version.Version == "" {
+				continue
+			}
+
+			resolved := version.ResolveMetricsExport()
+
+			if !resolved.Enabled {
+				rules.Exclusions = append(rules.Exclusions, InferenceScrapeExclusion{
+					Engine:  engine.Metadata.Name,
+					Version: version.Version,
+				})
+
+				// A dropped target needs no port or path override.
+				continue
+			}
+
+			override := InferenceScrapeOverride{
+				Engine:  engine.Metadata.Name,
+				Version: version.Version,
+			}
+
+			if resolved.Port != defaultPort {
+				override.Port = resolved.Port
+			}
+
+			if resolved.Path != defaultPath {
+				override.Path = resolved.Path
+			}
+
+			if override.HasPort() || override.HasPath() {
+				rules.Overrides = append(rules.Overrides, override)
+			}
+		}
+	}
+
+	// Stable ordering keeps the rendered config -- and therefore the config
+	// hash that triggers a vmagent restart -- from churning on every reconcile,
+	// since engine listing order is not guaranteed.
+	sort.Slice(rules.Exclusions, func(i, j int) bool {
+		if rules.Exclusions[i].Engine != rules.Exclusions[j].Engine {
+			return rules.Exclusions[i].Engine < rules.Exclusions[j].Engine
+		}
+
+		return rules.Exclusions[i].Version < rules.Exclusions[j].Version
+	})
+
+	sort.Slice(rules.Overrides, func(i, j int) bool {
+		if rules.Overrides[i].Engine != rules.Overrides[j].Engine {
+			return rules.Overrides[i].Engine < rules.Overrides[j].Engine
+		}
+
+		return rules.Overrides[i].Version < rules.Overrides[j].Version
+	})
+
+	return rules
+}

--- a/internal/cluster/component/metrics/inference_scrape_test.go
+++ b/internal/cluster/component/metrics/inference_scrape_test.go
@@ -1,0 +1,329 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+func engineWithVersions(name string, versions ...*v1.EngineVersion) v1.Engine {
+	return v1.Engine{
+		Metadata: &v1.Metadata{Name: name},
+		Spec:     &v1.EngineSpec{Versions: versions},
+	}
+}
+
+func TestBuildInferenceScrapeRules(t *testing.T) {
+	tests := []struct {
+		name           string
+		engines        []v1.Engine
+		wantExclusions []InferenceScrapeExclusion
+		wantOverrides  []InferenceScrapeOverride
+	}{
+		{
+			name:    "no engines",
+			engines: nil,
+		},
+		{
+			// The forward-compat case: engines registered before the capability
+			// protocol produce no rules at all, so the job keeps scraping them.
+			name: "undeclared engines produce no rules",
+			engines: []v1.Engine{
+				engineWithVersions("vllm", &v1.EngineVersion{Version: "v0.24.0"}),
+			},
+		},
+		{
+			name: "declaring the defaults produces no rules",
+			engines: []v1.Engine{
+				engineWithVersions("vllm", &v1.EngineVersion{
+					Version: "v0.24.0",
+					Capabilities: &v1.EngineCapabilities{
+						MetricsExport: &v1.MetricsExportCapability{
+							Enabled: true,
+							Port:    v1.DefaultMetricsExportPort,
+							Path:    v1.DefaultMetricsExportPath,
+						},
+					},
+				}),
+			},
+		},
+		{
+			name: "disabled engine version is excluded",
+			engines: []v1.Engine{
+				engineWithVersions("mineru", &v1.EngineVersion{
+					Version: "v1.0.0",
+					Capabilities: &v1.EngineCapabilities{
+						MetricsExport: &v1.MetricsExportCapability{Enabled: false},
+					},
+				}),
+			},
+			wantExclusions: []InferenceScrapeExclusion{{Engine: "mineru", Version: "v1.0.0"}},
+		},
+		{
+			name: "custom port and path become an override",
+			engines: []v1.Engine{
+				engineWithVersions("custom", &v1.EngineVersion{
+					Version: "v2",
+					Capabilities: &v1.EngineCapabilities{
+						MetricsExport: &v1.MetricsExportCapability{
+							Enabled: true,
+							Port:    9100,
+							Path:    "/internal/metrics",
+						},
+					},
+				}),
+			},
+			wantOverrides: []InferenceScrapeOverride{
+				{Engine: "custom", Version: "v2", Port: 9100, Path: "/internal/metrics"},
+			},
+		},
+		{
+			// A disabled version is dropped outright, so it must not also emit a
+			// port override that would never apply.
+			name: "disabled wins over a custom port",
+			engines: []v1.Engine{
+				engineWithVersions("custom", &v1.EngineVersion{
+					Version: "v2",
+					Capabilities: &v1.EngineCapabilities{
+						MetricsExport: &v1.MetricsExportCapability{Enabled: false, Port: 9100},
+					},
+				}),
+			},
+			wantExclusions: []InferenceScrapeExclusion{{Engine: "custom", Version: "v2"}},
+		},
+		{
+			name: "versions of one engine are handled independently",
+			engines: []v1.Engine{
+				engineWithVersions("vllm",
+					&v1.EngineVersion{Version: "v0.17.1"},
+					&v1.EngineVersion{
+						Version: "v0.24.0",
+						Capabilities: &v1.EngineCapabilities{
+							MetricsExport: &v1.MetricsExportCapability{Enabled: false},
+						},
+					},
+				),
+			},
+			wantExclusions: []InferenceScrapeExclusion{{Engine: "vllm", Version: "v0.24.0"}},
+		},
+		{
+			name: "malformed entries are skipped",
+			engines: []v1.Engine{
+				{Metadata: &v1.Metadata{Name: "no-spec"}},
+				engineWithVersions("nil-version", nil),
+				engineWithVersions("blank-version", &v1.EngineVersion{Version: ""}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildInferenceScrapeRules(tt.engines, v1.DefaultMetricsExportPort, v1.DefaultMetricsExportPath)
+
+			assert.Equal(t, tt.wantExclusions, got.Exclusions)
+			assert.Equal(t, tt.wantOverrides, got.Overrides)
+		})
+	}
+}
+
+// TestBuildInferenceScrapeRules_StableOrder pins the ordering guarantee: engine
+// listing order is not deterministic, and an unstable rule order would change
+// the rendered config on every reconcile, restarting vmagent each time.
+func TestBuildInferenceScrapeRules_StableOrder(t *testing.T) {
+	disabled := func(version string) *v1.EngineVersion {
+		return &v1.EngineVersion{
+			Version: version,
+			Capabilities: &v1.EngineCapabilities{
+				MetricsExport: &v1.MetricsExportCapability{Enabled: false},
+			},
+		}
+	}
+
+	forward := BuildInferenceScrapeRules([]v1.Engine{
+		engineWithVersions("zeta", disabled("v2"), disabled("v1")),
+		engineWithVersions("alpha", disabled("v1")),
+	}, v1.DefaultMetricsExportPort, v1.DefaultMetricsExportPath)
+
+	reversed := BuildInferenceScrapeRules([]v1.Engine{
+		engineWithVersions("alpha", disabled("v1")),
+		engineWithVersions("zeta", disabled("v1"), disabled("v2")),
+	}, v1.DefaultMetricsExportPort, v1.DefaultMetricsExportPath)
+
+	assert.Equal(t, forward.Exclusions, reversed.Exclusions)
+	assert.Equal(t, []InferenceScrapeExclusion{
+		{Engine: "alpha", Version: "v1"},
+		{Engine: "zeta", Version: "v1"},
+		{Engine: "zeta", Version: "v2"},
+	}, forward.Exclusions)
+}
+
+func TestInferenceScrapeRules_ExclusionRegex(t *testing.T) {
+	assert.Equal(t, "", InferenceScrapeRules{}.ExclusionRegex(),
+		"an empty regex is anchored and would match pods with empty labels, so it must be omitted instead")
+
+	// Versions contain dots, which are regex metacharacters: unquoted, "v0.24.0"
+	// would also match "v0x24y0".
+	rules := InferenceScrapeRules{Exclusions: []InferenceScrapeExclusion{
+		{Engine: "vllm", Version: "v0.24.0"},
+		{Engine: "mineru", Version: "v1.0.0"},
+	}}
+	assert.Equal(t, `vllm;v0\.24\.0|mineru;v1\.0\.0`, rules.ExclusionRegex())
+}
+
+// renderInferenceJob renders the full vmagent config and returns the
+// neutree-inference scrape job, parsed as YAML. Parsing rather than string
+// matching is the point: a template that emits subtly malformed YAML would
+// leave vmagent scraping nothing, and a string assertion would not notice.
+func renderInferenceJob(t *testing.T, rules InferenceScrapeRules) map[string]interface{} {
+	t.Helper()
+
+	rendered, err := renderKubernetesVMAgentConfig(MetricsManifestVariables{
+		ClusterName:          "test-cluster",
+		Workspace:            "default",
+		Namespace:            "neutree",
+		InferenceDefaultPort: v1.DefaultMetricsExportPort,
+		InferenceScrapeRules: rules,
+	})
+	require.NoError(t, err)
+
+	var config struct {
+		ScrapeConfigs []map[string]interface{} `yaml:"scrape_configs"`
+	}
+
+	require.NoError(t, yaml.Unmarshal([]byte(rendered), &config), "rendered config is not valid YAML:\n%s", rendered)
+
+	for _, job := range config.ScrapeConfigs {
+		if job["job_name"] == "neutree-inference" {
+			return job
+		}
+	}
+
+	t.Fatalf("neutree-inference job not found in rendered config:\n%s", rendered)
+
+	return nil
+}
+
+func relabelConfigs(t *testing.T, job map[string]interface{}) []map[string]interface{} {
+	t.Helper()
+
+	raw, ok := job["relabel_configs"].([]interface{})
+	require.True(t, ok, "relabel_configs missing or not a list")
+
+	configs := make([]map[string]interface{}, 0, len(raw))
+
+	for _, entry := range raw {
+		cfg, ok := entry.(map[string]interface{})
+		require.True(t, ok, "relabel entry is not a mapping")
+		configs = append(configs, cfg)
+	}
+
+	return configs
+}
+
+// TestRenderInferenceJob_NoRules is the forward-compat guard at the config
+// level: with no declarations, the job must keep the fixed :8000 target and
+// carry no drop rule at all.
+func TestRenderInferenceJob_NoRules(t *testing.T) {
+	job := renderInferenceJob(t, InferenceScrapeRules{})
+
+	for _, cfg := range relabelConfigs(t, job) {
+		assert.NotEqual(t, "drop", cfg["action"], "no engine declared anything, so nothing may be dropped")
+	}
+
+	assert.Contains(t, relabelReplacements(t, job), "$1:8000")
+}
+
+func relabelReplacements(t *testing.T, job map[string]interface{}) []string {
+	t.Helper()
+
+	replacements := []string{}
+
+	for _, cfg := range relabelConfigs(t, job) {
+		if replacement, ok := cfg["replacement"].(string); ok {
+			replacements = append(replacements, replacement)
+		}
+	}
+
+	return replacements
+}
+
+func TestRenderInferenceJob_Exclusions(t *testing.T) {
+	job := renderInferenceJob(t, InferenceScrapeRules{
+		Exclusions: []InferenceScrapeExclusion{{Engine: "mineru", Version: "v1.0.0"}},
+	})
+
+	var dropRules []map[string]interface{}
+
+	for _, cfg := range relabelConfigs(t, job) {
+		if cfg["action"] == "drop" {
+			dropRules = append(dropRules, cfg)
+		}
+	}
+
+	require.Len(t, dropRules, 1)
+	assert.Equal(t, `mineru;v1\.0\.0`, dropRules[0]["regex"])
+	assert.Equal(t,
+		[]interface{}{"__meta_kubernetes_pod_label_engine", "__meta_kubernetes_pod_label_engine_version"},
+		dropRules[0]["source_labels"])
+}
+
+func TestRenderInferenceJob_Overrides(t *testing.T) {
+	job := renderInferenceJob(t, InferenceScrapeRules{
+		Overrides: []InferenceScrapeOverride{
+			{Engine: "custom", Version: "v2", Port: 9100, Path: "/internal/metrics"},
+		},
+	})
+
+	configs := relabelConfigs(t, job)
+
+	defaultAddressIdx, overrideAddressIdx, pathIdx := -1, -1, -1
+
+	for i, cfg := range configs {
+		switch {
+		case cfg["target_label"] == "__address__" && cfg["replacement"] == "$1:8000":
+			defaultAddressIdx = i
+		case cfg["target_label"] == "__address__" && cfg["replacement"] == "$1:9100":
+			overrideAddressIdx = i
+		case cfg["target_label"] == "__metrics_path__":
+			pathIdx = i
+		}
+	}
+
+	require.NotEqual(t, -1, defaultAddressIdx, "default address rule missing")
+	require.NotEqual(t, -1, overrideAddressIdx, "override address rule missing")
+	require.NotEqual(t, -1, pathIdx, "metrics path override missing")
+
+	// Relabel rules apply in order and the override rewrites the same target
+	// label, so it only takes effect if it comes after the default.
+	assert.Greater(t, overrideAddressIdx, defaultAddressIdx,
+		"the port override must follow the default address rule to win")
+
+	assert.Equal(t, `(.+);custom;v2`, configs[overrideAddressIdx]["regex"])
+	assert.Equal(t, "/internal/metrics", configs[pathIdx]["replacement"])
+	assert.Equal(t, `custom;v2`, configs[pathIdx]["regex"])
+}
+
+// TestRenderInferenceJob_OtherJobsUnaffected guards the blast radius: the
+// router job shares the inference job's shape, and an over-broad template edit
+// would silently change it too.
+func TestRenderInferenceJob_OtherJobsUnaffected(t *testing.T) {
+	rendered, err := renderKubernetesVMAgentConfig(MetricsManifestVariables{
+		ClusterName:          "test-cluster",
+		Workspace:            "default",
+		Namespace:            "neutree",
+		InferenceDefaultPort: v1.DefaultMetricsExportPort,
+		InferenceScrapeRules: InferenceScrapeRules{
+			Exclusions: []InferenceScrapeExclusion{{Engine: "mineru", Version: "v1.0.0"}},
+		},
+	})
+	require.NoError(t, err)
+
+	routerJob := rendered[strings.Index(rendered, "job_name: 'neutree-router'"):strings.Index(rendered, "job_name: 'neutree-inference'")]
+	assert.NotContains(t, routerJob, "action: drop")
+	assert.Contains(t, routerJob, "replacement: $1:8000")
+}

--- a/internal/cluster/component/metrics/inference_scrape_test.go
+++ b/internal/cluster/component/metrics/inference_scrape_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -175,11 +174,11 @@ func TestInferenceScrapeRules_ExclusionRegex(t *testing.T) {
 	assert.Equal(t, `vllm;v0\.24\.0|mineru;v1\.0\.0`, rules.ExclusionRegex())
 }
 
-// renderInferenceJob renders the full vmagent config and returns the
-// neutree-inference scrape job, parsed as YAML. Parsing rather than string
-// matching is the point: a template that emits subtly malformed YAML would
-// leave vmagent scraping nothing, and a string assertion would not notice.
-func renderInferenceJob(t *testing.T, rules InferenceScrapeRules) map[string]interface{} {
+// renderJob renders the full vmagent config and returns one scrape job, parsed
+// as YAML. Parsing rather than string matching is the point: a template that
+// emits subtly malformed YAML would leave vmagent scraping nothing, and a
+// string assertion would not notice.
+func renderJob(t *testing.T, rules InferenceScrapeRules, jobName string) map[string]interface{} {
 	t.Helper()
 
 	rendered, err := renderKubernetesVMAgentConfig(MetricsManifestVariables{
@@ -198,14 +197,20 @@ func renderInferenceJob(t *testing.T, rules InferenceScrapeRules) map[string]int
 	require.NoError(t, yaml.Unmarshal([]byte(rendered), &config), "rendered config is not valid YAML:\n%s", rendered)
 
 	for _, job := range config.ScrapeConfigs {
-		if job["job_name"] == "neutree-inference" {
+		if job["job_name"] == jobName {
 			return job
 		}
 	}
 
-	t.Fatalf("neutree-inference job not found in rendered config:\n%s", rendered)
+	t.Fatalf("%s job not found in rendered config:\n%s", jobName, rendered)
 
 	return nil
+}
+
+func renderInferenceJob(t *testing.T, rules InferenceScrapeRules) map[string]interface{} {
+	t.Helper()
+
+	return renderJob(t, rules, "neutree-inference")
 }
 
 func relabelConfigs(t *testing.T, job map[string]interface{}) []map[string]interface{} {
@@ -312,18 +317,14 @@ func TestRenderInferenceJob_Overrides(t *testing.T) {
 // router job shares the inference job's shape, and an over-broad template edit
 // would silently change it too.
 func TestRenderInferenceJob_OtherJobsUnaffected(t *testing.T) {
-	rendered, err := renderKubernetesVMAgentConfig(MetricsManifestVariables{
-		ClusterName:          "test-cluster",
-		Workspace:            "default",
-		Namespace:            "neutree",
-		InferenceDefaultPort: v1.DefaultMetricsExportPort,
-		InferenceScrapeRules: InferenceScrapeRules{
-			Exclusions: []InferenceScrapeExclusion{{Engine: "mineru", Version: "v1.0.0"}},
-		},
-	})
-	require.NoError(t, err)
+	routerJob := renderJob(t, InferenceScrapeRules{
+		Exclusions: []InferenceScrapeExclusion{{Engine: "mineru", Version: "v1.0.0"}},
+	}, "neutree-router")
 
-	routerJob := rendered[strings.Index(rendered, "job_name: 'neutree-router'"):strings.Index(rendered, "job_name: 'neutree-inference'")]
-	assert.NotContains(t, routerJob, "action: drop")
-	assert.Contains(t, routerJob, "replacement: $1:8000")
+	for _, cfg := range relabelConfigs(t, routerJob) {
+		assert.NotEqual(t, "drop", cfg["action"], "the router job must not inherit inference drop rules")
+	}
+
+	assert.Contains(t, relabelReplacements(t, routerJob), "$1:8000",
+		"the router job keeps its own fixed address rule")
 }

--- a/internal/cluster/component/metrics/manifests.go
+++ b/internal/cluster/component/metrics/manifests.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/componentversion"
 	"github.com/neutree-ai/neutree/internal/semver"
 	"github.com/neutree-ai/neutree/internal/util"
@@ -565,6 +566,16 @@ type MetricsManifestVariables struct {
 	AcceleratorExporters             []metricsAcceleratorExporter
 	EnableVMAgent                    bool
 	VMAgentConfig                    string
+
+	// InferenceDefaultPort is the port the neutree-inference job scrapes when an
+	// engine version does not declare a different one.
+	InferenceDefaultPort int
+
+	// InferenceScrapeRules carries the per-engine-version adjustments derived
+	// from engine metrics-export declarations. Zero value means no engine
+	// declared anything that differs from the defaults, and the job renders as
+	// it did before engines could declare capabilities.
+	InferenceScrapeRules InferenceScrapeRules
 }
 
 // buildManifestVariables creates the data structure for rendering manifests
@@ -607,6 +618,8 @@ func (m *MetricsComponent) buildManifestVariables() MetricsManifestVariables {
 		NeutreeNodeAgentMetricsResources: neutreeNodeAgentMetricsResources,
 		KubeStateMetricsResources:        kubeStateMetricsResources,
 		HashSuffix:                       util.HashString(m.cluster.Key()),
+		InferenceDefaultPort:             v1.DefaultMetricsExportPort,
+		InferenceScrapeRules:             m.inferenceScrapeRules,
 	}
 }
 

--- a/internal/cluster/component/metrics/metrics.go
+++ b/internal/cluster/component/metrics/metrics.go
@@ -23,6 +23,18 @@ type MetricsComponent struct {
 	config     v1.KubernetesClusterConfig
 	ctrlClient client.Client
 	logger     klog.Logger
+
+	inferenceScrapeRules InferenceScrapeRules
+}
+
+// WithInferenceScrapeRules attaches the per-engine-version scrape adjustments
+// derived from engine metrics-export declarations. Optional: the zero value
+// renders the inference job exactly as it was before engines could declare
+// capabilities, which is also what the delete path wants.
+func (m *MetricsComponent) WithInferenceScrapeRules(rules InferenceScrapeRules) *MetricsComponent {
+	m.inferenceScrapeRules = rules
+
+	return m
 }
 
 func NewMetricsComponent(cluster *v1.Cluster, namespace, imagePrefix, imagePullSecret, metricsRemoteWriteURL string,

--- a/internal/cluster/component/metrics/vmagent_config.go
+++ b/internal/cluster/component/metrics/vmagent_config.go
@@ -72,12 +72,39 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_label_workspace]
     action: keep
     regex: {{ .Workspace | quote }}
-  # Set the __address__ to pod IP and port 8000
+{{- if .InferenceScrapeRules.ExclusionRegex }}
+  # Drop engine versions that declared they do not export metrics. This is an
+  # exclusion list, not an allow list: an engine version that declares nothing
+  # is absent here and keeps being scraped, exactly as before engines could
+  # declare capabilities.
+  - source_labels: [__meta_kubernetes_pod_label_engine, __meta_kubernetes_pod_label_engine_version]
+    action: drop
+    regex: {{ .InferenceScrapeRules.ExclusionRegex | quote }}
+{{- end }}
+  # Set the __address__ to pod IP and port {{ .InferenceDefaultPort }}
   - source_labels: [__meta_kubernetes_pod_ip]
     action: replace
     target_label: __address__
     regex: (.+)
-    replacement: $1:8000
+    replacement: $1:{{ .InferenceDefaultPort }}
+{{- range .InferenceScrapeRules.Overrides }}
+  # {{ .Engine }} {{ .Version }} declared a non-default metrics endpoint. These
+  # rules come after the default above, so they win for the pods they match.
+{{- if .HasPort }}
+  - source_labels: [__meta_kubernetes_pod_ip, __meta_kubernetes_pod_label_engine, __meta_kubernetes_pod_label_engine_version]
+    action: replace
+    target_label: __address__
+    regex: (.+);{{ .TargetRegex }}
+    replacement: $1:{{ .Port }}
+{{- end }}
+{{- if .HasPath }}
+  - source_labels: [__meta_kubernetes_pod_label_engine, __meta_kubernetes_pod_label_engine_version]
+    action: replace
+    target_label: __metrics_path__
+    regex: {{ .TargetRegex | quote }}
+    replacement: {{ .Path | quote }}
+{{- end }}
+{{- end }}
   # Add pod metadata as labels
   - source_labels: [__meta_kubernetes_namespace]
     action: replace

--- a/internal/cluster/kubernetes_cluster.go
+++ b/internal/cluster/kubernetes_cluster.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -204,6 +205,37 @@ func (c *NativeKubernetesClusterReconciler) reconcileComponents(reconcileCtx *Re
 	return nil
 }
 
+// inferenceScrapeRules derives the metrics-scrape adjustments for this cluster
+// from the engines registered in its workspace.
+//
+// A listing failure is not fatal: it yields the zero value, which renders the
+// inference job exactly as it did before engines could declare capabilities.
+// Failing the whole cluster reconcile over a capability refinement would be a
+// worse outcome than scraping one engine that asked not to be scraped.
+func (c *NativeKubernetesClusterReconciler) inferenceScrapeRules(cluster *v1.Cluster) metrics.InferenceScrapeRules {
+	if c.storage == nil {
+		return metrics.InferenceScrapeRules{}
+	}
+
+	engines, err := c.storage.ListEngine(storage.ListOption{
+		Filters: []storage.Filter{
+			{
+				Column:   "metadata->workspace",
+				Operator: "eq",
+				Value:    strconv.Quote(cluster.Metadata.Workspace),
+			},
+		},
+	})
+	if err != nil {
+		klog.Warningf("failed to list engines for cluster %s, falling back to scraping every inference pod: %v",
+			cluster.Metadata.WorkspaceName(), err)
+
+		return metrics.InferenceScrapeRules{}
+	}
+
+	return metrics.BuildInferenceScrapeRules(engines, v1.DefaultMetricsExportPort, v1.DefaultMetricsExportPath)
+}
+
 func (c *NativeKubernetesClusterReconciler) ComputeAdditionalComponents(reconcileCtx *ReconcileContext,
 	imagePrefix string) ([]component.Component, []component.Component) {
 	reconcileComps := []component.Component{}
@@ -211,7 +243,8 @@ func (c *NativeKubernetesClusterReconciler) ComputeAdditionalComponents(reconcil
 
 	metricsComp := metrics.NewMetricsComponent(reconcileCtx.Cluster,
 		reconcileCtx.clusterNamespace, imagePrefix, ImagePullSecretName,
-		c.metricsRemoteWriteURL, *reconcileCtx.kubernetesClusterConfig, reconcileCtx.ctrClient, c.acceleratorMgr)
+		c.metricsRemoteWriteURL, *reconcileCtx.kubernetesClusterConfig, reconcileCtx.ctrClient, c.acceleratorMgr).
+		WithInferenceScrapeRules(c.inferenceScrapeRules(reconcileCtx.Cluster))
 	reconcileComps = append(reconcileComps, metricsComp)
 
 	hamiComp := hami.NewHAMiComponent(reconcileCtx.Cluster,


### PR DESCRIPTION
## Issue

NEU-636

## Summary

Builds on #544 (the capability protocol), now merged. Rebased onto `main`, so this diff is metrics-only.

The `neutree-inference` scrape job discovers pods by `app=inference` and scrapes every one of them on a fixed `:8000/metrics`, whether or not the engine serves metrics there. This turns the metrics-export capability declared in #544 into actual relabel configuration.

## Changes

- **`internal/cluster/component/metrics/inference_scrape.go`** (new) — `BuildInferenceScrapeRules` walks the workspace's engines and produces two things: drop rules for engine versions that declared metrics export disabled, and address/path overrides for versions declaring a non-default endpoint. Rules are sorted, because engine listing order is not deterministic and unstable output would change the config hash and restart vmagent on every reconcile.
- **`vmagent_config.go`** — the `neutree-inference` job renders those rules. The port/path overrides are emitted *after* the default address rule, since relabel applies in order and both write the same target label.
- **`internal/cluster/kubernetes_cluster.go`** — the reconciler lists engines for the cluster's workspace and feeds the rules in. A listing failure degrades to the previous behaviour rather than failing the cluster reconcile; scraping one engine that asked not to be scraped beats blocking a reconcile over a refinement.

## Design note: why the config side, not pod metadata

The obvious implementation is a pod label or annotation (`prometheus.io/scrape`-style) plus a generic relabel rule. I did not do that, for two reasons:

1. **It would roll every inference workload on upgrade.** Any change to pod metadata changes the pod template hash, so the first reconcile after upgrading Neutree would restart every inference deployment — minutes of downtime per endpoint while models reload.
2. **It would not cover already-running pods.** They carry no such annotation until they happen to be redeployed, so the feature would apply unevenly for an unbounded period.

Pods already carry `engine` and `engine_version` labels, which is enough to target them from the config side. No pod change, no rollout, and the rules apply to running pods on the next vmagent config reload.

The tradeoff: an externally registered engine whose deploy template omits the `engine_version` label cannot be targeted. Such an engine falls into the default-scrape path, which is the compatible outcome, so it fails safe.

## Test Plan

- [x] Unit: `go test ./internal/... ./api/... ./controllers/...` — all pass. New coverage in `inference_scrape_test.go` renders the full vmagent config and **parses it as YAML** rather than string-matching, so a template edit that emits subtly malformed YAML — which would leave vmagent scraping nothing — fails the test. Covers: no-declarations renders no drop rule and keeps `:8000`; exclusion regex quoting (`v0.24.0` unquoted would also match `v0x24y0`); override ordering relative to the default rule; and that the structurally identical `neutree-router` job is untouched.
- [ ] E2E: **not run.** Wants a real Kubernetes cluster with an engine declaring `enabled: false`, confirming its pods disappear from vmagent targets while others keep reporting. See Risk below.
- [ ] DB integration: not affected — no schema change.
- [x] `golangci-lint` clean via the pre-commit hook.

## Risk & Rollback

Config-only change to one scrape job. Rollback is reverting the commit; vmagent picks up the previous config on the next reconcile.

The empty-rules path renders **byte-identical** config to before, which is the case for every existing deployment until an engine declares something. That is the main safety property and it is covered by a test.

**Not verified on a live cluster.** The relabel semantics I am relying on — drop-before-address ordering, `__metrics_path__` as a relabel target, the `;` default separator when joining two source labels — are standard Prometheus behaviour and the rendered config parses, but no vmagent has actually consumed this config yet. Worth one manual check against a real cluster before merge; I did not have one reachable.

## Correction to an earlier claim

I previously suggested this PR could also delete `setDefaultSGLangEnableMetrics` (`kubernetes_orchestrator_resource.go:109`) as another instance of name-based special-casing. That was wrong, and it is left in place: it sets the engine argument that makes SGLang *serve* metrics at all. That is engine configuration, not scrape configuration, and the capability protocol declares whether an engine exports metrics — it does not turn the exporter on. Removing it would silently stop SGLang from producing metrics.
