### PR TITLE
fix: enable SSH ControlMaster reuse for static node reconciler

### DIFF
--- a/internal/cluster/staticnode/runner.go
+++ b/internal/cluster/staticnode/runner.go
@@ -79,6 +79,10 @@ func (f *SSHRunnerFactory) NewStaticNodeRunner(
 		sshControlPath = cleanupDir
 	}
 
+	// Keyless (agent-auth) nodes have no temp key dir, so cleanupDir is empty and
+	// ControlMaster reuse stays off for them — each command opens a fresh
+	// connection, matching the pre-existing behavior.
+
 	return &staticNodeSSHRunner{
 		runner: commandrunner.NewSSHCommandRunner(
 			staticNodeRunnerID(node),
@@ -105,7 +109,19 @@ func (r *staticNodeSSHRunner) Files() commandrunner.FileClient {
 }
 
 func (r *staticNodeSSHRunner) Close() error {
-	if r == nil || r.cleanupDir == "" {
+	if r == nil {
+		return nil
+	}
+
+	// Reap the multiplexed master (if any) before unlinking its socket dir, so a
+	// ControlMaster=auto background daemon can't keep an authenticated connection
+	// to the node alive for ControlPersist after the cycle ends. Best-effort: a
+	// missing/stale socket is normal, and the real cleanup below is RemoveAll.
+	if r.runner != nil {
+		_ = r.runner.CloseControlMaster(context.Background())
+	}
+
+	if r.cleanupDir == "" {
 		return nil
 	}
 

--- a/internal/cluster/staticnode/runner.go
+++ b/internal/cluster/staticnode/runner.go
@@ -70,6 +70,15 @@ func (f *SSHRunnerFactory) NewStaticNodeRunner(
 		processExecute = executor.Execute
 	}
 
+	// Default the ControlPath to the per-runner temporary key directory. Scoping
+	// the multiplexed socket to the runner's own key dir keeps every reconcile
+	// cycle on a fresh ControlMaster (credential rotation takes effect
+	// immediately) while collapsing dozens of per-command SSH connections into
+	// one within the cycle. An explicit SSHControlPath override wins when set.
+	if sshControlPath == "" {
+		sshControlPath = cleanupDir
+	}
+
 	return &staticNodeSSHRunner{
 		runner: commandrunner.NewSSHCommandRunner(
 			staticNodeRunnerID(node),

--- a/internal/cluster/staticnode/runner_test.go
+++ b/internal/cluster/staticnode/runner_test.go
@@ -146,9 +146,22 @@ func TestStaticNodeRunnerControlPathScopedToRunnerKeyDir(t *testing.T) {
 
 	// Master options must be present so commands reuse the connection.
 	assert.Contains(t, calls[0].args, "ControlMaster=auto")
-	assert.Contains(t, calls[0].args, "ControlPersist=600s")
+	assert.Contains(t, calls[0].args, "ControlPersist="+commandrunner.SSHControlPersist)
 
+	// The real command must multiplex onto the same control path as the precheck,
+	// so the precheck becomes the master and the command rides it.
+	require.Len(t, calls, 2)
+	realControlPath := sshControlPath(calls[1].args)
+	assert.Equal(t, controlPath, realControlPath,
+		"real command should reuse the precheck's ControlPath")
+
+	// Close() must terminate the lingering multiplexed master (not just unlink
+	// the socket) so it cannot hold an authenticated connection past the cycle.
 	require.NoError(t, runner.Close())
+	require.Len(t, calls, 3)
+	require.Equal(t, "ssh", calls[2].name)
+	assert.Contains(t, calls[2].args, "-O")
+	assert.Contains(t, calls[2].args, "exit")
 }
 
 func TestSSHRunnerFactoryControlPathOverride(t *testing.T) {
@@ -184,7 +197,7 @@ func TestSSHRunnerFactoryControlPathOverride(t *testing.T) {
 
 	controlPath := sshControlPath(calls[0].args)
 	require.NotEmpty(t, controlPath)
-	assert.True(t, strings.HasPrefix(controlPath, override),
+	assert.Equal(t, override+"/%C", controlPath,
 		"explicit SSHControlPath %q should take precedence; got %q", override, controlPath)
 
 	require.NoError(t, runner.Close())

--- a/internal/cluster/staticnode/runner_test.go
+++ b/internal/cluster/staticnode/runner_test.go
@@ -3,6 +3,8 @@ package staticnode
 import (
 	"context"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,4 +92,100 @@ func sshArgValue(args []string, flag string) string {
 	}
 
 	return ""
+}
+
+func sshControlPath(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-o" && i+1 < len(args) && strings.HasPrefix(args[i+1], "ControlPath=") {
+			return strings.TrimPrefix(args[i+1], "ControlPath=")
+		}
+	}
+
+	return ""
+}
+
+func TestStaticNodeRunnerControlPathScopedToRunnerKeyDir(t *testing.T) {
+	var calls []processCall
+	factory := &SSHRunnerFactory{
+		ProcessExecute: func(_ context.Context, name string, args []string) ([]byte, error) {
+			calls = append(calls, processCall{name: name, args: args})
+			return []byte("up\n"), nil
+		},
+	}
+
+	runner, err := factory.NewStaticNodeRunner(context.Background(), &v1.StaticNode{
+		Metadata: &v1.Metadata{
+			Workspace: "default",
+			Name:      "head-0",
+		},
+		Spec: &v1.StaticNodeSpec{
+			IP: "10.0.0.10",
+			SSHAuth: &v1.Auth{
+				SSHUser:       "ray",
+				SSHPrivateKey: "cmF5LXBlbQo=",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = runner.Run(context.Background(), "docker ps")
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	require.Equal(t, "ssh", calls[0].name)
+
+	// ControlPath must be set (ControlMaster reuse active) and scoped inside the
+	// per-runner temp key dir, not a shared global path.
+	controlPath := sshControlPath(calls[0].args)
+	require.NotEmpty(t, controlPath, "ControlPath option must be present when reuse is enabled")
+	assert.True(t, strings.HasSuffix(controlPath, "/%C"),
+		"ControlPath %q should use the OpenSSH %%C hashed per-target filename", controlPath)
+
+	keyDir := filepath.Dir(sshArgValue(calls[0].args, "-i"))
+	assert.True(t, strings.HasPrefix(controlPath, keyDir),
+		"ControlPath %q should be scoped to the per-runner key dir %q", controlPath, keyDir)
+
+	// Master options must be present so commands reuse the connection.
+	assert.Contains(t, calls[0].args, "ControlMaster=auto")
+	assert.Contains(t, calls[0].args, "ControlPersist=600s")
+
+	require.NoError(t, runner.Close())
+}
+
+func TestSSHRunnerFactoryControlPathOverride(t *testing.T) {
+	var calls []processCall
+	override := "/var/run/neutree-ssh-mux"
+	factory := &SSHRunnerFactory{
+		ProcessExecute: func(_ context.Context, name string, args []string) ([]byte, error) {
+			calls = append(calls, processCall{name: name, args: args})
+			return []byte("up\n"), nil
+		},
+		SSHControlPath: override,
+	}
+
+	runner, err := factory.NewStaticNodeRunner(context.Background(), &v1.StaticNode{
+		Metadata: &v1.Metadata{
+			Workspace: "default",
+			Name:      "head-0",
+		},
+		Spec: &v1.StaticNodeSpec{
+			IP: "10.0.0.10",
+			SSHAuth: &v1.Auth{
+				SSHUser:       "ray",
+				SSHPrivateKey: "cmF5LXBlbQo=",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = runner.Run(context.Background(), "docker ps")
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	require.Equal(t, "ssh", calls[0].name)
+
+	controlPath := sshControlPath(calls[0].args)
+	require.NotEmpty(t, controlPath)
+	assert.True(t, strings.HasPrefix(controlPath, override),
+		"explicit SSHControlPath %q should take precedence; got %q", override, controlPath)
+
+	require.NoError(t, runner.Close())
 }

--- a/pkg/command_runner/ssh_command_runner.go
+++ b/pkg/command_runner/ssh_command_runner.go
@@ -187,7 +187,12 @@ func (s *SSHCommandRunner) getSSHOptions(sshOptionsOverrideSSHKey string) []stri
 		sshOptions = append(sshOptions,
 			"-o", "ControlMaster=auto",
 			"-o", fmt.Sprintf("ControlPath=%s/%%C", s.sshControlPath),
-			"-o", "ControlPersist=10s",
+			// Keep the multiplexed master alive across an entire reconcile cycle:
+			// component config writes, docker inspect/pull/run, and health checks
+			// can be separated by more than the old 10s, which would let the master
+			// exit and break reuse mid-cycle. 600s comfortably exceeds a full static
+			// node reconcile; the per-runner socket is removed on Close regardless.
+			"-o", "ControlPersist=600s",
 		)
 	}
 

--- a/pkg/command_runner/ssh_command_runner.go
+++ b/pkg/command_runner/ssh_command_runner.go
@@ -13,6 +13,13 @@ import (
 
 var (
 	ErrConnectionFailed = errors.New("connection failed")
+
+	// SSHControlPersist is the ControlPersist duration for the multiplexed SSH
+	// master. It must comfortably exceed the gap between commands within a single
+	// static node reconcile cycle (config writes, docker inspect/pull/run, health
+	// checks), which can be separated by minutes. The master is terminated
+	// explicitly on runner Close, so the generous ceiling is safe.
+	SSHControlPersist = "600s"
 )
 
 // staticClusterConnectionHint is appended to SSH connection-failure errors so
@@ -187,12 +194,7 @@ func (s *SSHCommandRunner) getSSHOptions(sshOptionsOverrideSSHKey string) []stri
 		sshOptions = append(sshOptions,
 			"-o", "ControlMaster=auto",
 			"-o", fmt.Sprintf("ControlPath=%s/%%C", s.sshControlPath),
-			// Keep the multiplexed master alive across an entire reconcile cycle:
-			// component config writes, docker inspect/pull/run, and health checks
-			// can be separated by more than the old 10s, which would let the master
-			// exit and break reuse mid-cycle. 600s comfortably exceeds a full static
-			// node reconcile; the per-runner socket is removed on Close regardless.
-			"-o", "ControlPersist=600s",
+			"-o", "ControlPersist="+SSHControlPersist,
 		)
 	}
 
@@ -201,4 +203,23 @@ func (s *SSHCommandRunner) getSSHOptions(sshOptionsOverrideSSHKey string) []stri
 	}
 
 	return sshOptions
+}
+
+// CloseControlMaster asks the multiplexed master (if any) to shut down. A
+// ControlMaster=auto connection daemonizes a background master that outlives the
+// originating command, so merely unlinking the socket (e.g. RemoveAll on the
+// ControlPath dir) leaves that master holding an authenticated connection until
+// ControlPersist expires. Closing it explicitly reaps it at the runner boundary.
+// A missing/stale socket (no master started this cycle) surfaces as an error,
+// which callers treat as best-effort cleanup.
+func (s *SSHCommandRunner) CloseControlMaster(ctx context.Context) error {
+	if s.sshControlPath == "" {
+		return nil
+	}
+
+	sshOptions := append(s.getSSHOptions(""), "-O", "exit", fmt.Sprintf("%s@%s", s.sshUser, s.sshIP))
+
+	_, err := s.processExecute(ctx, "ssh", sshOptions)
+
+	return err
 }

--- a/pkg/command_runner/ssh_command_runner_test.go
+++ b/pkg/command_runner/ssh_command_runner_test.go
@@ -220,6 +220,19 @@ func TestSSHCommandRunner_getSSHOptions_NoControlPath(t *testing.T) {
 }
 
 func TestSSHCommandRunner_getSSHOptions_WithControlPath(t *testing.T) {
+	controlPath := "/tmp/neutree-test-mux"
+	runner := NewSSHCommandRunner(testNode, testSSHIP, v1.Auth{
+		SSHPrivateKey: testSSHPrivateKey,
+		SSHUser:       testSSHUser,
+	}, controlPath, nil)
+
+	options := runner.getSSHOptions("")
+	assert.Contains(t, options, "ControlMaster=auto")
+	assert.Contains(t, options, "ControlPath="+controlPath+"/%C")
+	assert.Contains(t, options, "ControlPersist="+SSHControlPersist)
+}
+
+func TestSSHCommandRunner_CloseControlMaster(t *testing.T) {
 	mockExec := new(commandmocks.MockExecutor)
 	controlPath := "/tmp/neutree-test-mux"
 	runner := NewSSHCommandRunner(testNode, testSSHIP, v1.Auth{
@@ -227,10 +240,28 @@ func TestSSHCommandRunner_getSSHOptions_WithControlPath(t *testing.T) {
 		SSHUser:       testSSHUser,
 	}, controlPath, mockExec.Execute)
 
-	options := runner.getSSHOptions("")
-	assert.Contains(t, options, "ControlMaster=auto")
-	assert.Contains(t, options, "ControlPath="+controlPath+"/%C")
-	assert.Contains(t, options, "ControlPersist=600s")
+	mockExec.On("Execute", mock.Anything, "ssh", mock.Anything).Run(func(args mock.Arguments) {
+		cmd := args.Get(2).([]string)
+		assert.Contains(t, strings.Join(cmd, " "), "-O")
+		assert.Contains(t, strings.Join(cmd, " "), "exit")
+		assert.Contains(t, strings.Join(cmd, " "), "ControlPath="+controlPath+"/%C")
+	}).Return([]byte(""), nil).Once()
+
+	err := runner.CloseControlMaster(context.Background())
+	assert.NoError(t, err)
+	mockExec.AssertExpectations(t)
+}
+
+func TestSSHCommandRunner_CloseControlMaster_NoControlPath(t *testing.T) {
+	mockExec := new(commandmocks.MockExecutor)
+	runner := NewSSHCommandRunner(testNode, testSSHIP, v1.Auth{
+		SSHPrivateKey: testSSHPrivateKey,
+		SSHUser:       testSSHUser,
+	}, "", mockExec.Execute)
+
+	err := runner.CloseControlMaster(context.Background())
+	assert.NoError(t, err)
+	mockExec.AssertNotCalled(t, "Execute", mock.Anything, "ssh", mock.Anything)
 }
 
 func TestSSHCommandRunner_CheckConnection_PreservesUnderlyingErrorAsConnectionFailed(t *testing.T) {

--- a/pkg/command_runner/ssh_command_runner_test.go
+++ b/pkg/command_runner/ssh_command_runner_test.go
@@ -219,6 +219,20 @@ func TestSSHCommandRunner_getSSHOptions_NoControlPath(t *testing.T) {
 	assert.NotContains(t, options, "ControlPersist=10s")
 }
 
+func TestSSHCommandRunner_getSSHOptions_WithControlPath(t *testing.T) {
+	mockExec := new(commandmocks.MockExecutor)
+	controlPath := "/tmp/neutree-test-mux"
+	runner := NewSSHCommandRunner(testNode, testSSHIP, v1.Auth{
+		SSHPrivateKey: testSSHPrivateKey,
+		SSHUser:       testSSHUser,
+	}, controlPath, mockExec.Execute)
+
+	options := runner.getSSHOptions("")
+	assert.Contains(t, options, "ControlMaster=auto")
+	assert.Contains(t, options, "ControlPath="+controlPath+"/%C")
+	assert.Contains(t, options, "ControlPersist=600s")
+}
+
 func TestSSHCommandRunner_CheckConnection_PreservesUnderlyingErrorAsConnectionFailed(t *testing.T) {
 	mockExec := new(commandmocks.MockExecutor)
 	runner := newSSHCommandRunner(mockExec)


### PR DESCRIPTION
## Issue

n/a (direct description — operational bug found during static node cluster troubleshooting)

## Summary

Static node reconcile issues dozens of fresh SSH connections per cycle (each `Run()` = a `checkConnection` precheck plus the real command, with no multiplexing). When public SSH scan traffic occupies the sshd `MaxStartups` unauthenticated-connection slot, those bursts get dropped at the `kex_exchange_identification` stage, surfacing as `Connection reset by peer` and spurious `ImagePullFailed` / `ConfigWriteFailed` component failures on static nodes.

This wires up the already-present ControlMaster plumbing by defaulting the ControlPath to the per-runner temporary key directory and raising `ControlPersist`, so one reconcile cycle rides a single multiplexed connection instead of dozens.

## Changes

- `internal/cluster/staticnode/runner.go`: default `sshControlPath` to the per-runner temp key dir (`cleanupDir`) when no explicit `SSHControlPath` override is set. Scoping the multiplexed socket per-reconcile means credential rotation takes effect immediately and the socket is removed with the key dir on `Close()`.
- `pkg/command_runner/ssh_command_runner.go`: raise `ControlPersist` to a single sourced const (`SSHControlPersist = "600s"`) so the master survives the gaps between config writes, docker inspect/pull/run, and health checks within a reconcile cycle.
- `pkg/command_runner/ssh_command_runner.go`: add `CloseControlMaster()` — issues `ssh -O exit` to terminate the daemonized master on runner `Close()`, so a `ControlMaster=auto` background daemon can't hold an authenticated connection to the node for the full `ControlPersist` after the cycle ends.
- Tests (TDD): `TestSSHCommandRunner_getSSHOptions_WithControlPath`, `TestSSHCommandRunner_CloseControlMaster`, `TestStaticNodeRunnerControlPathScopedToRunnerKeyDir`, `TestSSHRunnerFactoryControlPathOverride`.

## Test Plan

- [x] Unit: `go test ./pkg/command_runner/... ./internal/cluster/staticnode/... -race` — PASS (RED observed on new tests before implementation)
- [x] Vet / lint: `go vet` + `golangci-lint` (repo-pinned v1.64.6) on changed packages — PASS
- [x] Manual e2e (hot-updated control plane on 10.255.1.54, static node 10.255.1.136):
  - Created static cluster `mux-test-*` (image registry `192.168.22.100/neutree-test`, cluster v1.1.1) and reconciled it to `phase: Running`, `ready_nodes: 1`, no error.
  - **Connection convergence**: during reconcile, `ss -tn state established '( sport = :22 )'` on the node showed exactly **1** established connection from the CP across 10 consecutive 1s samples (previously a burst of dozens per command-pair).
  - **Master reap**: the `[mux]` ControlMaster daemon becomes `<defunct>` after the cycle and the per-runner socket dir is removed (`/tmp/ssh-key-*` count = 0), confirming `Close()`'s `-O exit` + `RemoveAll` cleanup works with zero leak.
  - **Bug absent**: no `kex_exchange_identification: Connection reset by peer`, no `ImagePullFailed` / `ConfigWriteFailed` throughout the reconcile.
- [x] DB integration: not affected (no DB/schema change)

## Risk & Rollback

Low. Change is confined to SSH client option generation for static-node runners only (`ray_ssh_cluster` / `model_connect` paths intentionally left with empty ControlPath — same dead-code status as before, tracked as follow-up). Rollback = revert the commit; no DB migration or API contract change. The per-runner socket lives in the same temp dir as the SSH key and is terminated on runner `Close()` via `ssh -O exit`, so no stale-socket or orphaned-master accumulation.