### PR TITLE
feat(model-registry): ModelScope provider (NEU-627)

### DIFF
--- a/api/v1/model_registry_types.go
+++ b/api/v1/model_registry_types.go
@@ -19,6 +19,7 @@ type ModelRegistryType string
 
 const (
 	HuggingFaceModelRegistryType = "hugging-face"
+	ModelScopeModelRegistryType  = "model-scope"
 	BentoMLModelRegistryType     = "bentoml"
 )
 
@@ -34,12 +35,21 @@ const (
 // VisibilityForModelRegistryType states whether a registry kind is public.
 // Unknown kinds are private: a kind this build does not know about is not one
 // whose contents are on someone else's hub.
+//
+// This is one half of a pair. The other is api.visibility(), last redefined in
+// db/migrations/088_model_registry_visibility_model_scope.up.sql, which answers
+// the same question for clients reading the resource through PostgREST.
+// A public kind added to one and not the other is not a build failure and not a
+// visible error: the registry simply reports itself private, and the UI then
+// shows it storage figures that will never arrive and write controls that cannot
+// work. Add every new public kind to both.
 func VisibilityForModelRegistryType(registryType ModelRegistryType) string {
-	if registryType == HuggingFaceModelRegistryType {
+	switch registryType {
+	case HuggingFaceModelRegistryType, ModelScopeModelRegistryType:
 		return ModelRegistryVisibilityPublic
+	default:
+		return ModelRegistryVisibilityPrivate
 	}
-
-	return ModelRegistryVisibilityPrivate
 }
 
 type BentoMLModelRegistryConnectType string
@@ -59,9 +69,14 @@ const (
 )
 
 type ModelRegistrySpec struct {
-	Type        ModelRegistryType `json:"type"` // only support 'bentoml' | 'hugging-face'
-	Url         string            `json:"url"`  // only support 'file://localhost/path/to/model' | 'https://huggingface.co' | 'nfs://nfs-server:/path/to/model';
-	Credentials string            `json:"credentials" api:"-"`
+	// Type is one of 'bentoml' | 'hugging-face' | 'model-scope'.
+	Type ModelRegistryType `json:"type"`
+	// Url is the registry's address, in the form its type takes:
+	// 'file://localhost/path/to/model' or 'nfs://nfs-server:/path/to/model' for
+	// bentoml, and a hub or mirror address such as 'https://huggingface.co' or
+	// 'https://www.modelscope.cn' for the public kinds.
+	Url         string `json:"url"`
+	Credentials string `json:"credentials" api:"-"`
 }
 
 // ModelRegistryStats is a cached summary of what a registry currently holds. It

--- a/api/v1/model_registry_types_test.go
+++ b/api/v1/model_registry_types_test.go
@@ -1,0 +1,33 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The kinds a client must not be offered write controls or storage figures for.
+func TestVisibilityForModelRegistryType(t *testing.T) {
+	tests := []struct {
+		kind ModelRegistryType
+		want string
+	}{
+		{BentoMLModelRegistryType, ModelRegistryVisibilityPrivate},
+		{HuggingFaceModelRegistryType, ModelRegistryVisibilityPublic},
+		{ModelScopeModelRegistryType, ModelRegistryVisibilityPublic},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.kind), func(t *testing.T) {
+			assert.Equal(t, tt.want, VisibilityForModelRegistryType(tt.kind))
+		})
+	}
+}
+
+// A kind this build does not know is private, which is the safe direction:
+// calling it public would present somebody's own store as a read-only hub
+// operated by a third party, and would switch off the write controls they need.
+func TestVisibilityForModelRegistryTypeFailsSafeForUnknownKinds(t *testing.T) {
+	assert.Equal(t, ModelRegistryVisibilityPrivate,
+		VisibilityForModelRegistryType(ModelRegistryType("some-future-hub")))
+}

--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -35,6 +35,7 @@ type neutreeCoreInstallOptions struct {
 	// registry it can never reach.
 	enablePublicModelRegistries bool
 	huggingFaceEndpoint         string
+	modelScopeEndpoint          string
 }
 
 // defaultVictoriaLogsRetentionPeriod is the default VictoriaLogs log retention
@@ -65,6 +66,7 @@ Configuration Options:
   --victorialogs-retention-period VictoriaLogs log retention period (default: 30d; e.g. 30d, 90d, 1y)
   --enable-public-model-registries Provision built-in read-only public model registries (default: false)
   --hugging-face-endpoint  Address the built-in Hugging Face registry points at, e.g. an in-network mirror
+  --model-scope-endpoint   Address the built-in ModelScope registry points at, e.g. an in-network mirror
 
 Examples:
   # Basic installation
@@ -101,6 +103,9 @@ Examples:
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.huggingFaceEndpoint, "hugging-face-endpoint",
 		model_registry.DefaultHuggingFaceEndpoint,
 		"address the built-in Hugging Face registry points at, e.g. an in-network mirror")
+	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.modelScopeEndpoint, "model-scope-endpoint",
+		model_registry.DefaultModelScopeEndpoint,
+		"address the built-in ModelScope registry points at, e.g. an in-network mirror")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.adminPassword, "admin-password", "", "the password for the neutree admin user."+
 		"it is valid when starting neutree core for the first time. "+
 		"It is recommended to change it quickly after installation.")
@@ -226,6 +231,11 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 		huggingFaceEndpoint = model_registry.DefaultHuggingFaceEndpoint
 	}
 
+	modelScopeEndpoint := options.modelScopeEndpoint
+	if modelScopeEndpoint == "" {
+		modelScopeEndpoint = model_registry.DefaultModelScopeEndpoint
+	}
+
 	templateParams := map[string]string{
 		"NeutreeCoreWorkDir":           coreWorkDir,
 		"JwtSecret":                    options.jwtSecret,
@@ -246,6 +256,7 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 		"AdminPassword":                options.adminPassword,
 		"BuiltinPublicModelRegistries": builtinPublicModelRegistries,
 		"HuggingFaceEndpoint":          huggingFaceEndpoint,
+		"ModelScopeEndpoint":           modelScopeEndpoint,
 	}
 
 	err = util.BatchParseTemplateFiles(tempplateFiles, templateParams)

