### PR TITLE
fix: preserve pre-seeded AcceleratorManager when builder injects plugins

### DIFF
--- a/cmd/neutree-core/app/builder.go
+++ b/cmd/neutree-core/app/builder.go
@@ -118,13 +118,17 @@ func (b *Builder) Build() (*App, error) {
 		return nil, fmt.Errorf("gin engine is required")
 	}
 
-	if b.config.AcceleratorManager == nil || len(b.acceleratorPlugins) > 0 {
+	if b.config.AcceleratorManager == nil {
 		acceleratorManager, err := accelerator.NewManagerWithPlugins(b.config.GinEngine, b.acceleratorPlugins...)
 		if err != nil {
 			return nil, fmt.Errorf("create accelerator manager: %w", err)
 		}
 
 		b.config.AcceleratorManager = acceleratorManager
+	} else if len(b.acceleratorPlugins) > 0 {
+		if err := b.config.AcceleratorManager.AddInternalPlugins(b.acceleratorPlugins...); err != nil {
+			return nil, fmt.Errorf("register injected accelerator plugins: %w", err)
+		}
 	}
 
 	registerControllers := make(map[string]controllers.Controller)

--- a/cmd/neutree-core/app/builder_test.go
+++ b/cmd/neutree-core/app/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/neutree-ai/neutree/cmd/neutree-core/app/config"
+	"github.com/neutree-ai/neutree/internal/accelerator"
 	acceleratormocks "github.com/neutree-ai/neutree/internal/accelerator/mocks"
 	"github.com/neutree-ai/neutree/internal/accelerator/plugin"
 )
@@ -52,6 +53,29 @@ func TestBuilderBuildInjectsAcceleratorPlugins(t *testing.T) {
 	}
 	if _, ok := config.AcceleratorManager.GetPlugin("injected-test"); !ok {
 		t.Fatal("Build() did not register the injected accelerator plugin")
+	}
+}
+
+func TestBuilderBuildRegistersInjectedPluginsOnExistingManager(t *testing.T) {
+	engine := gin.New()
+	existingManager, err := accelerator.NewManagerWithPlugins(engine)
+	if err != nil {
+		t.Fatalf("NewManagerWithPlugins() error = %v", err)
+	}
+
+	config := &config.CoreConfig{GinEngine: engine, AcceleratorManager: existingManager}
+	injected := internalTestPlugin{AcceleratorPlugin: plugin.NewAcceleratorRestPlugin("injected-test", "http://plugin.example")}
+	builder := NewBuilder().WithConfig(config).WithAcceleratorPlugins(injected)
+	builder.controllerInits = map[string]ControllerFactory{}
+
+	if _, err := builder.Build(); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if config.AcceleratorManager != existingManager {
+		t.Fatal("Build() replaced the configured AcceleratorManager with injected plugins")
+	}
+	if _, ok := config.AcceleratorManager.GetPlugin("injected-test"); !ok {
+		t.Fatal("Build() did not register the injected accelerator plugin into the existing manager")
 	}
 }
 

