### PR TITLE
fix: release HTTP listener on context cancel in app Run

### DIFF
--- a/cmd/neutree-api/app/app.go
+++ b/cmd/neutree-api/app/app.go
@@ -12,10 +12,18 @@ import (
 	"github.com/neutree-ai/neutree/cmd/neutree-api/app/config"
 )
 
-// serverShutdownTimeout bounds how long Run waits for in-flight requests to
-// drain after context cancellation before returning; the OS reclaims the
-// listener once the server is shut down.
-const serverShutdownTimeout = 5 * time.Second
+const (
+	// serverShutdownTimeout bounds how long Run waits for in-flight requests
+	// to drain after context cancellation before returning; the OS reclaims
+	// the listener once the server is shut down.
+	serverShutdownTimeout = 5 * time.Second
+
+	// readHeaderTimeout bounds how long the server waits for a request header
+	// before dropping the connection, guarding against slowloris-style
+	// clients. Kept independent of the shutdown budget so that raising one
+	// never silently weakens the other.
+	readHeaderTimeout = 5 * time.Second
+)
 
 // App represents the main API application
 type App struct {
@@ -40,7 +48,7 @@ func (a *App) Run(ctx context.Context) error {
 	server := &http.Server{
 		Addr:              serverAddr,
 		Handler:           a.config.GinEngine,
-		ReadHeaderTimeout: serverShutdownTimeout,
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
 	errCh := make(chan error, 1)
@@ -59,7 +67,7 @@ func (a *App) Run(ctx context.Context) error {
 		defer cancel()
 
 		if err := server.Shutdown(shutdownCtx); err != nil {
-			return err
+			return fmt.Errorf("shutdown API server: %w", err)
 		}
 
 		return <-errCh

--- a/cmd/neutree-api/app/app.go
+++ b/cmd/neutree-api/app/app.go
@@ -2,12 +2,20 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	"k8s.io/klog/v2"
 
 	"github.com/neutree-ai/neutree/cmd/neutree-api/app/config"
 )
+
+// serverShutdownTimeout bounds how long Run waits for in-flight requests to
+// drain after context cancellation before returning; the OS reclaims the
+// listener once the server is shut down.
+const serverShutdownTimeout = 5 * time.Second
 
 // App represents the main API application
 type App struct {
@@ -29,13 +37,33 @@ func (a *App) Run(ctx context.Context) error {
 	serverAddr := fmt.Sprintf("%s:%d", a.config.ServerConfig.Host, a.config.ServerConfig.Port)
 	klog.Infof("Starting API server on %s", serverAddr)
 
+	server := &http.Server{
+		Addr:              serverAddr,
+		Handler:           a.config.GinEngine,
+		ReadHeaderTimeout: serverShutdownTimeout,
+	}
+
+	errCh := make(chan error, 1)
 	go func() {
-		if err := a.config.GinEngine.Run(serverAddr); err != nil {
-			klog.Fatalf("Failed to start API server: %s", err.Error())
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
 		}
+
+		errCh <- nil
 	}()
 
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
+		defer cancel()
 
-	return nil
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+
+		return <-errCh
+	case err := <-errCh:
+		return err
+	}
 }

--- a/cmd/neutree-api/app/app_run_test.go
+++ b/cmd/neutree-api/app/app_run_test.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neutree-ai/neutree/cmd/neutree-api/app/config"
+)
+
+const (
+	testHost            = "127.0.0.1"
+	testStartTimeout    = 10 * time.Second
+	testShutdownTimeout = 10 * time.Second
+)
+
+func newTestAPIApp(t *testing.T, port int) *App {
+	t.Helper()
+
+	return NewApp(&config.APIConfig{
+		GinEngine:    gin.New(),
+		ServerConfig: &config.ServerConfig{Host: testHost, Port: port},
+	})
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", net.JoinHostPort(testHost, "0"))
+	if err != nil {
+		t.Fatalf("allocate probe port: %v", err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close probe listener: %v", err)
+	}
+
+	return port
+}
+
+func startTestApp(t *testing.T, app *App, addr string) (context.CancelFunc, <-chan error) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.Run(ctx)
+	}()
+
+	waitForListener(t, addr, testStartTimeout)
+
+	return cancel, done
+}
+
+func waitForListener(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("listener %s not connectable within %v: %v", addr, timeout, err)
+		}
+
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func waitRunReturned(t *testing.T, done <-chan error, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("App.Run() error = %v", err)
+		}
+	case <-time.After(timeout):
+		t.Fatalf("App.Run() did not return within %v", timeout)
+	}
+}
+
+func waitPortRebindable(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		listener, err := net.Listen("tcp", addr)
+		if err == nil {
+			_ = listener.Close()
+
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("port %s still occupied within %v: %v", addr, timeout, err)
+		}
+
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func TestAppRunReleasesListenerOnContextCancel(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestAPIApp(t, port)
+
+	cancel, done := startTestApp(t, app, addr)
+	cancel()
+
+	waitRunReturned(t, done, testShutdownTimeout)
+	waitPortRebindable(t, addr, 5*time.Second)
+}
+
+func TestAppRunRepeatedStartStopReleasesListener(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+
+	for range 2 {
+		app := newTestAPIApp(t, port)
+
+		cancel, done := startTestApp(t, app, addr)
+		cancel()
+
+		waitRunReturned(t, done, testShutdownTimeout)
+		waitPortRebindable(t, addr, 5*time.Second)
+	}
+}
+
+func TestAppRunServesRequestsBeforeCancel(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestAPIApp(t, port)
+	app.config.GinEngine.GET("/healthz", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	cancel, done := startTestApp(t, app, addr)
+	defer cancel()
+
+	resp, err := http.Get("http://" + addr + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	cancel()
+
+	waitRunReturned(t, done, testShutdownTimeout)
+	waitPortRebindable(t, addr, 5*time.Second)
+}

--- a/cmd/neutree-api/app/app_run_test.go
+++ b/cmd/neutree-api/app/app_run_test.go
@@ -164,3 +164,88 @@ func TestAppRunServesRequestsBeforeCancel(t *testing.T) {
 	waitRunReturned(t, done, testShutdownTimeout)
 	waitPortRebindable(t, addr, 5*time.Second)
 }
+
+func TestAppRunShutdownTimeoutReleasesListenerWithInFlightRequest(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestAPIApp(t, port)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	app.config.GinEngine.GET("/slow", func(c *gin.Context) {
+		close(started)
+		<-release
+		c.String(http.StatusOK, "done")
+	})
+
+	cancel, done := startTestApp(t, app, addr)
+
+	go func() {
+		resp, err := http.Get("http://" + addr + "/slow")
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	<-started // the request is now in-flight inside the handler
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("App.Run() error = nil, want shutdown timeout error")
+		}
+	case <-time.After(testShutdownTimeout + 2*time.Second):
+		t.Fatalf("App.Run() did not return within %v", testShutdownTimeout+2*time.Second)
+	}
+
+	close(release)
+	waitPortRebindable(t, addr, 5*time.Second)
+}
+
+func TestAppRunReturnsErrorWhenPortOccupied(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestAPIApp(t, port)
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer listener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.Run(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("App.Run() error = nil, want bind error")
+		}
+	case <-time.After(testStartTimeout):
+		t.Fatalf("App.Run() did not return the bind error within %v", testStartTimeout)
+	}
+}
+
+func TestAppRunPreCancelledContextReleasesListener(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestAPIApp(t, port)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.Run(ctx)
+	}()
+
+	waitRunReturned(t, done, testShutdownTimeout)
+	waitPortRebindable(t, addr, 5*time.Second)
+}

