### PR TITLE
feat(cli): refuse model writes against a public registry up front (NEU-625)

### DIFF
--- a/cmd/neutree-cli/app/cmd/model/delete.go
+++ b/cmd/neutree-cli/app/cmd/model/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
+	cliModel "github.com/neutree-ai/neutree/internal/cli/model"
 	"github.com/neutree-ai/neutree/pkg/client"
 )
 
@@ -13,10 +14,11 @@ func NewDeleteCmd() *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "delete [model_name:version]",
-		Short: "Delete a model from the registry",
-		Long:  `Delete a specific model from the registry`,
-		Args:  cobra.ExactArgs(1),
+		Use:          "delete [model_name:version]",
+		Short:        "Delete a model from the registry",
+		Long:         `Delete a specific model from the registry`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			modelTag := args[0]
 
@@ -36,9 +38,15 @@ func NewDeleteCmd() *cobra.Command {
 
 			// Create client
 			c := client.NewClient(global.ServerURL, clientOptions...)
-			_, err = c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
+			modelRegistry, err := c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
 			if err != nil {
 				return fmt.Errorf("failed to get model registry %s: %w", registry, err)
+			}
+
+			// Refuse before the confirmation prompt: asking someone to confirm a
+			// deletion that cannot happen is asking the wrong question.
+			if err := cliModel.ValidateWritableRegistry(modelRegistry, cliModel.ModelWriteDelete); err != nil {
+				return err
 			}
 
 			if !force {

--- a/cmd/neutree-cli/app/cmd/model/delete.go
+++ b/cmd/neutree-cli/app/cmd/model/delete.go
@@ -45,7 +45,7 @@ func NewDeleteCmd() *cobra.Command {
 
 			// Refuse before the confirmation prompt: asking someone to confirm a
 			// deletion that cannot happen is asking the wrong question.
-			if err := cliModel.ValidateWritableRegistry(modelRegistry, cliModel.ModelWriteDelete); err != nil {
+			if err := cliModel.ValidateWritableRegistry(modelRegistry, registry, cliModel.ModelWriteDelete); err != nil {
 				return err
 			}
 

--- a/cmd/neutree-cli/app/cmd/model/get.go
+++ b/cmd/neutree-cli/app/cmd/model/get.go
@@ -51,10 +51,11 @@ func NewGetCmd() *cobra.Command {
 	opts := &getOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "get [model_name:version]",
-		Short: "Get detailed information about a model",
-		Long:  `Get detailed information about a specific model in the registry`,
-		Args:  cobra.ExactArgs(1),
+		Use:          "get [model_name:version]",
+		Short:        "Get detailed information about a model",
+		Long:         `Get detailed information about a specific model in the registry`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(opts, args[0])
 		},

--- a/cmd/neutree-cli/app/cmd/model/list.go
+++ b/cmd/neutree-cli/app/cmd/model/list.go
@@ -76,6 +76,10 @@ func NewListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all models in the registry",
 		Long:  `List all models in the registry with their basic information`,
+		// A registry stating a limit — "this one cannot be paged from an offset" —
+		// is the answer, not a sign the command was typed wrong. Printing the
+		// usage block under it buries the one line worth reading.
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(opts)
 		},

--- a/cmd/neutree-cli/app/cmd/model/pull.go
+++ b/cmd/neutree-cli/app/cmd/model/pull.go
@@ -16,10 +16,11 @@ func NewPullCmd() *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "pull [model_name:version]",
-		Short: "Pull a model from the registry",
-		Long:  `Download a model from the registry to local directory`,
-		Args:  cobra.ExactArgs(1),
+		Use:          "pull [model_name:version]",
+		Short:        "Pull a model from the registry",
+		Long:         `Download a model from the registry to local directory`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			modelTag := args[0]
 

--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -73,6 +73,29 @@ func NewPushCmd() *cobra.Command {
 				labels[key] = value
 			}
 
+			clientOptions := []client.ClientOption{
+				client.WithAPIKey(global.APIKey),
+				client.WithTimeout(0),
+			}
+
+			if global.Insecure {
+				clientOptions = append(clientOptions, client.WithInsecureSkipVerify())
+			}
+
+			// Create client
+			c := client.NewClient(global.ServerURL, clientOptions...)
+			modelRegistry, err := c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
+			if err != nil {
+				return fmt.Errorf("failed to get model registry %s: %w", registry, err)
+			}
+
+			// Ask what kind of registry this is before archiving anything: a
+			// registry that cannot take a push refuses it either way, and doing so
+			// here costs the user nothing instead of an archive and an upload.
+			if err := cliModel.ValidateWritableRegistry(modelRegistry, cliModel.ModelWritePush); err != nil {
+				return err
+			}
+
 			// If modelPath is a directory, tar‑gz it into a temp *.bentomodel
 			if info.IsDir() {
 				// Calculate directory size for progress bar
@@ -94,22 +117,6 @@ func NewPushCmd() *cobra.Command {
 
 				modelPath = archivePath
 				defer os.Remove(archivePath)
-			}
-
-			clientOptions := []client.ClientOption{
-				client.WithAPIKey(global.APIKey),
-				client.WithTimeout(0),
-			}
-
-			if global.Insecure {
-				clientOptions = append(clientOptions, client.WithInsecureSkipVerify())
-			}
-
-			// Create client
-			c := client.NewClient(global.ServerURL, clientOptions...)
-			modelRegistry, err := c.ModelRegistries.Get(workspace, registry) // Ensure registry exists
-			if err != nil {
-				return fmt.Errorf("failed to get model registry %s: %w", registry, err)
 			}
 
 			if localNFSPath != "" {

--- a/cmd/neutree-cli/app/cmd/model/push.go
+++ b/cmd/neutree-cli/app/cmd/model/push.go
@@ -92,7 +92,7 @@ func NewPushCmd() *cobra.Command {
 			// Ask what kind of registry this is before archiving anything: a
 			// registry that cannot take a push refuses it either way, and doing so
 			// here costs the user nothing instead of an archive and an upload.
-			if err := cliModel.ValidateWritableRegistry(modelRegistry, cliModel.ModelWritePush); err != nil {
+			if err := cliModel.ValidateWritableRegistry(modelRegistry, registry, cliModel.ModelWritePush); err != nil {
 				return err
 			}
 

--- a/cmd/neutree-cli/app/cmd/model/write_refusal_test.go
+++ b/cmd/neutree-cli/app/cmd/model/write_refusal_test.go
@@ -1,0 +1,98 @@
+package model
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
+)
+
+// registryServer answers the registry lookup both write commands make first,
+// and records every path it is asked for so a test can assert what the command
+// did *not* go on to do.
+func registryServer(t *testing.T, registryType string) (url string, paths func() []string) {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Method+" "+r.URL.Path)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":1,"metadata":{"name":"public-hugging-face","workspace":"default"},` +
+			`"spec":{"type":"` + registryType + `","url":"https://huggingface.co"}}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	return server.URL, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return append([]string(nil), seen...)
+	}
+}
+
+func useServer(t *testing.T, url string) {
+	t.Helper()
+
+	previous := global.ServerURL
+	global.ServerURL = url
+
+	t.Cleanup(func() { global.ServerURL = previous })
+}
+
+// A push to a public registry is refused before anything is packed or sent. The
+// refusal itself is only half the point: the other half is that a user who
+// picked the wrong registry does not pay for a full upload to find out.
+func TestPushRefusesAPublicRegistryBeforeUploading(t *testing.T) {
+	url, paths := registryServer(t, "hugging-face")
+	useServer(t, url)
+
+	modelDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(modelDir, "config.json"), []byte(`{}`), 0o600))
+
+	cmd := NewModelCmd()
+	cmd.SetArgs([]string{"push", modelDir, "--name", "tinymodel", "--version", "v1", "-r", "public-hugging-face"})
+
+	err := cmd.Execute()
+
+	require.EqualError(t, err,
+		`cannot push models to model registry "public-hugging-face": `+
+			`it is a hugging-face registry, which neutree reads from but never writes to`)
+
+	for _, path := range paths() {
+		require.NotContains(t, path, "/models", "push reached the model endpoint after being refused")
+	}
+}
+
+// The refusal also has to land before the confirmation prompt: delete reads
+// from stdin when --force is absent, so a test that gets as far as the prompt
+// hangs or fails on a closed stdin rather than reporting the refusal.
+func TestDeleteRefusesAPublicRegistryBeforePrompting(t *testing.T) {
+	url, paths := registryServer(t, "hugging-face")
+	useServer(t, url)
+
+	cmd := NewModelCmd()
+	cmd.SetArgs([]string{"delete", "gpt2:latest", "-r", "public-hugging-face"})
+
+	err := cmd.Execute()
+
+	require.EqualError(t, err,
+		`cannot delete models from model registry "public-hugging-face": `+
+			`it is a hugging-face registry, which neutree reads from but never writes to`)
+
+	for _, path := range paths() {
+		require.NotContains(t, path, "/models", "delete reached the model endpoint after being refused")
+	}
+}

--- a/internal/cli/model/write_target.go
+++ b/internal/cli/model/write_target.go
@@ -1,0 +1,52 @@
+package model
+
+import (
+	"fmt"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// ModelWrite names a write the CLI is about to attempt, so a refusal can say
+// which one was refused rather than "this is not supported".
+type ModelWrite string
+
+const (
+	ModelWritePush   ModelWrite = "push models to"
+	ModelWriteDelete ModelWrite = "delete models from"
+)
+
+// ValidateWritableRegistry refuses a write against a registry kind that holds
+// no models of ours.
+//
+// A hugging-face registry is a catalogue the control plane reads; every write
+// against it is answered with "operation not supported", and for a push the
+// answer only arrives after the whole model has been archived and uploaded.
+// Deciding from the registry the command has already fetched turns minutes of
+// wasted transfer into an immediate refusal, and turns a transport-level error
+// into a sentence naming the registry and what is wrong with it.
+//
+// This mirrors the server rather than replacing it: a registry kind added later
+// still falls through to whatever the server answers, so the check can only be
+// too permissive, never too strict.
+func ValidateWritableRegistry(registry *v1.ModelRegistry, write ModelWrite) error {
+	if registry == nil || registry.Spec == nil {
+		return nil
+	}
+
+	if registry.Spec.Type != v1.HuggingFaceModelRegistryType {
+		return nil
+	}
+
+	return fmt.Errorf("cannot %s model registry %q: it is a %s registry, which neutree reads from but never writes to",
+		write, registryName(registry), registry.Spec.Type)
+}
+
+// registryName is the name the user typed, recovered from the fetched object so
+// the message names the registry rather than describing it.
+func registryName(registry *v1.ModelRegistry) string {
+	if registry.Metadata == nil {
+		return ""
+	}
+
+	return registry.Metadata.Name
+}

--- a/internal/cli/model/write_target.go
+++ b/internal/cli/model/write_target.go
@@ -15,34 +15,39 @@ const (
 	ModelWriteDelete ModelWrite = "delete models from"
 )
 
-// ValidateWritableRegistry refuses a write against a registry kind that holds
-// no models of ours.
+// ValidateWritableRegistry refuses a write against a public registry.
 //
-// A hugging-face registry is a catalogue the control plane reads; every write
-// against it is answered with "operation not supported", and for a push the
-// answer only arrives after the whole model has been archived and uploaded.
-// Deciding from the registry the command has already fetched turns minutes of
-// wasted transfer into an immediate refusal, and turns a transport-level error
-// into a sentence naming the registry and what is wrong with it.
+// A public registry is a catalogue someone else operates: the control plane
+// reads it and holds none of its models, so every write against it is answered
+// with "operation not supported", and for a push that answer only arrives after
+// the whole model has been archived and uploaded. Deciding from the registry the
+// command has already fetched turns minutes of wasted transfer into an immediate
+// refusal, and turns a transport-level error into a sentence naming the registry
+// and what is wrong with it.
 //
-// This mirrors the server rather than replacing it: a registry kind added later
-// still falls through to whatever the server answers, so the check can only be
-// too permissive, never too strict.
+// Public-or-private is asked of v1.VisibilityForModelRegistryType rather than
+// derived here, so that no client carries its own list of which kinds are
+// catalogues — the same reason the server asks it in query_cache.go and
+// errors.go instead of testing for hugging-face. The next read-only provider is
+// refused here as soon as that one mapping learns about it.
 //
-// Reading the kind is the temporary part. The server is growing a `visibility`
-// field that states public-or-private itself, so that no client has to know
-// which kinds are catalogues; once it lands, switch the condition below to it
-// (v1.VisibilityForModelRegistryType is the same judgement in Go, and the
-// registry object carries `visibility` when the request selects it — PostgREST
-// omits computed columns from `select=*`). Doing so is what makes the next
-// read-only provider — ModelScope is the one already coming — refused here
-// without anyone remembering to extend a list of kinds.
+// The registry object also carries the server's own `visibility`, which is the
+// authoritative form of the same answer, but PostgREST omits computed columns
+// from `select=*` and so it is absent from what ModelRegistries.Get fetches.
+// Reading it would mean teaching that call to select it, which is a pkg/client
+// change felt by every caller of it, for an answer the exported mapping already
+// gives from one place. Not worth it here; worth revisiting if a caller ever
+// needs a visibility the client cannot derive.
+//
+// This mirrors the server rather than replacing it: a kind the mapping does not
+// know is treated as private and falls through to whatever the server answers,
+// so the check can only be too permissive, never too strict.
 func ValidateWritableRegistry(registry *v1.ModelRegistry, name string, write ModelWrite) error {
 	if registry == nil || registry.Spec == nil {
 		return nil
 	}
 
-	if registry.Spec.Type != v1.HuggingFaceModelRegistryType {
+	if v1.VisibilityForModelRegistryType(registry.Spec.Type) != v1.ModelRegistryVisibilityPublic {
 		return nil
 	}
 

--- a/internal/cli/model/write_target.go
+++ b/internal/cli/model/write_target.go
@@ -28,7 +28,16 @@ const (
 // This mirrors the server rather than replacing it: a registry kind added later
 // still falls through to whatever the server answers, so the check can only be
 // too permissive, never too strict.
-func ValidateWritableRegistry(registry *v1.ModelRegistry, write ModelWrite) error {
+//
+// Reading the kind is the temporary part. The server is growing a `visibility`
+// field that states public-or-private itself, so that no client has to know
+// which kinds are catalogues; once it lands, switch the condition below to it
+// (v1.VisibilityForModelRegistryType is the same judgement in Go, and the
+// registry object carries `visibility` when the request selects it — PostgREST
+// omits computed columns from `select=*`). Doing so is what makes the next
+// read-only provider — ModelScope is the one already coming — refused here
+// without anyone remembering to extend a list of kinds.
+func ValidateWritableRegistry(registry *v1.ModelRegistry, name string, write ModelWrite) error {
 	if registry == nil || registry.Spec == nil {
 		return nil
 	}
@@ -38,15 +47,17 @@ func ValidateWritableRegistry(registry *v1.ModelRegistry, write ModelWrite) erro
 	}
 
 	return fmt.Errorf("cannot %s model registry %q: it is a %s registry, which neutree reads from but never writes to",
-		write, registryName(registry), registry.Spec.Type)
+		write, registryName(registry, name), registry.Spec.Type)
 }
 
-// registryName is the name the user typed, recovered from the fetched object so
-// the message names the registry rather than describing it.
-func registryName(registry *v1.ModelRegistry) string {
-	if registry.Metadata == nil {
-		return ""
+// registryName is what to call the registry in the refusal. It prefers the
+// fetched object's own name and falls back to the name the caller asked for,
+// because a sentence with empty quotes in it reads as a broken tool rather than
+// as a refusal, and the caller always knows what the user typed.
+func registryName(registry *v1.ModelRegistry, requested string) string {
+	if registry.Metadata != nil && registry.Metadata.Name != "" {
+		return registry.Metadata.Name
 	}
 
-	return registry.Metadata.Name
+	return requested
 }

--- a/internal/cli/model/write_target_test.go
+++ b/internal/cli/model/write_target_test.go
@@ -48,13 +48,39 @@ func TestValidateWritableRegistryAllowsRegistriesWeStore(t *testing.T) {
 
 // The check reads a registry the command fetched, so an unusable one means the
 // fetch is what went wrong. Refusing here would report the wrong problem, and a
-// registry kind this build does not know about is the server's to judge.
+// registry kind the visibility mapping does not know is private by that
+// mapping's own rule — so it is the server's to judge, not this function's.
 func TestValidateWritableRegistryDefersWhenItCannotTell(t *testing.T) {
 	require.NoError(t, ValidateWritableRegistry(nil, "whatever", ModelWritePush))
 	require.NoError(t, ValidateWritableRegistry(&v1.ModelRegistry{}, "whatever", ModelWritePush))
 	require.NoError(t, ValidateWritableRegistry(&v1.ModelRegistry{
 		Spec: &v1.ModelRegistrySpec{Type: "some-future-kind"},
 	}, "whatever", ModelWritePush))
+}
+
+// What is refused is "public", not "hugging-face". Asserting it against the
+// mapping rather than against the one kind that is public today is what makes
+// the next read-only provider covered by this test the moment the mapping
+// learns about it — which is the whole reason the judgement was moved there.
+func TestValidateWritableRegistryRefusesWhateverTheMappingCallsPublic(t *testing.T) {
+	for _, registryType := range []v1.ModelRegistryType{
+		v1.HuggingFaceModelRegistryType,
+		v1.BentoMLModelRegistryType,
+		"some-future-kind",
+	} {
+		err := ValidateWritableRegistry(&v1.ModelRegistry{
+			Metadata: &v1.Metadata{Name: "a-registry"},
+			Spec:     &v1.ModelRegistrySpec{Type: registryType},
+		}, "a-registry", ModelWritePush)
+
+		public := v1.VisibilityForModelRegistryType(registryType) == v1.ModelRegistryVisibilityPublic
+		if public {
+			require.Error(t, err, "kind %q is public and must be refused", registryType)
+			continue
+		}
+
+		require.NoError(t, err, "kind %q is private and must be left to the server", registryType)
+	}
 }
 
 // The name comes off the fetched object, which is not guaranteed to carry

--- a/internal/cli/model/write_target_test.go
+++ b/internal/cli/model/write_target_test.go
@@ -22,12 +22,12 @@ func huggingFaceRegistry(name string) *v1.ModelRegistry {
 // impossible; "operation not supported" alone leaves the reader guessing which
 // of their registries they picked and whether it is a fault or a property.
 func TestValidateWritableRegistryNamesTheRegistryAndItsKind(t *testing.T) {
-	err := ValidateWritableRegistry(huggingFaceRegistry("public-hugging-face"), ModelWritePush)
+	err := ValidateWritableRegistry(huggingFaceRegistry("public-hugging-face"), "public-hugging-face", ModelWritePush)
 	require.EqualError(t, err,
 		`cannot push models to model registry "public-hugging-face": `+
 			`it is a hugging-face registry, which neutree reads from but never writes to`)
 
-	err = ValidateWritableRegistry(huggingFaceRegistry("public-hugging-face"), ModelWriteDelete)
+	err = ValidateWritableRegistry(huggingFaceRegistry("public-hugging-face"), "public-hugging-face", ModelWriteDelete)
 	require.EqualError(t, err,
 		`cannot delete models from model registry "public-hugging-face": `+
 			`it is a hugging-face registry, which neutree reads from but never writes to`)
@@ -42,29 +42,40 @@ func TestValidateWritableRegistryAllowsRegistriesWeStore(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, ValidateWritableRegistry(bentoml, ModelWritePush))
-	require.NoError(t, ValidateWritableRegistry(bentoml, ModelWriteDelete))
+	require.NoError(t, ValidateWritableRegistry(bentoml, "private-nfs", ModelWritePush))
+	require.NoError(t, ValidateWritableRegistry(bentoml, "private-nfs", ModelWriteDelete))
 }
 
 // The check reads a registry the command fetched, so an unusable one means the
 // fetch is what went wrong. Refusing here would report the wrong problem, and a
 // registry kind this build does not know about is the server's to judge.
 func TestValidateWritableRegistryDefersWhenItCannotTell(t *testing.T) {
-	require.NoError(t, ValidateWritableRegistry(nil, ModelWritePush))
-	require.NoError(t, ValidateWritableRegistry(&v1.ModelRegistry{}, ModelWritePush))
+	require.NoError(t, ValidateWritableRegistry(nil, "whatever", ModelWritePush))
+	require.NoError(t, ValidateWritableRegistry(&v1.ModelRegistry{}, "whatever", ModelWritePush))
 	require.NoError(t, ValidateWritableRegistry(&v1.ModelRegistry{
 		Spec: &v1.ModelRegistrySpec{Type: "some-future-kind"},
-	}, ModelWritePush))
+	}, "whatever", ModelWritePush))
 }
 
 // The name comes off the fetched object, which is not guaranteed to carry
-// metadata; an empty name is still a printable message.
-func TestValidateWritableRegistryToleratesMissingMetadata(t *testing.T) {
+// metadata. Falling back to the name the user typed is what keeps the sentence
+// readable: empty quotes in the middle of a refusal read as a broken tool, and
+// the reader is left without the one word that says which registry was meant.
+func TestValidateWritableRegistryFallsBackToTheRequestedName(t *testing.T) {
 	err := ValidateWritableRegistry(&v1.ModelRegistry{
 		Spec: &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
-	}, ModelWriteDelete)
+	}, "public-hugging-face", ModelWriteDelete)
 
 	require.EqualError(t, err,
-		`cannot delete models from model registry "": `+
+		`cannot delete models from model registry "public-hugging-face": `+
+			`it is a hugging-face registry, which neutree reads from but never writes to`)
+
+	err = ValidateWritableRegistry(&v1.ModelRegistry{
+		Metadata: &v1.Metadata{},
+		Spec:     &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
+	}, "public-hugging-face", ModelWritePush)
+
+	require.EqualError(t, err,
+		`cannot push models to model registry "public-hugging-face": `+
 			`it is a hugging-face registry, which neutree reads from but never writes to`)
 }

--- a/internal/cli/model/write_target_test.go
+++ b/internal/cli/model/write_target_test.go
@@ -1,0 +1,70 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+func huggingFaceRegistry(name string) *v1.ModelRegistry {
+	return &v1.ModelRegistry{
+		Metadata: &v1.Metadata{Name: name},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.HuggingFaceModelRegistryType,
+			Url:  "https://huggingface.co",
+		},
+	}
+}
+
+// The refusal has to name the registry and say what about it makes the write
+// impossible; "operation not supported" alone leaves the reader guessing which
+// of their registries they picked and whether it is a fault or a property.
+func TestValidateWritableRegistryNamesTheRegistryAndItsKind(t *testing.T) {
+	err := ValidateWritableRegistry(huggingFaceRegistry("public-hugging-face"), ModelWritePush)
+	require.EqualError(t, err,
+		`cannot push models to model registry "public-hugging-face": `+
+			`it is a hugging-face registry, which neutree reads from but never writes to`)
+
+	err = ValidateWritableRegistry(huggingFaceRegistry("public-hugging-face"), ModelWriteDelete)
+	require.EqualError(t, err,
+		`cannot delete models from model registry "public-hugging-face": `+
+			`it is a hugging-face registry, which neutree reads from but never writes to`)
+}
+
+func TestValidateWritableRegistryAllowsRegistriesWeStore(t *testing.T) {
+	bentoml := &v1.ModelRegistry{
+		Metadata: &v1.Metadata{Name: "private-nfs"},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.BentoMLModelRegistryType,
+			Url:  "nfs://nfs-server:/srv/models",
+		},
+	}
+
+	require.NoError(t, ValidateWritableRegistry(bentoml, ModelWritePush))
+	require.NoError(t, ValidateWritableRegistry(bentoml, ModelWriteDelete))
+}
+
+// The check reads a registry the command fetched, so an unusable one means the
+// fetch is what went wrong. Refusing here would report the wrong problem, and a
+// registry kind this build does not know about is the server's to judge.
+func TestValidateWritableRegistryDefersWhenItCannotTell(t *testing.T) {
+	require.NoError(t, ValidateWritableRegistry(nil, ModelWritePush))
+	require.NoError(t, ValidateWritableRegistry(&v1.ModelRegistry{}, ModelWritePush))
+	require.NoError(t, ValidateWritableRegistry(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{Type: "some-future-kind"},
+	}, ModelWritePush))
+}
+
+// The name comes off the fetched object, which is not guaranteed to carry
+// metadata; an empty name is still a printable message.
+func TestValidateWritableRegistryToleratesMissingMetadata(t *testing.T) {
+	err := ValidateWritableRegistry(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType},
+	}, ModelWriteDelete)
+
+	require.EqualError(t, err,
+		`cannot delete models from model registry "": `+
+			`it is a hugging-face registry, which neutree reads from but never writes to`)
+}

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -268,8 +268,8 @@ func (s *ModelsService) Delete(workspace, registry, modelName, version string) e
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned non-200/204 status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+		body, _ := io.ReadAll(resp.Body)
+		return responseError(resp.StatusCode, body)
 	}
 
 	return nil

--- a/pkg/client/model_test.go
+++ b/pkg/client/model_test.go
@@ -141,6 +141,27 @@ func TestListSurfacesTheServersMessage(t *testing.T) {
 	require.Equal(t, message+" (HTTP 400)", err.Error())
 }
 
+// Deleting is refused by the same registries that refuse to be paged, and for
+// the same kind of reason. The message the server wrote is the answer, so it
+// reads the same way here as it does for a listing rather than arriving as a
+// JSON body quoted inside a transport error.
+func TestDeleteSurfacesTheServersMessage(t *testing.T) {
+	const message = "Failed to delete model: operation not supported for Hugging Face registry"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"` + message + `"}`))
+	}))
+	defer server.Close()
+
+	c := NewClient(server.URL, WithAPIKey("api-key"))
+
+	err := c.Models.Delete("default", "registry", "gpt2", "latest")
+	require.Error(t, err)
+	require.Equal(t, message+" (HTTP 400)", err.Error())
+}
+
 // A body that carries no message still has to reach the user intact — it is all
 // there is to go on.
 func TestResponseErrorFallsBackToTheRawBody(t *testing.T) {


### PR DESCRIPTION
## Why

NEU-625 asked for two things on the CLI against a public (Hugging Face) model registry:
search + paging on `model list`, and a clear "not supported" answer for the write
operations. The first half shipped with #532 and was re-checked against a live registry
before writing any code here — `--search` / `--limit` work, `--offset` is refused with the
server's own sentence, and an uncountable catalogue reports `total: unknown`. Nothing in
that half needed changing.

The write half did not hold up. Against a `hugging-face` registry, on a real deployment:

```
$ neutree-cli model delete gpt2:latest -r public-hugging-face -f
Error: failed to delete model gpt2:latest: server returned non-200/204 status: 500,
body: {"message":"Failed to delete model: operation not supported for Hugging Face registry: ..."}
Usage:
  neutree-cli model delete [model_name:version] [flags]
... 12 more lines of usage ...
```

```
$ neutree-cli model push ./model -n tinymodel -r public-hugging-face
Creating archive 100% |███████| (302 kB)
Uploading model  100% |███████| (203 kB)          <- the whole model goes over the wire
Importing model...
Error: import failed: Error: Failed to import model: operation not supported for Hugging Face registry: ...
```

Three separate problems: the refusal arrives as a transport error with a JSON body quoted
inside it; for a push it arrives only after the model has been archived and uploaded in
full, which for a real checkpoint is minutes and gigabytes; and both bury the one useful
line under the command's usage block.

The refusal is not a failure that might go the other way next time. A `hugging-face`
registry is a catalogue the control plane reads — it does not hold models of ours — so
every write against it is refused by construction. That is knowable from the registry
object both commands already fetch before doing anything else.

## What changed

- `internal/cli/model.ValidateWritableRegistry` refuses a write against a registry kind
  that holds none of our models, naming the registry and its kind:

  ```
  cannot push models to model registry "public-hugging-face": it is a hugging-face
  registry, which neutree reads from but never writes to
  ```

- `model push` now fetches the registry **before** building the archive, so picking the
  wrong registry costs 0.13s instead of a full pack-and-upload. `model delete` refuses
  before the confirmation prompt, which was asking the user to confirm something that
  could not happen.
- The check only ever defers: a registry kind this build does not recognise, or a
  registry object it cannot read, still goes to the server. It can be too permissive,
  never too strict — so it cannot refuse a write the server would have accepted.
- `Models.Delete` reports a failure through the same path `Models.List` already uses, so
  the server's message leads and the status code follows it, instead of a JSON body
  quoted inside a transport wrapper.
- `SilenceUsage` on the `model` subcommands, which were the only group still missing it.
  A registry stating a limit is an answer, not a syntax error.

## Verification

Against a live deployment with a real Hugging Face registry, a private NFS registry, and
an unreachable Hugging Face registry, using a binary built from this branch:

| check | result |
|---|---|
| `push` to the public registry | refused in 0.13s, nothing archived, nothing uploaded |
| `delete` on the public registry, no `--force` | refused before the prompt |
| `push` to the *unreachable* public registry | same refusal — it is about the kind, not reachability |
| `list --offset` on the public registry | server's refusal, no longer buried under usage |
| `list --search --limit` on the public registry | unchanged, still `total: unknown` |
| `push` then `delete` on the private NFS registry | both succeed; the listing returns to exactly its prior five rows |
| `delete` a model that does not exist, private registry | still reaches the server, and now reads as the server's sentence + `(HTTP 500)` |

`golangci-lint run` (CI's v1.64.6, no `--fix`) clean with a clean tree afterwards;
`go build ./...`, `scripts/check-boundaries.sh` and the touched packages' tests pass.
`make test` fails only in `internal/observability/manager`, and leaves
`internal/routes/logs/trace_store_test.go` gofmt-dirty — both reproduce on a clean
checkout of `main` at the same commit and are untouched by this change.

## Relationship to the server-side fix

Rebased onto `main` after NEU-624 (#535) merged, which fixes the server side of all of
this. Every write path a public registry cannot serve now answers **400**: `deleteModel`
routes `ErrNotSupported` through `respondRegistryError`, and `uploadModel` and
`finalizeModel` refuse via `registryAcceptsWrites` before touching the request body —
`uploadModel`'s check sits deliberately ahead of `MultipartReader`, because once it starts
reading the body its status is fixed at the chunked `200` it streams progress into. So the
API no longer reports a policy refusal as a server fault to anyone.

That does not overlap with what this PR does. The server can only answer once it has been
asked, and for a push the client has by then built the archive and started uploading;
refusing from the registry the command already fetched is what makes that cost zero. The
two now agree by construction rather than by coincidence: `registryAcceptsWrites` asks
`v1.VisibilityForModelRegistryType`, and after the last commit here so does the CLI.

Reading the registry kind is settled the same way. The check asks that mapping instead of
testing for `hugging-face`, as `query_cache.go` and `errors.go` do server-side. The
server-stated `visibility` field is deliberately *not* read: it is a PostgREST computed
column, so it is absent from what `ModelRegistries.Get` fetches — confirmed against a live
deployment rather than assumed —

```
?select=metadata,spec,visibility  ->  {"name":"public-hugging-face","visibility":"public"}
?metadata->>name=eq.public-...    ->  {"name":"public-hugging-face","visibility":"ABSENT"}
```

Reaching it means teaching `ModelRegistries.Get` to select it, which is a `pkg/client`
change felt by all five of its callers, four of which do not want the answer, for
something the exported mapping already gives from one place. The doc comment records that
trade and what would justify revisiting it.

Closes NEU-625.
