### PR TITLE
feat(builder): declare engine capabilities from the package build script

### DIFF
--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -188,6 +188,11 @@ func (i *Importer) registerEngines(ctx context.Context, opts *ImportOptions, man
 				result.Errors = append(result.Errors, err)
 				return result, err
 			}
+
+			if err := validateCapabilities(engine); err != nil {
+				result.Errors = append(result.Errors, err)
+				return result, err
+			}
 		}
 
 		for _, engine := range manifest.Engines {
@@ -324,6 +329,38 @@ func validateModelTasks(em *EngineMetadata) error {
 	return fmt.Errorf("unknown model task value(s) — only %v are accepted: %s",
 		v1.KnownModelTasks(),
 		strings.Join(parts, "; "))
+}
+
+// validateCapabilities rejects an EngineMetadata whose any per-version
+// capabilities declaration is unusable (unknown playground mode, out-of-range
+// metrics port, metrics path without a leading slash).
+//
+// Import is a boundary that ingests hand-written manifests, so it is where a bad
+// declaration has to be caught: past this point the value is stored and every
+// consumer silently ignores what it cannot act on. Like validateModelTasks, all
+// offending versions are collected so one run reports every problem.
+func validateCapabilities(em *EngineMetadata) error {
+	if em == nil {
+		return nil
+	}
+
+	var bads []string
+
+	for _, v := range em.EngineVersions {
+		if v == nil {
+			continue
+		}
+
+		if err := v.Capabilities.Validate(); err != nil {
+			bads = append(bads, "engines["+em.Name+"].engine_versions["+v.Version+"].capabilities: "+err.Error())
+		}
+	}
+
+	if len(bads) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("invalid engine capability declaration(s): %s", strings.Join(bads, "; "))
 }
 
 // aggregateSupportedTasks unions the manifest top-level supported_tasks with each

--- a/internal/cli/packageimport/importer_test.go
+++ b/internal/cli/packageimport/importer_test.go
@@ -458,3 +458,106 @@ engines:
 		assert.Contains(t, err.Error(), "engine name is empty")
 	})
 }
+
+func TestValidateCapabilities(t *testing.T) {
+	tests := []struct {
+		name        string
+		em          *EngineMetadata
+		expectError bool
+		errorParts  []string
+	}{
+		{
+			name: "nil metadata → ok",
+			em:   nil,
+		},
+		{
+			// A package built before the protocol declares nothing, and must
+			// still import.
+			name: "no declaration → ok",
+			em: &EngineMetadata{
+				Name:           "my-engine",
+				EngineVersions: []*v1.EngineVersion{{Version: "v1"}},
+			},
+		},
+		{
+			name: "valid declaration → ok",
+			em: &EngineMetadata{
+				Name: "my-engine",
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", Capabilities: &v1.EngineCapabilities{
+						MetricsExport: &v1.MetricsExportCapability{Enabled: true, Port: 9100, Path: "/internal/metrics"},
+						Playground:    &v1.PlaygroundCapability{Enabled: true, Modes: []string{v1.PlaygroundModeChat}},
+					}},
+				},
+			},
+		},
+		{
+			name: "nil version entry is skipped",
+			em: &EngineMetadata{
+				Name:           "my-engine",
+				EngineVersions: []*v1.EngineVersion{nil},
+			},
+		},
+		{
+			name: "unknown playground mode → error names the version",
+			em: &EngineMetadata{
+				Name: "my-engine",
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v2", Capabilities: &v1.EngineCapabilities{
+						Playground: &v1.PlaygroundCapability{Enabled: true, Modes: []string{"vision"}},
+					}},
+				},
+			},
+			expectError: true,
+			errorParts:  []string{"my-engine", "v2", "vision"},
+		},
+		{
+			name: "metrics port out of range → error",
+			em: &EngineMetadata{
+				Name: "my-engine",
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", Capabilities: &v1.EngineCapabilities{
+						MetricsExport: &v1.MetricsExportCapability{Enabled: true, Port: 70000},
+					}},
+				},
+			},
+			expectError: true,
+			errorParts:  []string{"out of range"},
+		},
+		{
+			// Same contract as validateModelTasks: one run reports every bad
+			// version rather than making the user fix them one at a time.
+			name: "every offending version is reported",
+			em: &EngineMetadata{
+				Name: "my-engine",
+				EngineVersions: []*v1.EngineVersion{
+					{Version: "v1", Capabilities: &v1.EngineCapabilities{
+						Playground: &v1.PlaygroundCapability{Enabled: true, Modes: []string{"vision"}},
+					}},
+					{Version: "v2", Capabilities: &v1.EngineCapabilities{
+						MetricsExport: &v1.MetricsExportCapability{Enabled: true, Path: "metrics"},
+					}},
+				},
+			},
+			expectError: true,
+			errorParts:  []string{"v1", "v2", "vision", "must start with"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCapabilities(tt.em)
+
+			if !tt.expectError {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+
+			for _, part := range tt.errorParts {
+				assert.Contains(t, err.Error(), part)
+			}
+		})
+	}
+}

