### PR TITLE
fix: reject model catalog writes that blank the spec (NEU-654)

### DIFF
--- a/contributing/database.md
+++ b/contributing/database.md
@@ -12,7 +12,7 @@
 
 - Location: `db/migrations/`.
 - Naming: `NNN_<description>.up.sql` + `NNN_<description>.down.sql`.
-- Current highest number: **084** — start new migrations at 085.
+- Current highest number: **085** — start new migrations at 086.
 - Any migration that touches RLS or permissions must ship with an integration test under `db/dbtest/`.
 - **Redefining an existing function**: `CREATE OR REPLACE` replaces the whole body, so base it on the *latest* migration that defines the function, not the first one you find. `grep -l 'FUNCTION api.<name>' db/migrations/*.up.sql` lists them all — copying an older body silently reverts every change made in between.
 

--- a/db/dbtest/model_catalog_spec_test.go
+++ b/db/dbtest/model_catalog_spec_test.go
@@ -1,0 +1,177 @@
+package dbtest
+
+import (
+	"database/sql"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// A write may not leave a model catalog with a spec that declares neither a
+// model nor variants. These go through PostgREST rather than plain SQL because
+// the destructive shape only exists there: a PATCH replaces the whole composite
+// spec column, so an empty spec in the payload blanks every attribute.
+
+// createTestModelCatalog stores a valid ordinary catalog and returns its id.
+func createTestModelCatalog(t *testing.T, db *sql.DB, s storage.Storage, name string) int {
+	t.Helper()
+
+	require.NoError(t, s.CreateModelCatalog(&v1.ModelCatalog{
+		APIVersion: "v1",
+		Kind:       "ModelCatalog",
+		Metadata:   &v1.Metadata{Name: name, Workspace: "default"},
+		Spec: &v1.ModelCatalogSpec{
+			Model:  &v1.ModelSpec{Registry: "huggingface", Name: "org/" + name},
+			Engine: &v1.EndpointEngineSpec{Engine: "vllm", Version: "v0.9.1"},
+		},
+	}))
+
+	var id int
+	require.NoError(t, db.QueryRow(
+		"SELECT id FROM api.model_catalogs WHERE (metadata).name = $1 AND (metadata).workspace = 'default'",
+		name,
+	).Scan(&id))
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM api.model_catalogs WHERE id = $1", id)
+	})
+
+	return id
+}
+
+func modelNameOf(t *testing.T, s storage.Storage, id int) string {
+	t.Helper()
+
+	got, err := s.GetModelCatalog(strconv.Itoa(id))
+	require.NoError(t, err)
+	require.NotNil(t, got.Spec)
+	require.NotNil(t, got.Spec.Model)
+
+	return got.Spec.Model.Name
+}
+
+// TestModelCatalogRejectsEmptySpec is the regression for the reported bug: an
+// edit carrying an empty spec reported success and blanked the stored recipe.
+func TestModelCatalogRejectsEmptySpec(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	id := createTestModelCatalog(t, db, s, "mc-empty-spec")
+	before := modelNameOf(t, s, id)
+
+	err := s.UpdateModelCatalog(strconv.Itoa(id), &v1.ModelCatalog{Spec: &v1.ModelCatalogSpec{}})
+	require.Error(t, err, "an update to an empty spec must be rejected")
+
+	assert.Equal(t, before, modelNameOf(t, s, id), "the rejected update must not have changed the spec")
+}
+
+func TestModelCatalogRejectsEmptySpecOnCreate(t *testing.T) {
+	s := NewTestStorage(t)
+
+	err := s.CreateModelCatalog(&v1.ModelCatalog{
+		APIVersion: "v1",
+		Kind:       "ModelCatalog",
+		Metadata:   &v1.Metadata{Name: "mc-empty-spec-create", Workspace: "default"},
+		Spec:       &v1.ModelCatalogSpec{},
+	})
+	require.Error(t, err, "a catalog with an empty spec must not be creatable")
+}
+
+// TestModelCatalogRejectsNullSpec covers the other blanking shape: `spec: null`
+// sets the whole composite column to NULL rather than to a row of NULLs.
+func TestModelCatalogRejectsNullSpec(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	id := createTestModelCatalog(t, db, s, "mc-null-spec")
+
+	_, err := db.Exec("UPDATE api.model_catalogs SET spec = NULL WHERE id = $1", id)
+	require.Error(t, err, "nulling the spec column must be rejected")
+
+	assert.Equal(t, "org/mc-null-spec", modelNameOf(t, s, id))
+}
+
+// TestModelCatalogAllowsRecipeSpec guards the false positive: a recipe catalog
+// declares no top-level model, only variants, and must stay writable.
+func TestModelCatalogAllowsRecipeSpec(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	require.NoError(t, s.CreateModelCatalog(&v1.ModelCatalog{
+		APIVersion: "v1",
+		Kind:       "ModelCatalog",
+		Metadata:   &v1.Metadata{Name: "mc-recipe", Workspace: "default"},
+		Spec: &v1.ModelCatalogSpec{
+			Engine:   &v1.EndpointEngineSpec{Engine: "vllm", Version: "v0.9.1"},
+			Variants: map[string]v1.RecipeVariant{"default": {Model: &v1.ModelSpec{Name: "org/model"}}},
+		},
+	}))
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM api.model_catalogs WHERE (metadata).name = 'mc-recipe'")
+	})
+}
+
+// TestModelCatalogAllowsStatusOnlyUpdate guards the controller's hot path: it
+// writes status without a spec, which must not trip the guard.
+func TestModelCatalogAllowsStatusOnlyUpdate(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	id := createTestModelCatalog(t, db, s, "mc-status-only")
+
+	require.NoError(t, s.UpdateModelCatalog(strconv.Itoa(id), &v1.ModelCatalog{
+		Status: &v1.ModelCatalogStatus{Phase: v1.ModelCatalogPhaseREADY},
+	}))
+
+	got, err := s.GetModelCatalog(strconv.Itoa(id))
+	require.NoError(t, err)
+	assert.Equal(t, v1.ModelCatalogPhaseREADY, got.Status.Phase)
+	assert.Equal(t, "org/mc-status-only", modelNameOf(t, s, id))
+}
+
+// TestModelCatalogAlreadyEmptySpecStaysWritable covers rows blanked before the
+// guard existed. Freezing them would be worse than the bug: the controller
+// could no longer write status, so they could never be reconciled or repaired.
+func TestModelCatalogAlreadyEmptySpecStaysWritable(t *testing.T) {
+	db := GetTestDB(t)
+	s := NewTestStorage(t)
+
+	// Simulate pre-migration data: the guard has to be off to produce a row it
+	// would otherwise reject.
+	_, err := db.Exec("ALTER TABLE api.model_catalogs DISABLE TRIGGER validate_spec_on_model_catalogs")
+	require.NoError(t, err)
+
+	_, err = db.Exec(`INSERT INTO api.model_catalogs (api_version, kind, metadata, spec)
+        VALUES ('v1', 'ModelCatalog', ROW('mc-legacy-empty', NULL, 'default', NULL, NOW(), NOW(), NULL, NULL)::api.metadata, NULL)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec("ALTER TABLE api.model_catalogs ENABLE TRIGGER validate_spec_on_model_catalogs")
+	require.NoError(t, err)
+
+	var id int
+	require.NoError(t, db.QueryRow(
+		"SELECT id FROM api.model_catalogs WHERE (metadata).name = 'mc-legacy-empty'",
+	).Scan(&id))
+
+	t.Cleanup(func() {
+		_, _ = db.Exec("DELETE FROM api.model_catalogs WHERE id = $1", id)
+	})
+
+	// The controller can still move it through its state machine ...
+	require.NoError(t, s.UpdateModelCatalog(strconv.Itoa(id), &v1.ModelCatalog{
+		Status: &v1.ModelCatalogStatus{Phase: v1.ModelCatalogPhaseFAILED},
+	}))
+
+	// ... and an operator can still repair it.
+	require.NoError(t, s.UpdateModelCatalog(strconv.Itoa(id), &v1.ModelCatalog{
+		Spec: &v1.ModelCatalogSpec{Model: &v1.ModelSpec{Name: "org/repaired"}},
+	}))
+
+	assert.Equal(t, "org/repaired", modelNameOf(t, s, id))
+}

--- a/db/migrations/085_model_catalog_spec_required.down.sql
+++ b/db/migrations/085_model_catalog_spec_required.down.sql
@@ -1,0 +1,9 @@
+-- Rollback NEU-654: drop the model catalog spec emptiness guard, restoring the
+-- behaviour where a write may blank the whole composite spec column.
+BEGIN;
+
+DROP TRIGGER IF EXISTS validate_spec_on_model_catalogs ON api.model_catalogs;
+DROP FUNCTION IF EXISTS api.validate_model_catalog_spec();
+DROP FUNCTION IF EXISTS api.model_catalog_spec_is_empty(api.model_catalog_spec);
+
+COMMIT;

--- a/db/migrations/085_model_catalog_spec_required.up.sql
+++ b/db/migrations/085_model_catalog_spec_required.up.sql
@@ -1,0 +1,57 @@
+-- NEU-654: reject a model catalog whose spec declares neither a model nor
+-- variants.
+--
+-- A PATCH replaces the whole composite spec column instead of merging into it,
+-- so a request carrying an empty spec (`spec: {}`, `spec: null`, or an object
+-- whose only keys the Go DTO does not know) does not partially update the
+-- catalog -- it blanks every attribute. The API middleware rejects those
+-- payloads, but it is not the only writer: neutree-core and the CLI reach
+-- PostgREST directly with the service role and bypass it entirely. The
+-- invariant belongs here, next to the metadata required-field triggers in
+-- 004_required_fields.
+--
+-- An ordinary catalog declares spec.model; a recipe catalog declares
+-- spec.variants. Note the row-wise IS NULL semantics: for a composite value it
+-- is true when every attribute is null, which is exactly the blanked spec this
+-- guards against.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION api.model_catalog_spec_is_empty(spec api.model_catalog_spec)
+RETURNS BOOLEAN AS $$
+    SELECT spec IS NULL
+        OR (
+            (spec).model IS NULL
+            AND (
+                (spec).variants IS NULL
+                OR (spec).variants::jsonb = '{}'::jsonb
+            )
+        );
+$$ LANGUAGE sql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION api.validate_model_catalog_spec()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NOT api.model_catalog_spec_is_empty(NEW.spec) THEN
+        RETURN NEW;
+    END IF;
+
+    -- Only the non-empty -> empty transition is destructive. A catalog whose
+    -- spec is already empty predates this guard and stays writable: blocking it
+    -- would stop its controller from writing status, leaving the row unable to
+    -- reconcile and unable to be repaired.
+    IF TG_OP = 'UPDATE' AND api.model_catalog_spec_is_empty(OLD.spec) THEN
+        RETURN NEW;
+    END IF;
+
+    RAISE sqlstate 'PGRST'
+        USING message = '{"code": "10045","message": "model_catalog spec must declare a model or variants","hint": "Omit spec to leave it unchanged, or send a spec with a model (variants for a recipe catalog)"}',
+              detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_spec_on_model_catalogs
+    BEFORE INSERT OR UPDATE ON api.model_catalogs
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_model_catalog_spec();
+
+COMMIT;

--- a/internal/recipe/validate.go
+++ b/internal/recipe/validate.go
@@ -27,6 +27,7 @@ const (
 //     ambiguous about which one wins.
 //   - Every feature's conflicts_with entry must reference a real feature key
 //     so misconfigured catalogs fail on write, not later at compose time.
+//   - Reject a spec that declares neither a model nor variants.
 func ValidateModelCatalogSpec(spec *v1.ModelCatalogSpec) error {
 	if spec == nil {
 		return nil
@@ -80,6 +81,13 @@ func ValidateModelCatalogSpec(spec *v1.ModelCatalogSpec) error {
 		if err := validateFeatureShape(feat.Name, feat); err != nil {
 			return err
 		}
+	}
+
+	// An ordinary catalog carries spec.model, a recipe catalog carries
+	// spec.variants. A spec with neither is undeployable, and a PATCH carrying
+	// one blanks the whole stored spec rather than merging into it.
+	if spec.Model == nil && len(spec.Variants) == 0 {
+		return fmt.Errorf("model_catalog: spec must declare a model or variants")
 	}
 
 	return nil

--- a/internal/recipe/validate_test.go
+++ b/internal/recipe/validate_test.go
@@ -71,6 +71,19 @@ func TestValidateModelCatalogSpec(t *testing.T) {
 			},
 			wantErr: "lists itself",
 		},
+		{
+			name:    "empty spec rejected",
+			in:      &v1.ModelCatalogSpec{},
+			wantErr: "must declare a model or variants",
+		},
+		{
+			name: "spec with neither model nor variants rejected",
+			in: &v1.ModelCatalogSpec{
+				Engine:   &v1.EndpointEngineSpec{Engine: "vllm"},
+				Features: []v1.RecipeFeature{{Name: "a"}},
+			},
+			wantErr: "must declare a model or variants",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/routes/proxies/model_catalog_proxy.go
+++ b/internal/routes/proxies/model_catalog_proxy.go
@@ -73,10 +73,10 @@ func validateModelCatalogRecipe() gin.HandlerFunc {
 		}
 
 		// PostgREST accepts both a single object and an array (bulk insert).
-		var catalogs []v1.ModelCatalog
+		docs := []json.RawMessage{trimmed}
 
 		if trimmed[0] == '[' {
-			if err := json.Unmarshal(trimmed, &catalogs); err != nil {
+			if err := json.Unmarshal(trimmed, &docs); err != nil {
 				c.JSON(http.StatusBadRequest, &validationError{
 					Code:    "10223",
 					Message: "invalid model_catalog payload: " + err.Error(),
@@ -86,27 +86,38 @@ func validateModelCatalogRecipe() gin.HandlerFunc {
 
 				return
 			}
-		} else {
-			var one v1.ModelCatalog
-			if err := json.Unmarshal(trimmed, &one); err != nil {
-				c.JSON(http.StatusBadRequest, &validationError{
-					Code:    "10223",
-					Message: "invalid model_catalog payload: " + err.Error(),
-					Hint:    "Check the model catalog spec fields and types",
-				})
-				c.Abort()
-
-				return
-			}
-
-			catalogs = []v1.ModelCatalog{one}
 		}
 
-		for _, catalog := range catalogs {
-			// A metadata-only PATCH carries no spec — nothing recipe-related to
-			// validate.
+		for _, doc := range docs {
+			var catalog v1.ModelCatalog
+			if err := json.Unmarshal(doc, &catalog); err != nil {
+				c.JSON(http.StatusBadRequest, &validationError{
+					Code:    "10223",
+					Message: "invalid model_catalog payload: " + err.Error(),
+					Hint:    "Check the model catalog spec fields and types",
+				})
+				c.Abort()
+
+				return
+			}
+
+			// A nil Spec means either a metadata-only write, which carries
+			// nothing recipe-related to validate, or an explicit `spec: null`,
+			// which blanks the stored spec. Only the raw document tells the two
+			// apart.
 			if catalog.Spec == nil {
-				continue
+				if !specIsExplicitNull(doc) {
+					continue
+				}
+
+				c.JSON(http.StatusBadRequest, &validationError{
+					Code:    "10224",
+					Message: "model_catalog: spec must declare a model or variants",
+					Hint:    "Omit spec to leave it unchanged, or send a spec with a model (variants for a recipe catalog)",
+				})
+				c.Abort()
+
+				return
 			}
 
 			if err := recipe.ValidateModelCatalogSpec(catalog.Spec); err != nil {
@@ -123,4 +134,18 @@ func validateModelCatalogRecipe() gin.HandlerFunc {
 
 		c.Next()
 	}
+}
+
+// specIsExplicitNull reports whether the document carries a `spec` key set to
+// JSON null, as opposed to omitting the key altogether.
+func specIsExplicitNull(doc json.RawMessage) bool {
+	var fields struct {
+		Spec json.RawMessage `json:"spec"`
+	}
+
+	if err := json.Unmarshal(doc, &fields); err != nil {
+		return false
+	}
+
+	return bytes.Equal(bytes.TrimSpace(fields.Spec), []byte("null"))
 }

--- a/internal/routes/proxies/model_catalog_proxy_test.go
+++ b/internal/routes/proxies/model_catalog_proxy_test.go
@@ -16,9 +16,11 @@ import (
 func newRecipeValidationRouter() *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.POST("/model_catalogs", validateModelCatalogRecipe(), func(c *gin.Context) {
+	stub := func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"proxied": true})
-	})
+	}
+	r.POST("/model_catalogs", validateModelCatalogRecipe(), stub)
+	r.PATCH("/model_catalogs", validateModelCatalogRecipe(), stub)
 
 	return r
 }
@@ -38,6 +40,7 @@ func TestValidateModelCatalogRecipe(t *testing.T) {
 
 	tests := []struct {
 		name              string
+		method            string
 		body              string
 		expectStatus      int
 		expectCode        string
@@ -79,12 +82,65 @@ func TestValidateModelCatalogRecipe(t *testing.T) {
 			expectCode:        "10224",
 			expectMessagePart: "lists itself in conflicts_with",
 		},
+		// NEU-654: a PATCH replaces the whole composite spec column, so every
+		// payload below asks to blank the stored catalog rather than to leave
+		// it alone. None of them may reach the proxy.
+		{
+			name:              "empty spec object is rejected",
+			method:            http.MethodPatch,
+			body:              `{"spec": {}}`,
+			expectStatus:      http.StatusBadRequest,
+			expectCode:        "10224",
+			expectMessagePart: "must declare a model or variants",
+		},
+		{
+			name:              "explicit null spec is rejected",
+			method:            http.MethodPatch,
+			body:              `{"spec": null}`,
+			expectStatus:      http.StatusBadRequest,
+			expectCode:        "10224",
+			expectMessagePart: "must declare a model or variants",
+		},
+		{
+			name:              "spec of only unknown fields is rejected",
+			method:            http.MethodPatch,
+			body:              `{"spec": {"spec": null}}`,
+			expectStatus:      http.StatusBadRequest,
+			expectCode:        "10224",
+			expectMessagePart: "must declare a model or variants",
+		},
+		{
+			name:              "empty spec inside a bulk array is rejected",
+			method:            http.MethodPost,
+			body:              "[" + validRecipe + `, {"spec": {}}]`,
+			expectStatus:      http.StatusBadRequest,
+			expectCode:        "10224",
+			expectMessagePart: "must declare a model or variants",
+		},
+		{
+			name:         "metadata-only patch passes through",
+			method:       http.MethodPatch,
+			body:         `{"metadata": {"name": "mc", "workspace": "default"}}`,
+			expectStatus: http.StatusOK,
+		},
+		{
+			name:         "spec-only patch with a model passes through",
+			method:       http.MethodPatch,
+			body:         `{"spec": {"model": {"registry": "hf", "name": "org/model"}}}`,
+			expectStatus: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			router := newRecipeValidationRouter()
-			req := httptest.NewRequest(http.MethodPost, "/model_catalogs", strings.NewReader(tt.body))
+
+			method := tt.method
+			if method == "" {
+				method = http.MethodPost
+			}
+
+			req := httptest.NewRequest(method, "/model_catalogs", strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", "application/json")
 			w := httptest.NewRecorder()
 


### PR DESCRIPTION
## Issue

NEU-654

## Summary

A model catalog PATCH replaces the whole composite `spec` column instead of merging into it, so a payload carrying an empty spec does not partially update the catalog — it blanks every attribute. Three shapes did exactly that while reporting success: `spec: {}`, `spec: null`, and an object whose only keys the Go DTO does not know (`spec: {spec: null}`, which is what a bare-spec YAML document of `spec: null` produces). Model catalogs keep no version history, so the original recipe had to be reconstructed or re-imported by hand.

## Changes

- `internal/recipe/validate.go` — reject a spec declaring neither `model` nor `variants`. Checked last so a spec that is malformed *and* empty still reports the more specific problem.
- `internal/routes/proxies/model_catalog_proxy.go` — validate per raw document so an omitted `spec` can be told apart from an explicit `spec: null`. Both decode to a nil pointer, but the first is a metadata-only write with nothing to validate and the second asks to blank the column; only the raw JSON distinguishes them, which is why `spec: null` previously bypassed every Go-side check.
- `db/migrations/084_model_catalog_spec_required.{up,down}.sql` — the same invariant as a trigger, next to the metadata required-field checks in `004_required_fields`. The API is not the only writer: neutree-core and the CLI reach PostgREST directly with the service role and bypass the middleware entirely.
- Tests: 6 new `db/dbtest` cases and unit tests for both new rejection paths.

The trigger rejects only the non-empty → empty transition. A catalog blanked before this change has to stay writable — otherwise its controller could no longer write status, so the row could never be reconciled, nor repaired, since the repairing write would be rejected too.

Scope is server-side only. The YAML editor still sends the request and surfaces the API error; a parse-level, line-locatable message in the editor is out of scope here, as the UI has no shared mechanism for that class of validation yet.

## Test Plan

- [x] E2E (if affected): not affected — covered by the DB integration tests below plus a manual replay of the reported reproduction against a full local stack (migrations + PostgREST v14 + `neutree-api`). All three destructive payloads now return `400 / 10224` with the stored spec unchanged; whole-document edit (204), recipe catalog create (201), metadata-only PATCH (204) and the existing recipe negative checks are unaffected. Writing `{"spec":{}}` straight to PostgREST with the service role — bypassing the middleware — returns `400 / 10045` from the trigger.
- [x] DB integration (`make db-test`): pass, `ok github.com/neutree-ai/neutree/db/dbtest 7.5s`. New cases: empty spec on create and on update, `spec = NULL`, recipe catalog stays writable, status-only update stays writable, already-empty row stays writable.

## Risk & Rollback

Schema change: adds `api.model_catalog_spec_is_empty()`, `api.validate_model_catalog_spec()` and the `validate_spec_on_model_catalogs` trigger. No table or type change; `084_*.down.sql` drops all three.

Backward compat: writes that were already valid are unaffected — the controller's status-only updates leave `spec` untouched, and recipe catalogs (no top-level `model`) are explicitly allowed. The one behaviour change for existing clients is that a write blanking a catalog's spec now fails instead of silently succeeding. Rows blanked before this change keep working, by design.

New error codes: `10224` (API, reuses the existing recipe-validation code) and `10045` (SQL, next in the `100xx` required-field family after `10044` in `079_api_key_workspace_required`).