--- a/cmd/neutree-core/app/app.go
+++ b/cmd/neutree-core/app/app.go
@@ -14,10 +14,18 @@ import (
 	"github.com/neutree-ai/neutree/internal/cron"
 )
 
-// serverShutdownTimeout bounds how long Run waits for in-flight requests to
-// drain after context cancellation before returning; the OS reclaims the
-// listener once the server is shut down.
-const serverShutdownTimeout = 5 * time.Second
+const (
+	// serverShutdownTimeout bounds how long Run waits for in-flight requests
+	// to drain after context cancellation before returning; the OS reclaims
+	// the listener once the server is shut down.
+	serverShutdownTimeout = 5 * time.Second
+
+	// readHeaderTimeout bounds how long the server waits for a request header
+	// before dropping the connection, guarding against slowloris-style
+	// clients. Kept independent of the shutdown budget so that raising one
+	// never silently weakens the other.
+	readHeaderTimeout = 5 * time.Second
+)
 
 // App represents the main application
 type App struct {
@@ -61,7 +69,7 @@ func (a *App) Run(ctx context.Context) error {
 	server := &http.Server{
 		Addr:              coreServerListenAddr,
 		Handler:           a.config.GinEngine,
-		ReadHeaderTimeout: serverShutdownTimeout,
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
 	errCh := make(chan error, 1)
@@ -80,7 +88,7 @@ func (a *App) Run(ctx context.Context) error {
 		defer cancel()
 
 		if err := server.Shutdown(shutdownCtx); err != nil {
-			return err
+			return fmt.Errorf("shutdown core server: %w", err)
 		}
 
 		return <-errCh

--- a/cmd/neutree-core/app/app.go
+++ b/cmd/neutree-core/app/app.go
@@ -2,7 +2,10 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -10,6 +13,11 @@ import (
 	"github.com/neutree-ai/neutree/controllers"
 	"github.com/neutree-ai/neutree/internal/cron"
 )
+
+// serverShutdownTimeout bounds how long Run waits for in-flight requests to
+// drain after context cancellation before returning; the OS reclaims the
+// listener once the server is shut down.
+const serverShutdownTimeout = 5 * time.Second
 
 // App represents the main application
 type App struct {
@@ -45,19 +53,38 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	// Start core server
-	coreServerLinstenAddr := fmt.Sprintf("%s:%d",
+	coreServerListenAddr := fmt.Sprintf("%s:%d",
 		a.config.ServerConfig.Host,
 		a.config.ServerConfig.Port)
-	klog.Infof("Starting core server on %s", coreServerLinstenAddr)
+	klog.Infof("Starting core server on %s", coreServerListenAddr)
 
+	server := &http.Server{
+		Addr:              coreServerListenAddr,
+		Handler:           a.config.GinEngine,
+		ReadHeaderTimeout: serverShutdownTimeout,
+	}
+
+	errCh := make(chan error, 1)
 	go func() {
-		if err := a.config.GinEngine.Run(coreServerLinstenAddr); err != nil {
-			klog.Fatalf("failed to start core server: %s", err.Error())
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
 		}
+
+		errCh <- nil
 	}()
 
-	// Wait for context cancellation
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
+		defer cancel()
 
-	return nil
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+
+		return <-errCh
+	case err := <-errCh:
+		return err
+	}
 }

--- a/cmd/neutree-core/app/app_run_test.go
+++ b/cmd/neutree-core/app/app_run_test.go
@@ -194,6 +194,91 @@ func TestAppRunServesRequestsBeforeCancel(t *testing.T) {
 	waitPortRebindable(t, addr, 5*time.Second)
 }
 
+func TestAppRunShutdownTimeoutReleasesListenerWithInFlightRequest(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestCoreApp(t, port)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	app.config.GinEngine.GET("/slow", func(c *gin.Context) {
+		close(started)
+		<-release
+		c.String(http.StatusOK, "done")
+	})
+
+	cancel, done := startTestApp(t, app, addr)
+
+	go func() {
+		resp, err := http.Get("http://" + addr + "/slow")
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	<-started // the request is now in-flight inside the handler
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("App.Run() error = nil, want shutdown timeout error")
+		}
+	case <-time.After(testShutdownTimeout + 2*time.Second):
+		t.Fatalf("App.Run() did not return within %v", testShutdownTimeout+2*time.Second)
+	}
+
+	close(release)
+	waitPortRebindable(t, addr, 5*time.Second)
+}
+
+func TestAppRunReturnsErrorWhenPortOccupied(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestCoreApp(t, port)
+
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("occupy port: %v", err)
+	}
+	defer listener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.Run(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("App.Run() error = nil, want bind error")
+		}
+	case <-time.After(testStartTimeout):
+		t.Fatalf("App.Run() did not return the bind error within %v", testStartTimeout)
+	}
+}
+
+func TestAppRunPreCancelledContextReleasesListener(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestCoreApp(t, port)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.Run(ctx)
+	}()
+
+	waitRunReturned(t, done, testShutdownTimeout)
+	waitPortRebindable(t, addr, 5*time.Second)
+}
+
 func TestAppRunWithInjectedPluginShutsDownOnCancel(t *testing.T) {
 	port := freePort(t)
 	addr := net.JoinHostPort(testHost, strconv.Itoa(port))

--- a/cmd/neutree-core/app/app_run_test.go
+++ b/cmd/neutree-core/app/app_run_test.go
@@ -1,0 +1,217 @@
+package app
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neutree-ai/neutree/cmd/neutree-core/app/config"
+	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
+	"github.com/neutree-ai/neutree/internal/observability/manager"
+	mockstorage "github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+const (
+	testHost            = "127.0.0.1"
+	testStartTimeout    = 10 * time.Second
+	testShutdownTimeout = 10 * time.Second
+)
+
+// obsCollectConfigManagerStub satisfies ObsCollectConfigManager without
+// wiring the real observability collector, which is not under test.
+type obsCollectConfigManagerStub struct{}
+
+func (obsCollectConfigManagerStub) GetMetricsCollectConfigManager() manager.MetricsCollectConfigManager {
+	return nil
+}
+
+func (obsCollectConfigManagerStub) Start(context.Context) {}
+
+func newTestCoreConfig(t *testing.T, port int) *config.CoreConfig {
+	t.Helper()
+
+	return &config.CoreConfig{
+		GinEngine:               gin.New(),
+		ObsCollectConfigManager: obsCollectConfigManagerStub{},
+		Storage:                 mockstorage.NewMockStorage(t),
+		ServerConfig:            &config.ServerConfig{Host: testHost, Port: port},
+	}
+}
+
+func newTestCoreApp(t *testing.T, port int) *App {
+	t.Helper()
+
+	builder := NewBuilder().WithConfig(newTestCoreConfig(t, port))
+	builder.controllerInits = map[string]ControllerFactory{}
+
+	app, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	return app
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", net.JoinHostPort(testHost, "0"))
+	if err != nil {
+		t.Fatalf("allocate probe port: %v", err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close probe listener: %v", err)
+	}
+
+	return port
+}
+
+func startTestApp(t *testing.T, app *App, addr string) (context.CancelFunc, <-chan error) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.Run(ctx)
+	}()
+
+	waitForListener(t, addr, testStartTimeout)
+
+	return cancel, done
+}
+
+func waitForListener(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("listener %s not connectable within %v: %v", addr, timeout, err)
+		}
+
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func waitRunReturned(t *testing.T, done <-chan error, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("App.Run() error = %v", err)
+		}
+	case <-time.After(timeout):
+		t.Fatalf("App.Run() did not return within %v", timeout)
+	}
+}
+
+func waitPortRebindable(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		listener, err := net.Listen("tcp", addr)
+		if err == nil {
+			_ = listener.Close()
+
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("port %s still occupied within %v: %v", addr, timeout, err)
+		}
+
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func TestAppRunReleasesListenerOnContextCancel(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestCoreApp(t, port)
+
+	cancel, done := startTestApp(t, app, addr)
+	cancel()
+
+	waitRunReturned(t, done, testShutdownTimeout)
+	waitPortRebindable(t, addr, 5*time.Second)
+}
+
+func TestAppRunRepeatedStartStopReleasesListener(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+
+	for range 2 {
+		app := newTestCoreApp(t, port)
+
+		cancel, done := startTestApp(t, app, addr)
+		cancel()
+
+		waitRunReturned(t, done, testShutdownTimeout)
+		waitPortRebindable(t, addr, 5*time.Second)
+	}
+}
+
+func TestAppRunServesRequestsBeforeCancel(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	app := newTestCoreApp(t, port)
+	app.config.GinEngine.GET("/healthz", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	cancel, done := startTestApp(t, app, addr)
+	defer cancel()
+
+	resp, err := http.Get("http://" + addr + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /healthz status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	cancel()
+
+	waitRunReturned(t, done, testShutdownTimeout)
+	waitPortRebindable(t, addr, 5*time.Second)
+}
+
+func TestAppRunWithInjectedPluginShutsDownOnCancel(t *testing.T) {
+	port := freePort(t)
+	addr := net.JoinHostPort(testHost, strconv.Itoa(port))
+	cfg := newTestCoreConfig(t, port)
+	injected := internalTestPlugin{
+		AcceleratorPlugin: plugin.NewAcceleratorRestPlugin("injected-test", "http://plugin.example"),
+	}
+	builder := NewBuilder().WithConfig(cfg).WithAcceleratorPlugins(injected)
+	builder.controllerInits = map[string]ControllerFactory{}
+
+	app, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build() with injected plugin error = %v", err)
+	}
+
+	cancel, done := startTestApp(t, app, addr)
+	cancel()
+
+	waitRunReturned(t, done, testShutdownTimeout)
+	waitPortRebindable(t, addr, 5*time.Second)
+}


### PR DESCRIPTION
## Issue

NEU-670

## Summary

`App.Run` starts the gin server via `GinEngine.Run` in a goroutine and returns on context cancellation without ever shutting the server down, leaving the HTTP listener bound. Restarting the app in the same process then fails to rebind the run-owned port ("address already in use"). This was found while verifying the accelerator plugin start/stop lifecycle.

## Changes

- `cmd/neutree-core/app/app.go`: serve the gin engine through an explicit `http.Server`; on context cancellation call `Shutdown` with a bounded 5s timeout and only then return. A serve error other than `ErrServerClosed` is now returned from `Run` (the entrypoint already exits fatally on it) instead of `klog.Fatalf` from the goroutine.
- `cmd/neutree-api/app/app.go`: same fix (identical pattern).
- New lifecycle tests for both apps: context cancel releases the listener, repeated start/stop in the same process stays leak-free, requests are served normally before cancel, and the core app shuts down cleanly with an injected internal accelerator plugin.

## Test Plan

- [x] Unit tests (`go test ./cmd/neutree-core/app/... ./cmd/neutree-api/app/...`): 7 lifecycle tests — RED before the fix (`bind: address already in use` after `Run` returned), GREEN after; full package suites pass; `-race` clean.
- [x] `go vet` + `golangci-lint` (pinned v1.64.6) on changed packages: clean.
- [ ] E2E: not applicable — the bug only manifests when the app is stopped and restarted inside the same process; the deployed control plane runs as a single process per container, where OS exit reclaims the port, so the e2e harness cannot construct this scenario. The plugin lifecycle path is covered by the new unit test and the existing NEU-562 lifecycle case.
- [ ] DB integration: not affected.

## Risk & Rollback

No schema change, no API change. Startup-failure behavior is preserved (entrypoint still exits fatally, now via the error returned from `Run`). Rollback: revert this commit — the previous binary simply keeps the leak behavior.

## Classification

Trivial (per user downgrade — the change is Go cmd/ code that would normally be Standard): docs MR / TestRail / e2e skipped. Claude + Copilot review pipeline still applies.

## Follow-ups

- `cmd/neutree-api/neutree-api.go` has no signal handler wiring SIGTERM/SIGINT into the context passed to `App.Run`, so in production the API app's context never cancels and the shutdown path added here is exercised only by tests and future callers. Wiring a signal handler for the API app is a separate change.
- The graceful-shutdown pattern now exists in three places (`cmd/neutree-core/app/app.go`, `cmd/neutree-api/app/app.go`, `internal/observability/neutreemetrics/server.go`). Extracting a shared helper is a possible follow-up; the three copies are intentionally small and identical so a future extraction is mechanical.