### PR TITLE
refactor: fold cluster patch validation error contracts into generic errors

### DIFF
--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -204,12 +204,13 @@ func prepareClusterValidationInput(
 
 	filters := clusterPatchUpdateFilters(input.Patch, input.QueryParams)
 	if len(filters) == 0 {
-		return clusterPatchValidationIdentityError(input)
+		return clusterPatchValidationResolutionError(
+			errors.New("cluster identity is required when patching a cluster"))
 	}
 
 	current, err := resolveClusterForPatchUpdate(s, filters)
 	if err != nil {
-		return clusterPatchValidationPreparationError(input, err)
+		return clusterPatchValidationResolutionError(err)
 	}
 
 	newCluster, err := buildPostgrestClusterPatchValidationNew(current, input.Body)
@@ -221,74 +222,6 @@ func prepareClusterValidationInput(
 	input.New = newCluster
 
 	return nil
-}
-
-func clusterPatchValidationPreparationError(
-	input *ValidationInput[v1.Cluster], err error,
-) *validationError {
-	hasVersion, versionErr := clusterPatchDesiredVersionPayload(input.RawPayload)
-	if versionErr != nil {
-		return invalidClusterPayloadError(versionErr)
-	}
-
-	if hasVersion {
-		return clusterVersionUpdateResolutionError(err)
-	}
-
-	configurationUpdate, configurationErr := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
-	if configurationErr != nil {
-		return invalidClusterPayloadError(configurationErr)
-	}
-
-	if configurationUpdate.hasChanges() {
-		return clusterConfigurationUpdateResolutionError(err)
-	}
-
-	acceleratorVirtualizationMayDisable, acceleratorErr := clusterAcceleratorVirtualizationMayDisablePayload(input.RawPayload)
-	if acceleratorErr != nil {
-		return invalidClusterPayloadError(acceleratorErr)
-	}
-
-	if acceleratorVirtualizationMayDisable {
-		return clusterAcceleratorVirtualizationResolutionError(err)
-	}
-
-	return clusterPatchValidationResolutionError(err)
-}
-
-func clusterPatchValidationIdentityError(input *ValidationInput[v1.Cluster]) *validationError {
-	hasVersion, versionErr := clusterPatchDesiredVersionPayload(input.RawPayload)
-	if versionErr != nil {
-		return invalidClusterPayloadError(versionErr)
-	}
-
-	if hasVersion {
-		return clusterVersionUpdateResolutionError(
-			errors.New("cluster identity is required when updating spec.version"))
-	}
-
-	configurationUpdate, configurationErr := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
-	if configurationErr != nil {
-		return invalidClusterPayloadError(configurationErr)
-	}
-
-	if configurationUpdate.hasChanges() {
-		return clusterConfigurationUpdateResolutionError(
-			errors.New("cluster identity is required when updating cluster configuration"))
-	}
-
-	acceleratorVirtualizationMayDisable, acceleratorErr := clusterAcceleratorVirtualizationMayDisablePayload(input.RawPayload)
-	if acceleratorErr != nil {
-		return invalidClusterPayloadError(acceleratorErr)
-	}
-
-	if acceleratorVirtualizationMayDisable {
-		return clusterAcceleratorVirtualizationResolutionError(
-			errors.New("cluster identity is required when disabling accelerator virtualization"))
-	}
-
-	return clusterPatchValidationResolutionError(
-		errors.New("cluster identity is required when patching a cluster"))
 }
 
 // buildPostgrestClusterPatchValidationNew constructs the Cluster state that
@@ -373,151 +306,6 @@ func writeClusterDeletionError(c *gin.Context, err error) {
 		"hint":    deletionErr.Hint,
 	})
 	c.Abort()