--- a/internal/cli/packageimport/parser_test.go
+++ b/internal/cli/packageimport/parser_test.go
@@ -232,6 +232,124 @@ engines:
 		assert.Equal(t, "v0.10.2", manifest.Engines[0].EngineVersions[0].Version)
 	})
 
+	// The capability block below is byte-for-byte what
+	// scripts/builder/build-engine-package.sh emits for
+	// `--metrics-export true --metrics-export-port 9100
+	//  --metrics-export-path /internal/metrics --playground true
+	//  --playground-modes "chat,embedding"`. Keeping the two in the same shape is
+	// the point of the test: the script writes this file and the importer reads
+	// it, with no schema shared between them beyond the yaml tags.
+	t.Run("manifest with declared capabilities", func(t *testing.T) {
+		content := `
+manifest_version: "1.0"
+
+engines:
+- name: my-engine
+  engine_versions:
+  - version: "v1.0.0"
+    supported_tasks:
+      - "text-generation"
+
+    capabilities:
+      metrics_export:
+        enabled: true
+        port: 9100
+        path: "/internal/metrics"
+      playground:
+        enabled: true
+        modes:
+        - "chat"
+        - "embedding"
+
+    images:
+      nvidia_gpu:
+        image_name: "my-engine"
+        tag: "v1.0.0"
+`
+		dir := t.TempDir()
+		manifestPath := dir + "/manifest.yaml"
+		require.NoError(t, os.WriteFile(manifestPath, []byte(content), 0644))
+
+		manifest, err := parser.ParseManifestFile(manifestPath)
+		require.NoError(t, err)
+		require.Len(t, manifest.Engines, 1)
+		require.Len(t, manifest.Engines[0].EngineVersions, 1)
+
+		version := manifest.Engines[0].EngineVersions[0]
+		require.NotNil(t, version.Capabilities)
+
+		assert.Equal(t, v1.ResolvedMetricsExport{Enabled: true, Port: 9100, Path: "/internal/metrics"},
+			version.ResolveMetricsExport())
+		assert.Equal(t, v1.ResolvedPlayground{Enabled: true, Modes: []string{"chat", "embedding"}},
+			version.ResolvePlayground())
+		assert.NoError(t, version.Capabilities.Validate())
+	})
+
+	t.Run("manifest declaring capabilities off", func(t *testing.T) {
+		content := `
+manifest_version: "1.0"
+
+engines:
+- name: my-engine
+  engine_versions:
+  - version: "v1.0.0"
+
+    capabilities:
+      metrics_export:
+        enabled: false
+      playground:
+        enabled: false
+
+    images:
+      nvidia_gpu:
+        image_name: "my-engine"
+        tag: "v1.0.0"
+`
+		dir := t.TempDir()
+		manifestPath := dir + "/manifest.yaml"
+		require.NoError(t, os.WriteFile(manifestPath, []byte(content), 0644))
+
+		manifest, err := parser.ParseManifestFile(manifestPath)
+		require.NoError(t, err)
+
+		version := manifest.Engines[0].EngineVersions[0]
+		assert.False(t, version.ResolveMetricsExport().Enabled)
+		assert.False(t, version.ResolvePlayground().Enabled)
+	})
+
+	// A package built before the protocol -- or by a run of the build script with
+	// no capability flags -- carries no block at all, and must keep the behaviour
+	// Neutree had before engines could declare anything.
+	t.Run("manifest without capabilities keeps legacy behaviour", func(t *testing.T) {
+		content := `
+manifest_version: "1.0"
+
+engines:
+- name: my-engine
+  engine_versions:
+  - version: "v1.0.0"
+    images:
+      nvidia_gpu:
+        image_name: "my-engine"
+        tag: "v1.0.0"
+`
+		dir := t.TempDir()
+		manifestPath := dir + "/manifest.yaml"
+		require.NoError(t, os.WriteFile(manifestPath, []byte(content), 0644))
+
+		manifest, err := parser.ParseManifestFile(manifestPath)
+		require.NoError(t, err)
+
+		version := manifest.Engines[0].EngineVersions[0]
+		assert.Nil(t, version.Capabilities)
+		assert.Equal(t, v1.ResolvedMetricsExport{
+			Enabled: true,
+			Port:    v1.DefaultMetricsExportPort,
+			Path:    v1.DefaultMetricsExportPath,
+		}, version.ResolveMetricsExport())
+		assert.True(t, version.ResolvePlayground().Enabled)
+	})
+
 	t.Run("valid manifest with package_url", func(t *testing.T) {
 		content := `
 manifest_version: "1.0"

--- a/scripts/builder/build-engine-package.sh
+++ b/scripts/builder/build-engine-package.sh
@@ -151,6 +151,22 @@ Options:
     -s, --supported-tasks TASKS
                               Comma-separated list of supported tasks
                               Example: generate,embedding
+    --metrics-export BOOL     Declare whether this engine version exports Prometheus
+                              metrics (true|false). Omit to leave it undeclared,
+                              which keeps the legacy behaviour of scraping it.
+    --metrics-export-port PORT
+                              Metrics port, when it is not the default 8000.
+                              Only valid together with --metrics-export true.
+    --metrics-export-path PATH
+                              Metrics path, when it is not the default /metrics.
+                              Only valid together with --metrics-export true.
+    --playground BOOL         Declare whether this engine version can back the
+                              console Playground (true|false). Omit to leave it
+                              undeclared, which keeps the tab visible.
+    --playground-modes MODES  Comma-separated interaction modes the Playground can
+                              render: chat, embedding, rerank. Only valid together
+                              with --playground true. Omit to let the console infer
+                              the surface from the endpoint's model task.
     -m, --manifest FILE       Path to manifest template file (optional)
     -t, --template-dir DIR    Path to template directory containing kubernetes/default.yaml
     -c, --schema FILE         Path to engine_schema.json file (optional)
@@ -205,6 +221,25 @@ Examples:
         -t ./template \\
         -d "vLLM engine manifest only"
 
+    # Declare capabilities: metrics on the default endpoint, chat-only Playground
+    $0 -n my-engine -v v1.0.0 \\
+        -i "nvidia_gpu:my-registry/my-engine:v1.0.0" \\
+        -s "text-generation" \\
+        --metrics-export true \\
+        --playground true --playground-modes "chat"
+
+    # An engine that serves no metrics endpoint, but can still back a chat
+    # Playground even though it advertises no text-generation task
+    $0 -n my-engine -v v1.0.0 \\
+        -i "nvidia_gpu:my-registry/my-engine:v1.0.0" \\
+        --metrics-export false \\
+        --playground true --playground-modes "chat"
+
+    # Metrics served somewhere other than :8000/metrics
+    $0 -n my-engine -v v1.0.0 \\
+        -i "cpu:my-registry/my-engine:v1.0.0" \\
+        --metrics-export true --metrics-export-port 9100 --metrics-export-path /internal/metrics
+
 EOF
 }
 
@@ -219,6 +254,15 @@ SCHEMA_FILE=""
 OUTPUT_FILE=""
 DESCRIPTION=""
 MANIFEST_ONLY=""
+# Capability declarations. Empty means "undeclared", which is not the same as
+# declaring false: an engine version with no capabilities block keeps the
+# behaviour Neutree had before the protocol existed (scraped for metrics,
+# Playground shown). Never default these to a value.
+METRICS_EXPORT=""
+METRICS_EXPORT_PORT=""
+METRICS_EXPORT_PATH=""
+PLAYGROUND=""
+PLAYGROUND_MODES=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -236,6 +280,26 @@ while [[ $# -gt 0 ]]; do
             ;;
         -s|--supported-tasks)
             SUPPORTED_TASKS="$2"
+            shift 2
+            ;;
+        --metrics-export)
+            METRICS_EXPORT="$2"
+            shift 2
+            ;;
+        --metrics-export-port)
+            METRICS_EXPORT_PORT="$2"
+            shift 2
+            ;;
+        --metrics-export-path)
+            METRICS_EXPORT_PATH="$2"
+            shift 2
+            ;;
+        --playground)
+            PLAYGROUND="$2"
+            shift 2
+            ;;
+        --playground-modes)
+            PLAYGROUND_MODES="$2"
             shift 2
             ;;
         -m|--manifest)
@@ -469,6 +533,104 @@ ${DEPLOY_TEMPLATE_CONTENT}"
         SUPPORTED_TASKS_SECTION=""
     fi
 
+    # Generate capabilities section.
+    #
+    # Emitted only when something was actually declared. Omitting the block is
+    # meaningful: Neutree reads a missing capability as "undeclared" and falls
+    # back to its pre-protocol behaviour (metrics scraped on :8000/metrics,
+    # Playground shown). Writing a default here would silently change how every
+    # engine rebuilt with this script behaves.
+    CAPABILITIES_SECTION=""
+    CAPABILITIES_BODY=""
+
+    if [ -n "$METRICS_EXPORT" ]; then
+        if [ "$METRICS_EXPORT" != "true" ] && [ "$METRICS_EXPORT" != "false" ]; then
+            print_error "--metrics-export must be 'true' or 'false', got: $METRICS_EXPORT"
+            exit 1
+        fi
+
+        METRICS_BODY="        enabled: ${METRICS_EXPORT}"
+
+        if [ -n "$METRICS_EXPORT_PORT" ]; then
+            if ! [[ "$METRICS_EXPORT_PORT" =~ ^[0-9]+$ ]] || [ "$METRICS_EXPORT_PORT" -lt 1 ] || [ "$METRICS_EXPORT_PORT" -gt 65535 ]; then
+                print_error "--metrics-export-port must be an integer in 1-65535, got: $METRICS_EXPORT_PORT"
+                exit 1
+            fi
+
+            METRICS_BODY="${METRICS_BODY}
+        port: ${METRICS_EXPORT_PORT}"
+        fi
+
+        if [ -n "$METRICS_EXPORT_PATH" ]; then
+            case "$METRICS_EXPORT_PATH" in
+                /*) ;;
+                *)
+                    print_error "--metrics-export-path must start with '/', got: $METRICS_EXPORT_PATH"
+                    exit 1
+                    ;;
+            esac
+
+            METRICS_BODY="${METRICS_BODY}
+        path: \"${METRICS_EXPORT_PATH}\""
+        fi
+
+        CAPABILITIES_BODY="${CAPABILITIES_BODY}
+      metrics_export:
+${METRICS_BODY}"
+    elif [ -n "$METRICS_EXPORT_PORT" ] || [ -n "$METRICS_EXPORT_PATH" ]; then
+        # Without an enabled flag there is no capability to attach these to, and
+        # silently dropping them would ship a package that ignores what the
+        # caller asked for.
+        print_error "--metrics-export-port/--metrics-export-path require --metrics-export"
+        exit 1
+    fi
+
+    if [ -n "$PLAYGROUND" ]; then
+        if [ "$PLAYGROUND" != "true" ] && [ "$PLAYGROUND" != "false" ]; then
+            print_error "--playground must be 'true' or 'false', got: $PLAYGROUND"
+            exit 1
+        fi
+
+        PLAYGROUND_BODY="        enabled: ${PLAYGROUND}"
+
+        if [ -n "$PLAYGROUND_MODES" ]; then
+            PLAYGROUND_MODES_YAML=""
+            IFS=',' read -ra MODE_ARRAY <<< "$PLAYGROUND_MODES"
+            for mode in "${MODE_ARRAY[@]}"; do
+                mode=$(echo "$mode" | xargs)
+                [ -z "$mode" ] && continue
+
+                case "$mode" in
+                    chat|embedding|rerank) ;;
+                    *)
+                        print_error "--playground-modes accepts chat, embedding, rerank; got: $mode"
+                        exit 1
+                        ;;
+                esac
+
+                PLAYGROUND_MODES_YAML="${PLAYGROUND_MODES_YAML}
+        - \"${mode}\""
+            done
+
+            if [ -n "$PLAYGROUND_MODES_YAML" ]; then
+                PLAYGROUND_BODY="${PLAYGROUND_BODY}
+        modes:${PLAYGROUND_MODES_YAML}"
+            fi
+        fi
+
+        CAPABILITIES_BODY="${CAPABILITIES_BODY}
+      playground:
+${PLAYGROUND_BODY}"
+    elif [ -n "$PLAYGROUND_MODES" ]; then
+        print_error "--playground-modes requires --playground"
+        exit 1
+    fi
+
+    if [ -n "$CAPABILITIES_BODY" ]; then
+        CAPABILITIES_SECTION="
+    capabilities:${CAPABILITIES_BODY}"
+    fi
+
     # Generate values_schema section
     VALUES_SCHEMA_SECTION=""
     if [ -n "$SCHEMA_FILE" ]; then
@@ -526,6 +688,7 @@ ${VALUES_SCHEMA_SECTION}
 
 $DEPLOY_TEMPLATE_SECTION
 ${SUPPORTED_TASKS_SECTION}
+${CAPABILITIES_SECTION}
 
     images:$IMAGES_MAP
 EOF


### PR DESCRIPTION
## Issue

NEU-636, NEU-599 (follow-up to #544)

## Summary

The capability protocol landed in #544, but the only way to get a declaration into an engine package was to hand-edit the generated manifest. This adds the build-script flags, and validates the declaration at the point packages are ingested.

## Changes

- **`scripts/builder/build-engine-package.sh`** — `--metrics-export`, `--metrics-export-port`, `--metrics-export-path`, `--playground`, `--playground-modes`, emitted as the `engine_versions[*].capabilities` block. Rejects non-boolean flags, ports outside 1-65535, paths without a leading slash, unknown playground modes, and port/path/modes passed without the capability they belong to.
- **`internal/cli/packageimport/importer.go`** — `validateCapabilities` runs beside the existing `validateModelTasks`, before any engine in the manifest is written, so a bad declaration cannot land as a partial import. Collects every offending version into one error.

**No parser change was needed.** `EngineMetadata.EngineVersions` is already `[]*v1.EngineVersion`, so the yaml tags added in #544 carry the block through on their own. The new parser tests pin that end of the contract.

## The default is "undeclared", and that is load-bearing

Omitting the flags emits **no capabilities block at all** — not `enabled: false`. Neutree reads a missing capability as *undeclared* and falls back to its pre-protocol behaviour (metrics scraped on `:8000/metrics`, Playground shown). If these flags defaulted to a value, every engine rebuilt with this script would silently change behaviour. There is a comment at the variable declarations saying so, and a test for the no-flags path.

## Test Plan

- [x] Unit: `go test ./internal/... ./api/... ./controllers/...` — all pass.
  - Parser tests feed the **exact YAML the script emits** and assert `ResolveMetricsExport` / `ResolvePlayground`, plus a no-capabilities manifest resolving to the legacy defaults. Script and importer share no schema beyond the yaml tags, so this is the only thing keeping the two ends in step.
  - `validateCapabilities` covers nil metadata, no declaration, nil version entries, each rejection reason, and that multiple bad versions are all reported.
- [x] Script behaviour: drove the CLI through 15 cases — 10 rejections (non-boolean flags, port 0 / 70000 / non-numeric, path without slash, unknown mode, and each of port/path/modes orphaned from its capability) and 5 accepted combinations, each verified to produce a parseable manifest. All pass. `bash -n` clean.
- [ ] E2E: not affected — no runtime behaviour changes.
- [ ] DB integration: not affected — no schema change.
- [x] `golangci-lint` clean via the pre-commit hook. `shellcheck` **not run** — not installed locally; if CI runs it on `scripts/`, worth a look.

## Risk & Rollback

Additive: new optional flags, and a validation pass that only rejects declarations no consumer could have acted on anyway. A package built without the new flags produces a byte-identical manifest to before, apart from the `version:` metadata line the script already stamps from `git describe`.

The one behaviour change for existing users: a manifest that already carried a hand-written but invalid `capabilities` block now fails the import instead of being silently ignored. That seems right — the alternative is storing a declaration nothing will honour — but it is a change, and worth knowing if anyone has been hand-editing manifests.
