### PR TITLE
fix: lease NFS model registry mounts instead of unmounting per request (NEU-685)

### DIFF
--- a/controllers/model_registry_checked_at_test.go
+++ b/controllers/model_registry_checked_at_test.go
@@ -66,6 +66,7 @@ func TestModelRegistryController_HealthyRegistryAdvancesOnlyTheCheckTime(t *test
 	// rather than merely reported. What this test is about — which status writes
 	// that produces — is unchanged.
 	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
 	mockRegistry.On("HealthyCheck").Return(nil)
 
 	var written *v1.ModelRegistryStatus
@@ -107,6 +108,7 @@ func TestModelRegistryController_UnchangedResultIsNotRewrittenEveryCycle(t *test
 	mockStorage := &storagemocks.MockStorage{}
 	mockRegistry := &modelregistrymocks.MockModelRegistry{}
 	mockRegistry.On("Connect").Return(nil)
+	mockRegistry.On("Disconnect").Return(nil)
 	mockRegistry.On("HealthyCheck").Return(nil)
 
 	c := newCheckedAtController(t, mockStorage, mockRegistry, now)

--- a/controllers/model_registry_controller.go
+++ b/controllers/model_registry_controller.go
@@ -115,9 +115,20 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 	}
 
 	if obj.Status != nil && obj.Status.Phase == v1.ModelRegistryPhaseFAILED {
+		// A failed registry is reconnected from scratch. If other clients are reading
+		// through the backing mount right now, it is not this reconcile's to tear
+		// down: they were served fine, so the mount works, and removing it would
+		// break their reads to fix a status. Connect below is then a no-op.
 		if err = modelRegistry.Disconnect(); err != nil {
-			return errors.Wrapf(err, "failed to disconnect model registry %s/%s",
-				obj.Metadata.Workspace, obj.Metadata.Name)
+			if !errors.Is(err, model_registry.ErrMountBusy) {
+				return errors.Wrapf(err, "failed to disconnect model registry %s/%s",
+					obj.Metadata.Workspace, obj.Metadata.Name)
+			}
+
+			klog.V(4).Infof("model registry %s/%s is still being read, keeping its mount: %v",
+				obj.Metadata.Workspace, obj.Metadata.Name, err)
+
+			err = nil
 		}
 	}
 
@@ -125,6 +136,17 @@ func (c *ModelRegistryController) sync(obj *v1.ModelRegistry) (err error) {
 		return errors.Wrapf(err, "failed to connect model registry %s/%s",
 			obj.Metadata.Workspace, obj.Metadata.Name)
 	}
+
+	// This reconcile is one more reader of a mount point shared with every request
+	// handler, so it gives its lease back when it is done. It does not tear the
+	// mount down — releasing a lease never does — the mount stays up for the next
+	// reader, and only deletion or a reconnect after failure removes it.
+	defer func() {
+		if disconnectErr := modelRegistry.Disconnect(); disconnectErr != nil {
+			klog.Warningf("failed to release model registry %s/%s connection: %v",
+				obj.Metadata.Workspace, obj.Metadata.Name, disconnectErr)
+		}
+	}()
 
 	if err = modelRegistry.HealthyCheck(); err != nil {
 		return errors.Wrapf(err, "health check failed for model registry %s/%s",

--- a/controllers/model_registry_controller_test.go
+++ b/controllers/model_registry_controller_test.go
@@ -111,6 +111,7 @@ func TestModelRegistryController_Sync_PendingOrNoStatus(t *testing.T) {
 			input: testModelRegistry(),
 			mockSetup: func(input *v1.ModelRegistry, s *storagemocks.MockStorage, m *modelregistrymocks.MockModelRegistry) {
 				m.On("Connect").Return(nil)
+				m.On("Disconnect").Return(nil)
 				m.On("HealthyCheck").Return(nil)
 				s.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
 					obj := args.Get(1).(*v1.ModelRegistry)
@@ -209,6 +210,7 @@ func TestModelRegistryController_Sync_Connected(t *testing.T) {
 			input: testModelRegistry(),
 			mockSetup: func(input *v1.ModelRegistry, s *storagemocks.MockStorage, m *modelregistrymocks.MockModelRegistry) {
 				m.On("Connect").Return(nil)
+				m.On("Disconnect").Return(nil)
 				m.On("HealthyCheck").Return(nil)
 				// A registry with no counters yet is measured on the spot, and the
 				// result is written back even though the phase did not change.
@@ -227,6 +229,7 @@ func TestModelRegistryController_Sync_Connected(t *testing.T) {
 			input: testModelRegistry(),
 			mockSetup: func(input *v1.ModelRegistry, s *storagemocks.MockStorage, m *modelregistrymocks.MockModelRegistry) {
 				m.On("Connect").Return(nil)
+				m.On("Disconnect").Return(nil)
 				m.On("HealthyCheck").Return(errors.New("timed out reading NFS mount path /mnt/registry"))
 				s.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
 					obj := args.Get(1).(*v1.ModelRegistry)
@@ -431,6 +434,7 @@ func TestModelRegistryController_UpdateStatus_CarriesStatsForward(t *testing.T) 
 			wantPhase: v1.ModelRegistryPhaseFAILED,
 			mockSetup: func(m *modelregistrymocks.MockModelRegistry) {
 				m.On("Connect").Return(nil)
+				m.On("Disconnect").Return(nil)
 				m.On("HealthyCheck").Return(assert.AnError)
 			},
 			wantErr: true,
@@ -524,6 +528,7 @@ func TestModelRegistryController_Sync_ThrottlesStatsCollection(t *testing.T) {
 	mockModel := &modelregistrymocks.MockModelRegistry{}
 
 	mockModel.On("Connect").Return(nil)
+	mockModel.On("Disconnect").Return(nil)
 	mockModel.On("HealthyCheck").Return(nil)
 	mockModel.On("CollectUsage").Return(&model_registry.RegistryUsage{ModelCount: 1, StorageBytes: 64}, nil)
 
@@ -564,6 +569,7 @@ func TestModelRegistryController_Sync_UnreachableRegistryKeepsStats(t *testing.T
 	mockModel := &modelregistrymocks.MockModelRegistry{}
 
 	mockModel.On("Connect").Return(nil)
+	mockModel.On("Disconnect").Return(nil)
 	mockModel.On("HealthyCheck").Return(assert.AnError)
 	mockStorage.On("UpdateModelRegistry", "1", mock.Anything).Run(func(args mock.Arguments) {
 		written := args.Get(1).(*v1.ModelRegistry) //nolint:errcheck
@@ -591,6 +597,7 @@ func TestModelRegistryController_Sync_PublicRegistryHasNoStats(t *testing.T) {
 	mockModel := &modelregistrymocks.MockModelRegistry{}
 
 	mockModel.On("Connect").Return(nil)
+	mockModel.On("Disconnect").Return(nil)
 	mockModel.On("HealthyCheck").Return(nil)
 	mockModel.On("CollectUsage").Return(nil, pkgerrors.Wrap(model_registry.ErrNotSupported, "hugging face"))
 

--- a/db/dbtest/model_registry_stats_test.go
+++ b/db/dbtest/model_registry_stats_test.go
@@ -131,6 +131,9 @@ func TestModelRegistryStatsSurviveConnectivityReconcile(t *testing.T) {
 	// controller into a status write-back.
 	mockRegistry := modelregistrymocks.NewMockModelRegistry(t)
 	mockRegistry.On("Connect").Return(nil)
+	// The reconcile gives its mount lease back on the way out, whether or not the
+	// health check passed.
+	mockRegistry.On("Disconnect").Return(nil)
 	mockRegistry.On("HealthyCheck").Return(assert.AnError)
 
 	original := model_registry.NewModelRegistry

--- a/internal/model_registry/file_based.go
+++ b/internal/model_registry/file_based.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -277,17 +278,130 @@ type nfsFile struct {
 	bentomlStore
 
 	nfsServerPath string
+
+	// mu guards leased. A client is used by one request at a time, but Connect and
+	// Disconnect decide whether this client owns a lease on a mount point shared
+	// with every other client of the same registry, so the bookkeeping is not left
+	// to chance.
+	mu     sync.Mutex
+	leased bool
 }
 
+// Connect takes a read lease on the registry's mount point, mounting it if it is
+// not there yet. Every client of the same registry shares that one mount point,
+// so holding a lease is what keeps a concurrent Disconnect elsewhere from
+// unmounting the tree this client is about to read.
 func (n *nfsFile) Connect() error {
-	return nfs.MountNFS(n.nfsServerPath, n.path)
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.leased {
+		return nil
+	}
+
+	if err := nfs.AcquireMount(n.nfsServerPath, n.path); err != nil {
+		return err
+	}
+
+	n.leased = true
+
+	return nil
 }
 
+// Disconnect means two different things depending on who calls it, and the
+// difference is what this bug was about:
+//
+//   - A client that connected is a reader letting go. It drops its lease and
+//     leaves the mount alone: the registry's other readers, and the reconcile
+//     loop, are still using it.
+//   - A client that never connected is a lifecycle caller — registry deletion, or
+//     a reconnect after a failure — asking for the mount itself to go. That is
+//     the only path that unmounts, and it is refused with ErrMountBusy while
+//     readers hold leases.
 func (n *nfsFile) Disconnect() error {
-	// Disconnect intentionally keeps nfs.Unmount's synchronous behavior. A
-	// ListModels timeout has already made the registry Failed; unmount retains
-	// its lifecycle semantics before the controller reconnects.
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.leased {
+		nfs.ReleaseMount(n.path)
+		n.leased = false
+
+		return nil
+	}
+
 	return nfs.Unmount(n.path)
+}
+
+// ListModels tells an empty registry apart from a mount that disappeared. Reading
+// a BentoML tree whose root is gone looks exactly like reading an empty one, so
+// without this check a storage failure is served as a successful empty list — and
+// the caller believes the registry has no models.
+func (n *nfsFile) ListModels(option ListOption) (*ModelPage, error) {
+	page, err := n.bentomlStore.ListModels(option)
+	if err != nil {
+		return nil, n.explainStorageFailure(err)
+	}
+
+	if page.Total != nil && *page.Total == 0 {
+		if mountErr := n.checkMount(); mountErr != nil {
+			return nil, mountErr
+		}
+	}
+
+	return page, nil
+}
+
+func (n *nfsFile) GetModelVersion(name, version string) (*v1.ModelVersion, error) {
+	model, err := n.bentomlStore.GetModelVersion(name, version)
+	if err != nil {
+		return nil, n.explainStorageFailure(err)
+	}
+
+	return model, nil
+}
+
+func (n *nfsFile) GetModelDetail(name, version string) (*v1.ModelVersion, error) {
+	detail, err := n.bentomlStore.GetModelDetail(name, version)
+	if err != nil {
+		return nil, n.explainStorageFailure(err)
+	}
+
+	return detail, nil
+}
+
+func (n *nfsFile) GetReadme(name, version string) (*Readme, error) {
+	readme, err := n.bentomlStore.GetReadme(name, version)
+	if err != nil {
+		return nil, n.explainStorageFailure(err)
+	}
+
+	return readme, nil
+}
+
+// explainStorageFailure re-reads the mount before a read failure is reported as
+// what it appeared to be. A file that vanished mid-read, or a model that is
+// suddenly not found, is a different answer depending on whether the mount is
+// still there — and "the model does not exist" is the wrong thing to tell a user
+// whose storage dropped out.
+func (n *nfsFile) explainStorageFailure(err error) error {
+	if mountErr := n.checkMount(); mountErr != nil {
+		return mountErr
+	}
+
+	return err
+}
+
+func (n *nfsFile) checkMount() error {
+	exists, err := nfs.IsMountExist(n.nfsServerPath, n.path)
+	if err != nil {
+		return errors.Wrapf(ErrStorageUnavailable, "failed to check NFS mount %s at %s: %v", n.nfsServerPath, n.path, err)
+	}
+
+	if !exists {
+		return errors.Wrapf(ErrStorageUnavailable, "NFS mount %s at %s is no longer present", n.nfsServerPath, n.path)
+	}
+
+	return nil
 }
 
 func (n *nfsFile) HealthyCheck() error {

--- a/internal/model_registry/file_based_nfs_test.go
+++ b/internal/model_registry/file_based_nfs_test.go
@@ -1,0 +1,234 @@
+package model_registry
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	kmount "k8s.io/utils/mount"
+
+	"github.com/neutree-ai/neutree/internal/nfs"
+)
+
+const testNFSServerPath = "nfs.example.internal:/exports/models"
+
+// newTestNFSRegistry builds an NFS-backed registry over a real directory, with a
+// mount table that says the directory is that registry's mount. Symlinks are
+// resolved because the mount table records what the kernel would report.
+func newTestNFSRegistry(t *testing.T) (*nfsFile, *kmount.FakeMounter) {
+	t.Helper()
+
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	mountPoint := filepath.Join(base, "registry")
+	require.NoError(t, os.Mkdir(mountPoint, 0o755))
+
+	mounter := kmount.NewFakeMounter([]kmount.MountPoint{{
+		Device: testNFSServerPath,
+		Path:   mountPoint,
+		Type:   "nfs",
+	}})
+	t.Cleanup(nfs.SetMountInterfaceForTesting(mounter))
+
+	return &nfsFile{
+		bentomlStore:  bentomlStore{path: mountPoint},
+		nfsServerPath: testNFSServerPath,
+	}, mounter
+}
+
+// A registry with nothing in it and a registry whose mount vanished read exactly
+// the same from the filesystem. Reporting the second as an empty list is how a
+// storage outage reached users as "this registry has no models".
+func TestNFSListModelsReportsAVanishedMountInsteadOfAnEmptyList(t *testing.T) {
+	registry, mounter := newTestNFSRegistry(t)
+
+	mounter.MountPoints = nil
+
+	page, err := registry.ListModels(ListOption{})
+	require.Nil(t, page)
+	require.ErrorIs(t, err, ErrStorageUnavailable)
+	require.ErrorContains(t, err, registry.path)
+}
+
+func TestNFSListModelsAcceptsAnEmptyMountedRegistry(t *testing.T) {
+	registry, _ := newTestNFSRegistry(t)
+
+	page, err := registry.ListModels(ListOption{})
+	require.NoError(t, err)
+	require.Empty(t, page.Models)
+	require.NotNil(t, page.Total)
+	require.Equal(t, 0, *page.Total)
+}
+
+func TestNFSListModelsReturnsModelsWhileMounted(t *testing.T) {
+	registry, _ := newTestNFSRegistry(t)
+	writeStoredModel(t, registry.path, "qwen3", "v1", nil)
+
+	page, err := registry.ListModels(ListOption{})
+	require.NoError(t, err)
+	require.Len(t, page.Models, 1)
+	require.Equal(t, "qwen3", page.Models[0].Name)
+}
+
+// "Model not found" is a statement about the registry's contents. When the mount
+// is gone we do not know the contents, and saying it anyway sends the user
+// looking for a model they never lost.
+func TestNFSModelReadsReportAVanishedMountInsteadOfNotFound(t *testing.T) {
+	registry, mounter := newTestNFSRegistry(t)
+	writeStoredModel(t, registry.path, "qwen3", "v1", nil)
+
+	mounter.MountPoints = nil
+	require.NoError(t, os.RemoveAll(filepath.Join(registry.path, "models")))
+
+	t.Run("detail", func(t *testing.T) {
+		_, err := registry.GetModelDetail("qwen3", "v1")
+		require.ErrorIs(t, err, ErrStorageUnavailable)
+	})
+
+	t.Run("version", func(t *testing.T) {
+		_, err := registry.GetModelVersion("qwen3", "v1")
+		require.ErrorIs(t, err, ErrStorageUnavailable)
+	})
+
+	t.Run("readme", func(t *testing.T) {
+		_, err := registry.GetReadme("qwen3", "v1")
+		require.ErrorIs(t, err, ErrStorageUnavailable)
+	})
+}
+
+// A genuine miss on a healthy mount stays a miss.
+func TestNFSMissingModelOnAHealthyMountStaysNotFound(t *testing.T) {
+	registry, _ := newTestNFSRegistry(t)
+	writeStoredModel(t, registry.path, "qwen3", "v1", nil)
+
+	_, err := registry.GetModelVersion("qwen3", "v2")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrStorageUnavailable)
+}
+
+// The reported failure: three concurrent readers of one registry, and whichever
+// finished first unmounted the tree the other two were walking.
+func TestNFSDisconnectingOneReaderKeepsTheMountForTheOthers(t *testing.T) {
+	first, _ := newTestNFSRegistry(t)
+	writeStoredModel(t, first.path, "qwen3", "v1", nil)
+
+	second := &nfsFile{bentomlStore: bentomlStore{path: first.path}, nfsServerPath: testNFSServerPath}
+	third := &nfsFile{bentomlStore: bentomlStore{path: first.path}, nfsServerPath: testNFSServerPath}
+
+	for _, reader := range []*nfsFile{first, second, third} {
+		require.NoError(t, reader.Connect())
+	}
+
+	require.NoError(t, first.Disconnect())
+
+	for _, reader := range []*nfsFile{second, third} {
+		page, err := reader.ListModels(ListOption{})
+		require.NoError(t, err)
+		require.Len(t, page.Models, 1)
+		require.NoError(t, reader.HealthyCheck())
+	}
+
+	require.NoError(t, second.Disconnect())
+	require.NoError(t, third.Disconnect())
+}
+
+// A client that never connected is a lifecycle caller — deletion, or a reconnect
+// after failure. It is the one that unmounts, and it is refused while readers are
+// still holding the mount.
+func TestNFSTeardownWaitsForActiveReaders(t *testing.T) {
+	reader, _ := newTestNFSRegistry(t)
+
+	owner := &nfsFile{bentomlStore: bentomlStore{path: reader.path}, nfsServerPath: testNFSServerPath}
+
+	require.NoError(t, reader.Connect())
+	require.ErrorIs(t, owner.Disconnect(), ErrMountBusy)
+
+	exists, err := nfs.IsMountExist(testNFSServerPath, reader.path)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	require.NoError(t, reader.Disconnect())
+	require.NoError(t, owner.Disconnect())
+
+	exists, err = nfs.IsMountExist(testNFSServerPath, reader.path)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+// Connect is idempotent per client, so a client cannot leak a lease and leave the
+// mount undeletable forever.
+func TestNFSRepeatedConnectHoldsOneLease(t *testing.T) {
+	reader, _ := newTestNFSRegistry(t)
+	owner := &nfsFile{bentomlStore: bentomlStore{path: reader.path}, nfsServerPath: testNFSServerPath}
+
+	require.NoError(t, reader.Connect())
+	require.NoError(t, reader.Connect())
+	require.NoError(t, reader.Disconnect())
+
+	require.NoError(t, owner.Disconnect())
+}
+
+// The reported profile in miniature: rounds of three concurrent readers — a
+// filtered list, an unfiltered list and a detail read — each connecting and
+// disconnecting around its own request. Before the mount was leased, whichever
+// finished first unmounted the tree the other two were reading, and the round
+// came back with mount errors or an empty list.
+func TestNFSConcurrentReadersNeverLoseTheMount(t *testing.T) {
+	shared, _ := newTestNFSRegistry(t)
+	writeStoredModel(t, shared.path, "qwen3", "v1", nil)
+
+	read := func(t *testing.T, do func(*nfsFile) error) {
+		t.Helper()
+
+		client := &nfsFile{bentomlStore: bentomlStore{path: shared.path}, nfsServerPath: testNFSServerPath}
+		require.NoError(t, client.Connect())
+
+		defer func() { require.NoError(t, client.Disconnect()) }()
+
+		require.NoError(t, do(client))
+	}
+
+	for round := range 100 {
+		var wg sync.WaitGroup
+
+		wg.Add(3)
+
+		go func() {
+			defer wg.Done()
+			read(t, func(client *nfsFile) error {
+				page, err := client.ListModels(ListOption{})
+				if err == nil && len(page.Models) != 1 {
+					err = errors.Errorf("round %d: unfiltered list returned %d models", round, len(page.Models))
+				}
+
+				return err
+			})
+		}()
+
+		go func() {
+			defer wg.Done()
+			read(t, func(client *nfsFile) error {
+				page, err := client.ListModels(ListOption{Search: "qwen"})
+				if err == nil && len(page.Models) != 1 {
+					err = errors.Errorf("round %d: filtered list returned %d models", round, len(page.Models))
+				}
+
+				return err
+			})
+		}()
+
+		go func() {
+			defer wg.Done()
+			read(t, func(client *nfsFile) error {
+				_, err := client.GetModelDetail("qwen3", "v1")
+				return err
+			})
+		}()
+
+		wg.Wait()
+	}
+}

--- a/internal/model_registry/model_registry.go
+++ b/internal/model_registry/model_registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/nfs"
 )
 
 var (
@@ -17,6 +18,18 @@ var (
 	// ErrNotFound is returned when the registry is reachable but the requested
 	// object is not there.
 	ErrNotFound = errors.New("not found in model registry")
+	// ErrStorageUnavailable is returned when the registry's backing storage went
+	// away underneath a read — an NFS mount that disappeared, most often. It is
+	// deliberately distinct from ErrNotFound and from an empty listing: both of
+	// those are statements about the registry's contents, and reporting a storage
+	// outage as either tells the caller something false about what it holds.
+	// Retrying is the right response.
+	ErrStorageUnavailable = errors.New("model registry storage is temporarily unavailable")
+	// ErrMountBusy is returned when a registry's backing mount could not be torn
+	// down because other clients are still reading through it. Callers that were
+	// tearing it down for their own reasons can carry on; callers that need it
+	// gone should retry.
+	ErrMountBusy = nfs.ErrMountBusy
 )
 
 type ListOption struct {

--- a/internal/nfs/lease.go
+++ b/internal/nfs/lease.go
@@ -1,0 +1,131 @@
+package nfs
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+)
+
+// ErrMountBusy says a mount point still has active readers, so tearing it down
+// was refused. It is transient by nature: the caller either retries later or
+// leaves the mount to whoever is using it.
+var ErrMountBusy = errors.New("nfs mount is still in use")
+
+// ErrUnexpectedMountDevice says the mount point is occupied by a mount of some
+// other export. Usually that is a registry whose URL was edited: the mount point
+// is derived from the registry's identity, not its URL, so the old export is
+// still sitting there.
+var ErrUnexpectedMountDevice = errors.New("nfs mount point holds an unexpected device")
+
+// A single NFS registry is read through one fixed mount point by every request
+// handler and by the reconcile loop at the same time. Without a shared record of
+// who is using it, each of them mounts and unmounts on its own schedule, and one
+// finishing a read removes the mount another is still walking — which is how
+// concurrent list/detail requests turned into mount ENOENT errors and wrongly
+// empty listings.
+//
+// mountGuard is that shared record, keyed by mount point:
+//   - opMu serialises the mount and unmount syscalls, so two callers never race
+//     to create or remove the same mount point.
+//   - refs counts the leases handed out by AcquireMount. Unmount refuses while it
+//     is above zero.
+//
+// This is process-local. It makes concurrent readers inside one process safe
+// against each other, which is where the damage was measured; a mount shared
+// across processes still relies on each process only tearing down what it owns.
+type mountGuard struct {
+	opMu sync.Mutex
+
+	refMu sync.Mutex
+	refs  int
+}
+
+func (g *mountGuard) held() int {
+	g.refMu.Lock()
+	defer g.refMu.Unlock()
+
+	return g.refs
+}
+
+func (g *mountGuard) acquire() {
+	g.refMu.Lock()
+	defer g.refMu.Unlock()
+
+	g.refs++
+}
+
+func (g *mountGuard) release() {
+	g.refMu.Lock()
+	defer g.refMu.Unlock()
+
+	if g.refs > 0 {
+		g.refs--
+	}
+}
+
+var (
+	guardsMu sync.Mutex
+	// guards is never pruned. It holds one small struct per mount point the
+	// process has touched, which is bounded by the number of registries, and
+	// keeping entries alive means a lease and a teardown racing over the same path
+	// always meet on the same guard.
+	guards = map[string]*mountGuard{}
+)
+
+func guardFor(mountPoint string) *mountGuard {
+	guardsMu.Lock()
+	defer guardsMu.Unlock()
+
+	guard, ok := guards[mountPoint]
+	if !ok {
+		guard = &mountGuard{}
+		guards[mountPoint] = guard
+	}
+
+	return guard
+}
+
+// AcquireMount mounts device at mountPoint if needed and records that the caller
+// is reading through it. Every successful call must be paired with ReleaseMount,
+// usually deferred. While a lease is held, Unmount on that mount point fails with
+// ErrMountBusy instead of pulling the ground out from under the reader.
+func AcquireMount(device string, mountPoint string) error {
+	guard := guardFor(mountPoint)
+
+	guard.opMu.Lock()
+	defer guard.opMu.Unlock()
+
+	if err := mountLocked(device, mountPoint); err != nil {
+		// A leftover mount of a different export would otherwise wedge the mount
+		// point for the life of the process, now that reads no longer unmount on
+		// their way out. Replacing it is only safe because no lease is held: nobody
+		// is reading through the mount being removed.
+		if !errors.Is(err, ErrUnexpectedMountDevice) || guard.held() > 0 {
+			return err
+		}
+
+		klog.Warningf("replacing stale mount at %s with %s: %v", mountPoint, device, err)
+
+		if unmountErr := unmountLocked(mountPoint); unmountErr != nil {
+			return errors.Wrapf(unmountErr, "failed to clear stale mount at %s", mountPoint)
+		}
+
+		if err = mountLocked(device, mountPoint); err != nil {
+			return err
+		}
+	}
+
+	guard.acquire()
+
+	return nil
+}
+
+// ReleaseMount gives up one lease. It deliberately does not unmount when the last
+// one goes: the mount belongs to the registry's lifecycle, and a read finishing
+// is not a reason to tear it down — that is the unmount storm this whole
+// mechanism exists to stop. Teardown is Unmount, called from the paths that own
+// the registry.
+func ReleaseMount(mountPoint string) {
+	guardFor(mountPoint).release()
+}

--- a/internal/nfs/lease_test.go
+++ b/internal/nfs/lease_test.go
@@ -1,0 +1,206 @@
+package nfs
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	kmount "k8s.io/utils/mount"
+)
+
+// mountedFakeMounter is a fake whose mount table already contains target, the
+// state every one of these tests starts from: the registry is mounted and being
+// read.
+func mountedFakeMounter(target string) *kmount.FakeMounter {
+	return kmount.NewFakeMounter([]kmount.MountPoint{{
+		Device: testNFSDevice,
+		Path:   target,
+		Type:   "nfs",
+	}})
+}
+
+// targetDir returns a mount point path under a temporary directory, with symlinks
+// already resolved: the fake mounter records what the kernel would report, and on
+// macOS the temporary directory is reached through a symlink.
+func targetDir(t *testing.T) string {
+	t.Helper()
+
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	return filepath.Join(base, "registry")
+}
+
+func mountedTarget(t *testing.T) string {
+	t.Helper()
+
+	target := targetDir(t)
+	require.NoError(t, os.Mkdir(target, 0o755))
+
+	return target
+}
+
+// The bug this whole mechanism exists for: one reader finishing pulled the mount
+// out from under the readers still walking it.
+func TestUnmountIsRefusedWhileALeaseIsHeld(t *testing.T) {
+	target := mountedTarget(t)
+	mounter := mountedFakeMounter(target)
+	useMountInterface(t, mounter)
+
+	require.NoError(t, AcquireMount(testNFSDevice, target))
+
+	err := Unmount(target)
+	require.ErrorIs(t, err, ErrMountBusy)
+	require.ErrorContains(t, err, target)
+
+	exists, err := IsMountExist(testNFSDevice, target)
+	require.NoError(t, err)
+	require.True(t, exists, "the mount a reader still holds must survive another client's teardown")
+}
+
+// Releasing is not tearing down. A read finishing leaves the registry mounted for
+// the next one — unmount is a lifecycle decision, made by the paths that own the
+// registry.
+func TestReleaseMountLeavesTheMountInPlace(t *testing.T) {
+	target := mountedTarget(t)
+	useMountInterface(t, mountedFakeMounter(target))
+
+	require.NoError(t, AcquireMount(testNFSDevice, target))
+	ReleaseMount(target)
+
+	exists, err := IsMountExist(testNFSDevice, target)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestUnmountSucceedsOnceEveryLeaseIsReleased(t *testing.T) {
+	target := mountedTarget(t)
+	useMountInterface(t, mountedFakeMounter(target))
+
+	require.NoError(t, AcquireMount(testNFSDevice, target))
+	require.NoError(t, AcquireMount(testNFSDevice, target))
+
+	ReleaseMount(target)
+	require.ErrorIs(t, Unmount(target), ErrMountBusy, "one reader is still holding the mount")
+
+	ReleaseMount(target)
+	require.NoError(t, Unmount(target))
+
+	exists, err := IsMountExist(testNFSDevice, target)
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.NoFileExists(t, target)
+}
+
+// A mount point that still holds files after the unmount is left alone. Deleting
+// it recursively is how a teardown racing a remount erases the remote model tree.
+func TestUnmountDoesNotDeleteDirectoryContents(t *testing.T) {
+	target := mountedTarget(t)
+	useMountInterface(t, mountedFakeMounter(target))
+
+	model := filepath.Join(target, "model.yaml")
+	require.NoError(t, os.WriteFile(model, []byte("name: qwen3\n"), 0o644))
+
+	require.NoError(t, Unmount(target))
+	require.FileExists(t, model, "unmount must not remove what is inside the mount point")
+}
+
+// Concurrent readers of one registry: they share the mount, they mount it once,
+// and none of them ends up without it.
+func TestConcurrentLeasesShareASingleMount(t *testing.T) {
+	target := targetDir(t)
+	mounter := kmount.NewFakeMounter(nil)
+	useMountInterface(t, mounter)
+
+	const readers = 16
+
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		errs []error
+	)
+
+	for range readers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			if err := AcquireMount(testNFSDevice, target); err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+
+				return
+			}
+			defer ReleaseMount(target)
+
+			// Every reader must find the mount present for as long as it holds a
+			// lease, whatever the others are doing.
+			exists, err := IsMountExist(testNFSDevice, target)
+			if err == nil && !exists {
+				err = errors.New("mount disappeared while a lease was held")
+			}
+
+			if err != nil {
+				mu.Lock()
+				errs = append(errs, err)
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	require.Empty(t, errs)
+	require.Len(t, mounter.GetLog(), 1, "the shared mount point is mounted once, not once per reader")
+
+	// With every lease given back, the owner can still tear it down.
+	require.NoError(t, Unmount(target))
+}
+
+// A registry whose URL was edited leaves the old export mounted at a mount point
+// derived from the registry's identity. Since reads no longer unmount on their
+// way out, nothing would ever clear it — so acquiring replaces it, but only while
+// no one is reading through it.
+func TestAcquireMountReplacesAStaleMountOfAnotherExport(t *testing.T) {
+	const staleDevice = "old-nfs.example.internal:/exports/models"
+
+	target := mountedTarget(t)
+	mounter := kmount.NewFakeMounter([]kmount.MountPoint{{
+		Device: staleDevice,
+		Path:   target,
+		Type:   "nfs",
+	}})
+	useMountInterface(t, mounter)
+
+	require.NoError(t, AcquireMount(testNFSDevice, target))
+	defer ReleaseMount(target)
+
+	exists, err := IsMountExist(testNFSDevice, target)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestAcquireMountKeepsAStaleMountThatIsBeingRead(t *testing.T) {
+	const staleDevice = "old-nfs.example.internal:/exports/models"
+
+	target := mountedTarget(t)
+	useMountInterface(t, kmount.NewFakeMounter([]kmount.MountPoint{{
+		Device: staleDevice,
+		Path:   target,
+		Type:   "nfs",
+	}}))
+
+	require.NoError(t, AcquireMount(staleDevice, target))
+	defer ReleaseMount(target)
+
+	err := AcquireMount(testNFSDevice, target)
+	require.ErrorIs(t, err, ErrUnexpectedMountDevice)
+
+	exists, err := IsMountExist(staleDevice, target)
+	require.NoError(t, err)
+	require.True(t, exists, "a mount someone is reading is never replaced under them")
+}

--- a/internal/nfs/nfs.go
+++ b/internal/nfs/nfs.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
+	"k8s.io/klog/v2"
 	kmount "k8s.io/utils/mount"
 
 	"github.com/pkg/errors"
@@ -91,7 +93,19 @@ func GetNFSVersion(device string, mountPoint string) (string, error) {
 	return "", errors.Errorf("mount %s at %s not found", device, mountPoint)
 }
 
+// MountNFS mounts device at mountPoint if it is not already mounted there. It
+// takes no lease: use AcquireMount when the caller is about to read through the
+// mount and must not have it pulled out from under it.
 func MountNFS(device string, mountPoint string) error {
+	guard := guardFor(mountPoint)
+
+	guard.opMu.Lock()
+	defer guard.opMu.Unlock()
+
+	return mountLocked(device, mountPoint)
+}
+
+func mountLocked(device string, mountPoint string) error {
 	existed, unexpectedDevice, err := findMount(device, mountPoint)
 	if err != nil {
 		return err
@@ -102,7 +116,8 @@ func MountNFS(device string, mountPoint string) error {
 	}
 
 	if unexpectedDevice != "" {
-		return errors.Errorf("mount point %s is already mounted from unexpected source %s", mountPoint, unexpectedDevice)
+		return errors.Wrapf(ErrUnexpectedMountDevice,
+			"mount point %s is already mounted from unexpected source %s", mountPoint, unexpectedDevice)
 	}
 
 	err = os.MkdirAll(mountPoint, 0o755)
@@ -112,14 +127,34 @@ func MountNFS(device string, mountPoint string) error {
 
 	err = mountInterface.Mount(device, mountPoint, "nfs", defaultNFSMountOptions)
 	if err != nil {
-		_ = os.RemoveAll(mountPoint)
+		// Only the empty directory this call created is cleaned up. A recursive
+		// delete here would erase the remote tree if another goroutine or process
+		// mounted the same point in between.
+		_ = os.Remove(mountPoint)
+
 		return errors.Wrapf(err, "failed to mount nfs %s to %s", device, mountPoint)
 	}
 
 	return nil
 }
 
+// Unmount tears the mount point down. It refuses while any lease taken through
+// AcquireMount is still held: a reader that is halfway through walking the tree
+// must not have the mount removed under it.
 func Unmount(mountPoint string) error {
+	guard := guardFor(mountPoint)
+
+	guard.opMu.Lock()
+	defer guard.opMu.Unlock()
+
+	if guard.held() > 0 {
+		return errors.Wrapf(ErrMountBusy, "cannot unmount %s", mountPoint)
+	}
+
+	return unmountLocked(mountPoint)
+}
+
+func unmountLocked(mountPoint string) error {
 	mountPoints, err := mountInterface.List()
 	if err != nil {
 		return err
@@ -136,8 +171,17 @@ func Unmount(mountPoint string) error {
 		}
 	}
 
-	err = os.RemoveAll(mountPoint)
-	if err != nil {
+	// os.Remove, not os.RemoveAll: the directory is only ours to delete once it is
+	// empty. If the listing above missed a mount that is still live — a concurrent
+	// remount, or a mount made in another process — a recursive delete would walk
+	// into the remote tree and delete models. A non-empty leftover is local junk;
+	// leaving it behind is harmless and the next mount reuses it.
+	if err = os.Remove(mountPoint); err != nil && !os.IsNotExist(err) {
+		if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EBUSY) {
+			klog.Warningf("mount point %s is not empty after unmount, leaving it in place: %v", mountPoint, err)
+			return nil
+		}
+
 		return err
 	}
 

--- a/internal/nfs/testing.go
+++ b/internal/nfs/testing.go
@@ -1,0 +1,18 @@
+package nfs
+
+import (
+	kmount "k8s.io/utils/mount"
+)
+
+// SetMountInterfaceForTesting swaps the mounter this package drives and returns
+// a function that puts the original back. It exists so packages that read
+// through an NFS mount — the model registry, above all — can be tested against a
+// mount table they control instead of the host's.
+func SetMountInterfaceForTesting(mounter kmount.Interface) func() {
+	original := mountInterface
+	mountInterface = mounter
+
+	return func() {
+		mountInterface = original
+	}
+}

--- a/internal/routes/models/errors.go
+++ b/internal/routes/models/errors.go
@@ -57,7 +57,8 @@ func registryAcceptsWrites(registry *v1.ModelRegistry) bool {
 //
 // Status codes follow what the user can do about it: 400 when the registry as
 // configured cannot serve the request (wrong kind, or rejected credentials),
-// 404 when the thing is not there, and 429 passed through as itself.
+// 404 when the thing is not there, 429 passed through as itself, and 503 when
+// the registry's storage went away and the request is worth repeating.
 func respondRegistryError(c *gin.Context, context string, err error) bool {
 	switch {
 	case stderrors.Is(err, model_registry.ErrNotFound):
@@ -74,6 +75,14 @@ func respondRegistryError(c *gin.Context, context string, err error) bool {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"message": fmt.Sprintf("%s: %v", context, err),
 			"reason":  reasonUnauthorized,
+		})
+	case stderrors.Is(err, model_registry.ErrStorageUnavailable):
+		// 503, not 500: the registry's storage dropped out from under the read, the
+		// request was not wrong, and coming back later is the answer.
+		klog.Warningf("%s: %v", context, err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"message": fmt.Sprintf("%s: %v", context, err),
+			"reason":  reasonUnavailable,
 		})
 	case stderrors.Is(err, model_registry.ErrRateLimited):
 		klog.Warningf("%s: %v", context, err)

--- a/internal/routes/models/readme_test.go
+++ b/internal/routes/models/readme_test.go
@@ -122,6 +122,14 @@ func TestGetModelReadme_DistinguishesFailures(t *testing.T) {
 			wantReason: reasonUnauthorized,
 		},
 		{
+			// The mount the registry reads through went away. Not a fact about the
+			// model — answering 404 here would tell the user their model is gone.
+			name:       "the registry's storage dropped out",
+			err:        errors.Wrap(model_registry.ErrStorageUnavailable, "NFS mount is no longer present"),
+			wantStatus: http.StatusServiceUnavailable,
+			wantReason: reasonUnavailable,
+		},
+		{
 			// Nothing is wrong; come back later. Passed through as itself so a
 			// client does not have to parse prose to know that.
 			name:       "the registry is throttling us",


### PR DESCRIPTION
## Issue

NEU-685

## Summary

Concurrent reads of one NFS model registry unmounted each other. Every list/search/detail request built its own registry client, mounted the registry's fixed mount point on connect and unmounted it — plus `os.RemoveAll` — on the way out, with no lock, refcount or ownership between them. Any request finishing could remove the mount another request, or the reconcile loop, was still reading through. The reported profile measured 65% 5xx across 300 concurrent read requests, plus wrongly empty `200`s and false "model not found" answers, because a mount that had just disappeared reads exactly like an empty registry.

## Changes

- **Mount lease guard** (`internal/nfs/lease.go`): one guard per mount point holding a lock that serialises the mount/unmount syscalls and a count of active read leases. `AcquireMount` mounts if needed and takes a lease; `ReleaseMount` gives it back and never unmounts; `Unmount` refuses with `ErrMountBusy` while any lease is held.
- **`Disconnect()` now means two things** (`internal/model_registry/file_based.go`): a client that connected is a reader letting go — it drops its lease and leaves the mount for the others. A client that never connected is a lifecycle caller (registry deletion, or reconnect after failure) asking for the mount itself to go, and that is the only path that unmounts.
- **Reconcile takes a lease like any other reader** (`controllers/model_registry_controller.go`), and treats `ErrMountBusy` on the failed-registry reconnect as "leave the mount to the readers" instead of a reconcile error. Deletion still surfaces it and retries.
- **No recursive delete on a mount point** (`internal/nfs/nfs.go`): `os.RemoveAll` → `os.Remove` in both the unmount cleanup and the mount-failure cleanup. A teardown racing a remount could otherwise walk into the remote tree and delete models. A non-empty leftover is logged and left alone.
- **Empty registry vs. vanished mount**: NFS reads that come back empty or not-found re-check the mount, and a mount that is gone returns the new `model_registry.ErrStorageUnavailable`, answered as `503`/`unavailable` rather than a successful empty list or a false `404`.
- **Stale-device recovery**: because reads no longer unmount, a registry whose URL was edited would have wedged its mount point for the life of the process. `AcquireMount` replaces a mount of a different export, but only while no lease is held.

## Test Plan

- [x] Unit: new `internal/nfs/lease_test.go` and `internal/model_registry/file_based_nfs_test.go`, including a 100-round test of three concurrent readers (filtered list, unfiltered list, detail) connecting and disconnecting around their own requests. Verified non-vacuous: restoring the old `Connect`/`Disconnect` bodies makes both concurrency tests fail with the reported symptom (`NFS mount ... does not exist`). `go test ./internal/... ./controllers/...` and `golangci-lint` are green.
- [ ] E2E: **not run** — the ticket's acceptance criteria 3–5 (100 concurrent rounds against real NFS, model-tree hash unchanged across the run, NEU-620 TC4 canonical + supporting stability profile) need the testbed and are still outstanding.
- [x] DB integration (`make db-test`): `ok github.com/neutree-ai/neutree/db/dbtest 7.472s` locally. No schema change, but `TestModelRegistryStatsSurviveConnectivityReconcile` drives the real controller against a mocked registry and needed the new `Disconnect` expectation — CI caught this on the first run.

## Risk & Rollback

No DB or API schema change. Two behaviour changes reviewers should weigh:

1. **A registry's mount now outlives the requests that use it.** Previously every request unmounted on its way out; now the mount stays up until deletion or a failed-registry reconnect. That is the point of the fix, and it is one mount per registry per process, but it does mean the api-server keeps a mount for a registry deleted by the core process until it restarts.
2. **New `503` on model read paths** when the backing mount disappears, where callers previously saw `200` with an empty list or a `404`. Clients that treated an empty list as "registry has no models" now get an explicit retryable error instead of a wrong answer.

The guard is process-local. `neutree-core` and `neutree-api` run as separate containers, each with its own mount namespace and no propagated `/mnt` bind mount in either the Compose file or the Helm chart, so they never shared a mount point — coordination is only needed within a process. Rollback is a straight revert of the commit.