-}
-
-func validateClusterAcceleratorVirtualization(s storage.Storage) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
-			c.Next()
-			return
-		}
-
-		input, validationErr := readClusterValidationInput(c)
-		if validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
-			c.Abort()
-
-			return
-		}
-
-		if input.Operation == clusterValidationSoftDelete {
-			c.Next()
-
-			return
-		}
-
-		if input.Operation == clusterValidationPatch {
-			if _, updatesSpec := input.RawPayload["spec"]; !updatesSpec {
-				c.Next()
-
-				return
-			}
-		}
-
-		if validationErr := prepareClusterValidationInput(s, input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
-			c.Abort()
-
-			return
-		}
-
-		if validationErr := validateClusterAcceleratorVirtualizationInput(s, input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
-			c.Abort()
-
-			return
-		}
-
-		c.Next()
-	}
-}
-
-func validateClusterVersionUpdate(s storage.Storage) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if c.Request.Method != http.MethodPatch {
-			c.Next()
-			return
-		}
-
-		input, validationErr := readClusterValidationInput(c)
-		if validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
-			c.Abort()
-
-			return
-		}
-
-		if input.Operation != clusterValidationSoftDelete {
-			hasVersion, err := clusterPatchDesiredVersionPayload(input.RawPayload)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-				c.Abort()
-
-				return
-			}
-
-			if !hasVersion {
-				c.Next()
-
-				return
-			}
-
-			if validationErr := prepareClusterValidationInput(s, input); validationErr != nil {
-				c.JSON(http.StatusBadRequest, validationErr)
-				c.Abort()
-
-				return
-			}
-
-			if validationErr := validateClusterVersionUpdateInput(input); validationErr != nil {
-				c.JSON(http.StatusBadRequest, validationErr)
-				c.Abort()
-
-				return
-			}
-		}
-
-		c.Next()
-	}
-}
-
-func validateClusterConfigurationUpdate(s storage.Storage) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		if c.Request.Method != http.MethodPatch {
-			c.Next()
-			return
-		}
-
-		input, validationErr := readClusterValidationInput(c)
-		if validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
-			c.Abort()
-
-			return
-		}
-
-		if input.Operation != clusterValidationSoftDelete {
-			configurationUpdate, err := parseClusterPatchConfigurationUpdatePayload(input.RawPayload)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, invalidClusterPayloadError(err))
-				c.Abort()
-
-				return
-			}
-
-			if !configurationUpdate.hasChanges() {
-				c.Next()
-
-				return
-			}
-
-			if validationErr := prepareClusterValidationInput(s, input); validationErr != nil {
-				c.JSON(http.StatusBadRequest, validationErr)
-				c.Abort()
-
-				return
-			}
-
-			if validationErr := validateClusterConfigurationUpdateInput(input); validationErr != nil {
-				c.JSON(http.StatusBadRequest, validationErr)
-				c.Abort()
-
-				return
-			}
-		}
-
-		c.Next()
-	}
 }
 
 func clusterPatchIsSoftDelete(payload map[string]json.RawMessage) (bool, error) {
@@ -761,17 +549,12 @@ func validateClusterVersionInput(input *ValidationInput[v1.Cluster]) *validation
 }
 
 func validateClusterVersionUpdateInput(input *ValidationInput[v1.Cluster]) *validationError {
-	hasVersion, err := clusterPatchDesiredVersionPayload(input.RawPayload)
-	if err != nil {
-		return invalidClusterPayloadError(err)
-	}
-
-	if !hasVersion {
-		return nil
-	}
-
 	if input.Current == nil || input.New == nil {
 		return clusterPatchValidationResolutionError(errors.New("cluster validation objects are required"))
+	}
+
+	if input.New.GetVersion() == input.Current.GetVersion() {
+		return nil
 	}
 
 	if err := validateClusterVersionNotDowngrade(input.Current, input.New.GetVersion()); err != nil {
@@ -800,30 +583,6 @@ func validateClusterConfigurationUpdateInput(input *ValidationInput[v1.Cluster])
 	}
 
 	return nil
-}
-
-func clusterPatchDesiredVersionPayload(payload map[string]json.RawMessage) (bool, error) {
-	specRaw, ok := payload["spec"]
-	if !ok {
-		return false, nil
-	}
-
-	var spec map[string]json.RawMessage
-	if err := json.Unmarshal(specRaw, &spec); err != nil {
-		return false, err
-	}
-
-	versionRaw, ok := spec["version"]
-	if !ok {
-		return false, nil
-	}
-
-	var version string
-	if err := json.Unmarshal(versionRaw, &version); err != nil {
-		return false, err
-	}
-
-	return true, nil
 }
 
 func clusterPatchUpdateFilters(patch v1.Cluster, queryParams url.Values) []storage.Filter {
@@ -876,22 +635,6 @@ func clusterPatchValidationResolutionError(err error) *validationError {
 	return &validationError{
 		Code:    "10209",
 		Message: "failed to prepare cluster patch validation",
-		Hint:    err.Error(),
-	}
-}
-
-func clusterVersionUpdateResolutionError(err error) *validationError {
-	return &validationError{
-		Code:    "10212",
-		Message: "failed to validate cluster version update",
-		Hint:    err.Error(),
-	}
-}
-
-func clusterConfigurationUpdateResolutionError(err error) *validationError {
-	return &validationError{
-		Code:    "10209",
-		Message: "failed to validate cluster configuration update",
 		Hint:    err.Error(),
 	}
 }
@@ -949,42 +692,6 @@ func currentClusterSpecVersionBaseline(current *v1.Cluster) (string, error) {
 	}
 
 	return baseline, nil
-}
-
-// clusterAcceleratorVirtualizationMayDisablePayload preserves the legacy error
-// contract when Current/New cannot be built because the PATCH target is unknown.
-func clusterAcceleratorVirtualizationMayDisablePayload(payload map[string]json.RawMessage) (bool, error) {
-	specRaw, ok := payload["spec"]
-	if !ok {
-		return false, nil
-	}
-
-	var spec map[string]json.RawMessage
-	if err := json.Unmarshal(specRaw, &spec); err != nil {
-		return false, err
-	}
-
-	acceleratorVirtualizationRaw, ok := spec["accelerator_virtualization"]
-	if !ok {
-		return false, nil
-	}
-
-	var acceleratorVirtualization map[string]json.RawMessage
-	if err := json.Unmarshal(acceleratorVirtualizationRaw, &acceleratorVirtualization); err != nil {
-		return false, err
-	}
-
-	enabledRaw, ok := acceleratorVirtualization["enabled"]
-	if !ok {
-		return true, nil
-	}
-
-	var enabled bool
-	if err := json.Unmarshal(enabledRaw, &enabled); err != nil {
-		return false, err
-	}
-
-	return !enabled, nil
 }
 
 func clusterEndpointReferenceFilters(workspace, name string) []storage.Filter {
@@ -1069,14 +776,6 @@ func validateClusterAcceleratorVirtualizationDisableForCurrent(
 
 	return validateClusterAcceleratorVirtualizationDisableForIdentity(
 		s, current.Metadata.Workspace, current.Metadata.Name)
-}
-
-func clusterAcceleratorVirtualizationResolutionError(err error) *validationError {
-	return &validationError{
-		Code:    "10209",
-		Message: "failed to validate cluster accelerator virtualization",
-		Hint:    err.Error(),
-	}
 }
 
 func resolveClusterIdentityForAcceleratorVirtualizationDisable(
@@ -1168,21 +867,6 @@ func validateClusterAcceleratorVirtualizationInput(
 	}
 
 	return validateClusterAcceleratorVirtualizationDisableForCurrent(s, input.Current, input.Patch)
-}
-
-func validateClusterAcceleratorVirtualizationBody(body []byte) *validationError {
-	var cluster v1.Cluster
-	decoder := json.NewDecoder(bytes.NewReader(body))
-
-	if err := decoder.Decode(&cluster); err != nil {
-		return invalidClusterPayloadError(err)
-	}
-
-	if cluster.GetDeletionTimestamp() != "" {
-		return nil
-	}
-
-	return validateClusterAcceleratorVirtualizationCluster(cluster)
 }
 
 func validateClusterAcceleratorVirtualizationCluster(cluster v1.Cluster) *validationError {

--- a/internal/routes/proxies/cluster_proxy.go
+++ b/internal/routes/proxies/cluster_proxy.go
@@ -73,7 +73,7 @@ func validateClusterRequest(s storage.Storage) gin.HandlerFunc {
 
 		input, validationErr := readClusterValidationInput(c)
 		if validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
+			c.JSON(validationErrStatus(validationErr), validationErr)
 			c.Abort()
 
 			return
@@ -92,14 +92,14 @@ func validateClusterRequest(s storage.Storage) gin.HandlerFunc {
 		}
 
 		if validationErr := prepareClusterValidationInput(s, input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
+			c.JSON(validationErrStatus(validationErr), validationErr)
 			c.Abort()
 
 			return
 		}
 
 		if validationErr := validateClusterVersionInput(input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
+			c.JSON(validationErrStatus(validationErr), validationErr)
 			c.Abort()
 
 			return
@@ -107,14 +107,14 @@ func validateClusterRequest(s storage.Storage) gin.HandlerFunc {
 
 		if input.Operation == clusterValidationPatch {
 			if validationErr := validateClusterVersionUpdateInput(input); validationErr != nil {
-				c.JSON(http.StatusBadRequest, validationErr)
+				c.JSON(validationErrStatus(validationErr), validationErr)
 				c.Abort()
 
 				return
 			}
 
 			if validationErr := validateClusterConfigurationUpdateInput(input); validationErr != nil {
-				c.JSON(http.StatusBadRequest, validationErr)
+				c.JSON(validationErrStatus(validationErr), validationErr)
 				c.Abort()
 
 				return
@@ -122,7 +122,7 @@ func validateClusterRequest(s storage.Storage) gin.HandlerFunc {
 		}
 
 		if validationErr := validateClusterAcceleratorVirtualizationInput(s, input); validationErr != nil {
-			c.JSON(http.StatusBadRequest, validationErr)
+			c.JSON(validationErrStatus(validationErr), validationErr)
 			c.Abort()
 
 			return
@@ -210,6 +210,10 @@ func prepareClusterValidationInput(
 
 	current, err := resolveClusterForPatchUpdate(s, filters)
 	if err != nil {
+		if errors.Is(err, errClusterStorageUnavailable) {
+			return internalServerValidationError()
+		}
+
 		return clusterPatchValidationResolutionError(err)
 	}
 
@@ -597,10 +601,15 @@ func clusterPatchUpdateFilters(patch v1.Cluster, queryParams url.Values) []stora
 	return filters
 }
 
+// errClusterStorageUnavailable marks storage-layer failures (e.g. a database
+// outage) so they surface as internal server error responses instead of
+// client validation errors.
+var errClusterStorageUnavailable = errors.New("cluster storage unavailable")
+
 func resolveClusterForPatchUpdate(s storage.Storage, filters []storage.Filter) (*v1.Cluster, error) {
 	clusters, err := s.ListCluster(storage.ListOption{Filters: filters})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", errClusterStorageUnavailable, err)
 	}
 
 	if len(clusters) != 1 {
@@ -722,11 +731,7 @@ func validateClusterAcceleratorVirtualizationDisableForIdentity(
 ) *validationError {
 	endpoints, err := s.ListEndpoint(storage.ListOption{Filters: clusterEndpointReferenceFilters(workspace, name)})
 	if err != nil {
-		return &validationError{
-			Code:    "10209",
-			Message: "failed to validate cluster accelerator virtualization",
-			Hint:    err.Error(),
-		}
+		return internalServerValidationError()
 	}
 
 	vGPUEndpointCount := 0

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -709,7 +709,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
-	t.Run("reports the generic resolution error when the current cluster lookup fails", func(t *testing.T) {
+	t.Run("reports storage lookup failure as internal server error when the current cluster lookup fails", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
 		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
@@ -731,10 +731,10 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		router.ServeHTTP(recorder, req)
 
 		assert.False(t, proxyCalled)
-		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
-		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
-		assert.Contains(t, recorder.Body.String(), "read cluster failed")
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"500"`)
+		assert.Contains(t, recorder.Body.String(), "internal server error")
+		assert.NotContains(t, recorder.Body.String(), "read cluster failed")
 		mockStorage.AssertExpectations(t)
 	})
 
@@ -828,7 +828,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
-	t.Run("reports the generic resolution error when the current cluster lookup fails for an accelerator virtualization PATCH", func(t *testing.T) {
+	t.Run("reports storage lookup failure as internal server error when the current cluster lookup fails for an accelerator virtualization PATCH", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
 		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
@@ -848,10 +848,10 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		}`)))
 
 		assert.False(t, proxyCalled)
-		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
-		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
-		assert.Contains(t, recorder.Body.String(), "read cluster failed")
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"500"`)
+		assert.Contains(t, recorder.Body.String(), "internal server error")
+		assert.NotContains(t, recorder.Body.String(), "read cluster failed")
 		mockStorage.AssertExpectations(t)
 	})
 
@@ -1180,12 +1180,12 @@ func testValidateClusterAcceleratorVirtualizationDisable(t *testing.T) {
 			wantHint: "does not match patch target",
 		},
 		{
-			name:            "returns validation error when endpoint lookup fails",
+			name:            "returns internal server error when endpoint lookup fails",
 			patch:           cluster("gpu-cluster", &v1.AcceleratorVirtualizationSpec{Enabled: false}),
 			endpointErr:     errors.New("database error"),
 			lookupEndpoints: true,
-			wantCode:        "10209",
-			wantHint:        "database error",
+			wantCode:        "500",
+			wantMessage:     "internal server error",
 		},
 		{
 			name:            "rejects clearing accelerator virtualization with null while vGPU endpoint references cluster",
@@ -1448,6 +1448,42 @@ func testValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10211"`)
 		assert.Contains(t, recorder.Body.String(), "vGPU endpoint(s) still reference this cluster")
+		mockStorage.AssertExpectations(t)
+	})
+
+	t.Run("reports storage lookup failure as internal server error when disabling accelerator virtualization", func(t *testing.T) {
+		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListCluster", mock.Anything).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec: &v1.ClusterSpec{AcceleratorVirtualization: &v1.AcceleratorVirtualizationSpec{
+				Enabled: true,
+			}},
+		}}, nil).Once()
+		mockStorage.On("ListEndpoint", storage.ListOption{
+			Filters: clusterEndpointReferenceFilters("default", "gpu-cluster"),
+		}).Return(nil, errors.New("read endpoints failed")).Once()
+
+		proxyCalled := false
+		router := gin.New()
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+			proxyCalled = true
+			c.Status(http.StatusNoContent)
+		})
+
+		body := `{
+			"metadata": {"workspace": "default", "name": "gpu-cluster"},
+			"spec": {"version": "v1.1.0", "accelerator_virtualization": {"enabled": false}}
+		}`
+		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(body))
+		recorder := httptest.NewRecorder()
+
+		router.ServeHTTP(recorder, req)
+
+		assert.False(t, proxyCalled)
+		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), `"code":"500"`)
+		assert.Contains(t, recorder.Body.String(), "internal server error")
+		assert.NotContains(t, recorder.Body.String(), "read endpoints failed")
 		mockStorage.AssertExpectations(t)
 	})
 

