### PR TITLE
fix: reject negative model list pagination values

### DIFF
--- a/cmd/neutree-cli/app/cmd/model/list.go
+++ b/cmd/neutree-cli/app/cmd/model/list.go
@@ -89,7 +89,23 @@ func NewListCmd() *cobra.Command {
 	return cmd
 }
 
+func validatePagination(limit, offset int) error {
+	if limit < 0 {
+		return fmt.Errorf("--limit must be a non-negative integer, got %d", limit)
+	}
+
+	if offset < 0 {
+		return fmt.Errorf("--offset must be a non-negative integer, got %d", offset)
+	}
+
+	return nil
+}
+
 func runList(opts *listOptions) error {
+	if err := validatePagination(opts.limit, opts.offset); err != nil {
+		return err
+	}
+
 	clientOptions := []client.ClientOption{
 		client.WithAPIKey(global.APIKey),
 	}

--- a/cmd/neutree-cli/app/cmd/model/list_test.go
+++ b/cmd/neutree-cli/app/cmd/model/list_test.go
@@ -72,6 +72,64 @@ func TestRenderModelTableWritesOneLinePerModel(t *testing.T) {
 	require.True(t, strings.HasPrefix(lines[2], "b"))
 }
 
+func TestValidatePagination(t *testing.T) {
+	tests := []struct {
+		name      string
+		limit     int
+		offset    int
+		wantError string
+	}{
+		{name: "defaults", limit: 0, offset: 0},
+		{name: "positive values", limit: 10, offset: 20},
+		{name: "negative limit", limit: -1, offset: 0, wantError: "--limit must be a non-negative integer, got -1"},
+		{name: "negative offset", limit: 0, offset: -2, wantError: "--offset must be a non-negative integer, got -2"},
+		{
+			name:      "both negative reports limit first",
+			limit:     -3,
+			offset:    -4,
+			wantError: "--limit must be a non-negative integer, got -3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePagination(tt.limit, tt.offset)
+			if tt.wantError == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.EqualError(t, err, tt.wantError)
+		})
+	}
+}
+
+func TestRunListRejectsInvalidPaginationBeforeClientWork(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      listOptions
+		wantError string
+	}{
+		{
+			name:      "negative limit",
+			opts:      listOptions{limit: -1},
+			wantError: "--limit must be a non-negative integer, got -1",
+		},
+		{
+			name:      "negative offset",
+			opts:      listOptions{offset: -2},
+			wantError: "--offset must be a non-negative integer, got -2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.EqualError(t, runList(&tt.opts), tt.wantError)
+		})
+	}
+}
+
 func TestSummarisePageReportsTheServersTotal(t *testing.T) {
 	models := []v1.GeneralModel{{Name: "a"}, {Name: "b"}}
 	total := 42

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -81,6 +81,18 @@ type ModelListOptions struct {
 	Offset int
 }
 
+func (opts ModelListOptions) validate() error {
+	if opts.Limit < 0 {
+		return fmt.Errorf("limit must be a non-negative integer, got %d", opts.Limit)
+	}
+
+	if opts.Offset < 0 {
+		return fmt.Errorf("offset must be a non-negative integer, got %d", opts.Offset)
+	}
+
+	return nil
+}
+
 // ModelList is one page of a model listing.
 //
 // Raw is the response body exactly as the server sent it. Callers that render
@@ -108,6 +120,10 @@ type ModelList struct {
 
 // List lists models in the specified registry.
 func (s *ModelsService) List(workspace, registry string, opts ModelListOptions) (*ModelList, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
 	endpoint := fmt.Sprintf("%s/api/v1/workspaces/%s/model_registries/%s/models", s.client.baseURL, workspace, registry)
 
 	query := url.Values{}

--- a/pkg/client/model_test.go
+++ b/pkg/client/model_test.go
@@ -2,8 +2,11 @@ package client
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -82,6 +85,84 @@ func TestListOmitsUnsetQueryParameters(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, models.Models)
 	require.Nil(t, models.Total)
+}
+
+func TestListRejectsNegativePaginationBeforeRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      ModelListOptions
+		wantError string
+	}{
+		{
+			name:      "negative limit",
+			opts:      ModelListOptions{Limit: -1},
+			wantError: "limit must be a non-negative integer, got -1",
+		},
+		{
+			name:      "negative offset",
+			opts:      ModelListOptions{Offset: -2},
+			wantError: "offset must be a non-negative integer, got -2",
+		},
+		{
+			name:      "both negative reports limit first",
+			opts:      ModelListOptions{Limit: -3, Offset: -4},
+			wantError: "limit must be a non-negative integer, got -3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			defer server.Close()
+
+			c := NewClient(server.URL, WithAPIKey("api-key"))
+			models, err := c.Models.List("default", "registry", tt.opts)
+
+			require.Nil(t, models)
+			require.EqualError(t, err, tt.wantError)
+			require.Zero(t, requests.Load())
+		})
+	}
+}
+
+func TestListKeepsValidPaginationSemantics(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       ModelListOptions
+		wantLimit  string
+		wantOffset string
+	}{
+		{name: "defaults omit both parameters", opts: ModelListOptions{}},
+		{name: "zero values omit both parameters", opts: ModelListOptions{Limit: 0, Offset: 0}},
+		{name: "positive values", opts: ModelListOptions{Limit: 1, Offset: 2}, wantLimit: "1", wantOffset: "2"},
+		{
+			name:       "maximum integer values",
+			opts:       ModelListOptions{Limit: math.MaxInt, Offset: math.MaxInt},
+			wantLimit:  strconv.Itoa(math.MaxInt),
+			wantOffset: strconv.Itoa(math.MaxInt),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, tt.wantLimit, r.URL.Query().Get("limit"))
+				require.Equal(t, tt.wantOffset, r.URL.Query().Get("offset"))
+				_, _ = w.Write([]byte(`[]`))
+			}))
+			defer server.Close()
+
+			c := NewClient(server.URL, WithAPIKey("api-key"))
+			models, err := c.Models.List("default", "registry", tt.opts)
+
+			require.NoError(t, err)
+			require.Empty(t, models.Models)
+		})
+	}
 }
 
 // A server that names no range must not be read as one reporting the first


### PR DESCRIPTION
## Issue

NEU-675

## Summary

Reject negative `--limit` and `--offset` values in `neutree-cli model list` instead of silently omitting them and returning the default page.

## Changes

- Validate pagination values before creating a client or reading the model registry.
- Add defensive validation in `ModelsService.List` for non-CLI callers.
- Preserve the existing semantics for zero, positive, and maximum integer values.
- Add table-driven command and client tests, including zero-request assertions for invalid values.

## Test Plan

- [x] Target Go tests: `go test ./cmd/neutree-cli/app/cmd/model ./pkg/client -count=1`
- [x] Target `go vet` checks passed.
- [x] Repository architecture boundary checks passed.
- [x] `golangci-lint v1.64.6` passed for both affected packages using Go 1.23.0.
- [x] Integrated CLI fixture regression: 3/3 passed, including negative, combined-negative, and non-numeric pagination inputs with no HTTP request.
- [ ] Nightly artifact E2E: pending after a build containing this change is published.
- [x] DB integration: not affected.

## Risk & Rollback

The intentional compatibility change is limited to scripts that currently rely on negative pagination values being treated as unset. Zero and positive pagination behavior remains unchanged. Rollback consists of reverting this commit; there are no schema or server API changes.
