### PR TITLE
feat(db): add API key project workflows

### DIFF
--- a/db/dbtest/api_key_projects_test.go
+++ b/db/dbtest/api_key_projects_test.go
@@ -1,0 +1,209 @@
+package dbtest
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+func TestAPIKeyProjects(t *testing.T) {
+	db := GetTestDB(t)
+	user := CreateTestUser(t, "project-test", "project-test@example.com", "password")
+
+	WithUserContext(t, db, user.ID, func(tx *sql.Tx) {
+		var projectCount int
+		if err := tx.QueryRow(`SELECT count(*) FROM api.list_api_key_projects('default')`).Scan(&projectCount); err != nil {
+			t.Fatalf("list empty projects: %v", err)
+		}
+		if projectCount != 1 {
+			t.Fatalf("new users must receive one Default project, got %d", projectCount)
+		}
+
+		var defaultID string
+		var isDefault bool
+		if err := tx.QueryRow(`SELECT id, is_default FROM api.list_api_key_projects('default') WHERE name='Default'`).Scan(&defaultID, &isDefault); err != nil {
+			t.Fatalf("find Default project: %v", err)
+		}
+		if !isDefault {
+			t.Fatal("automatically created Default project must carry is_default=true")
+		}
+		if _, err := tx.Exec(`SELECT api.delete_api_key_project($1)`, defaultID); err == nil || !strings.Contains(err.Error(), "cannot be deleted") {
+			t.Fatalf("expected protected Default delete, got %v", err)
+		}
+
+		var source, target, disabled string
+		for _, item := range []struct {
+			name    string
+			enabled bool
+			dest    *string
+		}{
+			{"Source", true, &source}, {"Target", true, &target}, {"Disabled", false, &disabled},
+		} {
+			err := tx.QueryRow(`SELECT id FROM api.create_api_key_project('ws-a', $1, '')`, item.name).Scan(item.dest)
+			if err != nil {
+				t.Fatalf("create project %s: %v", item.name, err)
+			}
+			if !item.enabled {
+				if _, err = tx.Exec(`UPDATE api.api_key_projects SET enabled=false WHERE id=$1`, *item.dest); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+
+		var key1, key2 string
+		if err := tx.QueryRow(`SELECT id FROM api.create_api_key('ws-a','same',0,NULL,NULL,NULL,$1,'first')`, source).Scan(&key1); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.QueryRow(`SELECT id FROM api.create_api_key('ws-a','same',0,NULL,NULL,NULL,$1,'second')`, target).Scan(&key2); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tx.Exec(`SELECT api.create_api_key('ws-a','客服机器人（生产）',0,NULL,NULL,NULL,$1,'中文名称')`, source); err != nil {
+			t.Fatalf("create API key with Chinese name and punctuation: %v", err)
+		}
+		if _, err := tx.Exec(`SELECT api.create_api_key('ws-a','   ',0,NULL,NULL,NULL,$1,'blank name')`, source); err == nil || !strings.Contains(err.Error(), "name is required") {
+			t.Fatalf("expected blank API key name rejection, got %v", err)
+		}
+
+		var moved int
+		if err := tx.QueryRow(`SELECT api.move_api_keys_to_project(ARRAY[$1::uuid],$2)`, key1, target).Scan(&moved); err != nil {
+			t.Fatalf("move API key beside a same-name key: %v", err)
+		}
+		if moved != 1 {
+			t.Fatalf("moved=%d want 1", moved)
+		}
+		if _, err := tx.Exec(`SELECT api.move_api_keys_to_project(ARRAY[$1::uuid],$2)`, key1, disabled); err == nil || !strings.Contains(err.Error(), "disabled") {
+			t.Fatalf("expected disabled error, got %v", err)
+		}
+		if _, err := tx.Exec(`SELECT api.delete_api_key_project($1)`, source); err == nil || !strings.Contains(err.Error(), "1 API keys") {
+			t.Fatalf("expected protected delete, got %v", err)
+		}
+
+		if _, err := tx.Exec(`DELETE FROM api.api_keys WHERE id=$1`, key2); err != nil {
+			t.Fatal(err)
+		}
+		var history int
+		if err := tx.QueryRow(`SELECT count(*) FROM api.api_key_project_history WHERE api_key_id=$1`, key1).Scan(&history); err != nil || history != 1 {
+			t.Fatalf("history=%d err=%v", history, err)
+		}
+
+		var count, total int
+		if err := tx.QueryRow(`SELECT api_key_count, total_projects FROM api.get_api_key_project_groups('ws-a',NULL,NULL,NULL,1,1) LIMIT 1`).Scan(&count, &total); err != nil {
+			t.Fatal(err)
+		}
+		if total != 3 {
+			t.Fatalf("total projects=%d want 3", total)
+		}
+		var totalKeys int
+		if err := tx.QueryRow(`SELECT api.count_api_key_project_group_api_keys('ws-a',NULL,NULL,NULL)`).Scan(&totalKeys); err != nil {
+			t.Fatal(err)
+		}
+		if totalKeys != 2 {
+			t.Fatalf("total API keys=%d want 2", totalKeys)
+		}
+
+		if _, err := tx.Exec(`SELECT api.create_api_key_project('ws-b', 'Other workspace', '')`); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.QueryRow(`SELECT max(total_projects) FROM api.get_api_key_project_groups(NULL,NULL,NULL,NULL,1,20)`).Scan(&total); err != nil {
+			t.Fatal(err)
+		}
+		if total != 5 {
+			t.Fatalf("all-workspace total=%d want 5", total)
+		}
+
+		var keysJSON string
+		if err := tx.QueryRow(`SELECT api_keys::text FROM api.get_api_key_project_groups('ws-a','Target',NULL,NULL,1,20) WHERE (project).id=$1`, target).Scan(&keysJSON); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(keysJSON, `"name": "same"`) {
+			t.Fatalf("project match must return all keys: %s", keysJSON)
+		}
+		if err := tx.QueryRow(`SELECT api_keys::text FROM api.get_api_key_project_groups('ws-a','first',NULL,NULL,1,20) WHERE (project).id=$1`, target).Scan(&keysJSON); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(keysJSON, `"description": "first"`) {
+			t.Fatalf("key search did not return match: %s", keysJSON)
+		}
+		if err := tx.QueryRow(`SELECT api.count_api_key_project_group_api_keys('ws-a','first',NULL,NULL)`).Scan(&totalKeys); err != nil {
+			t.Fatal(err)
+		}
+		if totalKeys != 1 {
+			t.Fatalf("searched API key total=%d want 1", totalKeys)
+		}
+
+		if err := tx.QueryRow(`SELECT max(total_projects) FROM api.get_api_key_project_groups('ws-a',NULL,NULL,false,1,20)`).Scan(&total); err != nil {
+			t.Fatal(err)
+		}
+		if total != 2 {
+			t.Fatalf("active-key filter must omit empty projects: total=%d want 2", total)
+		}
+		if _, err := tx.Exec(`SELECT api.set_api_key_limits($1, '{"disabled": true}'::jsonb)`, key1); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.QueryRow(`SELECT max(total_projects) FROM api.get_api_key_project_groups('ws-a',NULL,NULL,true,1,20)`).Scan(&total); err != nil {
+			t.Fatal(err)
+		}
+		if total != 1 {
+			t.Fatalf("disabled-key filter projects=%d want 1", total)
+		}
+		if err := tx.QueryRow(`SELECT count(*) FROM api.get_api_key_project_groups('ws-a','first',NULL,false,1,20)`).Scan(&projectCount); err != nil {
+			t.Fatal(err)
+		}
+		if projectCount != 0 {
+			t.Fatalf("combined search and status filter returned %d projects, want 0", projectCount)
+		}
+
+		if err := tx.QueryRow(`SELECT api.move_api_keys_to_project(ARRAY[$1::uuid],$2)`, key1, source).Scan(&moved); err != nil {
+			t.Fatal(err)
+		}
+		if moved != 1 {
+			t.Fatalf("moved back=%d want 1", moved)
+		}
+
+		var editableKey string
+		if err := tx.QueryRow(`SELECT id FROM api.create_api_key('ws-a','editable',0,NULL,NULL,NULL,$1,'editable key')`, source).Scan(&editableKey); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tx.Exec(`SELECT api.update_api_key_configuration($1,$2,'{"rps": 25}'::jsonb)`, editableKey, disabled); err == nil || !strings.Contains(err.Error(), "disabled") {
+			t.Fatalf("expected disabled edit target rejection, got %v", err)
+		}
+		if _, err := tx.Exec(`SELECT api.update_api_key_configuration($1,$2,'{"rps": 25}'::jsonb)`, editableKey, target); err != nil {
+			t.Fatalf("update API key configuration: %v", err)
+		}
+		var configuredProject string
+		var configuredRPS int
+		if err := tx.QueryRow(`SELECT project_id, ((spec).limits->>'rps')::int FROM api.api_keys WHERE id=$1`, editableKey).Scan(&configuredProject, &configuredRPS); err != nil {
+			t.Fatal(err)
+		}
+		if configuredProject != target || configuredRPS != 25 {
+			t.Fatalf("configuration project=%s rps=%d", configuredProject, configuredRPS)
+		}
+		if _, err := tx.Exec(`DELETE FROM api.api_keys WHERE id=$1`, editableKey); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tx.Exec(`SELECT api.delete_api_key_project($1)`, target); err != nil {
+			t.Fatalf("delete empty project referenced by history: %v", err)
+		}
+		var historyWithDeletedProject int
+		if err := tx.QueryRow(`SELECT count(*) FROM api.api_key_project_history WHERE api_key_id=$1 AND (from_project_id IS NULL OR to_project_id IS NULL) AND from_project_name <> '' AND to_project_name <> '' AND workspace = 'ws-a'`, key1).Scan(&historyWithDeletedProject); err != nil {
+			t.Fatal(err)
+		}
+		if historyWithDeletedProject != 2 {
+			t.Fatalf("history rows with deleted project=%d want 2", historyWithDeletedProject)
+		}
+
+		var deletingKey string
+		if err := tx.QueryRow(`SELECT id FROM api.create_api_key('ws-a','deleting',0,NULL,NULL,NULL,$1,'pending deletion')`, source).Scan(&deletingKey); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tx.Exec(`UPDATE api.api_keys SET metadata.deletion_timestamp=now() WHERE id=$1`, deletingKey); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.QueryRow(`SELECT api_key_count, api_keys::text FROM api.get_api_key_project_groups('ws-a',NULL,NULL,NULL,1,20) WHERE (project).id=$1`, source).Scan(&count, &keysJSON); err != nil {
+			t.Fatal(err)
+		}
+		if count != 2 || strings.Contains(keysJSON, `"name": "deleting"`) {
+			t.Fatalf("deleting key must be hidden: count=%d keys=%s", count, keysJSON)
+		}
+	})
+}

--- a/db/migrations/087_api_key_projects.down.sql
+++ b/db/migrations/087_api_key_projects.down.sql
@@ -1,0 +1,44 @@
+BEGIN;
+DROP FUNCTION IF EXISTS api.move_api_keys_to_project(UUID[], UUID);
+DROP FUNCTION IF EXISTS api.get_api_key_project_groups(TEXT, TEXT, BOOLEAN, BOOLEAN, INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS api.delete_api_key_project(UUID);
+DROP FUNCTION IF EXISTS api.update_api_key_project(UUID, TEXT, TEXT, BOOLEAN);
+DROP FUNCTION IF EXISTS api.create_api_key_project(TEXT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS api.create_api_key(TEXT, TEXT, INTEGER, TEXT, INTEGER, JSONB, UUID, TEXT);
+DROP TABLE api.api_key_project_history;
+DROP TRIGGER touch_api_key_project ON api.api_key_projects;
+DROP FUNCTION api.touch_api_key_project();
+DROP INDEX IF EXISTS api.api_key_name_project_unique_idx;
+DROP TRIGGER validate_name_on_api_keys ON api.api_keys;
+DROP FUNCTION api.validate_api_key_name();
+CREATE TRIGGER validate_name_on_api_keys
+    BEFORE INSERT OR UPDATE ON api.api_keys
+    FOR EACH ROW EXECUTE FUNCTION api.validate_metadata_name();
+ALTER TABLE api.api_keys DROP COLUMN description, DROP COLUMN project_id;
+CREATE UNIQUE INDEX api_key_name_workspace_unique_idx ON api.api_keys (((metadata).workspace), ((metadata).name));
+DROP TABLE api.api_key_projects;
+
+CREATE FUNCTION api.create_api_key(
+    p_workspace TEXT, p_name TEXT, p_quota INTEGER, p_display_name TEXT DEFAULT NULL,
+    p_expires_in INTEGER DEFAULT NULL, p_limits JSONB DEFAULT NULL
+) RETURNS api.api_keys SECURITY DEFINER LANGUAGE plpgsql AS $$
+DECLARE p_user_id UUID; v_key_id UUID; v_key_value TEXT; v_quota BIGINT; v_result api.api_keys;
+BEGIN
+    p_user_id := auth.uid();
+    IF NOT EXISTS (SELECT 1 FROM api.user_profiles WHERE id=p_user_id) THEN RAISE EXCEPTION 'User profile not found'; END IF;
+    IF p_workspace IS NULL OR p_workspace='' THEN RAISE EXCEPTION 'workspace is required to create an API key' USING ERRCODE='22023'; END IF;
+    IF p_display_name IS NULL THEN p_display_name := p_name; END IF;
+    IF p_limits IS NULL AND p_quota IS NOT NULL AND p_quota>0 THEN p_limits:=jsonb_build_object('token_quota',jsonb_build_object('limit',p_quota,'period','monthly')); END IF;
+    PERFORM api.validate_api_key_limits(p_limits);
+    v_quota:=COALESCE((p_limits #>> '{token_quota,limit}')::bigint,0);
+    v_key_id:=gen_random_uuid(); v_key_value:=api.generate_api_key(p_user_id,v_key_id,p_expires_in);
+    INSERT INTO api.api_keys (id,api_version,kind,metadata,spec,status,user_id)
+    VALUES (v_key_id,'v1','ApiKey',ROW(p_name,p_display_name,p_workspace,NULL,now(),now(),'{}'::json,'{}'::json)::api.metadata,
+      ROW(v_quota,p_expires_in,p_limits)::api.api_key_spec,
+      ROW('Pending',now(),NULL,v_key_value,0,now(),NULL)::api.api_key_status,p_user_id)
+    RETURNING * INTO v_result;
+    RETURN v_result;
+END;
+$$;
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/087_api_key_projects.up.sql
+++ b/db/migrations/087_api_key_projects.up.sql
@@ -1,0 +1,266 @@
+-- Group API keys under workspace-scoped projects.
+BEGIN;
+
+CREATE TABLE api.api_key_projects (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL CHECK (length(trim(name)) > 0),
+    description TEXT NOT NULL DEFAULT '',
+    workspace TEXT NOT NULL CHECK (length(trim(workspace)) > 0),
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    user_id UUID NOT NULL REFERENCES api.user_profiles(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (user_id, workspace, name)
+);
+
+ALTER TABLE api.api_keys
+    ADD COLUMN project_id UUID REFERENCES api.api_key_projects(id) ON DELETE RESTRICT,
+    ADD COLUMN description TEXT NOT NULL DEFAULT '';
+
+INSERT INTO api.api_key_projects (name, description, workspace, user_id)
+SELECT 'Default', 'Migrated API keys', (metadata).workspace, user_id
+FROM api.api_keys
+GROUP BY (metadata).workspace, user_id;
+
+UPDATE api.api_keys k
+SET project_id = p.id
+FROM api.api_key_projects p
+WHERE p.user_id = k.user_id
+  AND p.workspace = (k.metadata).workspace
+  AND p.name = 'Default';
+
+ALTER TABLE api.api_keys ALTER COLUMN project_id SET NOT NULL;
+DROP INDEX api.api_key_name_workspace_unique_idx;
+CREATE INDEX api_keys_project_id_idx ON api.api_keys (project_id);
+
+-- API key names are business labels, not Kubernetes resource names. Keep the
+-- shared required/length guarantees while allowing Chinese, spaces and common
+-- punctuation as required by the API key product contract.
+DROP TRIGGER validate_name_on_api_keys ON api.api_keys;
+CREATE FUNCTION api.validate_api_key_name()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.metadata).name IS NULL OR length(trim((NEW.metadata).name)) = 0 THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10001","message": "API key name is required","hint": "Provide a non-empty API key name"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    IF length((NEW.metadata).name) > 63 THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10004","message": "API key name is too long","hint": "Name cannot exceed 63 characters"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER validate_name_on_api_keys
+    BEFORE INSERT OR UPDATE ON api.api_keys
+    FOR EACH ROW EXECUTE FUNCTION api.validate_api_key_name();
+
+CREATE TABLE api.api_key_project_history (
+    id BIGSERIAL PRIMARY KEY,
+    api_key_id UUID NOT NULL REFERENCES api.api_keys(id) ON DELETE CASCADE,
+    from_project_id UUID REFERENCES api.api_key_projects(id) ON DELETE SET NULL,
+    to_project_id UUID NOT NULL REFERENCES api.api_key_projects(id) ON DELETE RESTRICT,
+    moved_by UUID REFERENCES api.user_profiles(id) ON DELETE SET NULL,
+    from_project_name TEXT NOT NULL,
+    to_project_name TEXT NOT NULL,
+    workspace TEXT NOT NULL,
+    moved_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE api.api_key_projects ENABLE ROW LEVEL SECURITY;
+CREATE POLICY api_key_projects_select ON api.api_key_projects FOR SELECT
+    USING (user_id = auth.uid());
+-- Mutations go through SECURITY DEFINER RPCs below so lifecycle validation
+-- cannot be bypassed with direct PostgREST writes.
+
+ALTER TABLE api.api_key_project_history ENABLE ROW LEVEL SECURITY;
+CREATE POLICY api_key_project_history_select ON api.api_key_project_history FOR SELECT
+    USING (moved_by = auth.uid());
+
+CREATE OR REPLACE FUNCTION api.touch_api_key_project()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER touch_api_key_project
+    BEFORE UPDATE ON api.api_key_projects
+    FOR EACH ROW EXECUTE FUNCTION api.touch_api_key_project();
+
+CREATE OR REPLACE FUNCTION api.create_api_key_project(
+    p_workspace TEXT, p_name TEXT, p_description TEXT DEFAULT ''
+) RETURNS api.api_key_projects
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_result api.api_key_projects;
+BEGIN
+    IF p_workspace IS NULL OR length(trim(p_workspace)) = 0 THEN
+        RAISE EXCEPTION 'workspace is required' USING ERRCODE = '22023';
+    END IF;
+    IF p_name IS NULL OR length(trim(p_name)) = 0 THEN
+        RAISE EXCEPTION 'project name is required' USING ERRCODE = '22023';
+    END IF;
+    INSERT INTO api.api_key_projects (name, description, workspace, user_id)
+    VALUES (trim(p_name), COALESCE(p_description, ''), p_workspace, auth.uid())
+    RETURNING * INTO v_result;
+    RETURN v_result;
+EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'Project name already exists' USING ERRCODE = '23505';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.delete_api_key_project(p_project_id UUID)
+RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_count BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM api.api_key_projects WHERE id = p_project_id AND user_id = auth.uid()) THEN
+        RAISE EXCEPTION 'project not found or permission denied' USING ERRCODE = '42501';
+    END IF;
+    SELECT count(*) INTO v_count FROM api.api_keys WHERE project_id = p_project_id;
+    IF v_count > 0 THEN
+        RAISE EXCEPTION 'Project has % API keys', v_count USING ERRCODE = '23503', DETAIL = v_count::text;
+    END IF;
+    DELETE FROM api.api_key_projects WHERE id = p_project_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.update_api_key_project(
+    p_project_id UUID, p_name TEXT DEFAULT NULL, p_description TEXT DEFAULT NULL,
+    p_enabled BOOLEAN DEFAULT NULL
+) RETURNS api.api_key_projects LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_result api.api_key_projects;
+BEGIN
+    IF p_name IS NOT NULL AND length(trim(p_name)) = 0 THEN
+        RAISE EXCEPTION 'project name is required' USING ERRCODE = '22023';
+    END IF;
+    UPDATE api.api_key_projects SET
+        name = COALESCE(trim(p_name), name),
+        description = COALESCE(p_description, description),
+        enabled = COALESCE(p_enabled, enabled)
+    WHERE id = p_project_id AND user_id = auth.uid()
+    RETURNING * INTO v_result;
+    IF NOT FOUND THEN RAISE EXCEPTION 'project not found or permission denied' USING ERRCODE = '42501'; END IF;
+    RETURN v_result;
+EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'Project name already exists' USING ERRCODE = '23505';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.move_api_keys_to_project(p_api_key_ids UUID[], p_project_id UUID)
+RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_target api.api_key_projects; v_count INTEGER;
+BEGIN
+    IF COALESCE(array_length(p_api_key_ids, 1), 0) = 0 THEN
+        RAISE EXCEPTION 'at least one API key is required' USING ERRCODE = '22023';
+    END IF;
+    SELECT * INTO v_target FROM api.api_key_projects
+      WHERE id = p_project_id AND user_id = auth.uid();
+    IF NOT FOUND THEN RAISE EXCEPTION 'target project not found or permission denied' USING ERRCODE = '42501'; END IF;
+    IF NOT v_target.enabled THEN RAISE EXCEPTION 'target project is disabled' USING ERRCODE = '22023'; END IF;
+    IF EXISTS (SELECT 1 FROM unnest(p_api_key_ids) id LEFT JOIN api.api_keys k ON k.id=id
+               WHERE k.id IS NULL OR k.user_id <> auth.uid() OR (k.metadata).workspace <> v_target.workspace) THEN
+        RAISE EXCEPTION 'API key not found, permission denied, or workspace mismatch' USING ERRCODE = '42501';
+    END IF;
+    INSERT INTO api.api_key_project_history (
+        api_key_id, from_project_id, to_project_id, moved_by,
+        from_project_name, to_project_name, workspace
+    )
+    SELECT k.id, k.project_id, p_project_id, auth.uid(),
+           source.name, v_target.name, v_target.workspace
+    FROM api.api_keys k
+    JOIN api.api_key_projects source ON source.id = k.project_id
+    WHERE k.id = ANY(p_api_key_ids) AND k.project_id <> p_project_id;
+    UPDATE api.api_keys SET project_id = p_project_id
+    WHERE id = ANY(p_api_key_ids) AND project_id <> p_project_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.get_api_key_project_groups(
+    p_workspace TEXT, p_search TEXT DEFAULT NULL, p_project_enabled BOOLEAN DEFAULT NULL,
+    p_api_key_disabled BOOLEAN DEFAULT NULL, p_page INTEGER DEFAULT 1, p_page_size INTEGER DEFAULT 20
+) RETURNS TABLE (
+    project api.api_key_projects, api_keys JSONB, api_key_count BIGINT,
+    current_usage BIGINT, total_projects BIGINT
+) LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    WITH matching_projects AS (
+        SELECT p.*,
+               NULLIF(trim(p_search), '') IS NULL
+                   OR p.name ILIKE '%' || trim(p_search) || '%' AS project_matches
+        FROM api.api_key_projects p
+        WHERE p.user_id = auth.uid()
+          AND (p_workspace IS NULL OR p.workspace = p_workspace)
+          AND (p_project_enabled IS NULL OR p.enabled = p_project_enabled)
+          AND (
+              NULLIF(trim(p_search), '') IS NULL
+              OR p.name ILIKE '%' || trim(p_search) || '%'
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys k
+                  WHERE k.project_id = p.id
+                    AND ((k.metadata).name ILIKE '%' || trim(p_search) || '%'
+                         OR k.description ILIKE '%' || trim(p_search) || '%'
+                         OR (k.metadata).workspace ILIKE '%' || trim(p_search) || '%')
+              )
+          )
+    ), visible_projects AS (
+        SELECT p.*, count(*) OVER () AS total_projects
+        FROM matching_projects p
+        ORDER BY p.created_at, p.id
+        OFFSET GREATEST(p_page - 1, 0) * LEAST(GREATEST(p_page_size, 1), 100)
+        LIMIT LEAST(GREATEST(p_page_size, 1), 100)
+    )
+    SELECT ROW(p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+               p.created_at, p.updated_at)::api.api_key_projects,
+           COALESCE(jsonb_agg(to_jsonb(k) ORDER BY (k.metadata).creation_timestamp)
+                    FILTER (WHERE k.id IS NOT NULL), '[]'::jsonb),
+           (SELECT count(*) FROM api.api_keys all_keys WHERE all_keys.project_id = p.id),
+           COALESCE((SELECT sum((all_keys.status).usage)
+                     FROM api.api_keys all_keys WHERE all_keys.project_id = p.id), 0)::bigint,
+           p.total_projects
+    FROM visible_projects p
+    LEFT JOIN api.api_keys k ON k.project_id = p.id
+      AND (p_api_key_disabled IS NULL
+           OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false) = p_api_key_disabled)
+      AND (p.project_matches
+           OR (k.metadata).name ILIKE '%' || trim(p_search) || '%'
+           OR k.description ILIKE '%' || trim(p_search) || '%'
+           OR (k.metadata).workspace ILIKE '%' || trim(p_search) || '%')
+    GROUP BY p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+             p.created_at, p.updated_at, p.project_matches, p.total_projects
+    ORDER BY p.created_at, p.id;
+$$;
+
+-- Replace the latest create RPC, adding project and description while preserving limits.
+DROP FUNCTION api.create_api_key(TEXT, TEXT, INTEGER, TEXT, INTEGER, JSONB);
+CREATE OR REPLACE FUNCTION api.create_api_key(
+    p_workspace TEXT, p_name TEXT, p_quota INTEGER, p_display_name TEXT DEFAULT NULL,
+    p_expires_in INTEGER DEFAULT NULL, p_limits JSONB DEFAULT NULL,
+    p_project_id UUID DEFAULT NULL, p_description TEXT DEFAULT ''
+) RETURNS api.api_keys SECURITY DEFINER LANGUAGE plpgsql AS $$
+DECLARE p_user_id UUID; v_key_id UUID; v_key_value TEXT; v_quota BIGINT; v_result api.api_keys; v_project api.api_key_projects;
+BEGIN
+    p_user_id := auth.uid();
+    IF NOT EXISTS (SELECT 1 FROM api.user_profiles WHERE id=p_user_id) THEN RAISE EXCEPTION 'User profile not found'; END IF;
+    IF p_workspace IS NULL OR p_workspace='' THEN RAISE EXCEPTION 'workspace is required to create an API key' USING ERRCODE='22023'; END IF;
+    SELECT * INTO v_project FROM api.api_key_projects WHERE id=p_project_id AND user_id=p_user_id;
+    IF NOT FOUND OR v_project.workspace <> p_workspace THEN RAISE EXCEPTION 'project is required and must belong to the selected workspace' USING ERRCODE='22023'; END IF;
+    IF NOT v_project.enabled THEN RAISE EXCEPTION 'project is disabled' USING ERRCODE='22023'; END IF;
+    IF p_display_name IS NULL THEN p_display_name := p_name; END IF;
+    IF p_limits IS NULL AND p_quota IS NOT NULL AND p_quota>0 THEN p_limits:=jsonb_build_object('token_quota',jsonb_build_object('limit',p_quota,'period','monthly')); END IF;
+    PERFORM api.validate_api_key_limits(p_limits);
+    v_quota:=COALESCE((p_limits #>> '{token_quota,limit}')::bigint,0);
+    v_key_id:=gen_random_uuid(); v_key_value:=api.generate_api_key(p_user_id,v_key_id,p_expires_in);
+    INSERT INTO api.api_keys (id,api_version,kind,metadata,spec,status,user_id,project_id,description)
+    VALUES (v_key_id,'v1','ApiKey',ROW(p_name,p_display_name,p_workspace,NULL,now(),now(),'{}'::json,'{}'::json)::api.metadata,
+      ROW(v_quota,p_expires_in,p_limits)::api.api_key_spec,
+      ROW('Pending',now(),NULL,v_key_value,0,now(),NULL)::api.api_key_status,p_user_id,p_project_id,COALESCE(p_description,''))
+    RETURNING * INTO v_result;
+    RETURN v_result;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/088_api_key_project_defaults.down.sql
+++ b/db/migrations/088_api_key_project_defaults.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+DROP FUNCTION IF EXISTS api.list_api_key_projects(TEXT);
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/088_api_key_project_defaults.up.sql
+++ b/db/migrations/088_api_key_project_defaults.up.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- Project pickers and detail pages use an RPC because direct table access is
+-- intentionally not exposed through PostgREST.
+CREATE OR REPLACE FUNCTION api.list_api_key_projects(p_workspace TEXT)
+RETURNS SETOF api.api_key_projects
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    SELECT p.*
+    FROM api.api_key_projects p
+    WHERE p.user_id = auth.uid()
+      AND p.workspace = p_workspace
+    ORDER BY p.created_at, p.id;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/089_api_key_project_workflows.down.sql
+++ b/db/migrations/089_api_key_project_workflows.down.sql
@@ -1,0 +1,72 @@
+BEGIN;
+
+-- Keep the data model intact while restoring the pre-087 function behavior.
+CREATE OR REPLACE FUNCTION api.move_api_keys_to_project(
+    p_api_key_ids UUID[], p_project_id UUID
+) RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_target api.api_key_projects; v_count INTEGER;
+BEGIN
+    IF COALESCE(array_length(p_api_key_ids, 1), 0) = 0 THEN
+        RAISE EXCEPTION 'at least one API key is required' USING ERRCODE = '22023';
+    END IF;
+    SELECT * INTO v_target FROM api.api_key_projects WHERE id = p_project_id AND user_id = auth.uid();
+    IF NOT FOUND THEN RAISE EXCEPTION 'target project not found or permission denied' USING ERRCODE = '42501'; END IF;
+    IF NOT v_target.enabled THEN RAISE EXCEPTION 'target project is disabled' USING ERRCODE = '22023'; END IF;
+    IF EXISTS (SELECT 1 FROM unnest(p_api_key_ids) AS selected(key_id) LEFT JOIN api.api_keys k ON k.id=selected.key_id
+               WHERE k.id IS NULL OR k.user_id <> auth.uid() OR (k.metadata).workspace <> v_target.workspace) THEN
+        RAISE EXCEPTION 'API key not found, permission denied, or workspace mismatch' USING ERRCODE = '42501';
+    END IF;
+    INSERT INTO api.api_key_project_history (
+        api_key_id, from_project_id, to_project_id, moved_by,
+        from_project_name, to_project_name, workspace
+    )
+    SELECT k.id, k.project_id, p_project_id, auth.uid(),
+           source.name, v_target.name, v_target.workspace
+    FROM api.api_keys k
+    JOIN api.api_key_projects source ON source.id = k.project_id
+    WHERE k.id = ANY(p_api_key_ids) AND k.project_id <> p_project_id;
+    UPDATE api.api_keys SET project_id = p_project_id WHERE id = ANY(p_api_key_ids) AND project_id <> p_project_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.update_api_key_project(
+    p_project_id UUID, p_name TEXT DEFAULT NULL, p_description TEXT DEFAULT NULL,
+    p_enabled BOOLEAN DEFAULT NULL
+) RETURNS api.api_key_projects LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_result api.api_key_projects;
+BEGIN
+    IF p_name IS NOT NULL AND length(trim(p_name)) = 0 THEN
+        RAISE EXCEPTION 'project name is required' USING ERRCODE = '22023';
+    END IF;
+    UPDATE api.api_key_projects SET
+        name = COALESCE(trim(p_name), name),
+        description = COALESCE(p_description, description),
+        enabled = COALESCE(p_enabled, enabled)
+    WHERE id = p_project_id AND user_id = auth.uid()
+    RETURNING * INTO v_result;
+    IF NOT FOUND THEN RAISE EXCEPTION 'project not found or permission denied' USING ERRCODE = '42501'; END IF;
+    RETURN v_result;
+EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'Project name already exists' USING ERRCODE = '23505';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.delete_api_key_project(p_project_id UUID)
+RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_count BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM api.api_key_projects WHERE id = p_project_id AND user_id = auth.uid()) THEN
+        RAISE EXCEPTION 'project not found or permission denied' USING ERRCODE = '42501';
+    END IF;
+    SELECT count(*) INTO v_count FROM api.api_keys WHERE project_id = p_project_id;
+    IF v_count > 0 THEN
+        RAISE EXCEPTION 'Project has % API keys', v_count USING ERRCODE = '23503', DETAIL = v_count::text;
+    END IF;
+    DELETE FROM api.api_key_projects WHERE id = p_project_id;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/089_api_key_project_workflows.up.sql
+++ b/db/migrations/089_api_key_project_workflows.up.sql
@@ -1,0 +1,83 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION api.move_api_keys_to_project(
+    p_api_key_ids UUID[], p_project_id UUID
+) RETURNS INTEGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_target api.api_key_projects; v_count INTEGER;
+BEGIN
+    IF COALESCE(array_length(p_api_key_ids, 1), 0) = 0 THEN
+        RAISE EXCEPTION 'at least one API key is required' USING ERRCODE = '22023';
+    END IF;
+    SELECT * INTO v_target FROM api.api_key_projects
+      WHERE id = p_project_id AND user_id = auth.uid();
+    IF NOT FOUND THEN RAISE EXCEPTION 'target project not found or permission denied' USING ERRCODE = '42501'; END IF;
+    IF NOT v_target.enabled THEN RAISE EXCEPTION 'target project is disabled' USING ERRCODE = '22023'; END IF;
+    IF EXISTS (
+        SELECT 1
+        FROM unnest(p_api_key_ids) AS selected(key_id)
+        LEFT JOIN api.api_keys k ON k.id = selected.key_id
+        WHERE k.id IS NULL
+           OR k.user_id <> auth.uid()
+           OR (k.metadata).workspace <> v_target.workspace
+    ) THEN
+        RAISE EXCEPTION 'API key not found, permission denied, or workspace mismatch' USING ERRCODE = '42501';
+    END IF;
+
+    INSERT INTO api.api_key_project_history (
+        api_key_id, from_project_id, to_project_id, moved_by,
+        from_project_name, to_project_name, workspace
+    )
+    SELECT k.id, k.project_id, p_project_id, auth.uid(),
+           source.name, v_target.name, v_target.workspace
+    FROM api.api_keys k
+    JOIN api.api_key_projects source ON source.id = k.project_id
+    WHERE k.id = ANY(p_api_key_ids) AND k.project_id <> p_project_id;
+    UPDATE api.api_keys SET project_id = p_project_id
+    WHERE id = ANY(p_api_key_ids) AND project_id <> p_project_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.update_api_key_project(
+    p_project_id UUID, p_name TEXT DEFAULT NULL, p_description TEXT DEFAULT NULL,
+    p_enabled BOOLEAN DEFAULT NULL
+) RETURNS api.api_key_projects LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_result api.api_key_projects; v_current api.api_key_projects;
+BEGIN
+    SELECT * INTO v_current FROM api.api_key_projects
+    WHERE id = p_project_id AND user_id = auth.uid();
+    IF NOT FOUND THEN RAISE EXCEPTION 'project not found or permission denied' USING ERRCODE = '42501'; END IF;
+    IF p_name IS NOT NULL AND length(trim(p_name)) = 0 THEN
+        RAISE EXCEPTION 'project name is required' USING ERRCODE = '22023';
+    END IF;
+    UPDATE api.api_key_projects SET
+        name = COALESCE(trim(p_name), name),
+        description = COALESCE(p_description, description),
+        enabled = COALESCE(p_enabled, enabled)
+    WHERE id = p_project_id AND user_id = auth.uid()
+    RETURNING * INTO v_result;
+    RETURN v_result;
+EXCEPTION WHEN unique_violation THEN
+    RAISE EXCEPTION 'Project name already exists' USING ERRCODE = '23505';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.delete_api_key_project(p_project_id UUID)
+RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_count BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM api.api_key_projects
+                   WHERE id = p_project_id AND user_id = auth.uid()) THEN
+        RAISE EXCEPTION 'project not found or permission denied' USING ERRCODE = '42501';
+    END IF;
+    SELECT count(*) INTO v_count FROM api.api_keys WHERE project_id = p_project_id;
+    IF v_count > 0 THEN
+        RAISE EXCEPTION 'Project has % API keys', v_count USING ERRCODE = '23503', DETAIL = v_count::text;
+    END IF;
+    DELETE FROM api.api_key_projects WHERE id = p_project_id;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/090_api_key_project_deletion.down.sql
+++ b/db/migrations/090_api_key_project_deletion.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+DELETE FROM api.api_key_project_history WHERE to_project_id IS NULL;
+
+ALTER TABLE api.api_key_project_history
+    DROP CONSTRAINT api_key_project_history_to_project_id_fkey,
+    ALTER COLUMN to_project_id SET NOT NULL,
+    ADD CONSTRAINT api_key_project_history_to_project_id_fkey
+        FOREIGN KEY (to_project_id)
+        REFERENCES api.api_key_projects(id)
+        ON DELETE RESTRICT;
+
+COMMIT;

--- a/db/migrations/090_api_key_project_deletion.up.sql
+++ b/db/migrations/090_api_key_project_deletion.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE api.api_key_project_history
+    DROP CONSTRAINT api_key_project_history_to_project_id_fkey,
+    ALTER COLUMN to_project_id DROP NOT NULL,
+    ADD CONSTRAINT api_key_project_history_to_project_id_fkey
+        FOREIGN KEY (to_project_id)
+        REFERENCES api.api_key_projects(id)
+        ON DELETE SET NULL;
+
+COMMIT;

--- a/db/migrations/091_hide_deleting_api_keys.down.sql
+++ b/db/migrations/091_hide_deleting_api_keys.down.sql
@@ -1,0 +1,58 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION api.get_api_key_project_groups(
+    p_workspace TEXT, p_search TEXT DEFAULT NULL, p_project_enabled BOOLEAN DEFAULT NULL,
+    p_api_key_disabled BOOLEAN DEFAULT NULL, p_page INTEGER DEFAULT 1, p_page_size INTEGER DEFAULT 20
+) RETURNS TABLE (
+    project api.api_key_projects, api_keys JSONB, api_key_count BIGINT,
+    current_usage BIGINT, total_projects BIGINT
+) LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    WITH matching_projects AS (
+        SELECT p.*,
+               NULLIF(trim(p_search), '') IS NULL
+                   OR p.name ILIKE '%' || trim(p_search) || '%' AS project_matches
+        FROM api.api_key_projects p
+        WHERE p.user_id = auth.uid()
+          AND (p_workspace IS NULL OR p.workspace = p_workspace)
+          AND (p_project_enabled IS NULL OR p.enabled = p_project_enabled)
+          AND (
+              NULLIF(trim(p_search), '') IS NULL
+              OR p.name ILIKE '%' || trim(p_search) || '%'
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys k
+                  WHERE k.project_id = p.id
+                    AND ((k.metadata).name ILIKE '%' || trim(p_search) || '%'
+                         OR k.description ILIKE '%' || trim(p_search) || '%'
+                         OR (k.metadata).workspace ILIKE '%' || trim(p_search) || '%')
+              )
+          )
+    ), visible_projects AS (
+        SELECT p.*, count(*) OVER () AS total_projects
+        FROM matching_projects p
+        ORDER BY p.created_at, p.id
+        OFFSET GREATEST(p_page - 1, 0) * LEAST(GREATEST(p_page_size, 1), 100)
+        LIMIT LEAST(GREATEST(p_page_size, 1), 100)
+    )
+    SELECT ROW(p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+               p.created_at, p.updated_at)::api.api_key_projects,
+           COALESCE(jsonb_agg(to_jsonb(k) ORDER BY (k.metadata).creation_timestamp)
+                    FILTER (WHERE k.id IS NOT NULL), '[]'::jsonb),
+           (SELECT count(*) FROM api.api_keys all_keys WHERE all_keys.project_id = p.id),
+           COALESCE((SELECT sum((all_keys.status).usage)
+                     FROM api.api_keys all_keys WHERE all_keys.project_id = p.id), 0)::bigint,
+           p.total_projects
+    FROM visible_projects p
+    LEFT JOIN api.api_keys k ON k.project_id = p.id
+      AND (p_api_key_disabled IS NULL
+           OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false) = p_api_key_disabled)
+      AND (p.project_matches
+           OR (k.metadata).name ILIKE '%' || trim(p_search) || '%'
+           OR k.description ILIKE '%' || trim(p_search) || '%'
+           OR (k.metadata).workspace ILIKE '%' || trim(p_search) || '%')
+    GROUP BY p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+             p.created_at, p.updated_at, p.project_matches, p.total_projects
+    ORDER BY p.created_at, p.id;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/091_hide_deleting_api_keys.up.sql
+++ b/db/migrations/091_hide_deleting_api_keys.up.sql
@@ -1,0 +1,97 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION api.get_api_key_project_groups(
+    p_workspace TEXT, p_search TEXT DEFAULT NULL, p_project_enabled BOOLEAN DEFAULT NULL,
+    p_api_key_disabled BOOLEAN DEFAULT NULL, p_page INTEGER DEFAULT 1, p_page_size INTEGER DEFAULT 20
+) RETURNS TABLE (
+    project api.api_key_projects, api_keys JSONB, api_key_count BIGINT,
+    current_usage BIGINT, total_projects BIGINT
+) LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    WITH matching_projects AS (
+        SELECT p.*,
+               NULLIF(trim(p_search), '') IS NULL
+                   OR p.name ILIKE '%' || trim(p_search) || '%' AS project_matches
+        FROM api.api_key_projects p
+        WHERE p.user_id = auth.uid()
+          AND (p_workspace IS NULL OR p.workspace = p_workspace)
+          AND (p_project_enabled IS NULL OR p.enabled = p_project_enabled)
+          AND (
+              p_api_key_disabled IS NULL
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys status_key
+                  WHERE status_key.project_id = p.id
+                    AND (status_key.metadata).deletion_timestamp IS NULL
+                    AND COALESCE(((status_key.spec).limits ->> 'disabled')::boolean, false)
+                        = p_api_key_disabled
+              )
+          )
+          AND (
+              NULLIF(trim(p_search), '') IS NULL
+              OR p.name ILIKE '%' || trim(p_search) || '%'
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys k
+                  WHERE k.project_id = p.id
+                    AND (k.metadata).deletion_timestamp IS NULL
+                    AND (
+                        p_api_key_disabled IS NULL
+                        OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false)
+                            = p_api_key_disabled
+                    )
+                    AND ((k.metadata).name ILIKE '%' || trim(p_search) || '%'
+                         OR k.description ILIKE '%' || trim(p_search) || '%')
+              )
+          )
+    ), visible_projects AS (
+        SELECT p.*, count(*) OVER () AS total_projects
+        FROM matching_projects p
+        ORDER BY p.created_at, p.id
+        OFFSET GREATEST(p_page - 1, 0) * LEAST(GREATEST(p_page_size, 1), 100)
+        LIMIT LEAST(GREATEST(p_page_size, 1), 100)
+    ), key_periods AS (
+        SELECT k.id, k.project_id,
+               CASE COALESCE((k.spec).limits #>> '{token_quota,period}', 'monthly')
+                   WHEN 'daily' THEN CURRENT_DATE
+                   WHEN 'weekly' THEN date_trunc('week', CURRENT_DATE)::date
+                   WHEN 'monthly' THEN date_trunc('month', CURRENT_DATE)::date
+                   WHEN 'yearly' THEN date_trunc('year', CURRENT_DATE)::date
+                   ELSE date_trunc('month', CURRENT_DATE)::date
+               END AS period_start
+        FROM api.api_keys k
+        JOIN visible_projects p ON p.id = k.project_id
+        WHERE (k.metadata).deletion_timestamp IS NULL
+    ), project_usage AS (
+        SELECT kp.project_id,
+               COALESCE(sum((d.spec).total_usage), 0)::bigint AS current_usage
+        FROM key_periods kp
+        LEFT JOIN api.api_daily_usage d
+          ON (d.spec).api_key_id = kp.id
+         AND (d.spec).usage_date >= kp.period_start
+         AND (d.spec).usage_date <= CURRENT_DATE
+        GROUP BY kp.project_id
+    )
+    SELECT ROW(p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+               p.created_at, p.updated_at)::api.api_key_projects,
+           COALESCE(jsonb_agg(to_jsonb(k) ORDER BY (k.metadata).creation_timestamp)
+                    FILTER (WHERE k.id IS NOT NULL), '[]'::jsonb),
+           (SELECT count(*) FROM api.api_keys all_keys
+            WHERE all_keys.project_id = p.id
+              AND (all_keys.metadata).deletion_timestamp IS NULL),
+           COALESCE(pu.current_usage, 0),
+           p.total_projects
+    FROM visible_projects p
+    LEFT JOIN project_usage pu ON pu.project_id = p.id
+    LEFT JOIN api.api_keys k ON k.project_id = p.id
+      AND (k.metadata).deletion_timestamp IS NULL
+      AND (p_api_key_disabled IS NULL
+           OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false) = p_api_key_disabled)
+      AND (p.project_matches
+           OR (k.metadata).name ILIKE '%' || trim(p_search) || '%'
+           OR k.description ILIKE '%' || trim(p_search) || '%')
+    GROUP BY p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+             p.created_at, p.updated_at, p.project_matches, p.total_projects,
+             pu.current_usage
+    ORDER BY p.created_at, p.id;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/092_update_api_key_configuration.down.sql
+++ b/db/migrations/092_update_api_key_configuration.down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+DROP FUNCTION IF EXISTS api.update_api_key_configuration(UUID, UUID, JSONB);
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/092_update_api_key_configuration.up.sql
+++ b/db/migrations/092_update_api_key_configuration.up.sql
@@ -1,0 +1,55 @@
+BEGIN;
+
+-- Save the editable Project and limits panels as one transaction so the UI
+-- cannot report a partially applied API key edit.
+CREATE OR REPLACE FUNCTION api.update_api_key_configuration(
+    p_api_key_id UUID, p_project_id UUID, p_limits JSONB
+) RETURNS api.api_keys LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+    v_key api.api_keys;
+    v_target api.api_key_projects;
+BEGIN
+    SELECT * INTO v_key
+    FROM api.api_keys
+    WHERE id = p_api_key_id AND user_id = auth.uid();
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'API key not found or permission denied' USING ERRCODE = '42501';
+    END IF;
+
+    SELECT * INTO v_target
+    FROM api.api_key_projects
+    WHERE id = p_project_id AND user_id = auth.uid();
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'target project not found or permission denied' USING ERRCODE = '42501';
+    END IF;
+    IF NOT v_target.enabled THEN
+        RAISE EXCEPTION 'target project is disabled' USING ERRCODE = '22023';
+    END IF;
+    IF v_target.workspace <> (v_key.metadata).workspace THEN
+        RAISE EXCEPTION 'API key and Project must use the same workspace' USING ERRCODE = '22023';
+    END IF;
+
+    IF v_key.project_id <> p_project_id THEN
+        INSERT INTO api.api_key_project_history (
+            api_key_id, from_project_id, to_project_id, moved_by,
+            from_project_name, to_project_name, workspace
+        )
+        SELECT p_api_key_id, v_key.project_id, p_project_id, auth.uid(),
+               source.name, v_target.name, v_target.workspace
+        FROM api.api_key_projects source
+        WHERE source.id = v_key.project_id;
+
+        UPDATE api.api_keys
+        SET project_id = p_project_id
+        WHERE id = p_api_key_id;
+    END IF;
+
+    PERFORM api.set_api_key_limits(p_api_key_id, COALESCE(p_limits, '{}'::jsonb));
+
+    SELECT * INTO v_key FROM api.api_keys WHERE id = p_api_key_id;
+    RETURN v_key;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/093_default_api_key_projects.down.sql
+++ b/db/migrations/093_default_api_key_projects.down.sql
@@ -1,0 +1,134 @@
+BEGIN;
+
+DROP TRIGGER IF EXISTS create_default_api_key_projects_for_workspace ON api.workspaces;
+DROP FUNCTION IF EXISTS api.create_default_api_key_projects_for_workspace();
+DROP TRIGGER IF EXISTS create_default_api_key_projects_for_user ON api.user_profiles;
+DROP FUNCTION IF EXISTS api.create_default_api_key_projects_for_user();
+DROP FUNCTION IF EXISTS api.list_api_key_projects(TEXT);
+DROP FUNCTION IF EXISTS api.delete_api_key_project(UUID);
+DROP FUNCTION IF EXISTS api.get_api_key_project_groups(TEXT, TEXT, BOOLEAN, BOOLEAN, INTEGER, INTEGER);
+DROP INDEX IF EXISTS api.api_key_projects_one_default_idx;
+
+ALTER TABLE api.api_key_projects DROP COLUMN is_default;
+
+CREATE OR REPLACE FUNCTION api.list_api_key_projects(p_workspace TEXT)
+RETURNS SETOF api.api_key_projects
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    SELECT p.*
+    FROM api.api_key_projects p
+    WHERE p.user_id = auth.uid()
+      AND p.workspace = p_workspace
+    ORDER BY p.created_at, p.id;
+$$;
+
+CREATE OR REPLACE FUNCTION api.delete_api_key_project(p_project_id UUID)
+RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_count BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM api.api_key_projects
+                   WHERE id = p_project_id AND user_id = auth.uid()) THEN
+        RAISE EXCEPTION 'project not found or permission denied' USING ERRCODE = '42501';
+    END IF;
+    SELECT count(*) INTO v_count FROM api.api_keys WHERE project_id = p_project_id;
+    IF v_count > 0 THEN
+        RAISE EXCEPTION 'Project has % API keys', v_count USING ERRCODE = '23503', DETAIL = v_count::text;
+    END IF;
+    DELETE FROM api.api_key_projects WHERE id = p_project_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.get_api_key_project_groups(
+    p_workspace TEXT, p_search TEXT DEFAULT NULL, p_project_enabled BOOLEAN DEFAULT NULL,
+    p_api_key_disabled BOOLEAN DEFAULT NULL, p_page INTEGER DEFAULT 1, p_page_size INTEGER DEFAULT 20
+) RETURNS TABLE (
+    project api.api_key_projects, api_keys JSONB, api_key_count BIGINT,
+    current_usage BIGINT, total_projects BIGINT
+) LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    WITH matching_projects AS (
+        SELECT p.*,
+               NULLIF(trim(p_search), '') IS NULL
+                   OR p.name ILIKE '%' || trim(p_search) || '%' AS project_matches
+        FROM api.api_key_projects p
+        WHERE p.user_id = auth.uid()
+          AND (p_workspace IS NULL OR p.workspace = p_workspace)
+          AND (p_project_enabled IS NULL OR p.enabled = p_project_enabled)
+          AND (
+              p_api_key_disabled IS NULL
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys status_key
+                  WHERE status_key.project_id = p.id
+                    AND (status_key.metadata).deletion_timestamp IS NULL
+                    AND COALESCE(((status_key.spec).limits ->> 'disabled')::boolean, false)
+                        = p_api_key_disabled
+              )
+          )
+          AND (
+              NULLIF(trim(p_search), '') IS NULL
+              OR p.name ILIKE '%' || trim(p_search) || '%'
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys k
+                  WHERE k.project_id = p.id
+                    AND (k.metadata).deletion_timestamp IS NULL
+                    AND (
+                        p_api_key_disabled IS NULL
+                        OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false)
+                            = p_api_key_disabled
+                    )
+                    AND ((k.metadata).name ILIKE '%' || trim(p_search) || '%'
+                         OR k.description ILIKE '%' || trim(p_search) || '%')
+              )
+          )
+    ), visible_projects AS (
+        SELECT p.*, count(*) OVER () AS total_projects
+        FROM matching_projects p
+        ORDER BY p.created_at, p.id
+        OFFSET GREATEST(p_page - 1, 0) * LEAST(GREATEST(p_page_size, 1), 100)
+        LIMIT LEAST(GREATEST(p_page_size, 1), 100)
+    ), key_periods AS (
+        SELECT k.id, k.project_id,
+               CASE COALESCE((k.spec).limits #>> '{token_quota,period}', 'monthly')
+                   WHEN 'daily' THEN CURRENT_DATE
+                   WHEN 'weekly' THEN date_trunc('week', CURRENT_DATE)::date
+                   WHEN 'monthly' THEN date_trunc('month', CURRENT_DATE)::date
+                   WHEN 'yearly' THEN date_trunc('year', CURRENT_DATE)::date
+                   ELSE date_trunc('month', CURRENT_DATE)::date
+               END AS period_start
+        FROM api.api_keys k
+        JOIN visible_projects p ON p.id = k.project_id
+        WHERE (k.metadata).deletion_timestamp IS NULL
+    ), project_usage AS (
+        SELECT kp.project_id,
+               COALESCE(sum((d.spec).total_usage), 0)::bigint AS current_usage
+        FROM key_periods kp
+        LEFT JOIN api.api_daily_usage d
+          ON (d.spec).api_key_id = kp.id
+         AND (d.spec).usage_date >= kp.period_start
+         AND (d.spec).usage_date <= CURRENT_DATE
+        GROUP BY kp.project_id
+    )
+    SELECT ROW(p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+               p.created_at, p.updated_at)::api.api_key_projects,
+           COALESCE(jsonb_agg(to_jsonb(k) ORDER BY (k.metadata).creation_timestamp)
+                    FILTER (WHERE k.id IS NOT NULL), '[]'::jsonb),
+           (SELECT count(*) FROM api.api_keys all_keys
+            WHERE all_keys.project_id = p.id
+              AND (all_keys.metadata).deletion_timestamp IS NULL),
+           COALESCE(pu.current_usage, 0),
+           p.total_projects
+    FROM visible_projects p
+    LEFT JOIN project_usage pu ON pu.project_id = p.id
+    LEFT JOIN api.api_keys k ON k.project_id = p.id
+      AND (k.metadata).deletion_timestamp IS NULL
+      AND (p_api_key_disabled IS NULL
+           OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false) = p_api_key_disabled)
+      AND (p.project_matches
+           OR (k.metadata).name ILIKE '%' || trim(p_search) || '%'
+           OR k.description ILIKE '%' || trim(p_search) || '%')
+    GROUP BY p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+             p.created_at, p.updated_at, p.project_matches, p.total_projects,
+             pu.current_usage
+    ORDER BY p.created_at, p.id;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/093_default_api_key_projects.up.sql
+++ b/db/migrations/093_default_api_key_projects.up.sql
@@ -1,0 +1,190 @@
+BEGIN;
+
+ALTER TABLE api.api_key_projects
+    ADD COLUMN is_default BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Existing projects named Default are the projects created for historical keys.
+UPDATE api.api_key_projects
+SET is_default = TRUE
+WHERE name = 'Default';
+
+CREATE UNIQUE INDEX api_key_projects_one_default_idx
+    ON api.api_key_projects (user_id, workspace)
+    WHERE is_default;
+
+INSERT INTO api.api_key_projects (
+    name, description, workspace, enabled, user_id, is_default
+)
+SELECT 'Default', 'Default API key project', (w.metadata).name, TRUE, u.id, TRUE
+FROM api.user_profiles u
+CROSS JOIN api.workspaces w
+WHERE (w.metadata).deletion_timestamp IS NULL
+ON CONFLICT (user_id, workspace, name) DO UPDATE
+SET is_default = TRUE;
+
+CREATE OR REPLACE FUNCTION api.create_default_api_key_projects_for_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+    INSERT INTO api.api_key_projects (
+        name, description, workspace, enabled, user_id, is_default
+    )
+    SELECT 'Default', 'Default API key project', (w.metadata).name, TRUE, NEW.id, TRUE
+    FROM api.workspaces w
+    WHERE (w.metadata).deletion_timestamp IS NULL
+    ON CONFLICT (user_id, workspace, name) DO UPDATE
+    SET is_default = TRUE;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS create_default_api_key_projects_for_user ON api.user_profiles;
+CREATE TRIGGER create_default_api_key_projects_for_user
+    AFTER INSERT ON api.user_profiles
+    FOR EACH ROW EXECUTE FUNCTION api.create_default_api_key_projects_for_user();
+
+CREATE OR REPLACE FUNCTION api.create_default_api_key_projects_for_workspace()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+    INSERT INTO api.api_key_projects (
+        name, description, workspace, enabled, user_id, is_default
+    )
+    SELECT 'Default', 'Default API key project', (NEW.metadata).name, TRUE, u.id, TRUE
+    FROM api.user_profiles u
+    ON CONFLICT (user_id, workspace, name) DO UPDATE
+    SET is_default = TRUE;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS create_default_api_key_projects_for_workspace ON api.workspaces;
+CREATE TRIGGER create_default_api_key_projects_for_workspace
+    AFTER INSERT ON api.workspaces
+    FOR EACH ROW EXECUTE FUNCTION api.create_default_api_key_projects_for_workspace();
+
+CREATE OR REPLACE FUNCTION api.list_api_key_projects(p_workspace TEXT)
+RETURNS SETOF api.api_key_projects
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    SELECT p.*
+    FROM api.api_key_projects p
+    WHERE p.user_id = auth.uid()
+      AND p.workspace = p_workspace
+    ORDER BY NOT p.is_default, p.created_at, p.id;
+$$;
+
+CREATE OR REPLACE FUNCTION api.delete_api_key_project(p_project_id UUID)
+RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_count BIGINT; v_is_default BOOLEAN;
+BEGIN
+    SELECT is_default INTO v_is_default FROM api.api_key_projects
+    WHERE id = p_project_id AND user_id = auth.uid();
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'project not found or permission denied' USING ERRCODE = '42501';
+    END IF;
+    IF v_is_default THEN
+        RAISE EXCEPTION 'Default Project cannot be deleted' USING ERRCODE = '22023';
+    END IF;
+    SELECT count(*) INTO v_count FROM api.api_keys WHERE project_id = p_project_id;
+    IF v_count > 0 THEN
+        RAISE EXCEPTION 'Project has % API keys', v_count USING ERRCODE = '23503', DETAIL = v_count::text;
+    END IF;
+    DELETE FROM api.api_key_projects WHERE id = p_project_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION api.get_api_key_project_groups(
+    p_workspace TEXT, p_search TEXT DEFAULT NULL, p_project_enabled BOOLEAN DEFAULT NULL,
+    p_api_key_disabled BOOLEAN DEFAULT NULL, p_page INTEGER DEFAULT 1, p_page_size INTEGER DEFAULT 20
+) RETURNS TABLE (
+    project api.api_key_projects, api_keys JSONB, api_key_count BIGINT,
+    current_usage BIGINT, total_projects BIGINT
+) LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    WITH matching_projects AS (
+        SELECT p.*,
+               NULLIF(trim(p_search), '') IS NULL
+                   OR p.name ILIKE '%' || trim(p_search) || '%' AS project_matches
+        FROM api.api_key_projects p
+        WHERE p.user_id = auth.uid()
+          AND (p_workspace IS NULL OR p.workspace = p_workspace)
+          AND (p_project_enabled IS NULL OR p.enabled = p_project_enabled)
+          AND (
+              p_api_key_disabled IS NULL
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys status_key
+                  WHERE status_key.project_id = p.id
+                    AND (status_key.metadata).deletion_timestamp IS NULL
+                    AND COALESCE(((status_key.spec).limits ->> 'disabled')::boolean, false)
+                        = p_api_key_disabled
+              )
+          )
+          AND (
+              NULLIF(trim(p_search), '') IS NULL
+              OR p.name ILIKE '%' || trim(p_search) || '%'
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys k
+                  WHERE k.project_id = p.id
+                    AND (k.metadata).deletion_timestamp IS NULL
+                    AND (
+                        p_api_key_disabled IS NULL
+                        OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false)
+                            = p_api_key_disabled
+                    )
+                    AND ((k.metadata).name ILIKE '%' || trim(p_search) || '%'
+                         OR k.description ILIKE '%' || trim(p_search) || '%')
+              )
+          )
+    ), visible_projects AS (
+        SELECT p.*, count(*) OVER () AS total_projects
+        FROM matching_projects p
+        ORDER BY NOT p.is_default, p.created_at, p.id
+        OFFSET GREATEST(p_page - 1, 0) * LEAST(GREATEST(p_page_size, 1), 100)
+        LIMIT LEAST(GREATEST(p_page_size, 1), 100)
+    ), key_periods AS (
+        SELECT k.id, k.project_id,
+               CASE COALESCE((k.spec).limits #>> '{token_quota,period}', 'monthly')
+                   WHEN 'daily' THEN CURRENT_DATE
+                   WHEN 'weekly' THEN date_trunc('week', CURRENT_DATE)::date
+                   WHEN 'monthly' THEN date_trunc('month', CURRENT_DATE)::date
+                   WHEN 'yearly' THEN date_trunc('year', CURRENT_DATE)::date
+                   ELSE date_trunc('month', CURRENT_DATE)::date
+               END AS period_start
+        FROM api.api_keys k
+        JOIN visible_projects p ON p.id = k.project_id
+        WHERE (k.metadata).deletion_timestamp IS NULL
+    ), project_usage AS (
+        SELECT kp.project_id,
+               COALESCE(sum((d.spec).total_usage), 0)::bigint AS current_usage
+        FROM key_periods kp
+        LEFT JOIN api.api_daily_usage d
+          ON (d.spec).api_key_id = kp.id
+         AND (d.spec).usage_date >= kp.period_start
+         AND (d.spec).usage_date <= CURRENT_DATE
+        GROUP BY kp.project_id
+    )
+    SELECT ROW(p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+               p.created_at, p.updated_at, p.is_default)::api.api_key_projects,
+           COALESCE(jsonb_agg(to_jsonb(k) ORDER BY (k.metadata).creation_timestamp)
+                    FILTER (WHERE k.id IS NOT NULL), '[]'::jsonb),
+           (SELECT count(*) FROM api.api_keys all_keys
+            WHERE all_keys.project_id = p.id
+              AND (all_keys.metadata).deletion_timestamp IS NULL),
+           COALESCE(pu.current_usage, 0),
+           p.total_projects
+    FROM visible_projects p
+    LEFT JOIN project_usage pu ON pu.project_id = p.id
+    LEFT JOIN api.api_keys k ON k.project_id = p.id
+      AND (k.metadata).deletion_timestamp IS NULL
+      AND (p_api_key_disabled IS NULL
+           OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false) = p_api_key_disabled)
+      AND (p.project_matches
+           OR (k.metadata).name ILIKE '%' || trim(p_search) || '%'
+           OR k.description ILIKE '%' || trim(p_search) || '%')
+    GROUP BY p.id, p.name, p.description, p.workspace, p.enabled, p.user_id,
+             p.created_at, p.updated_at, p.is_default, p.project_matches,
+             p.total_projects, pu.current_usage
+    ORDER BY NOT p.is_default, p.created_at, p.id;
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/094_api_key_project_group_count.down.sql
+++ b/db/migrations/094_api_key_project_group_count.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP FUNCTION IF EXISTS api.count_api_key_project_group_api_keys(
+    TEXT, TEXT, BOOLEAN, BOOLEAN
+);
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;