--- a/internal/routes/proxies/cluster_proxy_test.go
+++ b/internal/routes/proxies/cluster_proxy_test.go
@@ -685,7 +685,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 	})
 
-	t.Run("preserves the version resolution error when PATCH has no identity", func(t *testing.T) {
+	t.Run("reports the generic resolution error for a version PATCH without identity", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
@@ -703,13 +703,13 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		assert.Contains(t, recorder.Body.String(), `"code":"10212"`)
-		assert.Contains(t, recorder.Body.String(), "failed to validate cluster version update")
-		assert.Contains(t, recorder.Body.String(), "cluster identity is required when updating spec.version")
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required when patching a cluster")
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
-	t.Run("preserves the version resolution error when the current cluster lookup fails", func(t *testing.T) {
+	t.Run("reports the generic resolution error when the current cluster lookup fails", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
 		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
@@ -732,13 +732,13 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-		assert.Contains(t, recorder.Body.String(), `"code":"10212"`)
-		assert.Contains(t, recorder.Body.String(), "failed to validate cluster version update")
+		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
+		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
 		assert.Contains(t, recorder.Body.String(), "read cluster failed")
 		mockStorage.AssertExpectations(t)
 	})
 
-	t.Run("preserves the configuration resolution error when PATCH has no identity", func(t *testing.T) {
+	t.Run("reports the generic resolution error for a configuration PATCH without identity", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
@@ -757,8 +757,8 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
-		assert.Contains(t, recorder.Body.String(), "failed to validate cluster configuration update")
-		assert.Contains(t, recorder.Body.String(), "cluster identity is required when updating cluster configuration")
+		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required when patching a cluster")
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
@@ -784,7 +784,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
-	t.Run("preserves the accelerator virtualization identity error when PATCH has no identity", func(t *testing.T) {
+	t.Run("reports the generic resolution error for an accelerator virtualization PATCH without identity", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
@@ -801,8 +801,8 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
-		assert.Contains(t, recorder.Body.String(), "failed to validate cluster accelerator virtualization")
-		assert.Contains(t, recorder.Body.String(), "cluster identity is required when disabling accelerator virtualization")
+		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
+		assert.Contains(t, recorder.Body.String(), "cluster identity is required when patching a cluster")
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
@@ -828,7 +828,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
 	})
 
-	t.Run("preserves the accelerator virtualization resolution error when the current cluster lookup fails", func(t *testing.T) {
+	t.Run("reports the generic resolution error when the current cluster lookup fails for an accelerator virtualization PATCH", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		query := url.Values{"id": []string{"eq.1"}}
 		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
@@ -850,7 +850,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		assert.False(t, proxyCalled)
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), `"code":"10209"`)
-		assert.Contains(t, recorder.Body.String(), "failed to validate cluster accelerator virtualization")
+		assert.Contains(t, recorder.Body.String(), "failed to prepare cluster patch validation")
 		assert.Contains(t, recorder.Body.String(), "read cluster failed")
 		mockStorage.AssertExpectations(t)
 	})
@@ -870,7 +870,7 @@ func TestValidateClusterRequestMiddleware(t *testing.T) {
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"image_registry": "replacement-registry"}
+			"spec": {"version": "v1.1.0", "image_registry": "replacement-registry"}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -975,10 +975,12 @@ func testValidateClusterAcceleratorVirtualizationDisableForCurrent(t *testing.T)
 
 func testValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
 	tests := []struct {
-		name        string
-		body        string
-		wantCode    string
-		wantMessage string
+		name           string
+		method         string
+		body           string
+		wantCode       string
+		wantMessage    string
+		countEndpoints bool
 	}{
 		{
 			name: "allows Kubernetes cluster to enable accelerator virtualization",
@@ -997,19 +999,19 @@ func testValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
 		{
 			name:        "rejects Kubernetes cluster missing version enabling accelerator virtualization",
 			body:        `{"spec":{"type":"kubernetes","accelerator_virtualization":{"enabled":true}}}`,
-			wantCode:    "10208",
-			wantMessage: "requires cluster version >= v1.1.0",
+			wantCode:    "10209",
+			wantMessage: "spec.version is required",
 		},
 		{
 			name:        "rejects invalid cluster version enabling accelerator virtualization",
 			body:        `{"spec":{"type":"kubernetes","version":"nightly","accelerator_virtualization":{"enabled":true}}}`,
-			wantCode:    "10209",
+			wantCode:    "10212",
 			wantMessage: "invalid cluster version",
 		},
 		{
 			name:     "rejects SSH cluster enabling accelerator virtualization",
 			body:     `{"spec":{"type":"ssh","accelerator_virtualization":{"enabled":true}}}`,
-			wantCode: "10208",
+			wantCode: "10209",
 		},
 		{
 			name:        "rejects non-bool enabled",
@@ -1024,8 +1026,10 @@ func testValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
 			wantMessage: "invalid cluster payload",
 		},
 		{
-			name: "skips accelerator virtualization validation for soft delete patch",
-			body: `{"metadata":{"name":"cluster","workspace":"default","deletion_timestamp":"2026-06-10T00:00:00Z"},"spec":{"type":"ssh","accelerator_virtualization":{"enabled":true}}}`,
+			name:           "skips accelerator virtualization validation for soft delete patch",
+			method:         http.MethodPatch,
+			body:           `{"metadata":{"name":"cluster","workspace":"default","deletion_timestamp":"2026-06-10T00:00:00Z"},"spec":{"type":"ssh","accelerator_virtualization":{"enabled":true}}}`,
+			countEndpoints: true,
 		},
 		{
 			name:        "rejects unsupported config patch key",
@@ -1042,32 +1046,55 @@ func testValidateClusterAcceleratorVirtualizationBody(t *testing.T) {
 		{
 			name:        "rejects partial patch missing cluster type and version",
 			body:        `{"metadata":{"name":"cluster","workspace":"default"},"spec":{"accelerator_virtualization":{"enabled":true}}}`,
-			wantCode:    "10208",
-			wantMessage: "only supported for Kubernetes",
+			wantCode:    "10209",
+			wantMessage: "spec.version is required",
 		},
 		{
 			name:        "rejects partial patch missing cluster version",
 			body:        `{"metadata":{"name":"cluster","workspace":"default"},"spec":{"type":"kubernetes","accelerator_virtualization":{"enabled":true}}}`,
-			wantCode:    "10208",
-			wantMessage: "requires cluster version >= v1.1.0",
+			wantCode:    "10209",
+			wantMessage: "spec.version is required",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateClusterAcceleratorVirtualizationBody([]byte(tt.body))
+			method := tt.method
+			if method == "" {
+				method = http.MethodPost
+			}
+
+			mockStorage := storageMocks.NewMockStorage(t)
+			if tt.countEndpoints {
+				mockStorage.On("Count", storage.ENDPOINT_TABLE, mock.Anything).Return(0, nil).Once()
+			}
+
+			proxyCalled := false
+			router := gin.New()
+			router.Handle(method, "/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
+				proxyCalled = true
+				c.Status(http.StatusNoContent)
+			})
+
+			req := httptest.NewRequest(method, "/clusters", strings.NewReader(tt.body))
+			recorder := httptest.NewRecorder()
+
+			router.ServeHTTP(recorder, req)
+
 			if tt.wantCode == "" {
-				assert.Nil(t, err)
+				assert.True(t, proxyCalled)
+				assert.Equal(t, http.StatusNoContent, recorder.Code)
 
 				return
 			}
 
-			if !assert.NotNil(t, err) {
-				return
-			}
-			assert.Equal(t, tt.wantCode, err.Code)
+			var response validationError
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+			assert.False(t, proxyCalled)
+			assert.Equal(t, tt.wantCode, response.Code)
 			if tt.wantMessage != "" {
-				assert.Contains(t, err.Message, tt.wantMessage)
+				assert.Contains(t, response.Message, tt.wantMessage)
 			}
 		})
 	}
@@ -1403,14 +1430,14 @@ func testValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterAcceleratorVirtualization(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		body := `{
 			"metadata": {"workspace": "default", "name": "gpu-cluster"},
-			"spec": {"accelerator_virtualization": {"enabled": false}}
+			"spec": {"version": "v1.1.0", "accelerator_virtualization": {"enabled": false}}
 		}`
 		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(body))
 		recorder := httptest.NewRecorder()
@@ -1443,7 +1470,7 @@ func testValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 		}}}}, nil).Once()
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterAcceleratorVirtualization(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -1461,14 +1488,18 @@ func testValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 
 	t.Run("allows non-disable patch to continue to proxy handler", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
+		mockStorage.On("ListCluster", mock.Anything).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "gpu-cluster"},
+			Spec:     &v1.ClusterSpec{},
+		}}, nil).Once()
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterAcceleratorVirtualization(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
-		body := `{"metadata": {"workspace": "default", "name": "gpu-cluster"}}`
+		body := `{"metadata": {"workspace": "default", "name": "gpu-cluster"}, "spec": {"version": "v1.1.0"}}`
 		req := httptest.NewRequest(http.MethodPatch, "/clusters", strings.NewReader(body))
 		recorder := httptest.NewRecorder()
 
@@ -1476,7 +1507,7 @@ func testValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 
 		assert.True(t, proxyCalled)
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertExpectations(t)
 		mockStorage.AssertNotCalled(t, "ListEndpoint", mock.Anything)
 	})
 