--- a/internal/accelerator/manager.go
+++ b/internal/accelerator/manager.go
@@ -51,6 +51,10 @@ type Manager interface {
 	// (e.g. "rocm" for amd_gpu). Returns empty string for default variant or if
 	// the accelerator type is not registered.
 	GetImageSuffix(acceleratorType string) string
+
+	// AddInternalPlugins registers internal accelerator plugins on an existing
+	// manager without re-registering manager-owned routes.
+	AddInternalPlugins(plugins ...publicaccelerator.Plugin) error
 }
 
 type registerPlugin struct {
@@ -91,10 +95,8 @@ func NewManagerWithPlugins(e *gin.Engine, injectedPlugins ...publicaccelerator.P
 		klog.Infof("Register local accelerator plugin: %s", p.Resource())
 	}
 
-	for _, p := range injectedPlugins {
-		if err := manager.addInternalPlugin(p); err != nil {
-			return nil, err
-		}
+	if err := manager.AddInternalPlugins(injectedPlugins...); err != nil {
+		return nil, err
 	}
 
 	// register plugin register handler
@@ -104,25 +106,40 @@ func NewManagerWithPlugins(e *gin.Engine, injectedPlugins ...publicaccelerator.P
 	return manager, nil
 }
 
-func (a *manager) addInternalPlugin(p publicaccelerator.Plugin) error {
-	if isNilPlugin(p) {
-		return fmt.Errorf("accelerator plugin is nil")
+// AddInternalPlugins registers internal accelerator plugins on an existing
+// manager. All plugins are validated before any is stored, so an invalid
+// input fails atomically without leaving partially registered plugins.
+func (a *manager) AddInternalPlugins(plugins ...publicaccelerator.Plugin) error {
+	seen := make(map[string]struct{}, len(plugins))
+
+	for _, p := range plugins {
+		if isNilPlugin(p) {
+			return fmt.Errorf("accelerator plugin is nil")
+		}
+
+		if p.Resource() == "" {
+			return fmt.Errorf("accelerator plugin resource is required")
+		}
+
+		if _, exists := seen[p.Resource()]; exists {
+			return fmt.Errorf("accelerator plugin resource %q is already registered", p.Resource())
+		}
+
+		if _, exists := a.acceleratorsMap.Load(p.Resource()); exists {
+			return fmt.Errorf("accelerator plugin resource %q is already registered", p.Resource())
+		}
+
+		seen[p.Resource()] = struct{}{}
 	}
 
-	if p.Resource() == "" {
-		return fmt.Errorf("accelerator plugin resource is required")
+	for _, p := range plugins {
+		a.acceleratorsMap.Store(p.Resource(), registerPlugin{
+			resource:         p.Resource(),
+			plugin:           p,
+			lastRegisterTime: time.Now(),
+		})
+		klog.Infof("Register internal accelerator plugin: %s", p.Resource())
 	}
-
-	if _, exists := a.acceleratorsMap.Load(p.Resource()); exists {
-		return fmt.Errorf("accelerator plugin resource %q is already registered", p.Resource())
-	}
-
-	a.acceleratorsMap.Store(p.Resource(), registerPlugin{
-		resource:         p.Resource(),
-		plugin:           p,
-		lastRegisterTime: time.Now(),
-	})
-	klog.Infof("Register internal accelerator plugin: %s", p.Resource())
 
 	return nil
 }

--- a/internal/accelerator/manager.go
+++ b/internal/accelerator/manager.go
@@ -53,7 +53,9 @@ type Manager interface {
 	GetImageSuffix(acceleratorType string) string
 
 	// AddInternalPlugins registers internal accelerator plugins on an existing
-	// manager without re-registering manager-owned routes.
+	// manager without re-registering manager-owned routes. All plugins must be
+	// internal type: the health sync loop removes any plugin whose Type() is
+	// not InternalPluginType. The batch is validated atomically.
 	AddInternalPlugins(plugins ...publicaccelerator.Plugin) error
 }
 
@@ -109,6 +111,7 @@ func NewManagerWithPlugins(e *gin.Engine, injectedPlugins ...publicaccelerator.P
 // AddInternalPlugins registers internal accelerator plugins on an existing
 // manager. All plugins are validated before any is stored, so an invalid
 // input fails atomically without leaving partially registered plugins.
+// Validation is per invocation: concurrent calls are not serialized.
 func (a *manager) AddInternalPlugins(plugins ...publicaccelerator.Plugin) error {
 	seen := make(map[string]struct{}, len(plugins))
 

--- a/internal/accelerator/manager_test.go
+++ b/internal/accelerator/manager_test.go
@@ -257,6 +257,48 @@ func TestNewManagerWithPluginsRejectsInvalidPlugins(t *testing.T) {
 	}
 }
 
+func TestManagerAddInternalPluginsRegistersPluginsOnExistingManager(t *testing.T) {
+	manager, err := NewManagerWithPlugins(gin.New())
+	require.NoError(t, err)
+
+	injected := &fakeStaticNodeAcceleratorPlugin{resourceSet: true, resource: "injected_gpu"}
+
+	err = manager.AddInternalPlugins(injected)
+
+	require.NoError(t, err)
+	assert.Contains(t, manager.SupportPlugins(), "injected_gpu")
+	assert.Contains(t, manager.SupportPlugins(), v1.AcceleratorTypeNVIDIAGPU.String())
+}
+
+func TestManagerAddInternalPluginsFailsAtomically(t *testing.T) {
+	valid := &fakeStaticNodeAcceleratorPlugin{resourceSet: true, resource: "injected_gpu"}
+	emptyResource := &fakeStaticNodeAcceleratorPlugin{resourceSet: true}
+	var typedNil *fakeStaticNodeAcceleratorPlugin
+
+	tests := []struct {
+		name    string
+		plugins []plugin.AcceleratorPlugin
+		message string
+	}{
+		{name: "batch with duplicate resource", plugins: []plugin.AcceleratorPlugin{valid, &fakeStaticNodeAcceleratorPlugin{resourceSet: true, resource: v1.AcceleratorTypeNVIDIAGPU.String()}}, message: "already registered"},
+		{name: "batch with empty resource", plugins: []plugin.AcceleratorPlugin{valid, emptyResource}, message: "resource is required"},
+		{name: "batch with typed nil", plugins: []plugin.AcceleratorPlugin{valid, typedNil}, message: "accelerator plugin is nil"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager, err := NewManagerWithPlugins(gin.New())
+			require.NoError(t, err)
+
+			err = manager.AddInternalPlugins(tt.plugins...)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.message)
+			assert.NotContains(t, manager.SupportPlugins(), "injected_gpu")
+		})
+	}
+}
+
 func TestManagerGetAcceleratorProfileFromExternalPlugin(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)

--- a/internal/accelerator/manager_test.go
+++ b/internal/accelerator/manager_test.go
@@ -280,7 +280,8 @@ func TestManagerAddInternalPluginsFailsAtomically(t *testing.T) {
 		plugins []plugin.AcceleratorPlugin
 		message string
 	}{
-		{name: "batch with duplicate resource", plugins: []plugin.AcceleratorPlugin{valid, &fakeStaticNodeAcceleratorPlugin{resourceSet: true, resource: v1.AcceleratorTypeNVIDIAGPU.String()}}, message: "already registered"},
+		{name: "batch with duplicate of manager-registered resource", plugins: []plugin.AcceleratorPlugin{valid, &fakeStaticNodeAcceleratorPlugin{resourceSet: true, resource: v1.AcceleratorTypeNVIDIAGPU.String()}}, message: "already registered"},
+		{name: "batch with duplicate resource within batch", plugins: []plugin.AcceleratorPlugin{valid, valid}, message: "already registered"},
 		{name: "batch with empty resource", plugins: []plugin.AcceleratorPlugin{valid, emptyResource}, message: "resource is required"},
 		{name: "batch with typed nil", plugins: []plugin.AcceleratorPlugin{valid, typedNil}, message: "accelerator plugin is nil"},
 	}

--- a/internal/accelerator/mocks/mock_manager.go
+++ b/internal/accelerator/mocks/mock_manager.go
@@ -5,7 +5,8 @@ package mocks
 import (
 	context "context"
 
-	pkgaccelerator "github.com/neutree-ai/neutree/pkg/accelerator"
+	accelerator "github.com/neutree-ai/neutree/pkg/accelerator"
+
 	mock "github.com/stretchr/testify/mock"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
@@ -22,6 +23,65 @@ type MockManager_Expecter struct {
 
 func (_m *MockManager) EXPECT() *MockManager_Expecter {
 	return &MockManager_Expecter{mock: &_m.Mock}
+}
+
+// AddInternalPlugins provides a mock function with given fields: plugins
+func (_m *MockManager) AddInternalPlugins(plugins ...accelerator.Plugin) error {
+	_va := make([]interface{}, len(plugins))
+	for _i := range plugins {
+		_va[_i] = plugins[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddInternalPlugins")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(...accelerator.Plugin) error); ok {
+		r0 = rf(plugins...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockManager_AddInternalPlugins_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddInternalPlugins'
+type MockManager_AddInternalPlugins_Call struct {
+	*mock.Call
+}
+
+// AddInternalPlugins is a helper method to define mock.On call
+//   - plugins ...accelerator.Plugin
+func (_e *MockManager_Expecter) AddInternalPlugins(plugins ...interface{}) *MockManager_AddInternalPlugins_Call {
+	return &MockManager_AddInternalPlugins_Call{Call: _e.mock.On("AddInternalPlugins",
+		append([]interface{}{}, plugins...)...)}
+}
+
+func (_c *MockManager_AddInternalPlugins_Call) Run(run func(plugins ...accelerator.Plugin)) *MockManager_AddInternalPlugins_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]accelerator.Plugin, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(accelerator.Plugin)
+			}
+		}
+		run(variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockManager_AddInternalPlugins_Call) Return(_a0 error) *MockManager_AddInternalPlugins_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockManager_AddInternalPlugins_Call) RunAndReturn(run func(...accelerator.Plugin) error) *MockManager_AddInternalPlugins_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // DetectAccelerator provides a mock function with given fields: ctx, nodeIP, sshAuth
@@ -144,19 +204,19 @@ func (_c *MockManager_GetAcceleratorProfile_Call) RunAndReturn(run func(context.
 }
 
 // GetAllConverters provides a mock function with no fields
-func (_m *MockManager) GetAllConverters() map[string]pkgaccelerator.ResourceConverter {
+func (_m *MockManager) GetAllConverters() map[string]accelerator.ResourceConverter {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllConverters")
 	}
 
-	var r0 map[string]pkgaccelerator.ResourceConverter
-	if rf, ok := ret.Get(0).(func() map[string]pkgaccelerator.ResourceConverter); ok {
+	var r0 map[string]accelerator.ResourceConverter
+	if rf, ok := ret.Get(0).(func() map[string]accelerator.ResourceConverter); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]pkgaccelerator.ResourceConverter)
+			r0 = ret.Get(0).(map[string]accelerator.ResourceConverter)
 		}
 	}
 
@@ -180,30 +240,30 @@ func (_c *MockManager_GetAllConverters_Call) Run(run func()) *MockManager_GetAll
 	return _c
 }
 
-func (_c *MockManager_GetAllConverters_Call) Return(_a0 map[string]pkgaccelerator.ResourceConverter) *MockManager_GetAllConverters_Call {
+func (_c *MockManager_GetAllConverters_Call) Return(_a0 map[string]accelerator.ResourceConverter) *MockManager_GetAllConverters_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockManager_GetAllConverters_Call) RunAndReturn(run func() map[string]pkgaccelerator.ResourceConverter) *MockManager_GetAllConverters_Call {
+func (_c *MockManager_GetAllConverters_Call) RunAndReturn(run func() map[string]accelerator.ResourceConverter) *MockManager_GetAllConverters_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetAllParsers provides a mock function with no fields
-func (_m *MockManager) GetAllParsers() map[string]pkgaccelerator.ResourceParser {
+func (_m *MockManager) GetAllParsers() map[string]accelerator.ResourceParser {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllParsers")
 	}
 
-	var r0 map[string]pkgaccelerator.ResourceParser
-	if rf, ok := ret.Get(0).(func() map[string]pkgaccelerator.ResourceParser); ok {
+	var r0 map[string]accelerator.ResourceParser
+	if rf, ok := ret.Get(0).(func() map[string]accelerator.ResourceParser); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]pkgaccelerator.ResourceParser)
+			r0 = ret.Get(0).(map[string]accelerator.ResourceParser)
 		}
 	}
 
@@ -227,34 +287,34 @@ func (_c *MockManager_GetAllParsers_Call) Run(run func()) *MockManager_GetAllPar
 	return _c
 }
 
-func (_c *MockManager_GetAllParsers_Call) Return(_a0 map[string]pkgaccelerator.ResourceParser) *MockManager_GetAllParsers_Call {
+func (_c *MockManager_GetAllParsers_Call) Return(_a0 map[string]accelerator.ResourceParser) *MockManager_GetAllParsers_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockManager_GetAllParsers_Call) RunAndReturn(run func() map[string]pkgaccelerator.ResourceParser) *MockManager_GetAllParsers_Call {
+func (_c *MockManager_GetAllParsers_Call) RunAndReturn(run func() map[string]accelerator.ResourceParser) *MockManager_GetAllParsers_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetConverter provides a mock function with given fields: acceleratorType
-func (_m *MockManager) GetConverter(acceleratorType string) (pkgaccelerator.ResourceConverter, bool) {
+func (_m *MockManager) GetConverter(acceleratorType string) (accelerator.ResourceConverter, bool) {
 	ret := _m.Called(acceleratorType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetConverter")
 	}
 
-	var r0 pkgaccelerator.ResourceConverter
+	var r0 accelerator.ResourceConverter
 	var r1 bool
-	if rf, ok := ret.Get(0).(func(string) (pkgaccelerator.ResourceConverter, bool)); ok {
+	if rf, ok := ret.Get(0).(func(string) (accelerator.ResourceConverter, bool)); ok {
 		return rf(acceleratorType)
 	}
-	if rf, ok := ret.Get(0).(func(string) pkgaccelerator.ResourceConverter); ok {
+	if rf, ok := ret.Get(0).(func(string) accelerator.ResourceConverter); ok {
 		r0 = rf(acceleratorType)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(pkgaccelerator.ResourceConverter)
+			r0 = ret.Get(0).(accelerator.ResourceConverter)
 		}
 	}
 
@@ -285,12 +345,12 @@ func (_c *MockManager_GetConverter_Call) Run(run func(acceleratorType string)) *
 	return _c
 }
 
-func (_c *MockManager_GetConverter_Call) Return(_a0 pkgaccelerator.ResourceConverter, _a1 bool) *MockManager_GetConverter_Call {
+func (_c *MockManager_GetConverter_Call) Return(_a0 accelerator.ResourceConverter, _a1 bool) *MockManager_GetConverter_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockManager_GetConverter_Call) RunAndReturn(run func(string) (pkgaccelerator.ResourceConverter, bool)) *MockManager_GetConverter_Call {
+func (_c *MockManager_GetConverter_Call) RunAndReturn(run func(string) (accelerator.ResourceConverter, bool)) *MockManager_GetConverter_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -517,23 +577,23 @@ func (_c *MockManager_GetNodeRuntimeConfig_Call) RunAndReturn(run func(context.C
 }
 
 // GetParser provides a mock function with given fields: acceleratorType
-func (_m *MockManager) GetParser(acceleratorType string) (pkgaccelerator.ResourceParser, bool) {
+func (_m *MockManager) GetParser(acceleratorType string) (accelerator.ResourceParser, bool) {
 	ret := _m.Called(acceleratorType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetParser")
 	}
 
-	var r0 pkgaccelerator.ResourceParser
+	var r0 accelerator.ResourceParser
 	var r1 bool
-	if rf, ok := ret.Get(0).(func(string) (pkgaccelerator.ResourceParser, bool)); ok {
+	if rf, ok := ret.Get(0).(func(string) (accelerator.ResourceParser, bool)); ok {
 		return rf(acceleratorType)
 	}
-	if rf, ok := ret.Get(0).(func(string) pkgaccelerator.ResourceParser); ok {
+	if rf, ok := ret.Get(0).(func(string) accelerator.ResourceParser); ok {
 		r0 = rf(acceleratorType)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(pkgaccelerator.ResourceParser)
+			r0 = ret.Get(0).(accelerator.ResourceParser)
 		}
 	}
 
@@ -564,34 +624,34 @@ func (_c *MockManager_GetParser_Call) Run(run func(acceleratorType string)) *Moc
 	return _c
 }
 
-func (_c *MockManager_GetParser_Call) Return(_a0 pkgaccelerator.ResourceParser, _a1 bool) *MockManager_GetParser_Call {
+func (_c *MockManager_GetParser_Call) Return(_a0 accelerator.ResourceParser, _a1 bool) *MockManager_GetParser_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockManager_GetParser_Call) RunAndReturn(run func(string) (pkgaccelerator.ResourceParser, bool)) *MockManager_GetParser_Call {
+func (_c *MockManager_GetParser_Call) RunAndReturn(run func(string) (accelerator.ResourceParser, bool)) *MockManager_GetParser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetPlugin provides a mock function with given fields: acceleratorType
-func (_m *MockManager) GetPlugin(acceleratorType string) (pkgaccelerator.Plugin, bool) {
+func (_m *MockManager) GetPlugin(acceleratorType string) (accelerator.Plugin, bool) {
 	ret := _m.Called(acceleratorType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPlugin")
 	}
 
-	var r0 pkgaccelerator.Plugin
+	var r0 accelerator.Plugin
 	var r1 bool
-	if rf, ok := ret.Get(0).(func(string) (pkgaccelerator.Plugin, bool)); ok {
+	if rf, ok := ret.Get(0).(func(string) (accelerator.Plugin, bool)); ok {
 		return rf(acceleratorType)
 	}
-	if rf, ok := ret.Get(0).(func(string) pkgaccelerator.Plugin); ok {
+	if rf, ok := ret.Get(0).(func(string) accelerator.Plugin); ok {
 		r0 = rf(acceleratorType)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(pkgaccelerator.Plugin)
+			r0 = ret.Get(0).(accelerator.Plugin)
 		}
 	}
 
@@ -622,12 +682,12 @@ func (_c *MockManager_GetPlugin_Call) Run(run func(acceleratorType string)) *Moc
 	return _c
 }
 
-func (_c *MockManager_GetPlugin_Call) Return(_a0 pkgaccelerator.Plugin, _a1 bool) *MockManager_GetPlugin_Call {
+func (_c *MockManager_GetPlugin_Call) Return(_a0 accelerator.Plugin, _a1 bool) *MockManager_GetPlugin_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockManager_GetPlugin_Call) RunAndReturn(run func(string) (pkgaccelerator.Plugin, bool)) *MockManager_GetPlugin_Call {
+func (_c *MockManager_GetPlugin_Call) RunAndReturn(run func(string) (accelerator.Plugin, bool)) *MockManager_GetPlugin_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Issue

NEU-671

## Summary

`Builder.Build()` recreated the accelerator manager whenever injected accelerator plugins were present, even when `CoreConfig` already held a manager bound to the GinEngine. The second manager re-registered the manager-owned `/v1/plugin/register` route on the same engine, panicking with "handlers are already registered for path '/v1/plugin/register'" and breaking control-plane startup for integrations that pre-seed a manager and inject internal plugins.

## Changes

- `internal/accelerator`: add `Manager.AddInternalPlugins` — registers internal plugins on an existing manager without re-registering manager-owned routes. The batch validates all inputs (nil, empty resource, duplicate — including intra-batch duplicates) before storing any plugin, so an invalid input fails atomically without leaving partially registered plugins. `NewManagerWithPlugins` now delegates to it.
- `cmd/neutree-core/app`: `Builder.Build()` only creates a new manager when none exists; otherwise the injected plugins are registered into the existing manager via `AddInternalPlugins` (singleton preserved, routes registered once).
- Regenerated `internal/accelerator/mocks/mock_manager.go` via `make mockgen`.

## Test Plan

- [x] Unit (TDD): `TestBuilderBuildRegistersInjectedPluginsOnExistingManager` reproduced the panic pre-fix (gin "handlers are already registered"), passes post-fix; `TestManagerAddInternalPluginsFailsAtomically` reproduced partial registration pre-fix, passes post-fix
- [x] `go test -race ./internal/accelerator/... ./cmd/neutree-core/app/...` — pass
- [x] `go vet` on changed packages — clean; `golangci-lint` (pinned v1.64.6) on changed packages — clean
- [ ] E2E: not applicable — change-level classified **Trivial** (user-confirmed): the failing combination requires a pre-seeded manager + injected internal plugins, which only occurs on the enterprise/internal integration path not exercised by community e2e; regression risk covered by unit tests on both the manager and builder layers
- [ ] DB integration (`make db-test`): not affected (no schema/storage change; local run blocked by missing Docker daemon)

## Risk & Rollback

No schema change; backward-compatible (interface addition only). Rollback: revert commit. The community startup path (nil manager) is byte-identical in behavior — `NewManagerWithPlugins` still handles creation and its plugin validation semantics are unchanged.