--- a/db/migrations/094_api_key_project_group_count.up.sql
+++ b/db/migrations/094_api_key_project_group_count.up.sql
@@ -1,0 +1,63 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION api.count_api_key_project_group_api_keys(
+    p_workspace TEXT, p_search TEXT DEFAULT NULL,
+    p_project_enabled BOOLEAN DEFAULT NULL,
+    p_api_key_disabled BOOLEAN DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE sql STABLE SECURITY DEFINER AS $$
+    WITH matching_projects AS (
+        SELECT p.*,
+               NULLIF(trim(p_search), '') IS NULL
+                   OR p.name ILIKE '%' || trim(p_search) || '%' AS project_matches
+        FROM api.api_key_projects p
+        WHERE p.user_id = auth.uid()
+          AND (p_workspace IS NULL OR p.workspace = p_workspace)
+          AND (p_project_enabled IS NULL OR p.enabled = p_project_enabled)
+          AND (
+              p_api_key_disabled IS NULL
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys status_key
+                  WHERE status_key.project_id = p.id
+                    AND (status_key.metadata).deletion_timestamp IS NULL
+                    AND COALESCE(((status_key.spec).limits ->> 'disabled')::boolean, false)
+                        = p_api_key_disabled
+              )
+          )
+          AND (
+              NULLIF(trim(p_search), '') IS NULL
+              OR p.name ILIKE '%' || trim(p_search) || '%'
+              OR EXISTS (
+                  SELECT 1 FROM api.api_keys search_key
+                  WHERE search_key.project_id = p.id
+                    AND (search_key.metadata).deletion_timestamp IS NULL
+                    AND (
+                        p_api_key_disabled IS NULL
+                        OR COALESCE(((search_key.spec).limits ->> 'disabled')::boolean, false)
+                            = p_api_key_disabled
+                    )
+                    AND (
+                        (search_key.metadata).name ILIKE '%' || trim(p_search) || '%'
+                        OR search_key.description ILIKE '%' || trim(p_search) || '%'
+                    )
+              )
+          )
+    )
+    SELECT count(k.id)
+    FROM matching_projects p
+    JOIN api.api_keys k ON k.project_id = p.id
+      AND (k.metadata).deletion_timestamp IS NULL
+      AND (
+          p_api_key_disabled IS NULL
+          OR COALESCE(((k.spec).limits ->> 'disabled')::boolean, false)
+              = p_api_key_disabled
+      )
+      AND (
+          p.project_matches
+          OR (k.metadata).name ILIKE '%' || trim(p_search) || '%'
+          OR k.description ILIKE '%' || trim(p_search) || '%'
+      );
+$$;
+
+NOTIFY pgrst, 'reload schema';
+COMMIT;


### PR DESCRIPTION
## Issue

NEU-678, NEU-679, NEU-680, NEU-681, NEU-682, NEU-683, NEU-684

## Summary

Introduce workspace-scoped API key Projects and the database contracts required for project-based API key creation, editing, grouping, filtering, movement, and lifecycle management.

## Changes

- Add API key Project schema, ownership isolation, RLS boundaries, descriptions, default-project provisioning, and historical-key backfill.
- Add project lookup, lifecycle, deletion, move-history, and atomic API key configuration RPCs.
- Add grouped list/count queries with search, status filters, usage aggregation, and deletion visibility.
- Add database coverage for defaults, lifecycle protection, ownership, moves, edits, filtering, counts, and migration history.

## Test Plan

- [ ] E2E: not run in this review pass
- [ ] DB integration (`make db-test`): not run in this review pass

## Risk & Rollback

This changes the database schema and API RPC surface across migrations 087-094. Running UI clients require these RPCs before the project workflows are available. Each migration includes a down migration; rollback should follow migration order and should be validated against retained project-move history and existing API keys before production use.