@@ -1484,7 +1515,7 @@ func testValidateClusterAcceleratorVirtualizationMiddleware(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterAcceleratorVirtualization(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -1516,13 +1547,13 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
-		router.POST("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.POST("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		req := httptest.NewRequest(http.MethodPost, "/clusters", strings.NewReader(`{
-			"spec": {"config": {"kubernetes_config": {"kubeconfig": []}}}
+			"spec": {"version": "v1.1.0", "config": {"kubernetes_config": null}}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -1547,13 +1578,13 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"image_registry": "replacement-registry"}
+			"spec": {"version": "v1.1.0", "image_registry": "replacement-registry"}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -1583,12 +1614,12 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
-		body := fmt.Sprintf(`{"spec":{"config":{"kubernetes_config":{"kubeconfig":%q}}}}`,
+		body := fmt.Sprintf(`{"spec":{"version":"v1.1.0","config":{"kubernetes_config":{"kubeconfig":%q}}}}`,
 			testEncodedKubeconfig("https://api.example.test:6443", "rotated-token"))
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
 		recorder := httptest.NewRecorder()
@@ -1619,12 +1650,12 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 				proxyCalled := false
 				router := gin.New()
-				router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+				router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 					proxyCalled = true
 					c.Status(http.StatusNoContent)
 				})
 
-				body := fmt.Sprintf(`{"spec":{"config":{"kubernetes_config":{"kubeconfig":%s}}}}`, kubeconfig)
+				body := fmt.Sprintf(`{"spec":{"version":"v1.1.0","config":{"kubernetes_config":{"kubeconfig":%s}}}}`, kubeconfig)
 				req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
 				recorder := httptest.NewRecorder()
 
@@ -1654,12 +1685,12 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
-		body := fmt.Sprintf(`{"spec":{"config":{"kubernetes_config":{"kubeconfig":%q}}}}`,
+		body := fmt.Sprintf(`{"spec":{"version":"v1.1.0","config":{"kubernetes_config":{"kubeconfig":%q}}}}`,
 			testEncodedKubeconfig("https://other-api.example.test:6443", "rotated-token"))
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
 		recorder := httptest.NewRecorder()
@@ -1690,13 +1721,13 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"config": null}
+			"spec": {"version": "v1.1.0", "config": null}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -1726,13 +1757,13 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"config": {"kubernetes_config": null}}
+			"spec": {"version": "v1.1.0", "config": {"kubernetes_config": null}}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -1762,12 +1793,12 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
-		body := fmt.Sprintf(`{"spec":{"config":{"ssh_config":{"auth":{"ssh_private_key":%q}}}}}`,
+		body := fmt.Sprintf(`{"spec":{"version":"v1.1.0","config":{"ssh_config":{"auth":{"ssh_private_key":%q}}}}}`,
 			base64.StdEncoding.EncodeToString([]byte("rotated-private-key")))
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
 		recorder := httptest.NewRecorder()
@@ -1793,12 +1824,12 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 				proxyCalled := false
 				router := gin.New()
-				router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+				router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 					proxyCalled = true
 					c.Status(http.StatusNoContent)
 				})
 
-				body := fmt.Sprintf(`{"spec":{"config":{"ssh_config":{"auth":{"ssh_private_key":%s}}}}}`, sshPrivateKey)
+				body := fmt.Sprintf(`{"spec":{"version":"v1.1.0","config":{"ssh_config":{"auth":{"ssh_private_key":%s}}}}}`, sshPrivateKey)
 				req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(body))
 				recorder := httptest.NewRecorder()
 
@@ -1823,13 +1854,13 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"config": {"ssh_config": {"auth": {"ssh_private_key": "invalid-base64"}}}}
+			"spec": {"version": "v1.1.0", "config": {"ssh_config": {"auth": {"ssh_private_key": "invalid-base64"}}}}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -1859,13 +1890,13 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"config": {"ssh_config": {"auth": null}}}
+			"spec": {"version": "v1.1.0", "config": {"ssh_config": {"auth": null}}}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -1895,13 +1926,13 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"config": {"ssh_config": null}}
+			"spec": {"version": "v1.1.0", "config": {"ssh_config": null}}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -1926,13 +1957,13 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"image_registry": "replacement-registry"}
+			"spec": {"version": "v1.1.0", "image_registry": "replacement-registry"}
 		}`))
 		recorder := httptest.NewRecorder()
 
@@ -1947,7 +1978,7 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -1967,10 +1998,18 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 	t.Run("restores request body and content length", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
-		body := `{"metadata":{"name":"cluster"}}`
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "cluster"},
+			Spec:     &v1.ClusterSpec{},
+		}}, nil).Once()
+
+		body := `{"metadata":{"name":"cluster"},"spec":{"version":"v1.1.0"}}`
 		originalBody := &trackingReadCloser{Reader: strings.NewReader(body)}
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterConfigurationUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			restoredBody, err := io.ReadAll(c.Request.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, body, string(restoredBody))
@@ -1989,7 +2028,7 @@ func testValidateClusterConfigurationUpdateMiddleware(t *testing.T) {
 
 		assert.True(t, originalBody.closed)
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertExpectations(t)
 	})
 }
 