--- a/cmd/neutree-cli/app/cmd/model/write_refusal_test.go
+++ b/cmd/neutree-cli/app/cmd/model/write_refusal_test.go
@@ -16,7 +16,7 @@ import (
 // registryServer answers the registry lookup both write commands make first,
 // and records every path it is asked for so a test can assert what the command
 // did *not* go on to do.
-func registryServer(t *testing.T, registryType string) (url string, paths func() []string) {
+func registryServer(t *testing.T, registryName, registryType, registryURL string) (url string, paths func() []string) {
 	t.Helper()
 
 	var (
@@ -30,8 +30,8 @@ func registryServer(t *testing.T, registryType string) (url string, paths func()
 		mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[{"id":1,"metadata":{"name":"public-hugging-face","workspace":"default"},` +
-			`"spec":{"type":"` + registryType + `","url":"https://huggingface.co"}}]`))
+		_, _ = w.Write([]byte(`[{"id":1,"metadata":{"name":"` + registryName + `","workspace":"default"},` +
+			`"spec":{"type":"` + registryType + `","url":"` + registryURL + `"}}]`))
 	}))
 	t.Cleanup(server.Close)
 
@@ -56,7 +56,7 @@ func useServer(t *testing.T, url string) {
 // refusal itself is only half the point: the other half is that a user who
 // picked the wrong registry does not pay for a full upload to find out.
 func TestPushRefusesAPublicRegistryBeforeUploading(t *testing.T) {
-	url, paths := registryServer(t, "hugging-face")
+	url, paths := registryServer(t, "public-hugging-face", "hugging-face", "https://huggingface.co")
 	useServer(t, url)
 
 	modelDir := t.TempDir()
@@ -80,7 +80,7 @@ func TestPushRefusesAPublicRegistryBeforeUploading(t *testing.T) {
 // from stdin when --force is absent, so a test that gets as far as the prompt
 // hangs or fails on a closed stdin rather than reporting the refusal.
 func TestDeleteRefusesAPublicRegistryBeforePrompting(t *testing.T) {
-	url, paths := registryServer(t, "hugging-face")
+	url, paths := registryServer(t, "public-hugging-face", "hugging-face", "https://huggingface.co")
 	useServer(t, url)
 
 	cmd := NewModelCmd()
@@ -91,6 +91,50 @@ func TestDeleteRefusesAPublicRegistryBeforePrompting(t *testing.T) {
 	require.EqualError(t, err,
 		`cannot delete models from model registry "public-hugging-face": `+
 			`it is a hugging-face registry, which neutree reads from but never writes to`)
+
+	for _, path := range paths() {
+		require.NotContains(t, path, "/models", "delete reached the model endpoint after being refused")
+	}
+}
+
+// The same two commands, against ModelScope, with no ModelScope-specific code
+// anywhere in the CLI.
+//
+// NEU-625 moved the judgement out of the commands and into
+// v1.VisibilityForModelRegistryType; NEU-627 taught that one mapping about
+// model-scope. If the mapping is the only thing that had to learn, these pass
+// as they are — and the exact sentence is asserted, not merely that an error
+// came back, because a refusal still reading "hugging-face" would mean the
+// judgement is not really coming from the mapping.
+func TestPushRefusesModelScopeWithNoModelScopeSpecificCLICode(t *testing.T) {
+	url, paths := registryServer(t, "public-model-scope", "model-scope", "https://www.modelscope.cn")
+	useServer(t, url)
+
+	modelDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(modelDir, "config.json"), []byte(`{}`), 0o600))
+
+	cmd := NewModelCmd()
+	cmd.SetArgs([]string{"push", modelDir, "--name", "tinymodel", "--version", "v1", "-r", "public-model-scope"})
+
+	require.EqualError(t, cmd.Execute(),
+		`cannot push models to model registry "public-model-scope": `+
+			`it is a model-scope registry, which neutree reads from but never writes to`)
+
+	for _, path := range paths() {
+		require.NotContains(t, path, "/models", "push reached the model endpoint after being refused")
+	}
+}
+
+func TestDeleteRefusesModelScopeWithNoModelScopeSpecificCLICode(t *testing.T) {
+	url, paths := registryServer(t, "public-model-scope", "model-scope", "https://www.modelscope.cn")
+	useServer(t, url)
+
+	cmd := NewModelCmd()
+	cmd.SetArgs([]string{"delete", "Qwen/Qwen3-8B:latest", "-r", "public-model-scope"})
+
+	require.EqualError(t, cmd.Execute(),
+		`cannot delete models from model registry "public-model-scope": `+
+			`it is a model-scope registry, which neutree reads from but never writes to`)
 
 	for _, path := range paths() {
 		require.NotContains(t, path, "/models", "delete reached the model endpoint after being refused")

--- a/cmd/neutree-core/app/options/model_registry.go
+++ b/cmd/neutree-core/app/options/model_registry.go
@@ -20,12 +20,15 @@ type ModelRegistryOptions struct {
 	// points at — the Hub, or a mirror reachable from inside the network. It has
 	// no effect unless the built-in registries are enabled.
 	HuggingFaceEndpoint string
+	// ModelScopeEndpoint is the ModelScope counterpart of HuggingFaceEndpoint.
+	ModelScopeEndpoint string
 }
 
 func NewModelRegistryOptions() *ModelRegistryOptions {
 	return &ModelRegistryOptions{
 		EnableBuiltinPublicRegistries: false,
 		HuggingFaceEndpoint:           model_registry.DefaultHuggingFaceEndpoint,
+		ModelScopeEndpoint:            model_registry.DefaultModelScopeEndpoint,
 	}
 }
 
@@ -35,4 +38,6 @@ func (o *ModelRegistryOptions) AddFlags(fs *pflag.FlagSet) {
 		"provision a built-in read-only model registry for each supported public hub in every workspace")
 	fs.StringVar(&o.HuggingFaceEndpoint, "hugging-face-endpoint", o.HuggingFaceEndpoint,
 		"address the built-in Hugging Face registry points at, e.g. an in-network mirror")
+	fs.StringVar(&o.ModelScopeEndpoint, "model-scope-endpoint", o.ModelScopeEndpoint,
+		"address the built-in ModelScope registry points at, e.g. an in-network mirror")
 }

--- a/cmd/neutree-core/app/options/options.go
+++ b/cmd/neutree-core/app/options/options.go
@@ -175,6 +175,7 @@ func (o *NeutreeCoreOptions) Config(scheme *scheme.Scheme) (*config.CoreConfig, 
 		Builtin: model_registry.BuiltinConfig{
 			Enabled:             o.ModelRegistry.EnableBuiltinPublicRegistries,
 			HuggingFaceEndpoint: o.ModelRegistry.HuggingFaceEndpoint,
+			ModelScopeEndpoint:  o.ModelRegistry.ModelScopeEndpoint,
 		},
 	}
 

--- a/controllers/workspace_model_registry_test.go
+++ b/controllers/workspace_model_registry_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/model_registry"
+	"github.com/neutree-ai/neutree/pkg/storage"
 	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
@@ -38,6 +40,59 @@ func builtinRegistryRow(id int, url string) v1.ModelRegistry {
 	}
 }
 
+func builtinModelScopeRow(id int, url string) v1.ModelRegistry {
+	row := builtinRegistryRow(id, url)
+	row.Metadata.Name = model_registry.BuiltinModelScopeRegistryName
+	row.Spec.Type = v1.ModelScopeModelRegistryType
+
+	return row
+}
+
+// provisionedRows installs a ListModelRegistry mock that honours the name filter
+// the reconcile sends.
+//
+// Provisioning walks every built-in kind and looks each one up by name, so a mock
+// answering every lookup with the same rows would show each kind the other's
+// registry — and the reconcile, seeing the wrong type, would rewrite it. Filtering
+// here is what keeps these tests about the behaviour they name.
+func provisionedRows(mockStorage *storagemocks.MockStorage, rows ...v1.ModelRegistry) {
+	mockStorage.On("ListModelRegistry", mock.Anything).Return(
+		func(option storage.ListOption) []v1.ModelRegistry {
+			wanted := ""
+
+			for _, filter := range option.Filters {
+				if filter.Column == "metadata->name" {
+					wanted = filter.Value
+				}
+			}
+
+			// No name filter means the caller wants the whole workspace, as the
+			// teardown path does.
+			if wanted == "" {
+				return rows
+			}
+
+			matched := []v1.ModelRegistry{}
+
+			for _, row := range rows {
+				if row.Metadata != nil && strconv.Quote(row.Metadata.Name) == wanted {
+					matched = append(matched, row)
+				}
+			}
+
+			return matched
+		}, nil)
+}
+
+// defaultRows is what a workspace looks like once provisioning has run with no
+// mirrors configured: one registry per built-in kind, at the hub's own address.
+func defaultRows() []v1.ModelRegistry {
+	return []v1.ModelRegistry{
+		builtinRegistryRow(4, model_registry.DefaultHuggingFaceEndpoint),
+		builtinModelScopeRow(5, model_registry.DefaultModelScopeEndpoint),
+	}
+}
+
 func workspaceNamed(name string) v1.Workspace {
 	return v1.Workspace{
 		ID:       1,
@@ -48,26 +103,36 @@ func workspaceNamed(name string) v1.Workspace {
 
 func TestSyncWorkspaceModelRegistry_ProvisionsWhenEnabled(t *testing.T) {
 	mockStorage := &storagemocks.MockStorage{}
-	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{}, nil)
+	provisionedRows(mockStorage)
 
-	var created *v1.ModelRegistry
+	created := map[string]*v1.ModelRegistry{}
 
 	mockStorage.On("CreateModelRegistry", mock.Anything).Run(func(args mock.Arguments) {
-		created, _ = args.Get(0).(*v1.ModelRegistry)
+		registry, _ := args.Get(0).(*v1.ModelRegistry)
+		created[registry.Metadata.Name] = registry
 	}).Return(nil)
 
 	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
 		Enabled:             true,
 		HuggingFaceEndpoint: "https://hf-mirror.example",
+		ModelScopeEndpoint:  "https://ms-mirror.example",
 	})
 
 	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
 
-	require.NotNil(t, created)
-	assert.Equal(t, model_registry.BuiltinHuggingFaceRegistryName, created.Metadata.Name)
-	assert.Equal(t, "default", created.Metadata.Workspace)
-	assert.Equal(t, "https://hf-mirror.example", created.Spec.Url)
-	assert.True(t, v1.IsBuiltin(created.Metadata.Annotations))
+	// Every supported public hub, not just the first one.
+	require.Len(t, created, 2)
+
+	for name, wantURL := range map[string]string{
+		model_registry.BuiltinHuggingFaceRegistryName: "https://hf-mirror.example",
+		model_registry.BuiltinModelScopeRegistryName:  "https://ms-mirror.example",
+	} {
+		registry := created[name]
+		require.NotNil(t, registry, "%s was not provisioned", name)
+		assert.Equal(t, "default", registry.Metadata.Workspace)
+		assert.Equal(t, wantURL, registry.Spec.Url)
+		assert.True(t, v1.IsBuiltin(registry.Metadata.Annotations))
+	}
 
 	mockStorage.AssertExpectations(t)
 }
@@ -94,8 +159,7 @@ func TestSyncWorkspaceModelRegistry_ProvisionsNothingWhenDisabled(t *testing.T) 
 // configuration flag flipped during an upgrade is nobody being present.
 func TestSyncWorkspaceModelRegistry_TurningTheSwitchOffLeavesProvisionedRegistries(t *testing.T) {
 	mockStorage := &storagemocks.MockStorage{}
-	mockStorage.On("ListModelRegistry", mock.Anything).
-		Return([]v1.ModelRegistry{builtinRegistryRow(4, "https://huggingface.co")}, nil).Maybe()
+	mockStorage.On("ListModelRegistry", mock.Anything).Return(defaultRows(), nil).Maybe()
 
 	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{})
 
@@ -107,13 +171,14 @@ func TestSyncWorkspaceModelRegistry_TurningTheSwitchOffLeavesProvisionedRegistri
 
 func TestSyncWorkspaceModelRegistry_RepointsAtANewMirror(t *testing.T) {
 	mockStorage := &storagemocks.MockStorage{}
-	mockStorage.On("ListModelRegistry", mock.Anything).
-		Return([]v1.ModelRegistry{builtinRegistryRow(4, "https://huggingface.co")}, nil)
+	provisionedRows(mockStorage, defaultRows()...)
 
-	var updated *v1.ModelRegistry
+	updated := map[string]*v1.ModelRegistry{}
 
-	mockStorage.On("UpdateModelRegistry", "4", mock.Anything).Run(func(args mock.Arguments) {
-		updated, _ = args.Get(1).(*v1.ModelRegistry)
+	mockStorage.On("UpdateModelRegistry", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		id, _ := args.Get(0).(string)
+		registry, _ := args.Get(1).(*v1.ModelRegistry)
+		updated[id] = registry
 	}).Return(nil)
 
 	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
@@ -123,15 +188,16 @@ func TestSyncWorkspaceModelRegistry_RepointsAtANewMirror(t *testing.T) {
 
 	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
 
-	require.NotNil(t, updated)
-	assert.Equal(t, "https://hf-mirror.example", updated.Spec.Url)
+	require.NotNil(t, updated["4"])
+	assert.Equal(t, "https://hf-mirror.example", updated["4"].Spec.Url)
+	// Mirroring one hub does not disturb the other.
+	assert.NotContains(t, updated, "5")
 	mockStorage.AssertExpectations(t)
 }
 
 func TestSyncWorkspaceModelRegistry_LeavesAMatchingRegistryAlone(t *testing.T) {
 	mockStorage := &storagemocks.MockStorage{}
-	mockStorage.On("ListModelRegistry", mock.Anything).
-		Return([]v1.ModelRegistry{builtinRegistryRow(4, "https://huggingface.co")}, nil)
+	provisionedRows(mockStorage, defaultRows()...)
 
 	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{Enabled: true})
 
@@ -144,15 +210,18 @@ func TestSyncWorkspaceModelRegistry_LeavesAMatchingRegistryAlone(t *testing.T) {
 // Provisioning must never adopt a registry a user created, even one sitting
 // under the name the control plane would have used.
 func TestSyncWorkspaceModelRegistry_NeverTouchesAUserRegistry(t *testing.T) {
-	userOwned := builtinRegistryRow(4, "https://huggingface.co")
-	userOwned.Metadata.Annotations = nil
+	rows := defaultRows()
+	for i := range rows {
+		rows[i].Metadata.Annotations = nil
+	}
 
 	mockStorage := &storagemocks.MockStorage{}
-	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{userOwned}, nil)
+	provisionedRows(mockStorage, rows...)
 
 	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
 		Enabled:             true,
 		HuggingFaceEndpoint: "https://elsewhere.example",
+		ModelScopeEndpoint:  "https://elsewhere.example",
 	})
 
 	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
@@ -163,15 +232,18 @@ func TestSyncWorkspaceModelRegistry_NeverTouchesAUserRegistry(t *testing.T) {
 
 // A row already on its way out is left to the teardown that is under way.
 func TestSyncWorkspaceModelRegistry_SkipsARegistryBeingDeleted(t *testing.T) {
-	deleting := builtinRegistryRow(4, "https://huggingface.co")
-	deleting.Metadata.DeletionTimestamp = time.Now().UTC().Format(time.RFC3339)
+	rows := defaultRows()
+	for i := range rows {
+		rows[i].Metadata.DeletionTimestamp = time.Now().UTC().Format(time.RFC3339)
+	}
 
 	mockStorage := &storagemocks.MockStorage{}
-	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{deleting}, nil)
+	provisionedRows(mockStorage, rows...)
 
 	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{
 		Enabled:             true,
 		HuggingFaceEndpoint: "https://elsewhere.example",
+		ModelScopeEndpoint:  "https://elsewhere.example",
 	})
 
 	require.NoError(t, c.syncWorkspaceModelRegistry(workspaceNamed("default")))
@@ -183,11 +255,11 @@ func TestSyncWorkspaceModelRegistry_SkipsARegistryBeingDeleted(t *testing.T) {
 // Credentials a user attached to the built-in registry are theirs; re-pointing
 // the URL must not take them away.
 func TestSyncWorkspaceModelRegistry_KeepsUserSuppliedCredentials(t *testing.T) {
-	stored := builtinRegistryRow(4, "https://huggingface.co")
-	stored.Spec.Credentials = "hf_token"
+	rows := defaultRows()
+	rows[0].Spec.Credentials = "hf_token"
 
 	mockStorage := &storagemocks.MockStorage{}
-	mockStorage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{stored}, nil)
+	provisionedRows(mockStorage, rows...)
 
 	var updated *v1.ModelRegistry
 
@@ -214,17 +286,20 @@ func TestDeleteWorkspaceModelRegistry(t *testing.T) {
 	userOwned.Metadata.Name = "mine"
 	userOwned.Metadata.Annotations = nil
 
+	rows := append(defaultRows(), userOwned)
+
 	mockStorage := &storagemocks.MockStorage{}
-	mockStorage.On("ListModelRegistry", mock.Anything).
-		Return([]v1.ModelRegistry{builtinRegistryRow(4, "https://huggingface.co"), userOwned}, nil)
+	mockStorage.On("ListModelRegistry", mock.Anything).Return(rows, nil)
 	mockStorage.On("DeleteModelRegistry", "4").Return(nil)
+	// Every provisioned registry, not just the first kind.
+	mockStorage.On("DeleteModelRegistry", "5").Return(nil)
 
 	c := newBuiltinRegistryController(mockStorage, model_registry.BuiltinConfig{Enabled: true})
 
 	workspace := workspaceNamed("default")
 	require.NoError(t, c.DeleteWorkspaceModelRegistry(&workspace))
 
-	// Only the provisioned one. A user's registry is theirs, and workspace
+	// Only the provisioned ones. A user's registry is theirs, and workspace
 	// deletion is already refused while any remain.
 	mockStorage.AssertNotCalled(t, "DeleteModelRegistry", "9")
 	mockStorage.AssertExpectations(t)

--- a/db/migrations/088_model_registry_visibility_model_scope.down.sql
+++ b/db/migrations/088_model_registry_visibility_model_scope.down.sql
@@ -1,0 +1,13 @@
+-- Restore the definition from 084: Hugging Face is the only public kind.
+--
+-- Rolling back leaves any stored model-scope registry reporting itself private,
+-- which is the same state a build without the ModelScope provider would see.
+CREATE OR REPLACE FUNCTION api.visibility(registry api.model_registries)
+RETURNS TEXT AS $$
+    SELECT CASE
+        WHEN (registry.spec).type = 'hugging-face' THEN 'public'
+        ELSE 'private'
+    END;
+$$ LANGUAGE sql STABLE;
+
+NOTIFY pgrst, 'reload schema';

--- a/db/migrations/088_model_registry_visibility_model_scope.up.sql
+++ b/db/migrations/088_model_registry_visibility_model_scope.up.sql
@@ -1,0 +1,23 @@
+-- NEU-627: ModelScope is a public registry too.
+
+-- api.visibility enumerates the public kinds by name, so a provider added in Go
+-- without a matching migration neither fails to build nor raises an error: the
+-- registry reports itself private, and clients then offer it storage figures
+-- that never arrive and write controls that cannot work. Redefined here rather
+-- than edited into 084, which has shipped.
+--
+-- Must be kept in step with v1.VisibilityForModelRegistryType in
+-- api/v1/model_registry_types.go, which is the same rule for callers inside the
+-- control plane. Add every new public kind to both.
+--
+-- Body based on 084_model_registry_checked_at_and_visibility.up.sql, the latest
+-- migration to define this function.
+CREATE OR REPLACE FUNCTION api.visibility(registry api.model_registries)
+RETURNS TEXT AS $$
+    SELECT CASE
+        WHEN (registry.spec).type IN ('hugging-face', 'model-scope') THEN 'public'
+        ELSE 'private'
+    END;
+$$ LANGUAGE sql STABLE;
+
+NOTIFY pgrst, 'reload schema';

--- a/deploy/chart/neutree/templates/neutree-core-deployment.yaml
+++ b/deploy/chart/neutree/templates/neutree-core-deployment.yaml
@@ -49,6 +49,7 @@ spec:
             {{- if .Values.publicModelRegistries.enabled }}
             - --enable-builtin-public-model-registries
             - --hugging-face-endpoint={{ .Values.publicModelRegistries.huggingFace.url }}
+            - --model-scope-endpoint={{ .Values.publicModelRegistries.modelScope.url }}
             {{- end }}
           image: {{ include "neutree.image" (dict "global" .Values.global "componentRegistry" .Values.core.image.registry "repository" .Values.core.image.repository "tag" .Values.core.image.tag "defaultTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.core.image.pullPolicy }}

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -45,6 +45,10 @@ publicModelRegistries:
     # Address the built-in Hugging Face registry points at. Set this to a mirror
     # reachable from inside the network when the Hub itself is not.
     url: "https://huggingface.co"
+  modelScope:
+    # Address the built-in ModelScope registry points at. Set this to a mirror
+    # reachable from inside the network when the hub itself is not.
+    url: "https://www.modelscope.cn"
 
 metrics:
   # Specify the URL for remote write if using an external metrics storage system.

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -191,6 +191,7 @@ services:
 {{ if .BuiltinPublicModelRegistries }}
       - --enable-builtin-public-model-registries
       - --hugging-face-endpoint={{ .HuggingFaceEndpoint }}
+      - --model-scope-endpoint={{ .ModelScopeEndpoint }}
 {{ end }}
     volumes:
       - {{ .NeutreeCoreWorkDir }}/collect:/etc/neutree/collect

--- a/internal/cli/model/write_target_test.go
+++ b/internal/cli/model/write_target_test.go
@@ -65,6 +65,7 @@ func TestValidateWritableRegistryDefersWhenItCannotTell(t *testing.T) {
 func TestValidateWritableRegistryRefusesWhateverTheMappingCallsPublic(t *testing.T) {
 	for _, registryType := range []v1.ModelRegistryType{
 		v1.HuggingFaceModelRegistryType,
+		v1.ModelScopeModelRegistryType,
 		v1.BentoMLModelRegistryType,
 		"some-future-kind",
 	} {
@@ -104,4 +105,33 @@ func TestValidateWritableRegistryFallsBackToTheRequestedName(t *testing.T) {
 	require.EqualError(t, err,
 		`cannot push models to model registry "public-hugging-face": `+
 			`it is a hugging-face registry, which neutree reads from but never writes to`)
+}
+
+// NEU-627's whole shape rests on this being true: ModelScope became writable-
+// refusable in the CLI without a line of CLI code, because NEU-625 moved the
+// judgement to v1.VisibilityForModelRegistryType and NEU-627 taught that one
+// mapping about the kind.
+//
+// Asserted on the exact sentence rather than on "an error happened", because
+// the claim is that the CLI names the new kind correctly without knowing it
+// exists — a refusal reading "hugging-face" would mean something is still
+// hard-coded, and a bare require.Error would not catch that.
+func TestValidateWritableRegistryRefusesModelScopeWithNoCLIChange(t *testing.T) {
+	modelScope := &v1.ModelRegistry{
+		Metadata: &v1.Metadata{Name: "public-model-scope"},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.ModelScopeModelRegistryType,
+			Url:  "https://www.modelscope.cn",
+		},
+	}
+
+	require.EqualError(t,
+		ValidateWritableRegistry(modelScope, "public-model-scope", ModelWritePush),
+		`cannot push models to model registry "public-model-scope": `+
+			`it is a model-scope registry, which neutree reads from but never writes to`)
+
+	require.EqualError(t,
+		ValidateWritableRegistry(modelScope, "public-model-scope", ModelWriteDelete),
+		`cannot delete models from model registry "public-model-scope": `+
+			`it is a model-scope registry, which neutree reads from but never writes to`)
 }

--- a/internal/model_registry/builtin.go
+++ b/internal/model_registry/builtin.go
@@ -13,6 +13,12 @@ const (
 	// DefaultHuggingFaceEndpoint is the Hub itself, used when the built-in
 	// registry is enabled without naming a mirror.
 	DefaultHuggingFaceEndpoint = "https://huggingface.co"
+	// BuiltinModelScopeRegistryName is the ModelScope counterpart of
+	// BuiltinHuggingFaceRegistryName.
+	BuiltinModelScopeRegistryName = "public-model-scope"
+	// DefaultModelScopeEndpoint is the hub itself, used when the built-in
+	// registry is enabled without naming a mirror.
+	DefaultModelScopeEndpoint = "https://www.modelscope.cn"
 )
 
 // BuiltinConfig says whether this installation offers public model registries,
@@ -24,15 +30,44 @@ type BuiltinConfig struct {
 	// HuggingFaceEndpoint is the Hub address to use — a mirror inside the network,
 	// or the Hub itself. Empty means DefaultHuggingFaceEndpoint.
 	HuggingFaceEndpoint string
+	// ModelScopeEndpoint is the ModelScope address to use. Empty means
+	// DefaultModelScopeEndpoint.
+	ModelScopeEndpoint string
 }
 
 func (c BuiltinConfig) huggingFaceEndpoint() string {
-	endpoint := strings.TrimSpace(c.HuggingFaceEndpoint)
+	return endpointOrDefault(c.HuggingFaceEndpoint, DefaultHuggingFaceEndpoint)
+}
+
+func (c BuiltinConfig) modelScopeEndpoint() string {
+	return endpointOrDefault(c.ModelScopeEndpoint, DefaultModelScopeEndpoint)
+}
+
+func endpointOrDefault(configured, fallback string) string {
+	endpoint := strings.TrimSpace(configured)
 	if endpoint == "" {
-		return DefaultHuggingFaceEndpoint
+		return fallback
 	}
 
 	return strings.TrimSuffix(endpoint, "/")
+}
+
+// EndpointFlagForModelRegistryType names the neutree-core setting that owns the
+// address of a built-in registry of this kind, or "" for a kind that has no
+// built-in form.
+//
+// It exists so that a refusal to edit that address can send the operator to the
+// setting which actually governs the registry in front of them; naming one hub's
+// flag for every hub would send them to edit a value with no effect on it.
+func EndpointFlagForModelRegistryType(registryType v1.ModelRegistryType) string {
+	switch registryType {
+	case v1.HuggingFaceModelRegistryType:
+		return "--hugging-face-endpoint"
+	case v1.ModelScopeModelRegistryType:
+		return "--model-scope-endpoint"
+	default:
+		return ""
+	}
 }
 
 // BuiltinModelRegistries returns the registries this deployment provisions for a
@@ -59,6 +94,19 @@ func BuiltinModelRegistries(config BuiltinConfig, workspace string) []*v1.ModelR
 			Spec: &v1.ModelRegistrySpec{
 				Type: v1.HuggingFaceModelRegistryType,
 				Url:  config.huggingFaceEndpoint(),
+			},
+		},
+		{
+			APIVersion: "v1",
+			Kind:       "ModelRegistry",
+			Metadata: &v1.Metadata{
+				Name:        BuiltinModelScopeRegistryName,
+				Workspace:   workspace,
+				Annotations: v1.WithBuiltinAnnotation(nil),
+			},
+			Spec: &v1.ModelRegistrySpec{
+				Type: v1.ModelScopeModelRegistryType,
+				Url:  config.modelScopeEndpoint(),
 			},
 		},
 	}

--- a/internal/model_registry/builtin_test.go
+++ b/internal/model_registry/builtin_test.go
@@ -9,12 +9,24 @@ import (
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
+// byName indexes a provisioning result so a test can assert about one hub
+// without depending on the order they come back in.
+func byName(registries []*v1.ModelRegistry) map[string]*v1.ModelRegistry {
+	indexed := map[string]*v1.ModelRegistry{}
+	for _, registry := range registries {
+		indexed[registry.Metadata.Name] = registry
+	}
+
+	return indexed
+}
+
 func TestBuiltinModelRegistries(t *testing.T) {
 	tests := []struct {
-		name     string
-		config   BuiltinConfig
-		wantURL  string
-		wantNone bool
+		name            string
+		config          BuiltinConfig
+		wantHuggingFace string
+		wantModelScope  string
+		wantNone        bool
 	}{
 		{
 			// The default. An installation with no route out would otherwise show
@@ -29,19 +41,36 @@ func TestBuiltinModelRegistries(t *testing.T) {
 			wantNone: true,
 		},
 		{
-			name:    "enabled without an endpoint uses the hub",
-			config:  BuiltinConfig{Enabled: true},
-			wantURL: DefaultHuggingFaceEndpoint,
+			name:            "enabled without endpoints uses the hubs themselves",
+			config:          BuiltinConfig{Enabled: true},
+			wantHuggingFace: DefaultHuggingFaceEndpoint,
+			wantModelScope:  DefaultModelScopeEndpoint,
 		},
 		{
-			name:    "enabled with a mirror",
-			config:  BuiltinConfig{Enabled: true, HuggingFaceEndpoint: "https://hf-mirror.example/"},
-			wantURL: "https://hf-mirror.example",
+			name: "enabled with mirrors",
+			config: BuiltinConfig{
+				Enabled:             true,
+				HuggingFaceEndpoint: "https://hf-mirror.example/",
+				ModelScopeEndpoint:  "https://ms-mirror.example/",
+			},
+			wantHuggingFace: "https://hf-mirror.example",
+			wantModelScope:  "https://ms-mirror.example",
 		},
 		{
-			name:    "blank endpoint falls back to the hub",
-			config:  BuiltinConfig{Enabled: true, HuggingFaceEndpoint: "   "},
-			wantURL: DefaultHuggingFaceEndpoint,
+			// Mirroring one hub must not silently repoint the other.
+			name: "a mirror for one hub leaves the other on its default",
+			config: BuiltinConfig{
+				Enabled:            true,
+				ModelScopeEndpoint: "https://ms-mirror.example",
+			},
+			wantHuggingFace: DefaultHuggingFaceEndpoint,
+			wantModelScope:  "https://ms-mirror.example",
+		},
+		{
+			name:            "blank endpoints fall back to the hubs",
+			config:          BuiltinConfig{Enabled: true, HuggingFaceEndpoint: "   ", ModelScopeEndpoint: "  "},
+			wantHuggingFace: DefaultHuggingFaceEndpoint,
+			wantModelScope:  DefaultModelScopeEndpoint,
 		},
 	}
 
@@ -55,29 +84,68 @@ func TestBuiltinModelRegistries(t *testing.T) {
 				return
 			}
 
-			require.Len(t, got, 1)
+			require.Len(t, got, 2)
+			indexed := byName(got)
 
-			registry := got[0]
-			assert.Equal(t, BuiltinHuggingFaceRegistryName, registry.Metadata.Name)
-			assert.Equal(t, "default", registry.Metadata.Workspace)
-			assert.Equal(t, v1.ModelRegistryType(v1.HuggingFaceModelRegistryType), registry.Spec.Type)
-			assert.Equal(t, tt.wantURL, registry.Spec.Url)
-			// The annotation is what makes withdrawal safe: it is the only thing
-			// telling a provisioned registry from one a user created by hand.
-			assert.True(t, v1.IsBuiltin(registry.Metadata.Annotations))
-			// A public registry is read-only, so it carries no credentials of its
-			// own. Anything a user attaches later is theirs.
-			assert.Empty(t, registry.Spec.Credentials)
+			for _, expected := range []struct {
+				name     string
+				kind     string
+				endpoint string
+			}{
+				{BuiltinHuggingFaceRegistryName, v1.HuggingFaceModelRegistryType, tt.wantHuggingFace},
+				{BuiltinModelScopeRegistryName, v1.ModelScopeModelRegistryType, tt.wantModelScope},
+			} {
+				registry := indexed[expected.name]
+				require.NotNil(t, registry, "no built-in registry named %s", expected.name)
+
+				assert.Equal(t, "default", registry.Metadata.Workspace)
+				assert.Equal(t, v1.ModelRegistryType(expected.kind), registry.Spec.Type)
+				assert.Equal(t, expected.endpoint, registry.Spec.Url)
+				// The annotation is what makes withdrawal safe: it is the only thing
+				// telling a provisioned registry from one a user created by hand.
+				assert.True(t, v1.IsBuiltin(registry.Metadata.Annotations))
+				// A public registry is read-only, so it carries no credentials of its
+				// own. Anything a user attaches later is theirs.
+				assert.Empty(t, registry.Spec.Credentials)
+			}
 		})
 	}
 }
 
 func TestBuiltinModelRegistriesArePublic(t *testing.T) {
 	// The registries this provisions must be the ones the cache and the storage
-	// figures treat as public — one rule, not two.
+	// figures treat as public — one rule, not two. A hub added to the built-in
+	// set but not to VisibilityForModelRegistryType would be provisioned into
+	// every workspace and then treated as a private store it can never measure.
 	got := BuiltinModelRegistries(BuiltinConfig{Enabled: true}, "default")
-	require.Len(t, got, 1)
+	require.Len(t, got, 2)
 
-	assert.Equal(t, v1.ModelRegistryVisibilityPublic,
-		v1.VisibilityForModelRegistryType(got[0].Spec.Type))
+	for _, registry := range got {
+		assert.Equal(t, v1.ModelRegistryVisibilityPublic,
+			v1.VisibilityForModelRegistryType(registry.Spec.Type),
+			"built-in registry %s is not public", registry.Metadata.Name)
+	}
+}
+
+// The refusal to edit a built-in registry's address names the setting that owns
+// it, so every kind that is provisioned must have one to name. A kind added here
+// without one would be refused with an explanation that points nowhere.
+func TestBuiltinModelRegistriesNameTheirEndpointFlag(t *testing.T) {
+	for _, registry := range BuiltinModelRegistries(BuiltinConfig{Enabled: true}, "default") {
+		assert.NotEmpty(t, EndpointFlagForModelRegistryType(registry.Spec.Type),
+			"built-in registry %s has no configuration setting to name", registry.Metadata.Name)
+	}
+
+	// A kind with no built-in form has nothing to point at, and says so rather
+	// than naming some other hub's setting.
+	assert.Empty(t, EndpointFlagForModelRegistryType(v1.BentoMLModelRegistryType))
+}
+
+// Every kind provisioned by default has to be one the factory can build a client
+// for, or the registry appears in every workspace and then fails every read.
+func TestBuiltinModelRegistriesAreConstructible(t *testing.T) {
+	for _, registry := range BuiltinModelRegistries(BuiltinConfig{Enabled: true}, "default") {
+		_, err := new(registry)
+		assert.NoError(t, err, "built-in registry %s cannot be constructed", registry.Metadata.Name)
+	}
 }

--- a/internal/model_registry/hugging_face.go
+++ b/internal/model_registry/hugging_face.go
@@ -302,7 +302,7 @@ func (hf *huggingFace) GetModelDetail(name, version string) (*v1.ModelVersion, e
 	}
 
 	return &v1.ModelVersion{
-		Name: reportedVersion(version),
+		Name: reportedVersion(version, defaultRevision),
 		Info: info,
 	}, nil
 }
@@ -395,11 +395,22 @@ func (hf *huggingFace) revision(version string) string {
 // reportedVersion is the version name given back to callers, and it must be the
 // one ListModels emits: a version read from a listing is what a client puts into
 // "model get <name>:<version>" and into a detail URL, so a detail that answered
-// with the hub's own "main" would name a version the listing never shows and
-// that a subsequent lookup would not resolve. The hub's branch name stays on the
-// wire only — see revision.
-func reportedVersion(version string) string {
-	if version == "" || version == defaultRevision {
+// with the registry's own branch name would name a version the listing never
+// shows and that a subsequent lookup would not resolve. The branch name stays on
+// the wire only — see each provider's revision.
+//
+// The rule is one rule and lives here. What a registry calls its default branch
+// is not part of it — it is provider knowledge, and it differs: the Hub's is
+// "main", ModelScope's is "master". Hard-coding either would report a real
+// branch of the other registry as "latest", which is both wrong and a version
+// name that registry would not resolve. Pass "" for a registry with no single
+// name for its default.
+func reportedVersion(version, defaultBranch string) string {
+	if version == "" {
+		return v1.LatestVersion
+	}
+
+	if defaultBranch != "" && version == defaultBranch {
 		return v1.LatestVersion
 	}
 

--- a/internal/model_registry/model_registry.go
+++ b/internal/model_registry/model_registry.go
@@ -134,6 +134,8 @@ func new(registry *v1.ModelRegistry) (ModelRegistry, error) {
 	switch registry.Spec.Type {
 	case v1.HuggingFaceModelRegistryType:
 		return newHuggingFace(registry)
+	case v1.ModelScopeModelRegistryType:
+		return newModelScope(registry)
 	case v1.BentoMLModelRegistryType:
 		return newFileBased(registry)
 	default:

--- a/internal/model_registry/model_scope.go
+++ b/internal/model_registry/model_scope.go
@@ -1,0 +1,746 @@
+package model_registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/model_registry/modelmeta"
+)
+
+const (
+	// modelScopeSearchPath is the catalogue search. It answers to PUT, not POST or
+	// GET; the other verbs are not routed.
+	modelScopeSearchPath = "/api/v1/dolphin/models"
+	// modelScopeModelPath prefixes the per-repository endpoints, which are
+	// addressed as <prefix>/<owner>/<name>.
+	modelScopeModelPath = "/api/v1/models"
+	// modelScopeRepoFilePath fetches one file out of a repository, appended to a
+	// model's path: <modelScopeModelPath>/<owner>/<name>/repo?Revision=&FilePath=
+	modelScopeRepoFilePath = "/repo"
+	// modelScopeRepoFilesPath lists a revision's files, appended the same way and
+	// taking a Root= parameter for the subtree.
+	modelScopeRepoFilesPath = "/repo/files"
+	// modelScopeLoginPath evaluates an access token. Nothing else does: the read
+	// endpoints below answer a request carrying a bogus token exactly as they
+	// answer an anonymous one.
+	modelScopeLoginPath = "/api/v1/login"
+
+	// modelScopeMaxPageSize is the largest page the hub will serve. Asking for
+	// more is not refused, it is silently truncated to this, so a client that
+	// trusted its own PageSize would quietly skip rows.
+	modelScopeMaxPageSize = 100
+	// modelScopeMaxResultWindow bounds how deep the catalogue can be paged:
+	// offset + page size may not exceed it. Past that the hub answers HTTP 500,
+	// which would otherwise be reported to the user as "the registry is down".
+	modelScopeMaxResultWindow = 10000
+	// modelScopeDefaultLimit is the page served when a caller names no limit. The
+	// catalogue has hundreds of thousands of entries, so "all of them" is not an
+	// option the way it is for a private registry.
+	modelScopeDefaultLimit = modelScopeMaxPageSize
+
+	// modelScopeDefaultRevision is what ModelScope calls a repository's default
+	// branch. Surveyed across seven repositories of different kinds — Qwen,
+	// DeepSeek, Llama, Wan, iic, AI-ModelScope, moonshotai — every one reports
+	// Revision "master" and lists "master" as its only non-PR branch.
+	//
+	// It is emphatically not "main", which is the Hub's name. On
+	// Qwen/Qwen2.5-0.5B-Instruct, Revision=main behaves exactly like a revision
+	// that was never created: the file endpoint 404s and the tree endpoint
+	// answers 200 with a null file list. Hard-coding the Hub's name here would
+	// therefore point at nothing, not merely at something differently named.
+	//
+	// This names a version back to a caller; it does not address one. The wire
+	// never carries it — see revision — so a repository that somehow used another
+	// default is still read correctly; that branch would only be reported under
+	// its own name rather than as "latest".
+	modelScopeDefaultRevision = "master"
+)
+
+// Where a ModelScope model's files come from, for whoever wires the download
+// path (NEU-689). All three are on the /api/v1 REST API; the /api/... routes
+// without the version segment are the website's SPA and answer HTML.
+//
+//	list a revision's files  GET <url>/api/v1/models/<owner>/<name>/repo/files?Revision=<rev>&Root=<subtree>
+//	fetch one file           GET <url>/api/v1/models/<owner>/<name>/repo?Revision=<rev>&FilePath=<path>
+//	repository metadata      GET <url>/api/v1/models/<owner>/<name>
+//
+// The pieces to reuse rather than re-derive: <owner>/<name> is
+// v1.GeneralModel.Name exactly as a listing emits it; <rev> is what revision()
+// returns, and it must go through revision() because "" means "the repository's
+// own default" and is the only safe way to spell that (see
+// modelScopeDefaultRevision); listRepoFiles already carries the null-file-list
+// trap below, so use it rather than decoding the tree again.
+//
+// Files are listed with a Size and an IsLFS flag, so a downloader can budget
+// before fetching. The registry stays read-only: nothing here writes.
+
+// errModelScopeNotSupported wraps ErrNotSupported for the operations a public
+// catalogue has no answer for at all. ModelScope is read-only here.
+var errModelScopeNotSupported = errors.Wrap(ErrNotSupported, "operation not supported for ModelScope registry")
+
+type modelScope struct {
+	apiToken string
+	client   *http.Client
+	url      string
+}
+
+func newModelScope(registry *v1.ModelRegistry) (*modelScope, error) {
+	if registry.Spec.Url == "" {
+		return nil, errors.New("registry.Spec.Url cannot be empty")
+	}
+
+	parsedUrl, err := url.Parse(registry.Spec.Url)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid registry.Spec.Url")
+	}
+
+	if parsedUrl.Host == "" || parsedUrl.Scheme == "" {
+		return nil, errors.New("invalid registry.Spec.Url")
+	}
+
+	return &modelScope{
+		url:      strings.TrimSuffix(parsedUrl.String(), "/"),
+		apiToken: registry.Spec.Credentials,
+		client:   sharedClient,
+	}, nil
+}
+
+func (ms *modelScope) Connect() error {
+	return ms.healthyCheck()
+}
+
+func (ms *modelScope) Disconnect() error {
+	return nil
+}
+
+// modelScopeEnvelope is the shape every ModelScope endpoint answers in. Code and
+// Message carry the hub's own classification, which is finer-grained than the
+// HTTP status and is what appears in an error the user reads.
+type modelScopeEnvelope struct {
+	Code    int64           `json:"Code"`
+	Message string          `json:"Message"`
+	Success bool            `json:"Success"`
+	Data    json.RawMessage `json:"Data"`
+}
+
+// modelScopeModel is the subset of a catalogue entry we use. The hub returns
+// around eighty fields per model; naming the four we read keeps the decode from
+// silently depending on the rest.
+type modelScopeModel struct {
+	// Name is the repository name and Path its owner; the model is addressed as
+	// "<Path>/<Name>" everywhere else, including in a deploy request.
+	Name string `json:"Name"`
+	Path string `json:"Path"`
+	// CreatedTime is Unix seconds.
+	CreatedTime int64 `json:"CreatedTime"`
+}
+
+func (m modelScopeModel) id() string {
+	if m.Path == "" {
+		return m.Name
+	}
+
+	return m.Path + "/" + m.Name
+}
+
+type modelScopeSearchData struct {
+	Model struct {
+		Models     []modelScopeModel `json:"Models"`
+		TotalCount int               `json:"TotalCount"`
+	} `json:"Model"`
+}
+
+// ListModels serves one page of the catalogue.
+//
+// Unlike the Hugging Face Hub, ModelScope pages by row offset and reports how
+// many models matched, so both are passed through as they are: Offset is honoured
+// and Total is the hub's own count. Verified against the live API — a page of ten
+// is exactly two consecutive pages of five, in the same order.
+//
+// The one thing it cannot do is page arbitrarily deep: offset plus page size may
+// not exceed modelScopeMaxResultWindow, and past that the hub answers HTTP 500.
+// That is refused here as ErrNotSupported, so the user is told the catalogue
+// cannot be walked that far rather than that it is unreachable.
+func (ms *modelScope) ListModels(option ListOption) (*ModelPage, error) {
+	limit := option.Limit
+	if limit <= 0 {
+		limit = modelScopeDefaultLimit
+	}
+
+	offset := option.Offset
+	if offset >= modelScopeMaxResultWindow {
+		return nil, errors.Wrapf(ErrNotSupported,
+			"the ModelScope API cannot list models past offset %d; narrow the search instead",
+			modelScopeMaxResultWindow)
+	}
+
+	// The requested rows, clipped to the window. Clipping rather than refusing
+	// means the last reachable page is short instead of absent.
+	end := offset + limit
+	if end > modelScopeMaxResultWindow {
+		end = modelScopeMaxResultWindow
+	}
+
+	pageSize := modelScopePageSize(offset, limit)
+	firstPage := offset/pageSize + 1
+	// How many rows of the first fetched page fall before the requested offset.
+	skip := offset - (firstPage-1)*pageSize
+	want := end - offset
+
+	var (
+		collected []modelScopeModel
+		total     int
+	)
+
+	for page := firstPage; len(collected) < skip+want; page++ {
+		batch, matched, err := ms.searchModels(option.Search, pageSize, page)
+		if err != nil {
+			return nil, err
+		}
+
+		collected = append(collected, batch...)
+		total = matched
+
+		// A short page is the end of the catalogue for this search.
+		if len(batch) < pageSize {
+			break
+		}
+	}
+
+	if skip > len(collected) {
+		skip = len(collected)
+	}
+
+	collected = collected[skip:]
+	if len(collected) > want {
+		collected = collected[:want]
+	}
+
+	result := make([]v1.GeneralModel, 0, len(collected))
+
+	for i := range collected {
+		result = append(result, v1.GeneralModel{
+			Name: collected[i].id(),
+			Versions: []v1.ModelVersion{
+				{
+					Name:         v1.LatestVersion,
+					CreationTime: time.Unix(collected[i].CreatedTime, 0).UTC().Format(time.RFC3339Nano),
+				},
+			},
+		})
+	}
+
+	return &ModelPage{Models: result, Total: KnownTotal(total)}, nil
+}
+
+// modelScopePageSize picks the page size to ask the hub for.
+//
+// The hub pages by page number, so a requested offset is only directly
+// expressible when it is a whole number of pages. When it is — the case every
+// paging client produces — the page is fetched exactly. Otherwise the request is
+// served by fetching maximum-size pages around it and slicing, which costs at
+// most one extra round trip.
+//
+// modelScopeMaxPageSize is also the fallback because it divides
+// modelScopeMaxResultWindow: that is what keeps the last reachable page from
+// asking for a window the hub refuses.
+func modelScopePageSize(offset, limit int) int {
+	if limit <= modelScopeMaxPageSize && offset%limit == 0 && offset+limit <= modelScopeMaxResultWindow {
+		return limit
+	}
+
+	return modelScopeMaxPageSize
+}
+
+// searchModels asks for one page of the catalogue. Page numbers are 1-based.
+func (ms *modelScope) searchModels(search string, pageSize, pageNumber int) ([]modelScopeModel, int, error) {
+	body, err := json.Marshal(map[string]interface{}{
+		"PageSize":   pageSize,
+		"PageNumber": pageNumber,
+		"SortBy":     "Default",
+		"Target":     "",
+		// The hub requires the key even when no facet filter is applied.
+		"SingleCriterion": []interface{}{},
+		"Name":            search,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// PUT, not POST: the other verbs are not routed on this path.
+	req, err := http.NewRequest(http.MethodPut, ms.url+modelScopeSearchPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	raw, err := ms.do(req, "failed to list models")
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var data modelScopeSearchData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, 0, errors.Wrap(err, "failed to list models")
+	}
+
+	return data.Model.Models, data.Model.TotalCount, nil
+}
+
+// HealthyCheck checks the health of the ModelScope API.
+func (ms *modelScope) HealthyCheck() error {
+	return ms.healthyCheck()
+}
+
+func (ms *modelScope) healthyCheck() error {
+	if ms.apiToken != "" {
+		if err := ms.validateToken(); err != nil {
+			return errors.Wrap(err, "invalid ModelScope access token")
+		}
+	}
+
+	if _, _, err := ms.searchModels("", 1, 1); err != nil {
+		return errors.Wrap(err, "failed to list models from ModelScope API")
+	}
+
+	return nil
+}
+
+// validateToken is the only way a bad credential surfaces at all: the catalogue
+// and file endpoints answer a request carrying a rejected token exactly as they
+// answer an anonymous one, so without this check a registry configured with a
+// dead token would report itself healthy and then quietly fail to see anything
+// private.
+//
+// Any refusal here is a credential problem — the hub answers a bad token with
+// 400, not 401 — so the whole call is mapped to ErrUnauthorized rather than
+// going through responseError.
+func (ms *modelScope) validateToken() error {
+	body, err := json.Marshal(map[string]string{"AccessToken": ms.apiToken})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, ms.url+modelScopeLoginPath, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ms.doWithRetry(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to validate ModelScope access token")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return errors.Wrapf(ErrRateLimited, "failed to validate ModelScope access token: %s", resp.Status)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		detail := modelScopeErrorDetail(resp)
+
+		return errors.Wrapf(ErrUnauthorized,
+			"the configured access token was rejected (%s)%s", resp.Status, detail)
+	}
+
+	return nil
+}
+
+// Implement the remaining ModelRegistry interface methods with "not supported" errors
+
+func (ms *modelScope) GetModelVersion(name, version string) (*v1.ModelVersion, error) {
+	return nil, errModelScopeNotSupported
+}
+
+// ModelScopeRepoFile is one entry of a repository revision's file tree. Size and
+// IsLFS are what let a downloader decide what to fetch and what it will cost
+// before fetching any of it.
+type ModelScopeRepoFile struct {
+	// Path is the file's path within the repository, which is what the file
+	// endpoint's FilePath parameter takes.
+	Path string `json:"Path"`
+	Name string `json:"Name"`
+	// Size is the file's size in bytes.
+	Size int64 `json:"Size"`
+	// Type is "blob" for a file and "tree" for a directory.
+	Type string `json:"Type"`
+	// IsLFS marks a file stored via LFS, which is how the weights are stored.
+	IsLFS bool `json:"IsLFS"`
+}
+
+// modelScopeRepoTree is the tree endpoint's payload. Files is a pointer so that
+// an absent or null list stays distinguishable from an empty one — that
+// difference is the whole point of listRepoFiles.
+type modelScopeRepoTree struct {
+	Files *[]ModelScopeRepoFile `json:"Files"`
+}
+
+// listRepoFiles lists the files of one revision of a repository.
+//
+// It exists as much for the trap it closes as for the listing. Asked for a
+// revision that does not exist, ModelScope does not answer with an error: it
+// answers HTTP 200 with `Code: 200`, `Success: true`, `Message: "success"` and a
+// **null** file list — measured on Qwen/Qwen2.5-0.5B-Instruct, where
+// `Revision=main` and `Revision=zzz-not-real` are indistinguishable from each
+// other and differ from `Revision=master` only in that field. A caller that read
+// that as "the repository is empty" would show a user an empty directory for
+// what is actually a typo, and a downloader would fetch nothing and report
+// success.
+//
+// So a null list is reported as ErrNotFound naming the revision. A genuinely
+// empty repository is a real, separate answer and comes back as an empty slice
+// with no error; only the hub's own "I have nothing to say about this revision"
+// is an error. A repository that does not exist at all is a plain 404 and is
+// mapped by responseError.
+func (ms *modelScope) listRepoFiles(name, version string) ([]ModelScopeRepoFile, error) {
+	params := url.Values{}
+	// Root selects a subtree; empty means the repository root.
+	params.Set("Root", "")
+
+	if revision := ms.revision(version); revision != "" {
+		params.Set("Revision", revision)
+	}
+
+	requestURL := fmt.Sprintf("%s%s/%s%s?%s",
+		ms.url, modelScopeModelPath, name, modelScopeRepoFilesPath, params.Encode())
+
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	context := fmt.Sprintf("failed to list files of model %s", name)
+
+	raw, err := ms.do(req, context)
+	if err != nil {
+		return nil, err
+	}
+
+	var tree modelScopeRepoTree
+	if err := json.Unmarshal(raw, &tree); err != nil {
+		return nil, errors.Wrap(err, context)
+	}
+
+	if tree.Files == nil {
+		return nil, errors.Wrapf(ErrNotFound,
+			"model %s has no revision %q", name, ms.describeRevision(version))
+	}
+
+	return *tree.Files, nil
+}
+
+// describeRevision names a revision in a message. The default is addressed by
+// omitting it on the wire, which has no name to quote, so it is described as
+// what the caller asked for.
+func (ms *modelScope) describeRevision(version string) string {
+	if revision := ms.revision(version); revision != "" {
+		return revision
+	}
+
+	return v1.LatestVersion
+}
+
+// missingRevision reports the revision as absent, or nil if it is not provably
+// absent.
+//
+// The file endpoint answers the same 404 for a file that is not in the
+// repository and for a revision that does not exist, so "no config.json" and
+// "you spelled the branch wrong" arrive identical. The tree endpoint can tell
+// them apart, so it is asked — once, and only on a miss.
+//
+// Nil is returned when the tree lookup itself fails for any other reason: a
+// secondary request must never replace a real answer with its own trouble.
+func (ms *modelScope) missingRevision(name, version string) error {
+	if _, err := ms.listRepoFiles(name, version); errors.Is(err, ErrNotFound) {
+		return err
+	}
+
+	return nil
+}
+
+// GetModelDetail reads what a public checkpoint states about its own shape.
+//
+// It fetches config.json and nothing else — the weights are never downloaded —
+// and parses it with modelmeta.ParseConfig, the same parser Hugging Face and the
+// private path use, so a model reports the same shape whichever registry it came
+// from.
+//
+// ModelScope publishes no equivalent of the Hub's safetensors tally, so the
+// parameter count is reported as missing rather than derived from something that
+// is not it: the detail endpoint's StorageSize is bytes on disk.
+func (ms *modelScope) GetModelDetail(name, version string) (*v1.ModelVersion, error) {
+	raw, err := ms.fetchFile(name, version, configFile)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			return nil, err
+		}
+
+		// "No config.json" and "no such revision" reach here as the same 404, and
+		// swallowing both would hand back a model whose every field is missing —
+		// a mistyped revision rendered as a real checkpoint that happens to say
+		// nothing about itself. Ask which one it was.
+		if revErr := ms.missingRevision(name, version); revErr != nil {
+			return nil, revErr
+		}
+	}
+
+	// A repository with no config.json is a real answer, not a failure; the parser
+	// treats an empty file as "every field missing", which is exactly right.
+	info := modelmeta.ParseConfig(raw)
+	info.MarkFieldMissing(v1.ModelInfoFieldParameterCount)
+
+	return &v1.ModelVersion{
+		Name: reportedVersion(version, modelScopeDefaultRevision),
+		Info: info,
+	}, nil
+}
+
+// GetReadme fetches the model card, returned exactly as stored, front matter
+// and all.
+//
+// A repository with no README and a revision that does not exist answer the
+// same 404 here, so the tree is consulted on a miss to say which it was — see
+// missingRevision. Both are ErrNotFound; only the sentence differs, and it is
+// the sentence the reader acts on.
+func (ms *modelScope) GetReadme(name, version string) (*Readme, error) {
+	raw, err := ms.fetchFile(name, version, readmeFileName)
+	if err != nil {
+		// "This model has no README" is the wrong thing to tell someone who
+		// mistyped a revision, and the file endpoint reports both the same way.
+		if errors.Is(err, ErrNotFound) {
+			if revErr := ms.missingRevision(name, version); revErr != nil {
+				return nil, revErr
+			}
+		}
+
+		return nil, err
+	}
+
+	return readCappedReadme(bytes.NewReader(raw))
+}
+
+// fetchFile reads one file out of a repository, capped at MaxReadmeBytes. The
+// cap applies to every file: these are small metadata files, and the read is from
+// a server this deployment does not control.
+//
+// Revision is omitted for the default version rather than being set to a guessed
+// branch name, because the hub resolves an absent Revision to the repository's
+// own default, and a wrong guess is not a different name for the same thing —
+// it is a 404 (see modelScopeDefaultRevision).
+//
+// The 404 this maps to ErrNotFound is ambiguous: it is the same answer for a
+// file that is absent and for a revision that never existed. Callers that report
+// the miss to a user resolve it with missingRevision.
+func (ms *modelScope) fetchFile(name, version, file string) ([]byte, error) {
+	params := url.Values{}
+	params.Set("FilePath", file)
+
+	if revision := ms.revision(version); revision != "" {
+		params.Set("Revision", revision)
+	}
+
+	requestURL := fmt.Sprintf("%s%s/%s%s?%s",
+		ms.url, modelScopeModelPath, name, modelScopeRepoFilePath, params.Encode())
+
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := ms.request(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch %s of model %s", file, name)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errors.Wrapf(ErrNotFound, "model %s has no %s on ModelScope", name, file)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, ms.responseError(resp, fmt.Sprintf("failed to fetch %s of model %s", file, name))
+	}
+
+	// A file is served as its own bytes, not wrapped in the JSON envelope.
+	return io.ReadAll(io.LimitReader(resp.Body, MaxReadmeBytes+1))
+}
+
+// revision maps a version onto the hub's wire name for it, and returns "" for
+// "whatever the repository's default is" — see fetchFile. The name given back to
+// a caller is reportedVersion's business, not this one's; the two are a pair, and
+// the split is what keeps a listing and a detail from naming the same version
+// differently.
+func (ms *modelScope) revision(version string) string {
+	if version == "" || version == v1.LatestVersion {
+		return ""
+	}
+
+	return version
+}
+
+// do sends a request that answers in the standard envelope and returns its Data.
+func (ms *modelScope) do(req *http.Request, context string) (json.RawMessage, error) {
+	resp, err := ms.request(req)
+	if err != nil {
+		return nil, errors.Wrap(err, context)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, ms.responseError(resp, context)
+	}
+
+	var envelope modelScopeEnvelope
+	if err := json.NewDecoder(io.LimitReader(resp.Body, MaxReadmeBytes)).Decode(&envelope); err != nil {
+		return nil, errors.Wrap(err, context)
+	}
+
+	// A 200 whose envelope says otherwise is still a failure. The hub is
+	// consistent about the status today, but the envelope is what it treats as
+	// authoritative.
+	if !envelope.Success && envelope.Code != http.StatusOK {
+		return nil, errors.Errorf("%s: %s (code %d)", context, envelope.Message, envelope.Code)
+	}
+
+	return envelope.Data, nil
+}
+
+// request sends a request with the registry's credentials attached, retrying a
+// 429 the same way the Hugging Face client does.
+func (ms *modelScope) request(req *http.Request) (*http.Response, error) {
+	if ms.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+ms.apiToken)
+	}
+
+	return ms.doWithRetry(req)
+}
+
+// doWithRetry sends a request, retrying a 429 and nothing else. Transport errors
+// are left alone: the client already has a timeout, and an unreachable hub is
+// what the reachability check reports.
+//
+// A retried request has to be replayable, so the body is rewound between
+// attempts; every request this client sends carries a GetBody, because they are
+// all built by http.NewRequest over a bytes.Reader or have no body at all.
+func (ms *modelScope) doWithRetry(req *http.Request) (*http.Response, error) {
+	var lastResp *http.Response
+
+	for attempt := 0; attempt < hubRetryAttempts; attempt++ {
+		if attempt > 0 && req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return lastResp, nil
+			}
+
+			req.Body = body
+		}
+
+		resp, err := ms.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		lastResp = resp
+
+		if attempt == hubRetryAttempts-1 {
+			break
+		}
+
+		// The body is not needed and the connection is worth reusing.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, hubErrorBodyLimit)) //nolint:errcheck
+		resp.Body.Close()
+
+		time.Sleep(retryDelay(resp, attempt))
+	}
+
+	return lastResp, nil
+}
+
+// responseError turns a non-OK response into an error a caller can act on.
+// Credentials and throttling get their own types because the remedies differ;
+// anything else keeps the hub's own words.
+func (ms *modelScope) responseError(resp *http.Response, context string) error {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		hint := "a token is required"
+		if ms.apiToken != "" {
+			hint = "the configured token was rejected or does not grant access"
+		}
+
+		return errors.Wrapf(ErrUnauthorized, "%s: %s (%s)", context, hint, resp.Status)
+	case http.StatusTooManyRequests:
+		return errors.Wrapf(ErrRateLimited, "%s: %s", context, resp.Status)
+	default:
+		return errors.Errorf("%s: %s%s", context, resp.Status, modelScopeErrorDetail(resp))
+	}
+}
+
+// modelScopeErrorDetail quotes the hub's own explanation, when it gave one, in a
+// form that can be appended to a message. The read is bounded because the
+// endpoint may be a misconfigured proxy serving a whole HTML page.
+func modelScopeErrorDetail(resp *http.Response) string {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, hubErrorBodyLimit)) //nolint:errcheck
+
+	var envelope modelScopeEnvelope
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Message != "" {
+		return fmt.Sprintf(": %s (code %d)", envelope.Message, envelope.Code)
+	}
+
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		return ""
+	}
+
+	return ": " + detail
+}
+
+// DeleteModel returns an error for ModelScope as it's read-only
+func (ms *modelScope) DeleteModel(name, version string) error {
+	return errModelScopeNotSupported
+}
+
+// ImportModel returns an error for ModelScope as it's read-only
+func (ms *modelScope) ImportModel(reader io.Reader, name, version string, progress io.Writer) error {
+	return errModelScopeNotSupported
+}
+
+// ExportModel returns an error for ModelScope as it's read-only
+func (ms *modelScope) ExportModel(name, version, outputPath string) error {
+	return errModelScopeNotSupported
+}
+
+// GetModelPath returns an error for ModelScope as it's read-only
+func (ms *modelScope) GetModelPath(name, version string) (string, error) {
+	return "", errModelScopeNotSupported
+}
+
+// SetManualModelInfo returns an error for ModelScope as it's read-only
+func (ms *modelScope) SetManualModelInfo(name, version string, info *v1.ModelInfo) error {
+	return errModelScopeNotSupported
+}
+
+// CollectUsage is not implemented for ModelScope: the hub's storage is not ours
+// to measure, and the model count is unbounded.
+func (ms *modelScope) CollectUsage() (*RegistryUsage, error) {
+	return nil, errModelScopeNotSupported
+}
+
+func (ms *modelScope) GetNFSVersion() (string, error) {
+	return "", nil
+}

--- a/internal/model_registry/model_scope_test.go
+++ b/internal/model_registry/model_scope_test.go
@@ -1,0 +1,1069 @@
+package model_registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// The stubs below reproduce what www.modelscope.cn was measured to do on
+// 2026-08-12; nothing here touches the network.
+
+const modelScopeTestURL = "https://www.modelscope.cn"
+
+// modelScopeSearchRequest is the body the search endpoint receives, decoded so a
+// test can assert on the paging the provider chose rather than on a JSON string.
+type modelScopeSearchRequest struct {
+	PageSize   int    `json:"PageSize"`
+	PageNumber int    `json:"PageNumber"`
+	Name       string `json:"Name"`
+}
+
+// modelScopeCatalogue is a fake hub holding an ordered list of model ids and
+// serving them by page, the way the real search endpoint does.
+type modelScopeCatalogue struct {
+	ids   []string
+	total int
+	// requests records every (PageSize, PageNumber) asked for, in order.
+	requests []modelScopeSearchRequest
+	// window mimics the hub's deep-paging limit when non-zero.
+	window int
+}
+
+func (c *modelScopeCatalogue) client() *http.Client {
+	return &http.Client{Transport: &MockRoundTripper{RoundTripFunc: c.roundTrip}}
+}
+
+func (c *modelScopeCatalogue) roundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Path != modelScopeSearchPath {
+		return nil, fmt.Errorf("unexpected path %s", req.URL.Path)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var decoded modelScopeSearchRequest
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, err
+	}
+
+	c.requests = append(c.requests, decoded)
+
+	if c.window > 0 && (decoded.PageNumber-1)*decoded.PageSize+decoded.PageSize > c.window {
+		// What the hub really answers past the window: a 500, not a 4xx.
+		return jsonResponse(http.StatusInternalServerError,
+			`{"Code":10010207001,"Message":"list_models_failed","Success":false}`), nil
+	}
+
+	start := (decoded.PageNumber - 1) * decoded.PageSize
+	end := start + decoded.PageSize
+
+	if start > len(c.ids) {
+		start = len(c.ids)
+	}
+
+	if end > len(c.ids) {
+		end = len(c.ids)
+	}
+
+	models := make([]map[string]interface{}, 0, end-start)
+	for _, id := range c.ids[start:end] {
+		owner, name, _ := strings.Cut(id, "/")
+		models = append(models, map[string]interface{}{
+			"Path": owner, "Name": name, "CreatedTime": 1745834265,
+		})
+	}
+
+	total := c.total
+	if total == 0 {
+		total = len(c.ids)
+	}
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"Code": 200, "Message": "success", "Success": true,
+		"Data": map[string]interface{}{
+			"Model": map[string]interface{}{"Models": models, "TotalCount": total},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonResponse(http.StatusOK, string(payload)), nil
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Header:     make(http.Header),
+	}
+}
+
+func catalogueOf(n int) []string {
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		ids = append(ids, fmt.Sprintf("owner/model-%03d", i))
+	}
+
+	return ids
+}
+
+func modelIDs(page *ModelPage) []string {
+	ids := make([]string, 0, len(page.Models))
+	for _, model := range page.Models {
+		ids = append(ids, model.Name)
+	}
+
+	return ids
+}
+
+func TestNewModelScope(t *testing.T) {
+	tests := []struct {
+		name          string
+		url           string
+		wantErrString string
+	}{
+		{name: "empty url", url: "", wantErrString: "cannot be empty"},
+		{name: "no scheme", url: "invalid-url", wantErrString: "invalid registry.Spec.Url"},
+		{name: "no host", url: "http://", wantErrString: "invalid registry.Spec.Url"},
+		{name: "unparseable", url: "http://%zz", wantErrString: "invalid registry.Spec.Url"},
+		{name: "the hub", url: modelScopeTestURL},
+		{name: "a mirror with a trailing slash", url: "https://ms-mirror.example/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms, err := newModelScope(&v1.ModelRegistry{
+				Spec: &v1.ModelRegistrySpec{Type: v1.ModelScopeModelRegistryType, Url: tt.url},
+			})
+
+			if tt.wantErrString != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrString)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.False(t, strings.HasSuffix(ms.url, "/"), "the base url keeps no trailing slash")
+		})
+	}
+}
+
+// The factory has to know the kind, or a registry stored as model-scope is
+// rejected at every read with "unsupported model registry type".
+func TestNewModelRegistryBuildsModelScope(t *testing.T) {
+	registry, err := new(&v1.ModelRegistry{
+		Spec: &v1.ModelRegistrySpec{Type: v1.ModelScopeModelRegistryType, Url: modelScopeTestURL},
+	})
+	require.NoError(t, err)
+	assert.IsType(t, &modelScope{}, registry)
+}
+
+// Unlike the Hugging Face Hub, ModelScope pages by row offset, so an offset is
+// honoured rather than refused. Measured: a page of ten is exactly two
+// consecutive pages of five, same order.
+func TestModelScope_ListModelsHonoursAnOffset(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(50), total: 23809}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Offset: 10, Limit: 5})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"owner/model-010", "owner/model-011", "owner/model-012",
+		"owner/model-013", "owner/model-014",
+	}, modelIDs(page))
+
+	// An aligned offset is one page number, so it costs exactly one request.
+	require.Len(t, catalogue.requests, 1)
+	assert.Equal(t, modelScopeSearchRequest{PageSize: 5, PageNumber: 3}, catalogue.requests[0])
+}
+
+// The hub states how many models matched, so that number is passed through
+// instead of being reported as unknown the way the Hub's is.
+func TestModelScope_ListModelsReportsTheRealTotal(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(50), total: 23809}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Limit: 5})
+	require.NoError(t, err)
+
+	require.NotNil(t, page.Total, "ModelScope reports a match count; it must not be dropped")
+	assert.Equal(t, 23809, *page.Total)
+	// Total is what matched, not what was returned.
+	assert.Len(t, page.Models, 5)
+}
+
+// Paging is only useful if consecutive pages tile the catalogue: no repeats, no
+// gaps. This is the property the offset support exists for.
+func TestModelScope_ConsecutivePagesTileTheCatalogue(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(50)}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	var walked []string
+
+	for offset := 0; offset < 20; offset += 5 {
+		page, err := ms.ListModels(ListOption{Offset: offset, Limit: 5})
+		require.NoError(t, err)
+		walked = append(walked, modelIDs(page)...)
+	}
+
+	assert.Equal(t, catalogueOf(50)[:20], walked)
+}
+
+// An offset that is not a whole number of pages cannot be asked for directly,
+// because the hub pages by page number. It is served by fetching around it and
+// slicing rather than by refusing or by quietly returning the wrong rows.
+func TestModelScope_ListModelsServesAnUnalignedOffset(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(300)}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Offset: 7, Limit: 5})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"owner/model-007", "owner/model-008", "owner/model-009",
+		"owner/model-010", "owner/model-011",
+	}, modelIDs(page))
+	assert.Equal(t, modelScopeMaxPageSize, catalogue.requests[0].PageSize)
+}
+
+// A request that straddles a page boundary needs a second fetch, and the two
+// have to be joined without losing or duplicating the row on the seam.
+func TestModelScope_ListModelsSpansTwoPages(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(300)}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Offset: 98, Limit: 4})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"owner/model-098", "owner/model-099", "owner/model-100", "owner/model-101",
+	}, modelIDs(page))
+	assert.Len(t, catalogue.requests, 2)
+}
+
+// Asking for more than the hub will serve in one page is not an error: the hub
+// truncates silently at modelScopeMaxPageSize, so the provider has to keep
+// asking rather than trust its own PageSize.
+func TestModelScope_ListModelsAboveTheMaximumPageSize(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(300)}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Limit: 250})
+	require.NoError(t, err)
+
+	assert.Len(t, page.Models, 250)
+	assert.Equal(t, "owner/model-249", page.Models[249].Name)
+
+	for _, request := range catalogue.requests {
+		assert.LessOrEqual(t, request.PageSize, modelScopeMaxPageSize)
+	}
+}
+
+// Running out of catalogue ends the walk. Without this the loop would keep
+// asking the hub for pages past the end of a short search result.
+func TestModelScope_ListModelsStopsAtTheEndOfTheCatalogue(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(3)}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Limit: 250})
+	require.NoError(t, err)
+
+	assert.Len(t, page.Models, 3)
+	assert.Len(t, catalogue.requests, 1)
+}
+
+// An offset past the end is an empty page, not an error — the same answer the
+// private registries give.
+func TestModelScope_ListModelsPastTheEndIsEmpty(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(10)}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Offset: 40, Limit: 5})
+	require.NoError(t, err)
+	assert.Empty(t, page.Models)
+}
+
+// Past the hub's deep-paging window the request is refused here, because the hub
+// answers it with a 500 that is indistinguishable from an outage. The user is
+// told the catalogue cannot be walked that far, not that ModelScope is down.
+func TestModelScope_ListModelsRefusesADeepOffset(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(10), window: modelScopeMaxResultWindow}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Offset: modelScopeMaxResultWindow, Limit: 20})
+
+	assert.Nil(t, page)
+	assert.ErrorIs(t, err, ErrNotSupported)
+	assert.Empty(t, catalogue.requests, "the hub is not asked a question it answers with a 500")
+}
+
+// The last reachable page is short rather than absent: a request that starts
+// inside the window and ends outside it is clipped, and — the part that actually
+// breaks if the arithmetic is wrong — every page it fetches stays inside the
+// window the hub enforces.
+func TestModelScope_ListModelsClipsTheLastPageToTheWindow(t *testing.T) {
+	catalogue := &modelScopeCatalogue{
+		ids:    catalogueOf(modelScopeMaxResultWindow),
+		window: modelScopeMaxResultWindow,
+	}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Offset: modelScopeMaxResultWindow - 10, Limit: 30})
+	require.NoError(t, err)
+
+	assert.Len(t, page.Models, 10)
+
+	for _, request := range catalogue.requests {
+		assert.LessOrEqual(t, request.PageNumber*request.PageSize, modelScopeMaxResultWindow,
+			"asked the hub for a window it refuses with a 500")
+	}
+}
+
+// Every page size the provider can choose has to stay inside the window at the
+// deepest offset it will accept. The failure this guards is silent in unit tests
+// that only exercise round numbers: it appears as a 500 from the hub.
+func TestModelScope_PageSizeNeverOverrunsTheWindow(t *testing.T) {
+	for _, limit := range []int{1, 3, 7, 10, 25, 30, 50, 99, 100, 250} {
+		for _, offset := range []int{0, 1, 7, 9000, 9960, 9970, 9990, 9999} {
+			pageSize := modelScopePageSize(offset, limit)
+			require.LessOrEqual(t, pageSize, modelScopeMaxPageSize)
+
+			end := offset + limit
+			if end > modelScopeMaxResultWindow {
+				end = modelScopeMaxResultWindow
+			}
+
+			lastPage := (end-1)/pageSize + 1
+			assert.LessOrEqual(t, lastPage*pageSize, modelScopeMaxResultWindow,
+				"offset %d limit %d chose page size %d", offset, limit, pageSize)
+		}
+	}
+}
+
+// A caller that names no limit gets a page, not the whole catalogue: there are
+// hundreds of thousands of entries.
+func TestModelScope_ListModelsWithoutALimit(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(500), total: 237969}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{})
+	require.NoError(t, err)
+
+	assert.Len(t, page.Models, modelScopeDefaultLimit)
+	require.NotNil(t, page.Total)
+	assert.Equal(t, 237969, *page.Total)
+}
+
+// A model is addressed as "<owner>/<name>" everywhere else in the product, so
+// that is the name a listing reports.
+func TestModelScope_ListModelsReportsQualifiedNames(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: []string{"Qwen/Qwen3-8B"}}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Limit: 1})
+	require.NoError(t, err)
+
+	require.Len(t, page.Models, 1)
+	assert.Equal(t, "Qwen/Qwen3-8B", page.Models[0].Name)
+	require.Len(t, page.Models[0].Versions, 1)
+	assert.Equal(t, v1.LatestVersion, page.Models[0].Versions[0].Name)
+	assert.Equal(t, "2025-04-28T09:57:45Z", page.Models[0].Versions[0].CreationTime)
+}
+
+func TestModelScope_ListModelsPassesTheSearchTerm(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: catalogueOf(5)}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	_, err := ms.ListModels(ListOption{Search: "deepseek r1", Limit: 5})
+	require.NoError(t, err)
+
+	require.Len(t, catalogue.requests, 1)
+	assert.Equal(t, "deepseek r1", catalogue.requests[0].Name)
+}
+
+// requestRecorder answers everything with one status and body and records the
+// URLs asked for.
+func requestRecorder(status int, body string) (*http.Client, *[]string) {
+	requested := []string{}
+
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			requested = append(requested, req.URL.String())
+
+			return jsonResponse(status, body), nil
+		},
+	}}
+
+	return client, &requested
+}
+
+// The model card is the one part of a public model that can be read without
+// downloading the checkpoint, so it is served rather than refused.
+func TestModelScope_GetReadme(t *testing.T) {
+	client, requested := requestRecorder(http.StatusOK, "---\nlicense: apache-2.0\n---\n# Qwen3\n")
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	readme, err := ms.GetReadme("Qwen/Qwen3-8B", v1.LatestVersion)
+	require.NoError(t, err)
+
+	// Verbatim markdown, front matter included: the server renders nothing.
+	assert.Equal(t, "---\nlicense: apache-2.0\n---\n# Qwen3\n", readme.Content)
+	assert.False(t, readme.Truncated)
+
+	// No Revision at all for the default version. The hub resolves an absent
+	// Revision to the repository's own default branch, and its repositories do
+	// not agree on what that is called — Qwen/Qwen3-8B is on "master", and asking
+	// it for "main" is a 404.
+	require.Len(t, *requested, 1)
+	assert.Equal(t, modelScopeTestURL+"/api/v1/models/Qwen/Qwen3-8B/repo?FilePath=README.md", (*requested)[0])
+}
+
+func TestModelScope_GetReadmeUsesTheRequestedRevision(t *testing.T) {
+	client, requested := requestRecorder(http.StatusOK, "# Qwen3\n")
+	ms := &modelScope{url: "https://ms-mirror.example", client: client}
+
+	_, err := ms.GetReadme("Qwen/Qwen3-8B", "v1.0.0")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"https://ms-mirror.example/api/v1/models/Qwen/Qwen3-8B/repo?FilePath=README.md&Revision=v1.0.0",
+		(*requested)[0])
+}
+
+// "there is no model card" has to be distinguishable from "the hub could not be
+// asked", or a caller cannot tell the user which one happened.
+func TestModelScope_GetReadmeMissingIsNotFound(t *testing.T) {
+	client, _ := requestRecorder(http.StatusNotFound,
+		`{"Code":10990101007,"Message":"获取模型文件失败，文件内容为空","Success":false}`)
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	_, err := ms.GetReadme("Qwen/Qwen3-8B", v1.LatestVersion)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestModelScope_GetReadmeIsCapped(t *testing.T) {
+	client, _ := requestRecorder(http.StatusOK, string(bytes.Repeat([]byte("a"), MaxReadmeBytes+4096)))
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	readme, err := ms.GetReadme("Qwen/Qwen3-8B", v1.LatestVersion)
+	require.NoError(t, err)
+	assert.True(t, readme.Truncated)
+	assert.Len(t, readme.Content, MaxReadmeBytes)
+}
+
+const modelScopeTestConfig = `{
+	"architectures": ["Qwen3ForCausalLM"],
+	"num_hidden_layers": 36,
+	"num_attention_heads": 32,
+	"num_key_value_heads": 8,
+	"head_dim": 128,
+	"max_position_embeddings": 40960,
+	"torch_dtype": "bfloat16"
+}`
+
+// The shape a model reports must not depend on which registry it came from: the
+// same config.json parser runs for ModelScope, Hugging Face and the private path.
+func TestModelScope_GetModelDetail(t *testing.T) {
+	client, requested := requestRecorder(http.StatusOK, modelScopeTestConfig)
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	version, err := ms.GetModelDetail("Qwen/Qwen3-8B", v1.LatestVersion)
+	require.NoError(t, err)
+
+	assert.Equal(t, v1.LatestVersion, version.Name)
+	assert.Equal(t, "Qwen3ForCausalLM", version.Info.Architecture)
+	require.NotNil(t, version.Info.NumHiddenLayers)
+	assert.Equal(t, 36, *version.Info.NumHiddenLayers)
+	require.NotNil(t, version.Info.NumKeyValueHeads)
+	assert.Equal(t, 8, *version.Info.NumKeyValueHeads)
+	require.NotNil(t, version.Info.HeadDim)
+	assert.Equal(t, 128, *version.Info.HeadDim)
+
+	// The weights are never downloaded: config.json is the only file read.
+	require.Len(t, *requested, 1)
+	assert.Contains(t, (*requested)[0], "FilePath=config.json")
+}
+
+// ModelScope publishes no equivalent of the Hub's safetensors tally, and its
+// StorageSize is bytes on disk rather than a parameter count. Saying so is the
+// point — the acceptance criterion is that what cannot be read is reported
+// missing rather than guessed.
+func TestModelScope_GetModelDetailReportsAnUnknownParameterCount(t *testing.T) {
+	client, _ := requestRecorder(http.StatusOK, modelScopeTestConfig)
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	version, err := ms.GetModelDetail("Qwen/Qwen3-8B", v1.LatestVersion)
+	require.NoError(t, err)
+
+	assert.Empty(t, version.Info.ParameterCount)
+	assert.Contains(t, version.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+	assert.Equal(t, 1, countOccurrences(version.Info.MissingFields, v1.ModelInfoFieldParameterCount),
+		"parameter_count is listed once, not once per code path that noticed it")
+}
+
+func countOccurrences(values []string, want string) int {
+	count := 0
+
+	for _, value := range values {
+		if value == want {
+			count++
+		}
+	}
+
+	return count
+}
+
+// A repository with no config.json is a real answer, not a failure: plenty of
+// things on the hub are not transformers checkpoints.
+func TestModelScope_GetModelDetailWithoutConfig(t *testing.T) {
+	client, _ := requestRecorder(http.StatusNotFound,
+		`{"Code":10990101007,"Message":"获取模型文件失败，文件内容为空","Success":false}`)
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	version, err := ms.GetModelDetail("owner/not-a-checkpoint", v1.LatestVersion)
+	require.NoError(t, err)
+
+	assert.Empty(t, version.Info.Architecture)
+	assert.Contains(t, version.Info.MissingFields, v1.ModelInfoFieldArchitecture)
+	assert.Contains(t, version.Info.MissingFields, v1.ModelInfoFieldParameterCount)
+}
+
+// A refusal is not a missing checkpoint, and the difference decides whether the
+// user is asked for a token or told the model has no config.
+func TestModelScope_GetModelDetailRefusalIsNotNotFound(t *testing.T) {
+	client, _ := requestRecorder(http.StatusForbidden, `{"Code":10010205001,"Message":"forbidden"}`)
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	_, err := ms.GetModelDetail("owner/gated", v1.LatestVersion)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnauthorized)
+	assert.NotErrorIs(t, err, ErrNotFound)
+}
+
+// The three failures the ticket asks a client to be able to tell apart, each
+// arriving as its own type rather than as a message to match on.
+func TestModelScope_ErrorsAreDistinguishable(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  *http.Client
+		wantIs  error
+		wantNot []error
+	}{
+		{
+			name: "unreachable",
+			client: &http.Client{Transport: &MockRoundTripper{
+				RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return nil, fmt.Errorf("dial tcp: connect: network is unreachable")
+				},
+			}},
+			wantNot: []error{ErrUnauthorized, ErrRateLimited, ErrNotFound, ErrNotSupported},
+		},
+		{
+			name: "credentials rejected",
+			client: func() *http.Client {
+				client, _ := requestRecorder(http.StatusUnauthorized, `{"Code":10010103009,"Message":"token"}`)
+
+				return client
+			}(),
+			wantIs:  ErrUnauthorized,
+			wantNot: []error{ErrRateLimited, ErrNotFound},
+		},
+		{
+			name: "throttled",
+			client: func() *http.Client {
+				client, _ := requestRecorder(http.StatusTooManyRequests, `{"Code":429,"Message":"slow down"}`)
+
+				return client
+			}(),
+			wantIs:  ErrRateLimited,
+			wantNot: []error{ErrUnauthorized, ErrNotFound},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms := &modelScope{url: modelScopeTestURL, client: tt.client}
+
+			_, err := ms.ListModels(ListOption{Limit: 1})
+			require.Error(t, err)
+
+			if tt.wantIs != nil {
+				assert.ErrorIs(t, err, tt.wantIs)
+			}
+
+			for _, unwanted := range tt.wantNot {
+				assert.NotErrorIs(t, err, unwanted)
+			}
+		})
+	}
+}
+
+// A throttled request is retried before it is reported, and a retried request
+// carries its body again — a search is a PUT, so a body that was consumed on the
+// first attempt would make the retry ask a different question.
+func TestModelScope_RateLimitRecoversOnRetry(t *testing.T) {
+	var bodies []string
+
+	attempt := 0
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+
+			bodies = append(bodies, string(body))
+			attempt++
+
+			if attempt == 1 {
+				return jsonResponse(http.StatusTooManyRequests, `{"Code":429}`), nil
+			}
+
+			return jsonResponse(http.StatusOK,
+				`{"Code":200,"Success":true,"Data":{"Model":{"Models":[{"Path":"owner","Name":"m"}],"TotalCount":1}}}`), nil
+		},
+	}}
+
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	page, err := ms.ListModels(ListOption{Search: "qwen", Limit: 1})
+	require.NoError(t, err)
+	assert.Len(t, page.Models, 1)
+
+	require.Len(t, bodies, 2)
+	assert.Equal(t, bodies[0], bodies[1], "the retry must ask the same question as the first attempt")
+	assert.Contains(t, bodies[1], `"Name":"qwen"`)
+}
+
+// The catalogue and file endpoints answer a request carrying a rejected token
+// exactly as they answer an anonymous one, so a bad credential is only ever
+// visible on the login endpoint. Without this check a registry configured with a
+// dead token would report itself healthy.
+func TestModelScope_HealthyCheckValidatesTheToken(t *testing.T) {
+	var paths []string
+
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			paths = append(paths, req.URL.Path)
+
+			if req.URL.Path == modelScopeLoginPath {
+				// What the hub really answers a bad token: 400, not 401.
+				return jsonResponse(http.StatusBadRequest,
+					`{"Code":10010103009,"Message":"AccessToken error","Success":false}`), nil
+			}
+
+			return jsonResponse(http.StatusOK,
+				`{"Code":200,"Success":true,"Data":{"Model":{"Models":[],"TotalCount":0}}}`), nil
+		},
+	}}
+
+	ms := &modelScope{url: modelScopeTestURL, client: client, apiToken: "ms-dead-token"}
+
+	err := ms.HealthyCheck()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnauthorized,
+		"a 400 from the login endpoint is a credential problem, not a malformed request")
+	assert.Equal(t, []string{modelScopeLoginPath}, paths,
+		"the catalogue is not consulted once the token is known to be bad")
+}
+
+func TestModelScope_HealthyCheckWithAGoodToken(t *testing.T) {
+	var authorization []string
+
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			authorization = append(authorization, req.Header.Get("Authorization"))
+
+			if req.URL.Path == modelScopeLoginPath {
+				return jsonResponse(http.StatusOK, `{"Code":200,"Success":true,"Data":{}}`), nil
+			}
+
+			return jsonResponse(http.StatusOK,
+				`{"Code":200,"Success":true,"Data":{"Model":{"Models":[{"Path":"a","Name":"b"}],"TotalCount":1}}}`), nil
+		},
+	}}
+
+	ms := &modelScope{url: modelScopeTestURL, client: client, apiToken: "ms-good-token"}
+
+	require.NoError(t, ms.HealthyCheck())
+	require.Len(t, authorization, 2)
+	// The catalogue request carries the credential too, so a token that grants
+	// extra visibility is actually used.
+	assert.Equal(t, "Bearer ms-good-token", authorization[1])
+}
+
+// Without a token there is nothing to validate, so the reachability check is the
+// catalogue request alone.
+func TestModelScope_HealthyCheckWithoutAToken(t *testing.T) {
+	var paths []string
+
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			paths = append(paths, req.URL.Path)
+			assert.Empty(t, req.Header.Get("Authorization"))
+
+			return jsonResponse(http.StatusOK,
+				`{"Code":200,"Success":true,"Data":{"Model":{"Models":[],"TotalCount":0}}}`), nil
+		},
+	}}
+
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	require.NoError(t, ms.Connect())
+	assert.Equal(t, []string{modelScopeSearchPath}, paths)
+}
+
+func TestModelScope_HealthyCheckReportsAnUnreachableHub(t *testing.T) {
+	client := &http.Client{Transport: &MockRoundTripper{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial tcp: i/o timeout")
+		},
+	}}
+
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	err := ms.Connect()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "i/o timeout")
+	assert.NotErrorIs(t, err, ErrUnauthorized)
+}
+
+// A 200 whose envelope says the call failed is still a failure. The hub is
+// consistent about the status today; the envelope is what it treats as
+// authoritative.
+func TestModelScope_UnsuccessfulEnvelopeIsAnError(t *testing.T) {
+	client, _ := requestRecorder(http.StatusOK,
+		`{"Code":10010207001,"Message":"list_models_failed","Success":false}`)
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	_, err := ms.ListModels(ListOption{Limit: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list_models_failed")
+}
+
+// A public catalogue is read-only. Each refusal has to carry ErrNotSupported so
+// the API answers "this registry cannot do that" rather than a server error.
+func TestModelScope_UnsupportedOperationsAreTyped(t *testing.T) {
+	ms := &modelScope{url: modelScopeTestURL}
+
+	_, err := ms.GetModelVersion("m", "v")
+	assert.ErrorIs(t, err, ErrNotSupported)
+
+	assert.ErrorIs(t, ms.DeleteModel("m", "v"), ErrNotSupported)
+	assert.ErrorIs(t, ms.ImportModel(strings.NewReader(""), "m", "v", io.Discard), ErrNotSupported)
+	assert.ErrorIs(t, ms.ExportModel("m", "v", "/tmp"), ErrNotSupported)
+	assert.ErrorIs(t, ms.SetManualModelInfo("m", "v", &v1.ModelInfo{}), ErrNotSupported)
+
+	_, err = ms.GetModelPath("m", "v")
+	assert.ErrorIs(t, err, ErrNotSupported)
+
+	// Storage figures are refused rather than reported as zero, which is what
+	// makes the list show "-" instead of "0 B" for a hub.
+	_, err = ms.CollectUsage()
+	assert.ErrorIs(t, err, ErrNotSupported)
+
+	version, err := ms.GetNFSVersion()
+	assert.NoError(t, err)
+	assert.Empty(t, version)
+}
+
+// A version read from a listing is what a client puts into "model get
+// <name>:<version>" and into a detail URL, so a detail that answered with the
+// hub's own branch name would name a version the listing never shows. Both
+// providers go through reportedVersion for exactly this reason; this pins that
+// ModelScope did not grow a second rule.
+func TestModelScope_DetailNamesTheVersionTheListingEmits(t *testing.T) {
+	catalogue := &modelScopeCatalogue{ids: []string{"Qwen/Qwen3-8B"}}
+	ms := &modelScope{url: modelScopeTestURL, client: catalogue.client()}
+
+	page, err := ms.ListModels(ListOption{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, page.Models[0].Versions, 1)
+
+	listed := page.Models[0].Versions[0].Name
+	assert.Equal(t, v1.LatestVersion, listed)
+
+	client, _ := requestRecorder(http.StatusOK, modelScopeTestConfig)
+	ms.client = client
+
+	detail, err := ms.GetModelDetail("Qwen/Qwen3-8B", listed)
+	require.NoError(t, err)
+	assert.Equal(t, listed, detail.Name,
+		"a detail must answer under the version name the listing emitted")
+}
+
+// The shared rule takes the registry's own default-branch name, and getting that
+// name from the provider is the whole point: "master" is ModelScope's default and
+// maps back to "latest", while "main" is a branch ModelScope repositories do not
+// have — reporting it as "latest" would both lose the caller's request and name a
+// version that repository cannot resolve.
+func TestReportedVersionUsesTheProvidersDefaultBranch(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		defaultBranch string
+		want          string
+	}{
+		{"hub default branch", defaultRevision, defaultRevision, v1.LatestVersion},
+		{"modelscope default branch", modelScopeDefaultRevision, modelScopeDefaultRevision, v1.LatestVersion},
+		{"empty is the default branch", "", modelScopeDefaultRevision, v1.LatestVersion},
+		{"latest stays latest", v1.LatestVersion, modelScopeDefaultRevision, v1.LatestVersion},
+		// The regression this parameter exists for.
+		{"main is a real branch elsewhere", defaultRevision, modelScopeDefaultRevision, defaultRevision},
+		{"master is a real branch on the hub", modelScopeDefaultRevision, defaultRevision, modelScopeDefaultRevision},
+		{"a tag is itself", "v1.0.0", modelScopeDefaultRevision, "v1.0.0"},
+		{"no single default name", "master", "", "master"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, reportedVersion(tt.version, tt.defaultBranch))
+		})
+	}
+}
+
+// The measured fact behind modelScopeDefaultRevision, asserted where it is used:
+// a caller naming ModelScope's default branch gets "latest" back, and one naming
+// "main" gets "main" — because ModelScope repositories do not have a "main".
+func TestModelScope_DetailNamesTheDefaultBranchLatest(t *testing.T) {
+	client, _ := requestRecorder(http.StatusOK, modelScopeTestConfig)
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	detail, err := ms.GetModelDetail("Qwen/Qwen3-8B", "master")
+	require.NoError(t, err)
+	assert.Equal(t, v1.LatestVersion, detail.Name)
+
+	detail, err = ms.GetModelDetail("Qwen/Qwen3-8B", "main")
+	require.NoError(t, err)
+	assert.Equal(t, "main", detail.Name, "main is not ModelScope's default branch and must not be renamed")
+}
+
+// An explicit revision is reported back as itself: it is a real name on the hub
+// and a client that asked for it must be able to ask for it again.
+func TestModelScope_DetailKeepsAnExplicitRevision(t *testing.T) {
+	client, requested := requestRecorder(http.StatusOK, modelScopeTestConfig)
+	ms := &modelScope{url: modelScopeTestURL, client: client}
+
+	detail, err := ms.GetModelDetail("Qwen/Qwen3-8B", "v1.0.0")
+	require.NoError(t, err)
+
+	assert.Equal(t, "v1.0.0", detail.Name)
+	assert.Contains(t, (*requested)[0], "Revision=v1.0.0")
+}
+
+// The visibility rule is what turns off the write controls, the storage figures
+// and the read-through cache. A kind that is public in the provider but private
+// here would get all three wrong, silently.
+func TestModelScope_IsPublic(t *testing.T) {
+	assert.Equal(t, v1.ModelRegistryVisibilityPublic,
+		v1.VisibilityForModelRegistryType(v1.ModelScopeModelRegistryType))
+}
+
+// modelScopeRepo answers the two file endpoints the way the hub does, so a test
+// can exercise the disagreement between them: the file endpoint 404s on an
+// unknown revision, the tree endpoint answers 200 with a null list.
+type modelScopeRepo struct {
+	// revisions maps a revision to the files it holds. A revision absent from the
+	// map is one the repository does not have. The empty string is the default.
+	revisions map[string][]map[string]interface{}
+	// files maps "<revision>/<path>" to its bytes.
+	files map[string]string
+	// requested records every URL asked for.
+	requested []string
+}
+
+func (r *modelScopeRepo) client() *http.Client {
+	return &http.Client{Transport: &MockRoundTripper{RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+		r.requested = append(r.requested, req.URL.String())
+
+		revision := req.URL.Query().Get("Revision")
+		files, known := r.revisions[revision]
+
+		if strings.HasSuffix(req.URL.Path, modelScopeRepoFilesPath) {
+			// The trap: an unknown revision is not an error here. It is a success
+			// whose file list happens to be null.
+			payload := map[string]interface{}{
+				"Code": 200, "Message": "success", "Success": true,
+				"Data": map[string]interface{}{"Files": nil},
+			}
+			if known {
+				payload["Data"] = map[string]interface{}{"Files": files}
+			}
+
+			body, err := json.Marshal(payload)
+			if err != nil {
+				return nil, err
+			}
+
+			return jsonResponse(http.StatusOK, string(body)), nil
+		}
+
+		content, ok := r.files[revision+"/"+req.URL.Query().Get("FilePath")]
+		if !ok {
+			// Missing file and unknown revision are the same answer here.
+			return jsonResponse(http.StatusNotFound,
+				`{"Code":10990101007,"Message":"获取模型文件失败，文件内容为空","Success":false}`), nil
+		}
+
+		return jsonResponse(http.StatusOK, content), nil
+	}}}
+}
+
+// A repository whose default revision holds config.json and README.md.
+func populatedRepo() *modelScopeRepo {
+	return &modelScopeRepo{
+		revisions: map[string][]map[string]interface{}{
+			"": {
+				{"Name": "config.json", "Path": "config.json", "Size": 659, "Type": "blob", "IsLFS": false},
+				{"Name": "model.safetensors", "Path": "model.safetensors", "Size": 988097824, "Type": "blob", "IsLFS": true},
+			},
+			"v1.0.0": {
+				{"Name": "config.json", "Path": "config.json", "Size": 659, "Type": "blob", "IsLFS": false},
+			},
+		},
+		files: map[string]string{
+			"/config.json":       modelScopeTestConfig,
+			"/README.md":         "# a model\n",
+			"v1.0.0/config.json": modelScopeTestConfig,
+		},
+	}
+}
+
+// The trap this exists for: ModelScope answers an unknown revision with HTTP 200,
+// Code 200, Success true and a *null* file list — measured on
+// Qwen/Qwen2.5-0.5B-Instruct, where Revision=main and Revision=zzz-not-real are
+// indistinguishable from each other. Reading that as "no files" would show a
+// user an empty repository for what is a typo.
+func TestModelScope_ListRepoFilesRejectsANullFileList(t *testing.T) {
+	repo := populatedRepo()
+	ms := &modelScope{url: modelScopeTestURL, client: repo.client()}
+
+	files, err := ms.listRepoFiles("Qwen/Qwen2.5-0.5B-Instruct", "zzz-not-real")
+
+	assert.Nil(t, files)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound, "a null file list is not an empty repository")
+	assert.Contains(t, err.Error(), "zzz-not-real")
+}
+
+// The same applies to "main", which is the Hub's default branch name and not
+// ModelScope's. It is not a differently-spelled default; it is nothing.
+func TestModelScope_ListRepoFilesRejectsTheHubsDefaultBranchName(t *testing.T) {
+	repo := populatedRepo()
+	ms := &modelScope{url: modelScopeTestURL, client: repo.client()}
+
+	_, err := ms.listRepoFiles("Qwen/Qwen2.5-0.5B-Instruct", defaultRevision)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// An empty list is a real answer and must stay distinguishable from a null one:
+// a repository can legitimately hold nothing.
+func TestModelScope_ListRepoFilesAllowsAnEmptyRepository(t *testing.T) {
+	repo := populatedRepo()
+	repo.revisions["empty-branch"] = []map[string]interface{}{}
+	ms := &modelScope{url: modelScopeTestURL, client: repo.client()}
+
+	files, err := ms.listRepoFiles("owner/empty", "empty-branch")
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+// What NEU-689 reads: a path to fetch by, a size to budget with, and the LFS
+// flag that marks the weights.
+func TestModelScope_ListRepoFilesCarriesWhatADownloaderNeeds(t *testing.T) {
+	repo := populatedRepo()
+	ms := &modelScope{url: modelScopeTestURL, client: repo.client()}
+
+	files, err := ms.listRepoFiles("Qwen/Qwen2.5-0.5B-Instruct", v1.LatestVersion)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+
+	assert.Equal(t, "config.json", files[0].Path)
+	assert.Equal(t, int64(659), files[0].Size)
+	assert.False(t, files[0].IsLFS)
+	assert.Equal(t, "model.safetensors", files[1].Path)
+	assert.Equal(t, int64(988097824), files[1].Size)
+	assert.True(t, files[1].IsLFS, "the weights are LFS-stored and a downloader has to know")
+
+	// The default revision is addressed by omitting Revision, never by guessing a
+	// branch name.
+	require.Len(t, repo.requested, 1)
+	assert.NotContains(t, repo.requested[0], "Revision=")
+	assert.Contains(t, repo.requested[0], "/repo/files?")
+}
+
+// A mistyped revision must not be rendered as a real checkpoint that happens to
+// say nothing about itself. The file endpoint cannot tell the two apart, so the
+// tree is consulted on the miss.
+func TestModelScope_GetModelDetailRejectsAnUnknownRevision(t *testing.T) {
+	repo := populatedRepo()
+	ms := &modelScope{url: modelScopeTestURL, client: repo.client()}
+
+	version, err := ms.GetModelDetail("Qwen/Qwen2.5-0.5B-Instruct", "zzz-not-real")
+
+	assert.Nil(t, version)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Contains(t, err.Error(), "no revision", "the reader has to be told which of the two it was")
+}
+
+// The other half: a repository that really has no config.json still answers, with
+// every field missing. Losing this would trade one silent wrong answer for
+// another.
+func TestModelScope_GetModelDetailStillAnswersWithoutConfigOnAKnownRevision(t *testing.T) {
+	repo := populatedRepo()
+	repo.revisions["no-config"] = []map[string]interface{}{
+		{"Name": "README.md", "Path": "README.md", "Size": 10, "Type": "blob", "IsLFS": false},
+	}
+	ms := &modelScope{url: modelScopeTestURL, client: repo.client()}
+
+	version, err := ms.GetModelDetail("owner/not-a-checkpoint", "no-config")
+	require.NoError(t, err)
+
+	assert.Equal(t, "no-config", version.Name)
+	assert.Contains(t, version.Info.MissingFields, v1.ModelInfoFieldArchitecture)
+}
+
+// A README miss gets the same treatment: "this model has no README" is the wrong
+// thing to tell someone who mistyped a branch.
+func TestModelScope_GetReadmeRejectsAnUnknownRevision(t *testing.T) {
+	repo := populatedRepo()
+	ms := &modelScope{url: modelScopeTestURL, client: repo.client()}
+
+	_, err := ms.GetReadme("Qwen/Qwen2.5-0.5B-Instruct", "zzz-not-real")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Contains(t, err.Error(), "no revision")
+
+	// And a revision that does exist but has no README still says so.
+	_, err = ms.GetReadme("Qwen/Qwen2.5-0.5B-Instruct", "v1.0.0")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Contains(t, err.Error(), "has no README.md")
+}
+
+// The extra tree lookup happens only on a miss. A detail that found its
+// config.json costs exactly one request, as it did before this check existed.
+func TestModelScope_GetModelDetailCostsOneRequestOnTheHappyPath(t *testing.T) {
+	repo := populatedRepo()
+	ms := &modelScope{url: modelScopeTestURL, client: repo.client()}
+
+	_, err := ms.GetModelDetail("Qwen/Qwen2.5-0.5B-Instruct", v1.LatestVersion)
+	require.NoError(t, err)
+	assert.Len(t, repo.requested, 1)
+}

--- a/internal/model_registry/query_cache_test.go
+++ b/internal/model_registry/query_cache_test.go
@@ -295,3 +295,23 @@ func TestQueryCache_TTLIsConfigurable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, client.calls, "an entry past the configured TTL must not be served")
 }
+
+// The cache keys on visibility, not on the registry kind, so a new public hub is
+// supposed to be cached without touching this file. That is a claim, and it is
+// only worth anything if something checks it.
+func TestQueryCache_CachesEveryPublicKind(t *testing.T) {
+	for _, registry := range BuiltinModelRegistries(BuiltinConfig{Enabled: true}, "default") {
+		t.Run(string(registry.Spec.Type), func(t *testing.T) {
+			cache := NewQueryCache(0)
+			client := &countingRegistry{page: onePage("qwen/qwen3")}
+
+			for i := 0; i < 2; i++ {
+				_, meta, err := cache.ListModels(registry, client, ListOption{Search: "qwen", Limit: 2})
+				require.NoError(t, err)
+				assert.Equal(t, i > 0, meta.Cached)
+			}
+
+			assert.Equal(t, 1, client.calls, "the second identical query must not reach the hub")
+		})
+	}
+}

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -429,6 +429,9 @@ func (k *kubernetesOrchestrator) setModelRegistryVariables(data *DeploymentManif
 		data.ModelArgs["version"] = modelRealVersion
 		data.ModelArgs["registry_path"] = endpoint.Spec.Model.Name
 		data.ModelArgs["path"] = filepath.Join(v1.DefaultK8sClusterModelCacheMountPath, modelCacheRelativePath, endpoint.Spec.Model.Name, modelRealVersion)
+	case v1.ModelScopeModelRegistryType:
+		// Removed by NEU-689, which wires the downloader. See the error's own comment.
+		return errModelScopeDeployNotWiredYet
 	}
 
 	return nil

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -3809,3 +3809,32 @@ func int32Ptr(v int32) *int32 { return &v }
 func klogTestLogger() klog.Logger {
 	return klog.Background()
 }
+
+// ModelScope is browsable but not yet deployable from, because the container's
+// downloader speaks only the Hugging Face Hub API. Until NEU-689 wires it, that
+// is refused with a reason here rather than falling through the switch, which
+// would produce a manifest carrying no model path at all and fail inside the
+// container with nothing to read.
+func TestKubernetesOrchestrator_setModelRegistryVariables_RefusesModelScopeUntilNEU689(t *testing.T) {
+	k := &kubernetesOrchestrator{}
+
+	data := &DeploymentManifestVariables{
+		Env:       map[string]string{},
+		ModelArgs: map[string]interface{}{},
+	}
+
+	err := k.setModelRegistryVariables(data, &v1.Endpoint{
+		Spec: &v1.EndpointSpec{Model: &v1.ModelSpec{Name: "Qwen/Qwen3-8B"}},
+	}, &v1.Cluster{}, &v1.ModelRegistry{
+		Metadata: &v1.Metadata{Name: "public-model-scope"},
+		Spec: &v1.ModelRegistrySpec{
+			Type: v1.ModelScopeModelRegistryType,
+			Url:  "https://www.modelscope.cn",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot deploy a model from a ModelScope registry yet")
+	// Nothing half-built is handed back for a caller to deploy anyway.
+	assert.Empty(t, data.ModelArgs)
+}

--- a/internal/orchestrator/model_connect.go
+++ b/internal/orchestrator/model_connect.go
@@ -71,7 +71,12 @@ func (o *RayOrchestrator) connectSSHNodeEndpointModel(config *v1.RaySSHProvision
 	endpoint v1.Endpoint, nodeIP string, op string) error {
 	klog.V(4).Infof("Connect endpoint %s model to node %s", endpoint.Metadata.Name, nodeIP)
 
-	if modelRegistry.Spec.Type == v1.HuggingFaceModelRegistryType {
+	// A public hub is fetched over the network by the container itself, so there
+	// is nothing to attach to the node. Whether the runtime can actually fetch
+	// from it is decided when the application is built, which is where a refusal
+	// carries an explanation; answering it here would report the gap as an
+	// unknown registry kind.
+	if v1.VisibilityForModelRegistryType(modelRegistry.Spec.Type) == v1.ModelRegistryVisibilityPublic {
 		return nil
 	}
 

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -965,6 +965,9 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 		modelArgs["version"] = modelRealVersion
 		modelArgs["registry_path"] = endpoint.Spec.Model.Name
 		modelArgs["path"] = filepath.Join(v1.DefaultSSHClusterModelCacheMountPath, modelCacheRelativePath, endpoint.Spec.Model.Name, modelRealVersion)
+	case v1.ModelScopeModelRegistryType:
+		// Removed by NEU-689, which wires the downloader. See the error's own comment.
+		return dashboard.RayServeApplication{}, errModelScopeDeployNotWiredYet
 	}
 
 	app.Args["model"] = modelArgs

--- a/internal/orchestrator/util.go
+++ b/internal/orchestrator/util.go
@@ -18,6 +18,23 @@ import (
 
 const acceleratorTypeCPU = "cpu"
 
+// errModelScopeDeployNotWiredYet is what both orchestrators answer when asked to
+// build an application from a ModelScope registry.
+//
+// It is a statement about this repository, not about ModelScope. The hub serves
+// both operations a downloader needs — list a revision's files, fetch one by
+// path — and internal/model_registry/model_scope.go names those endpoints. What
+// is missing is the container-side downloader, which today speaks only the
+// Hugging Face Hub API. NEU-689 wires it and deletes this refusal together with
+// the two cases that raise it.
+//
+// Until then the refusal is explicit rather than a fall-through, because falling
+// through the per-kind switch produces an application with no model path at all
+// and fails inside the container with nothing to read.
+var errModelScopeDeployNotWiredYet = errors.New(
+	"cannot deploy a model from a ModelScope registry yet: its models can be browsed and selected, " +
+		"but the inference runtime's downloader does not speak the ModelScope API")
+
 // engineTPArgKey returns the underscore-form engine_args key the engine
 // uses for tensor parallel size. vLLM uses `tensor_parallel_size`; SGLang's
 // ServerArgs dataclass field is `tp_size`. Returns "" when the engine

--- a/internal/routes/proxies/builtin_model_registry.go
+++ b/internal/routes/proxies/builtin_model_registry.go
@@ -10,6 +10,7 @@ import (
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/middleware"
+	"github.com/neutree-ai/neutree/internal/model_registry"
 	"github.com/neutree-ai/neutree/internal/utils/request"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
@@ -125,9 +126,7 @@ func guardBuiltinRegistrySpec(c *gin.Context, deps *Dependencies, bodyMap map[st
 	}
 
 	if stringFieldChanged(spec, "url", storedURL(stored)) {
-		abortBuiltinRegistry(c, workspace, name,
-			"the address of a built-in model registry comes from this deployment's configuration "+
-				"(--hugging-face-endpoint); change it there, since the reconcile restores it otherwise")
+		abortBuiltinRegistry(c, workspace, name, builtinRegistryURLRefusal(stored))
 
 		return false
 	}
@@ -224,6 +223,21 @@ func findStoredModelRegistry(s storage.Storage, workspace, name string) (*v1.Mod
 	}
 
 	return &registries[0], nil
+}
+
+// builtinRegistryURLRefusal explains where a built-in registry's address is
+// really set. Each hub has its own setting, so the flag is looked up from the
+// registry's kind rather than written into the sentence: a ModelScope registry
+// that told the operator to edit --hugging-face-endpoint would send them to
+// change a value that has no effect on it.
+func builtinRegistryURLRefusal(stored *v1.ModelRegistry) string {
+	message := "the address of a built-in model registry comes from this deployment's configuration"
+
+	if flag := model_registry.EndpointFlagForModelRegistryType(stored.Spec.Type); flag != "" {
+		message += " (" + flag + ")"
+	}
+
+	return message + "; change it there, since the reconcile restores it otherwise"
 }
 
 // builtinAnnotationChanged reports whether a patch adds or removes the built-in

--- a/internal/routes/proxies/builtin_model_registry_test.go
+++ b/internal/routes/proxies/builtin_model_registry_test.go
@@ -37,6 +37,15 @@ func builtinRegistryRow(builtin bool) v1.ModelRegistry {
 	}
 }
 
+func builtinModelScopeRegistryRow() v1.ModelRegistry {
+	row := builtinRegistryRow(true)
+	row.Metadata.Name = "public-model-scope"
+	row.Spec.Type = v1.ModelScopeModelRegistryType
+	row.Spec.Url = "https://www.modelscope.cn"
+
+	return row
+}
+
 // runGuard drives the middleware over one PATCH body and reports whether the
 // request was allowed through.
 func runGuard(t *testing.T, storage *storagemocks.MockStorage, body map[string]interface{},
@@ -124,6 +133,88 @@ func TestBuiltinModelRegistryGuard_RefusesAddressChange(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "hugging-face-endpoint")
 	// Refused for everyone, so it is not a permission question and none is asked.
 	storage.AssertNotCalled(t, "CallDatabaseFunction", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// The refusal has to name the setting that governs the registry in front of the
+// operator. Each hub has its own, so a single hard-coded flag would send anyone
+// with a ModelScope registry to edit a value that has no effect on it.
+func TestBuiltinModelRegistryGuard_AddressRefusalNamesThisRegistrysSetting(t *testing.T) {
+	tests := []struct {
+		name     string
+		row      v1.ModelRegistry
+		wantFlag string
+	}{
+		{"hugging face", builtinRegistryRow(true), "--hugging-face-endpoint"},
+		{"model scope", builtinModelScopeRegistryRow(), "--model-scope-endpoint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storage := &storagemocks.MockStorage{}
+			storage.On("ListModelRegistry", mock.Anything).Return([]v1.ModelRegistry{tt.row}, nil)
+
+			w, passed := runGuard(t, storage, patchBody(map[string]interface{}{
+				"url": "https://mirror.example",
+			}, ""), "admin")
+
+			assert.False(t, passed)
+			assert.Contains(t, w.Body.String(), tt.wantFlag)
+		})
+	}
+}
+
+// The guard keys on the built-in annotation, not on the registry kind, so it
+// covers a provisioned ModelScope registry exactly as it covers the Hugging Face
+// one. Asserted rather than assumed: a second built-in kind was added in this
+// change, and "it is annotation-driven" is a claim about code that nothing was
+// checking.
+func TestBuiltinModelRegistryGuard_CoversEveryBuiltinKind(t *testing.T) {
+	refusals := []struct {
+		name string
+		body map[string]interface{}
+		want string
+	}{
+		{"delete", patchBody(nil, "2026-08-12T00:00:00Z"), "cannot be deleted"},
+		{"type change", patchBody(map[string]interface{}{
+			"type": string(v1.BentoMLModelRegistryType),
+		}, ""), "type cannot be changed"},
+		{"address change", patchBody(map[string]interface{}{
+			"url": "https://mirror.example",
+		}, ""), "deployment's configuration"},
+	}
+
+	for _, refusal := range refusals {
+		t.Run(refusal.name, func(t *testing.T) {
+			storage := &storagemocks.MockStorage{}
+			storage.On("ListModelRegistry", mock.Anything).
+				Return([]v1.ModelRegistry{builtinModelScopeRegistryRow()}, nil)
+
+			w, passed := runGuard(t, storage, refusal.body, "admin")
+
+			assert.False(t, passed)
+			assert.Contains(t, w.Body.String(), refusal.want)
+		})
+	}
+}
+
+// Removing the marker from a provisioned ModelScope registry is refused the same
+// way it is for the Hugging Face one: the annotation is an identity, and it is
+// not self-service in either direction.
+func TestBuiltinModelRegistryGuard_ModelScopeAnnotationIsNotSelfService(t *testing.T) {
+	storage := &storagemocks.MockStorage{}
+	storage.On("ListModelRegistry", mock.Anything).
+		Return([]v1.ModelRegistry{builtinModelScopeRegistryRow()}, nil)
+
+	w, passed := runGuard(t, storage, map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"workspace":   "default",
+			"name":        "public-model-scope",
+			"annotations": map[string]interface{}{},
+		},
+	}, "admin")
+
+	assert.False(t, passed)
+	assert.Contains(t, w.Body.String(), v1.BuiltinAnnotationKey)
 }
 
 // Credentials are the user's, so they stay editable — by someone trusted with


### PR DESCRIPTION
## What

NEU-627. A read-only ModelScope provider alongside the Hugging Face one: catalogue search with **real offset paging and a real match count**, model detail parsed from `config.json`, and the model card served verbatim. Stacked on NEU-624 (#535), now rebased onto `main` since that merged as `1dc152e`.

## Paging: ModelScope is not the Hub, and the difference is the point

NEU-620 established that the Hugging Face Hub cannot express "start at row N", so `ListModels` refuses a non-zero offset and reports `Content-Range: 0-1/*`. That conclusion is about the Hub, not about public registries, and it does not carry over. Measured against `https://www.modelscope.cn`:

| | Hugging Face Hub | ModelScope |
|---|---|---|
| row offset | not expressible (opaque cursor; `skip` deprecated) | `offset = (PageNumber-1) * PageSize` |
| match count | not reported | `TotalCount` |
| depth limit | n/a | `offset + PageSize <= 10000` |

- **Offset is row-exact.** `PageSize=10, PageNumber=1` returned exactly `PageSize=5, PageNumber=1` ++ `PageSize=5, PageNumber=2` — same order, no overlap, no gap.
- **Total is real**: `Name:"qwen"` → 23809; `Name:""` → 237969. So `Content-Range` carries a genuine total and a client's paging control can offer Prev/Next instead of an open-ended feed. That is what the capability check in the UI and CLI is for; neither needs a ModelScope branch.
- **`PageSize` caps at 100 silently** — `PageSize=1000` answers `200` with 100 rows. A client trusting its own page size would skip rows, so the provider pages in bounded requests and slices.
- **Depth**: the window is `offset + PageSize <= 10000`, measured at the boundary from both sides — `(10,1000)` ok / `(10,1001)` fails, `(100,100)` ok / `(100,101)` fails, `(1,10000)` ok / `(1,10001)` fails. Over the line the hub answers **HTTP 500**, which is indistinguishable from an outage. So the provider refuses past that itself, as a typed `ErrNotSupported` → `400 not_supported`, rather than letting a paging click be reported as "ModelScope is down". The last reachable page is clipped rather than dropped.

### Relation to #556

No overlap and no contradiction — three layers, three different conditions:

| layer | condition | when |
|---|---|---|
| CLI flags / `pkg/client` (#556) | `limit < 0`, `offset < 0` | before a request is sent |
| server route `intQuery` | same, → `400` | on arrival |
| this provider | `offset >= 10000` | against the upstream's own limit |

#556 rejects input that is malformed; this rejects a well-formed request the upstream cannot serve. The silent `PageSize > 100` truncation is absorbed entirely inside the provider — it fetches in bounded chunks and slices, so no layer above ever sees it. Nothing in this change loosens or duplicates #556's validation.

## Version naming

Follows the rule review settled on in #535 — a listing and a detail answer the same name, and the repository's default branch is reported as `latest` — with one addition: `reportedVersion` now takes **the registry's own name for that branch** instead of hard-coding the Hub's.

That name is provider knowledge, not part of the rule, and the two registries disagree. The Hub's default branch is `main`; ModelScope's is `master`, surveyed across seven repositories of different kinds (Qwen, DeepSeek, Llama, Wan, iic, AI-ModelScope, moonshotai) — every one reports `Revision: "master"` and lists `master` as its only non-PR branch. With `main` hard-coded, a caller asking ModelScope for `main` got `latest` back: a name that both lost what they asked for and, since ModelScope repositories have no `main`, would not resolve on a follow-up lookup. So the rule stays in one function and the provider difference stays in the provider.

On ModelScope, `main` is not a differently-spelled default — it is **nothing**, and behaves exactly like a revision that was never created (the table below). Hard-coding the Hub's name therefore pointed at something absent, not at something misnamed.

On the wire ModelScope carries no branch name at all: **omitting `Revision` makes the hub resolve the repository's own default**, so a repository that somehow used a different default is still read correctly.

## The CLI needed no change at all, and that is now measured

NEU-625 (#546) moved `model push` / `model delete`'s refusal off a hard-coded `hugging-face` and onto `v1.VisibilityForModelRegistryType` (`internal/cli/model/write_target.go`). Teaching that one mapping about `model-scope` is therefore the entire CLI change:

```
$ neutree-cli model push ./m --name tinymodel -r public-model-scope
cannot push models to model registry "public-model-scope": it is a model-scope
registry, which neutree reads from but never writes to
```

Verified rather than asserted, in two directions:

- **Positively** — `TestPushRefusesModelScopeWithNoModelScopeSpecificCLICode` and `TestDeleteRefusesModelScopeWithNoModelScopeSpecificCLICode` drive the real cobra commands against a stub registry server returning `type: model-scope`, and assert the exact sentence (not merely that an error came back — a refusal still reading `hugging-face` would mean the judgement was not coming from the mapping). Both also assert the command never reached the model endpoint, so a push is refused before anything is archived or uploaded.
- **By falsification** — with `ModelScopeModelRegistryType` temporarily removed from `VisibilityForModelRegistryType` and nothing else touched, all three tests fail; restored, all pass. So they are genuinely driven by that mapping and not by anything else.

Outside the tests, `git diff origin/main -- internal/cli/model/ cmd/neutree-cli/app/cmd/model/` is empty. The one non-test CLI change on this branch is the `--model-scope-endpoint` launch flag, which belongs to the built-in registry below.

This is the first hard evidence that the "render by server capability, not by provider" line held.

## Reuse

Nothing new was invented where NEU-624 already had a vocabulary:

- **Error classification** — `not_found` / `not_supported` / `registry_unauthorized` / `rate_limited` / `unavailable` and `respondRegistryError`, unchanged. `TestModelScope_ErrorsAreDistinguishable` pins that unreachable / rejected-credentials / throttled arrive as three distinct types.
- **Query cache** — provider-agnostic, keys on visibility. It works for ModelScope untouched; `TestQueryCache_CachesEveryPublicKind` now asserts that for every built-in kind rather than leaving it a claim.
- **Availability status** — `last_checked_at`, retry, the built-in switch: all provider-agnostic, all unchanged.
- **Read-only** — `refuseReadOnlyRegistry` via `registryAcceptsWrites`, which reads visibility, so it covers ModelScope as soon as the kind is public.
- **Built-in registry guard** — the same guard, not a second one. It keys on the `neutree.ai/builtin` annotation, so refusing deletion, type changes, address changes and hand-editing of the marker all already cover a provisioned ModelScope registry; `TestBuiltinModelRegistryGuard_CoversEveryBuiltinKind` asserts that rather than leaving it a claim. The only change to the guard is that its address refusal now names *that registry's* setting: a ModelScope registry telling an operator to change `--hugging-face-endpoint` would send them to edit a value with no effect on it.

## `api.visibility()` — the part the ticket got wrong

The ticket says `spec.type` is bare `TEXT` with no `CHECK`, so a new kind needs no migration. True of the column; **not** true of `api.visibility()`, which #535 introduced and which enumerates public kinds *by name*:

```sql
WHEN (registry.spec).type = 'hugging-face' THEN 'public' ELSE 'private'
```

Left alone, every ModelScope registry reports itself **private** — no build failure, no error, no log line. Downstream: storage figures that never arrive, write controls that cannot work (the client fails closed on `undefined`, not on a definite-but-wrong value), and no runtime-download hint on the deploy form. Since 084 has shipped, the function is redefined in a new migration rather than edited in place — **088**. 085, 086 and 087 were each claimed by other PRs while this branch was open, so the number is whatever `ls db/migrations | sed -E 's/_.*//' | sort -n | tail -1` reports after the latest rebase, not a number carried forward. `scripts/check-migrations.sh` (NEU-704, #571, now on `main`) enforces that mechanically and is run here as part of the pre-push gate. Its Go twin `v1.VisibilityForModelRegistryType` is updated with it, and each now carries a comment pointing at the other.

## Credentials

Public read endpoints **ignore `Authorization` entirely** — a syntactically valid bogus bearer token still gets `Code 200`, so a dead token cannot be detected on a read and the registry would report itself healthy. `POST /api/v1/login` does evaluate it (bad token → HTTP **400**, `Code 10010103009`), so that is the ModelScope counterpart of the Hub's `whoami-v2` and the only thing that turns a misconfigured token into `registry_unauthorized`. Requests carry `Authorization: Bearer`, the convention `modelscope/modelscope_hub` uses on its OpenAPI surface.

## Built-in registry — an addition beyond the ticket's scope

**NEU-627 does not ask for this.** Its scope is the provider, the type constants, URL/credential validation, read-only writes and credential masking. The built-in ModelScope registry — `public-model-scope`, behind the same `--enable-builtin-public-model-registries` switch, with `--model-scope-endpoint` for an in-network mirror, wired through both the compose and Helm manifests — is added deliberately anyway.

The reason is the phase's own acceptance criterion, that a user can search ModelScope inside the product, together with the constraint that the follow-up UI/CLI patch should be empty. Without a built-in registry a user has to create one by hand, and the create form's registry-type list is hard-coded in the front end — so "P5 is empty" would have turned into "P5 needs a new branch", which is exactly the outcome this line of work is trying to avoid. The existing option already describes itself as provisioning "a built-in read-only model registry **for each supported public hub**", so this is filling in a shape that was already there rather than inventing one.

Happy to drop it if the scope call goes the other way; the consequence is that the UI has to grow the type option instead.

## Deployment: refused for now, and the reason is ours not ModelScope's

**Correcting something I got wrong earlier in this PR.** I reported that ModelScope does not serve the API a downloader needs, having probed `https://www.modelscope.cn/api/models/{id}` — which is the **website's SPA route** and answers HTML. The versioned REST API is complete. Full URLs and responses, so this is checkable rather than assertable:

| request | response |
|---|---|
| `GET /api/models/Qwen/Qwen2.5-0.5B-Instruct` | `200 text/html` — the SPA. **This is what I probed.** |
| `GET /api/v1/models/Qwen/Qwen2.5-0.5B-Instruct` | `200 application/json`, 13486 B, `Architectures: ["Qwen2ForCausalLM"]` |
| `GET /api/v1/models/{id}/repo/files?Revision=master&Root=` | `200`, 11 files, each with `Path`, `Size`, `Type`, `IsLFS` |
| `GET /api/v1/models/{id}/repo?Revision=master&FilePath=config.json` | `200 application/octet-stream`, 659 B, correct contents |

List-a-revision's-files and fetch-a-file-by-path are both there, so "ModelScope models cannot be deployed" was wrong and the capability bit I added on the strength of it is gone — a flag that would have been permanently true once the downloader lands.

What is missing is on our side: the container's downloader speaks only the Hugging Face Hub API. So both orchestrators still refuse a ModelScope deploy **explicitly**, because falling through the per-kind switch builds an application with no model path at all and fails inside the container with nothing to read. The error says the refusal is about this repository, and NEU-689 deletes it along with the two cases that raise it.

## What NEU-689 needs from this layer

Written into `model_scope.go` next to the code, so it does not have to be rediscovered:

```
list a revision's files  GET <url>/api/v1/models/<owner>/<name>/repo/files?Revision=<rev>&Root=<subtree>
fetch one file           GET <url>/api/v1/models/<owner>/<name>/repo?Revision=<rev>&FilePath=<path>
repository metadata      GET <url>/api/v1/models/<owner>/<name>
```

- `<owner>/<name>` is `v1.GeneralModel.Name` exactly as a listing emits it.
- `<rev>` must come from `revision()`: `""` means "the repository's own default", and that is the only safe way to spell it (below).
- `listRepoFiles` already carries the trap below and returns `Path`, `Size` and `IsLFS` per file, so a downloader can budget before fetching and knows which entries are the LFS-stored weights.

## The trap: an unknown revision is not an error

`/repo/files` answers a revision that does not exist with **HTTP 200, `Code: 200`, `Success: true`, `Message: "success"` and a null `Files`**. Measured on `Qwen/Qwen2.5-0.5B-Instruct`:

| `Revision=` | HTTP | `Code` / `Success` | `Files` |
|---|---|---|---|
| `master` | 200 | 200 / true | 11 |
| *omitted* | 200 | 200 / true | 11 |
| `main` | 200 | 200 / true | **null** |
| `zzz-not-real` | 200 | 200 / true | **null** |

Read as "this model is empty", that shows a user an empty directory for what is a typo, and would let a downloader fetch nothing and report success. So `listRepoFiles` reports a null list as `ErrNotFound` naming the revision — while keeping a genuinely **empty** list a real answer, since a repository is allowed to hold nothing.

The file endpoint has the mirror-image problem: `Revision=main` and `Revision=zzz-not-real` both give `404 Code 10990101007`, which is also what a missing file gives. `GetModelDetail` used to swallow that 404 and return a model with every field missing — so a mistyped revision rendered as a real checkpoint that says nothing about itself. Both it and `GetReadme` now consult the tree on a miss, and only on a miss (the happy path is still one request, asserted).

Verified by falsification as well as by passing: with the null-list guard replaced by "treat null as empty", `TestModelScope_ListRepoFilesRejectsANullFileList`, `...RejectsTheHubsDefaultBranchName`, `TestModelScope_GetModelDetailRejectsAnUnknownRevision` and `TestModelScope_GetReadmeRejectsAnUnknownRevision` all fail; restored, all pass.

## Not derived, reported missing

ModelScope publishes no equivalent of the Hub's `?expand[]=safetensors` tally. `StorageSize` is bytes on disk, not a parameter count, so `parameter_count` goes to `missing_fields` rather than being guessed at.

## Testing

Unit tests stub the transport and touch no network, per the ticket. The protocol they stub was measured against the live API first, not imagined: paging arithmetic including both sides of the 10000 boundary, the silent `PageSize` truncation, `Revision` omission, the 404 shapes, and the login-only credential check.

`TestModelScope_PageSizeNeverOverrunsTheWindow` is deliberately exhaustive over offset/limit combinations — the failure it guards is invisible to tests that only use round numbers, and shows up in production as an HTTP 500 from the hub.

### Verified before pushing

Run on a clean tree, with the no-`--fix` variants of the CI checks (`make lint` and `make test` both run `--fix` forms that rewrite files and then exit 0):

- `golangci-lint run` (v1.64.6, no `--fix`) — clean
- `go build ./...`, `go vet ./...` — clean
- `go test` over the CI package set — passes
- `scripts/check-boundaries.sh`, `scripts/check-migration-pairs.sh origin/main` — pass
- `git status --porcelain` empty afterwards

Every package this change touches passes: `internal/model_registry` 86.7% covered, `internal/routes/proxies` 77.6%, `internal/orchestrator` 68.6%, `cmd/neutree-cli/app/cmd/model` 56.4%, `internal/cli/model` 54.1%, `api/v1` 26.8%.

Three failures predate this branch. Each was re-run on a clean `origin/main` checkout and reproduces there unchanged, so none of them is from these changes:

- `TestClusterController_Sync_PendingOrNoStatus` panics in `syncInternalMetricsMonitor` (`cluster_controller.go:141`) — identical stack on `origin/main`.
- `TestNewObsCollectConfigManager/success_with_local_deploy_type` fails at `manager_test.go:44` — same failure on `origin/main`.
- `gofmt -l` flags `internal/routes/logs/trace_store_test.go` — also flagged on `origin/main`.

`make db-test` needs Docker Compose and was not run here; CI covers it. Migration 088 is a `CREATE OR REPLACE` of one function, based on 084 — re-checked after this rebase as still the latest migration to define `api.visibility()`, rather than carried over from the previous verification — with a `.down.sql` restoring 084's body. `scripts/check-migrations.sh origin/main` passes; it also caught the 087 collision on this branch before the renumber, which is as good a proof that it fires as an injected one.