@@ -2001,40 +2040,14 @@ func TestValidateClusterVersion(t *testing.T) {
 func testValidateClusterVersionUpdateMiddleware(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	t.Run("skips version validation for a configuration-only patch", func(t *testing.T) {
+	t.Run("rejects malformed configuration before any storage lookup", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
-
-		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"spec": {"config": {"kubernetes_config": {"kubeconfig": "updated-kubeconfig"}}}
-		}`))
-		recorder := httptest.NewRecorder()
-
-		router.ServeHTTP(recorder, req)
-
-		assert.True(t, proxyCalled)
-		assert.Equal(t, http.StatusNoContent, recorder.Code)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
-	})
-
-	t.Run("rejects malformed configuration before resolving version update", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		proxyCalled := false
-		router := gin.New()
-		router.PATCH(
-			"/clusters",
-			validateClusterVersionUpdate(mockStorage),
-			validateClusterConfigurationUpdate(mockStorage),
-			func(c *gin.Context) {
-				proxyCalled = true
-				c.Status(http.StatusNoContent)
-			},
-		)
 
 		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
 			"spec": {
@@ -2064,7 +2077,7 @@ func testValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -2094,7 +2107,7 @@ func testValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -2122,7 +2135,7 @@ func testValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		proxyCalled := false
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			proxyCalled = true
 			c.Status(http.StatusNoContent)
 		})
@@ -2140,33 +2153,20 @@ func testValidateClusterVersionUpdateMiddleware(t *testing.T) {
 		mockStorage.AssertExpectations(t)
 	})
 
-	t.Run("skips storage lookup when patch does not update version", func(t *testing.T) {
-		mockStorage := storageMocks.NewMockStorage(t)
-		proxyCalled := false
-		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
-			proxyCalled = true
-			c.Status(http.StatusNoContent)
-		})
-
-		req := httptest.NewRequest(http.MethodPatch, "/clusters?id=eq.1", strings.NewReader(`{
-			"metadata": {"name": "cluster"}
-		}`))
-		recorder := httptest.NewRecorder()
-
-		router.ServeHTTP(recorder, req)
-
-		assert.True(t, proxyCalled)
-		assert.Equal(t, http.StatusNoContent, recorder.Code)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
-	})
-
 	t.Run("restores request body and content length", func(t *testing.T) {
 		mockStorage := storageMocks.NewMockStorage(t)
-		body := `{"metadata":{"name":"cluster"}}`
+		query := url.Values{"id": []string{"eq.1"}}
+		mockStorage.On("ListCluster", mock.MatchedBy(func(opt storage.ListOption) bool {
+			return sameFilters(opt.Filters, queryParamsToFilters(query))
+		})).Return([]v1.Cluster{{
+			Metadata: &v1.Metadata{Workspace: "default", Name: "cluster"},
+			Spec:     &v1.ClusterSpec{},
+		}}, nil).Once()
+
+		body := `{"metadata":{"name":"cluster"},"spec":{"version":"v1.1.0"}}`
 		originalBody := &trackingReadCloser{Reader: strings.NewReader(body)}
 		router := gin.New()
-		router.PATCH("/clusters", validateClusterVersionUpdate(mockStorage), func(c *gin.Context) {
+		router.PATCH("/clusters", validateClusterRequest(mockStorage), func(c *gin.Context) {
 			restoredBody, err := io.ReadAll(c.Request.Body)
 			assert.NoError(t, err)
 			assert.Equal(t, body, string(restoredBody))
@@ -2185,7 +2185,7 @@ func testValidateClusterVersionUpdateMiddleware(t *testing.T) {
 
 		assert.True(t, originalBody.closed)
 		assert.Equal(t, http.StatusNoContent, recorder.Code)
-		mockStorage.AssertNotCalled(t, "ListCluster", mock.Anything)
+		mockStorage.AssertExpectations(t)
 	})
 }
 

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -222,21 +222,11 @@ func validateEndpointPatchVGPU(store storage.Storage, input *endpointValidationI
 }
 
 func validateEndpointClusterImmutable(input *endpointValidationInput) *validationError {
-	if !endpointPatchIncludesSpec(input.RawPayload) {
-		return nil
-	}
-
 	if endpointClusterChanged(input.Current, input.New) {
 		return endpointClusterImmutableError()
 	}
 
 	return nil
-}
-
-func endpointPatchIncludesSpec(payload map[string]json.RawMessage) bool {
-	_, ok := payload["spec"]
-
-	return ok
 }
 
 func endpointClusterChanged(existing *v1.Endpoint, patch *v1.Endpoint) bool {
@@ -264,6 +254,11 @@ func parseEndpointBody(body []byte) (*v1.Endpoint, *validationError) {
 // it forwards a PATCH: supplied top-level columns replace their current
 // values. A supplied spec therefore replaces the complete PostgreSQL
 // composite rather than recursively merging its attributes.
+//
+// Masked-column backfill only runs when the resource declares api:"-" masked
+// fields (mirroring the proxy's len(excludeFields) > 0 guard). Endpoints have
+// no masked fields; running the merge anyway would inject empty skeleton maps
+// for every omitted sibling key and replace the current values with them.
 func buildPostgrestEndpointPatchValidationNew(current *v1.Endpoint, body []byte) (*v1.Endpoint, error) {
 	if current == nil {
 		return nil, errors.New("current endpoint is required")
@@ -297,7 +292,9 @@ func buildPostgrestEndpointPatchValidationNew(current *v1.Endpoint, body []byte)
 	}
 
 	tagConfig := extractStructTagConfig(reflect.TypeOf(v1.Endpoint{}))
-	mergeExcludedFields(patchPayload, currentPayload, tagConfig.excludeFields, tagConfig.arrayMergeKeys)
+	if len(tagConfig.excludeFields) > 0 {
+		mergeExcludedFields(patchPayload, currentPayload, tagConfig.excludeFields, tagConfig.arrayMergeKeys)
+	}
 
 	for field, value := range patchPayload {
 		currentPayload[field] = value
@@ -370,7 +367,8 @@ func resolveEndpointPatch(
 
 	endpoints, err := store.ListEndpoint(storage.ListOption{Filters: filters})
 	if err != nil {
-		return nil, endpointPatchLookupError("failed to look up endpoint for endpoint PATCH")
+		return nil, endpointPatchLookupError(
+			fmt.Sprintf("failed to look up endpoint for endpoint PATCH: %v", err))
 	}
 
 	if len(endpoints) == 0 {

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -357,7 +357,7 @@ func resolveEndpointPatch(
 	queryParams url.Values,
 ) (*v1.Endpoint, *validationError) {
 	if store == nil {
-		return nil, endpointPatchLookupError("storage is required to resolve endpoint PATCH target")
+		return nil, internalServerValidationError()
 	}
 
 	filters := queryParamsToFilters(queryParams)
@@ -367,8 +367,7 @@ func resolveEndpointPatch(
 
 	endpoints, err := store.ListEndpoint(storage.ListOption{Filters: filters})
 	if err != nil {
-		return nil, endpointPatchLookupError(
-			fmt.Sprintf("failed to look up endpoint for endpoint PATCH: %v", err))
+		return nil, internalServerValidationError()
 	}
 
 	if len(endpoints) == 0 {
@@ -384,7 +383,7 @@ func resolveEndpointPatch(
 
 func resolveEndpointVGPUCluster(store storage.Storage, endpoint *v1.Endpoint) (*v1.Cluster, *validationError) {
 	if store == nil {
-		return nil, endpointVGPULookupError("storage is required to validate endpoint accelerator virtualization")
+		return nil, internalServerValidationError()
 	}
 
 	clusterName := endpoint.Spec.Cluster
@@ -401,7 +400,7 @@ func resolveEndpointVGPUCluster(store storage.Storage, endpoint *v1.Endpoint) (*
 		Filters: endpointClusterLookupFilters(clusterName, workspace),
 	})
 	if err != nil {
-		return nil, endpointVGPULookupError("failed to look up cluster for endpoint accelerator virtualization")
+		return nil, internalServerValidationError()
 	}
 
 	if len(clusters) == 0 {
@@ -677,20 +676,6 @@ func endpointPatchTargetError(hint string) *validationError {
 		Message: "invalid endpoint patch target",
 		Hint:    hint,
 	}
-}
-
-func endpointVGPULookupError(hint string) *validationError {
-	err := endpointVGPUTargetError(hint)
-	err.HTTPStatus = http.StatusServiceUnavailable
-
-	return err
-}
-
-func endpointPatchLookupError(hint string) *validationError {
-	err := endpointPatchTargetError(hint)
-	err.HTTPStatus = http.StatusServiceUnavailable
-
-	return err
 }
 
 func validationErrStatus(err *validationError) int {

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -252,7 +252,7 @@ func TestEndpointVGPUValidationRejectsPostWhenMemoryMIBExceedsPhysicalCardSpec(t
 	assert.False(t, handlerCalled)
 }
 
-func TestEndpointVGPUValidationReturnsServiceUnavailableOnClusterLookupError(t *testing.T) {
+func TestEndpointVGPUValidationReturnsInternalServerErrorOnClusterLookupError(t *testing.T) {
 	clusterStorage := &fakeClusterStorage{
 		listError: errors.New("database is down"),
 	}
@@ -275,10 +275,10 @@ func TestEndpointVGPUValidationReturnsServiceUnavailableOnClusterLookupError(t *
 	recorder, handlerCalled := runEndpointVGPUValidationWithHandler(http.MethodPost, body, clusterStorage)
 
 	var response validationError
-	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-	assert.Equal(t, "10221", response.Code)
-	assert.Contains(t, response.Hint, "failed to look up cluster")
+	assert.Equal(t, "500", response.Code)
+	assert.Equal(t, "internal server error", response.Message)
 	assert.NotContains(t, response.Hint, "database is down")
 	assert.False(t, handlerCalled)
 }
@@ -421,6 +421,8 @@ func TestEndpointValidationRejectsPatchWithInvalidTarget(t *testing.T) {
 		path               string
 		clusterStorage     *fakeClusterStorage
 		expectedStatus     int
+		expectedCode       string
+		expectedMessage    string
 		expectedHint       string
 		expectedHintSuffix string
 		expectedListCalls  int
@@ -447,10 +449,11 @@ func TestEndpointValidationRejectsPatchWithInvalidTarget(t *testing.T) {
 			clusterStorage: &fakeClusterStorage{
 				endpointListError: errors.New("database is down"),
 			},
-			expectedStatus:     http.StatusServiceUnavailable,
-			expectedHint:       "failed to look up endpoint",
-			expectedHintSuffix: "database is down",
-			expectedListCalls:  1,
+			expectedStatus:    http.StatusInternalServerError,
+			expectedCode:      "500",
+			expectedMessage:   "internal server error",
+			expectedHint:      "",
+			expectedListCalls: 1,
 		},
 		{
 			name: "when multiple endpoints match",
@@ -476,8 +479,16 @@ func TestEndpointValidationRejectsPatchWithInvalidTarget(t *testing.T) {
 			var response validationError
 			assert.Equal(t, tt.expectedStatus, recorder.Code)
 			assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
-			assert.Equal(t, "10221", response.Code)
-			assert.Equal(t, "invalid endpoint patch target", response.Message)
+			expectedCode := tt.expectedCode
+			if expectedCode == "" {
+				expectedCode = "10221"
+			}
+			expectedMessage := tt.expectedMessage
+			if expectedMessage == "" {
+				expectedMessage = "invalid endpoint patch target"
+			}
+			assert.Equal(t, expectedCode, response.Code)
+			assert.Equal(t, expectedMessage, response.Message)
 			assert.Contains(t, response.Hint, tt.expectedHint)
 			if tt.expectedHintSuffix != "" {
 				assert.Contains(t, response.Hint, tt.expectedHintSuffix)

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -417,12 +417,13 @@ func TestEndpointVGPUValidationRejectsPatchWithoutEndpointFilters(t *testing.T) 
 
 func TestEndpointValidationRejectsPatchWithInvalidTarget(t *testing.T) {
 	tests := []struct {
-		name              string
-		path              string
-		clusterStorage    *fakeClusterStorage
-		expectedStatus    int
-		expectedHint      string
-		expectedListCalls int
+		name               string
+		path               string
+		clusterStorage     *fakeClusterStorage
+		expectedStatus     int
+		expectedHint       string
+		expectedHintSuffix string
+		expectedListCalls  int
 	}{
 		{
 			name:              "without endpoint filters",
@@ -446,9 +447,10 @@ func TestEndpointValidationRejectsPatchWithInvalidTarget(t *testing.T) {
 			clusterStorage: &fakeClusterStorage{
 				endpointListError: errors.New("database is down"),
 			},
-			expectedStatus:    http.StatusServiceUnavailable,
-			expectedHint:      "failed to look up endpoint",
-			expectedListCalls: 1,
+			expectedStatus:     http.StatusServiceUnavailable,
+			expectedHint:       "failed to look up endpoint",
+			expectedHintSuffix: "database is down",
+			expectedListCalls:  1,
 		},
 		{
 			name: "when multiple endpoints match",
@@ -477,6 +479,9 @@ func TestEndpointValidationRejectsPatchWithInvalidTarget(t *testing.T) {
 			assert.Equal(t, "10221", response.Code)
 			assert.Equal(t, "invalid endpoint patch target", response.Message)
 			assert.Contains(t, response.Hint, tt.expectedHint)
+			if tt.expectedHintSuffix != "" {
+				assert.Contains(t, response.Hint, tt.expectedHintSuffix)
+			}
 			assert.NotContains(t, response.Hint, "vGPU")
 			assert.False(t, handlerCalled)
 			assert.Equal(t, tt.expectedListCalls, tt.clusterStorage.endpointListCalls)

--- a/internal/routes/proxies/validation_error.go
+++ b/internal/routes/proxies/validation_error.go
@@ -1,8 +1,22 @@
 package proxies
 
+import "net/http"
+
 type validationError struct {
 	Code       string `json:"code"`
 	Message    string `json:"message"`
 	Hint       string `json:"hint"`
 	HTTPStatus int    `json:"-"`
+}
+
+// internalServerValidationError is the response for validation-time
+// infrastructure failures (e.g. a database outage). The underlying error is
+// deliberately not included: it reveals internal state and the caller cannot
+// act on it either way.
+func internalServerValidationError() *validationError {
+	return &validationError{
+		Code:       "500",
+		Message:    "internal server error",
+		HTTPStatus: http.StatusInternalServerError,
+	}
 }


### PR DESCRIPTION
## Summary

The cluster patch validators classified errors by payload shape to preserve legacy per-domain error codes (10209/10212) from the three standalone middlewares that preceded the aggregate `validateClusterRequest`. That classification is redundant — identity resolution and the domain checks already produce the right errors — so the fallback wrappers collapse to literal error construction. The endpoint side drops its payload-presence gate, which the backfilled `New`/`Current` comparison already covers.

Rebased on #529 (`validateClusterVersionInput`): the pre-validation gate rejects config-only PATCHes and invalid/empty versions (10209/10212) before the patch branch runs, so the removed cluster-side presence logic and the standalone middlewares are provably dead code.

## Changes

**Cluster (`internal/routes/proxies/cluster_proxy.go`)**
- `clusterPatchValidationIdentityError` / `clusterPatchValidationPreparationError` folded into direct construction of `clusterPatchValidationResolutionError` (10209)
- Removed the three standalone middlewares (`validateClusterAcceleratorVirtualization`, `validateClusterVersionUpdate`, `validateClusterConfigurationUpdate`) — the aggregate `validateClusterRequest` is the single entry point; shared body logic kept in `validateClusterAcceleratorVirtualizationCluster`
- `validateClusterVersionUpdateInput` type-ified: consumes resolved `New`/`Current` instead of re-parsing the payload
- Configuration validation stays payload-based on purpose: the clear-vs-unset-vs-empty intent signals (`config: null`, `kubernetes_config: null`, `kubeconfig: ""`) are not recoverable from a typed diff
- Net: ~-280 lines

**Endpoint (`internal/routes/proxies/endpoint_validation.go`)**
- Dropped the `endpointPatchIncludesSpec` gate: a patch without a spec backfills to the current endpoint (no-op), a spec without a cluster is caught as an immutability violation (10225)
- Guarded masked-column backfill behind `len(excludeFields) > 0`, mirroring the proxy's own guard. Endpoints declare no `api:"-"` masked fields; running the merge unconditionally injected empty skeleton maps for omitted sibling keys and wiped current values (`spec.cluster`), which the gate removal exposed
- `resolveEndpointPatch` now surfaces the underlying storage error

## Storage-failure status (follow-up commit)

Cluster PATCH validation previously wrapped storage-layer failures (database outages) in the 10209 client error, returning 400 Bad Request whose hint leaked the underlying database error. Storage lookup failures now respond with HTTP 500 and a generic `code: "500" / "internal server error"` body — on both cluster and endpoint paths — without echoing the underlying error. The cluster middleware responds via `validationErrStatus` instead of a hardcoded 400.

## Error contract changes (response-level only)

PATCHes that previously hit the legacy per-domain resolution errors now receive the generic one — no API/schema change, e2e suites assert no error codes on these paths (0 assertions affected). Tests aligned to #529 semantics: middleware-group PATCH fixtures now carry a valid `spec.version`, and the config-only-patch case now expects the pre-validation rejection instead of a pass-through.

## Test plan

- [x] Unit tests updated/renamed to pin the generic contract; all pass (`go test ./internal/routes/proxies/`)
- [x] `go vet` + `gofmt` clean on the package
- [x] Full `go test ./internal/...` — all green
- [ ] Review feedback loop