### PR TITLE
feat(downloader): deploy models from ModelScope (NEU-689)

### DIFF
--- a/api/v1/model_registry_types.go
+++ b/api/v1/model_registry_types.go
@@ -65,6 +65,20 @@ const (
 	HFTokenEnv = "HF_TOKEN"
 	HFEndpoint = "HF_ENDPOINT"
 
+	// ModelScopeEndpointEnv and ModelScopeTokenEnv carry the registry's address
+	// and credential into the inference container, the same way the HF_* pair
+	// does. The names are ModelScope's own, so a mirror configured for the
+	// official SDK is configured for this downloader too.
+	//
+	// Deliberately distinct from HF_TOKEN rather than reusing a single
+	// "the hub token" variable: a cluster can have both registries, and a
+	// Hugging Face token sent to ModelScope is a credential disclosed to a third
+	// party for no benefit.
+	ModelScopeEndpointEnv = "MODELSCOPE_ENDPOINT"
+	// gosec flags this as a hardcoded credential; it is the *name* of the
+	// variable a credential is read from, which is exactly why it is a constant.
+	ModelScopeTokenEnv = "MODELSCOPE_API_TOKEN" //nolint:gosec // G101: env var name, not a secret
+
 	BentoMLHomeEnv = "BENTOML_HOME"
 )
 

--- a/cluster-image-builder/serve/llama_cpp/v0_3_7/app.py
+++ b/cluster-image-builder/serve/llama_cpp/v0_3_7/app.py
@@ -124,7 +124,7 @@ class Backend:
         Backend deployment for LlamaCpp model inference.
 
         Args:
-            model_registry_type: Type of model registry ("bentoml" or "hugging-face")
+            model_registry_type: Type of model registry ("bentoml", "hugging-face" or "model-scope")
             model_name: Name of the model in the registry
             model_version: Version of the model
             model_file: Specific model file name (for hugging-face)

--- a/cluster-image-builder/serve/sglang/v0_5_10/app.py
+++ b/cluster-image-builder/serve/sglang/v0_5_10/app.py
@@ -189,7 +189,7 @@ class Backend:
         """Backend deployment for SGLang inference.
 
         Args:
-            model_registry_type: Type of model registry ("bentoml" or "hugging-face")
+            model_registry_type: Type of model registry ("bentoml", "hugging-face" or "model-scope")
             model_name: Name of the model in the registry
             model_version: Version of the model
             model_file: Specific model file name (registry-dependent)

--- a/cluster-image-builder/serve/vllm/v0_17_1/app.py
+++ b/cluster-image-builder/serve/vllm/v0_17_1/app.py
@@ -67,7 +67,7 @@ class Backend:
         Backend deployment for vLLM inference.
 
         Args:
-            model_registry_type: Type of model registry ("bentoml" or "hugging-face")
+            model_registry_type: Type of model registry ("bentoml", "hugging-face" or "model-scope")
             model_name: Name of the model in the registry
             model_version: Version of the model
             model_file: Specific model file name (for bentoml)

--- a/cluster-image-builder/serve/vllm/v0_24_0/app.py
+++ b/cluster-image-builder/serve/vllm/v0_24_0/app.py
@@ -71,7 +71,7 @@ class Backend:
         Backend deployment for vLLM inference.
 
         Args:
-            model_registry_type: Type of model registry ("bentoml" or "hugging-face")
+            model_registry_type: Type of model registry ("bentoml", "hugging-face" or "model-scope")
             model_name: Name of the model in the registry
             model_version: Version of the model
             model_file: Specific model file name (for bentoml)

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -455,9 +455,21 @@ func (k *kubernetesOrchestrator) setModelRegistryVariables(data *DeploymentManif
 		data.ModelArgs["version"] = modelRealVersion
 		data.ModelArgs["registry_path"] = endpoint.Spec.Model.Name
 		data.ModelArgs["path"] = filepath.Join(v1.DefaultK8sClusterModelCacheMountPath, modelCacheRelativePath, endpoint.Spec.Model.Name, modelRealVersion)
+
 	case v1.ModelScopeModelRegistryType:
-		// Removed by NEU-689, which wires the downloader. See the error's own comment.
-		return errModelScopeDeployNotWiredYet
+		data.Env[v1.ModelScopeEndpointEnv] = strings.TrimSuffix(modelRegistry.Spec.Url, "/")
+		if modelRegistry.Spec.Credentials != "" {
+			data.Env[v1.ModelScopeTokenEnv] = modelRegistry.Spec.Credentials
+		}
+
+		modelRealVersion, err := getDeployedModelRealVersion(modelRegistry, endpoint.Spec.Model.Name, endpoint.Spec.Model.Version)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get deployed model real version for model %s", endpoint.Spec.Model.Name)
+		}
+
+		data.ModelArgs["version"] = modelRealVersion
+		data.ModelArgs["registry_path"] = endpoint.Spec.Model.Name
+		data.ModelArgs["path"] = filepath.Join(v1.DefaultK8sClusterModelCacheMountPath, modelCacheRelativePath, endpoint.Spec.Model.Name, modelRealVersion)
 	}
 
 	return nil

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -4301,12 +4301,10 @@ func klogTestLogger() klog.Logger {
 	return klog.Background()
 }
 
-// ModelScope is browsable but not yet deployable from, because the container's
-// downloader speaks only the Hugging Face Hub API. Until NEU-689 wires it, that
-// is refused with a reason here rather than falling through the switch, which
-// would produce a manifest carrying no model path at all and fail inside the
-// container with nothing to read.
-func TestKubernetesOrchestrator_setModelRegistryVariables_RefusesModelScopeUntilNEU689(t *testing.T) {
+// The ModelScope deploy path, end to end through the orchestrator: the registry
+// address and credential reach the container under ModelScope's own variable
+// names, and the model args name the repository the downloader will fetch.
+func TestKubernetesOrchestrator_setModelRegistryVariables_ModelScope(t *testing.T) {
 	k := &kubernetesOrchestrator{}
 
 	data := &DeploymentManifestVariables{
@@ -4315,7 +4313,50 @@ func TestKubernetesOrchestrator_setModelRegistryVariables_RefusesModelScopeUntil
 	}
 
 	err := k.setModelRegistryVariables(data, &v1.Endpoint{
-		Spec: &v1.EndpointSpec{Model: &v1.ModelSpec{Name: "Qwen/Qwen3-8B"}},
+		Metadata: &v1.Metadata{Name: "ms-endpoint", Workspace: "default"},
+		Spec: &v1.EndpointSpec{
+			Model: &v1.ModelSpec{Name: "Qwen/Qwen2.5-0.5B-Instruct-GGUF", Version: "latest"},
+		},
+	}, &v1.Cluster{}, &v1.ModelRegistry{
+		Metadata: &v1.Metadata{Name: "public-model-scope"},
+		Spec: &v1.ModelRegistrySpec{
+			Type:        v1.ModelScopeModelRegistryType,
+			Url:         "https://www.modelscope.cn/",
+			Credentials: "ms-token",
+		},
+	})
+
+	require.NoError(t, err)
+
+	// Trailing slash trimmed, as for HF_ENDPOINT.
+	assert.Equal(t, "https://www.modelscope.cn", data.Env[v1.ModelScopeEndpointEnv])
+	assert.Equal(t, "ms-token", data.Env[v1.ModelScopeTokenEnv])
+	// A ModelScope credential must never be presented as a Hugging Face one.
+	assert.NotContains(t, data.Env, v1.HFTokenEnv)
+
+	assert.Equal(t, "Qwen/Qwen2.5-0.5B-Instruct-GGUF", data.ModelArgs["registry_path"])
+	// "latest" is normalised to empty so the downloader omits Revision and lets
+	// the hub resolve the repository's own default branch — which is "master",
+	// not "main", and which the hub does not report as an error when guessed
+	// wrongly.
+	assert.Equal(t, "", data.ModelArgs["version"])
+	assert.Contains(t, data.ModelArgs["path"], "Qwen/Qwen2.5-0.5B-Instruct-GGUF")
+}
+
+// A registry with no credential must not put an empty token in the container's
+// environment: the downloader would then send "Authorization: Bearer " on every
+// request instead of making an anonymous one.
+func TestKubernetesOrchestrator_setModelRegistryVariables_ModelScopeWithoutCredentials(t *testing.T) {
+	k := &kubernetesOrchestrator{}
+
+	data := &DeploymentManifestVariables{
+		Env:       map[string]string{},
+		ModelArgs: map[string]interface{}{},
+	}
+
+	err := k.setModelRegistryVariables(data, &v1.Endpoint{
+		Metadata: &v1.Metadata{Name: "ms-endpoint", Workspace: "default"},
+		Spec:     &v1.EndpointSpec{Model: &v1.ModelSpec{Name: "Qwen/Qwen3-8B"}},
 	}, &v1.Cluster{}, &v1.ModelRegistry{
 		Metadata: &v1.Metadata{Name: "public-model-scope"},
 		Spec: &v1.ModelRegistrySpec{
@@ -4324,8 +4365,6 @@ func TestKubernetesOrchestrator_setModelRegistryVariables_RefusesModelScopeUntil
 		},
 	})
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot deploy a model from a ModelScope registry yet")
-	// Nothing half-built is handed back for a caller to deploy anyway.
-	assert.Empty(t, data.ModelArgs)
+	require.NoError(t, err)
+	assert.NotContains(t, data.Env, v1.ModelScopeTokenEnv)
 }

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -969,8 +969,19 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 		modelArgs["registry_path"] = endpoint.Spec.Model.Name
 		modelArgs["path"] = filepath.Join(v1.DefaultSSHClusterModelCacheMountPath, modelCacheRelativePath, endpoint.Spec.Model.Name, modelRealVersion)
 	case v1.ModelScopeModelRegistryType:
-		// Removed by NEU-689, which wires the downloader. See the error's own comment.
-		return dashboard.RayServeApplication{}, errModelScopeDeployNotWiredYet
+		applicationEnv[v1.ModelScopeEndpointEnv] = strings.TrimSuffix(modelRegistry.Spec.Url, "/")
+		if modelRegistry.Spec.Credentials != "" {
+			applicationEnv[v1.ModelScopeTokenEnv] = modelRegistry.Spec.Credentials
+		}
+
+		modelRealVersion, err := getDeployedModelRealVersion(modelRegistry, endpoint.Spec.Model.Name, endpoint.Spec.Model.Version)
+		if err != nil {
+			return dashboard.RayServeApplication{}, errors.Wrapf(err, "failed to get deployed model real version for model %s", endpoint.Spec.Model.Name)
+		}
+
+		modelArgs["version"] = modelRealVersion
+		modelArgs["registry_path"] = endpoint.Spec.Model.Name
+		modelArgs["path"] = filepath.Join(v1.DefaultSSHClusterModelCacheMountPath, modelCacheRelativePath, endpoint.Spec.Model.Name, modelRealVersion)
 	}
 
 	app.Args["model"] = modelArgs

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -4143,3 +4143,99 @@ func TestEndpointToApplication_WithoutModelRegistry(t *testing.T) {
 	// Registry-specific placement never ran, so no path was invented.
 	assert.NotContains(t, modelArgs, "registry_path")
 }
+
+// The ModelScope deploy path through the Ray (SSH cluster) orchestrator. The
+// Kubernetes orchestrator has the same test; both are here because the two
+// build their model args independently and a fix applied to one has silently
+// missed the other before.
+func TestEndpointToApplication_ModelScope(t *testing.T) {
+	endpoint := &v1.Endpoint{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "ms-endpoint"},
+		Spec: &v1.EndpointSpec{
+			Engine:            &v1.EndpointEngineSpec{Engine: "llama-cpp", Version: "0.3.7"},
+			Resources:         &v1.ResourceSpec{Accelerator: map[string]string{}},
+			DeploymentOptions: map[string]interface{}{},
+			Model: &v1.ModelSpec{
+				Name:    "Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+				File:    "*q2_k.gguf",
+				Version: v1.LatestVersion,
+				Task:    "text-generation",
+			},
+		},
+	}
+
+	modelRegistry := &v1.ModelRegistry{
+		Metadata: &v1.Metadata{Name: "public-model-scope"},
+		Spec: &v1.ModelRegistrySpec{
+			Type:        v1.ModelScopeModelRegistryType,
+			Url:         "https://www.modelscope.cn/",
+			Credentials: "ms-token",
+		},
+	}
+
+	app, err := EndpointToApplication(endpoint, &v1.Cluster{}, modelRegistry, nil, nil,
+		&acceleratormocks.MockManager{})
+	require.NoError(t, err)
+
+	modelArgs, ok := app.Args["model"].(map[string]interface{})
+	require.True(t, ok, "the application must carry model args")
+
+	// The repository the downloader will fetch. Before NEU-689 this path was
+	// refused outright, and before the refusal existed it fell through the
+	// switch leaving registry_path empty — an application with no model to load.
+	assert.Equal(t, "Qwen/Qwen2.5-0.5B-Instruct-GGUF", modelArgs["registry_path"])
+	// endpointModelRegistryType renders the kind as a bare string, which is what
+	// the downloader's --registry_type is built from.
+	assert.Equal(t, string(v1.ModelScopeModelRegistryType), modelArgs["registry_type"])
+	// "latest" is normalised away so the downloader omits Revision and the hub
+	// resolves its own default branch ("master", not "main").
+	assert.Equal(t, "", modelArgs["version"])
+	// The served model id carries no revision suffix, matching Hugging Face.
+	assert.Equal(t, "Qwen/Qwen2.5-0.5B-Instruct-GGUF", modelArgs["serve_name"])
+
+	env, ok := app.RuntimeEnv["env_vars"].(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "https://www.modelscope.cn", env[v1.ModelScopeEndpointEnv])
+	assert.Equal(t, "ms-token", env[v1.ModelScopeTokenEnv])
+	// A ModelScope credential must never be presented as a Hugging Face one.
+	assert.NotContains(t, env, v1.HFTokenEnv)
+	assert.NotContains(t, env, v1.HFEndpoint)
+}
+
+// Hugging Face regression guard (acceptance criterion 3): adding the ModelScope
+// case must not have changed anything on the path that already worked.
+func TestEndpointToApplication_HuggingFaceUnchangedByModelScopeSupport(t *testing.T) {
+	endpoint := &v1.Endpoint{
+		Metadata: &v1.Metadata{Workspace: "default", Name: "hf-endpoint"},
+		Spec: &v1.EndpointSpec{
+			Engine:            &v1.EndpointEngineSpec{Engine: "vllm", Version: "0.5.0"},
+			Resources:         &v1.ResourceSpec{Accelerator: map[string]string{}},
+			DeploymentOptions: map[string]interface{}{},
+			Model:             &v1.ModelSpec{Name: "Qwen/Qwen3-8B", Version: "main"},
+		},
+	}
+
+	modelRegistry := &v1.ModelRegistry{
+		Metadata: &v1.Metadata{Name: "public-hugging-face"},
+		Spec: &v1.ModelRegistrySpec{
+			Type:        v1.HuggingFaceModelRegistryType,
+			Url:         "https://huggingface.co/",
+			Credentials: "hf-token",
+		},
+	}
+
+	app, err := EndpointToApplication(endpoint, &v1.Cluster{}, modelRegistry, nil, nil,
+		&acceleratormocks.MockManager{})
+	require.NoError(t, err)
+
+	modelArgs := app.Args["model"].(map[string]interface{})
+	assert.Equal(t, "Qwen/Qwen3-8B", modelArgs["registry_path"])
+	// Passed through verbatim, as before — HF does its own default-branch handling.
+	assert.Equal(t, "main", modelArgs["version"])
+
+	env := app.RuntimeEnv["env_vars"].(map[string]string)
+	assert.Equal(t, "https://huggingface.co", env[v1.HFEndpoint])
+	assert.Equal(t, "hf-token", env[v1.HFTokenEnv])
+	assert.NotContains(t, env, v1.ModelScopeEndpointEnv)
+	assert.NotContains(t, env, v1.ModelScopeTokenEnv)
+}

--- a/internal/orchestrator/util.go
+++ b/internal/orchestrator/util.go
@@ -18,23 +18,6 @@ import (
 
 const acceleratorTypeCPU = "cpu"
 
-// errModelScopeDeployNotWiredYet is what both orchestrators answer when asked to
-// build an application from a ModelScope registry.
-//
-// It is a statement about this repository, not about ModelScope. The hub serves
-// both operations a downloader needs — list a revision's files, fetch one by
-// path — and internal/model_registry/model_scope.go names those endpoints. What
-// is missing is the container-side downloader, which today speaks only the
-// Hugging Face Hub API. NEU-689 wires it and deletes this refusal together with
-// the two cases that raise it.
-//
-// Until then the refusal is explicit rather than a fall-through, because falling
-// through the per-kind switch produces an application with no model path at all
-// and fails inside the container with nothing to read.
-var errModelScopeDeployNotWiredYet = errors.New(
-	"cannot deploy a model from a ModelScope registry yet: its models can be browsed and selected, " +
-		"but the inference runtime's downloader does not speak the ModelScope API")
-
 // engineTPArgKey returns the underscore-form engine_args key the engine
 // uses for tensor parallel size. vLLM uses `tensor_parallel_size`; SGLang's
 // ServerArgs dataclass field is `tp_size`. Returns "" when the engine
@@ -52,6 +35,14 @@ func engineTPArgKey(engineName string) string {
 	}
 }
 
+// endpointModelServeName is the model id the endpoint answers to over the
+// OpenAI-compatible API.
+//
+// A version is appended only for registries where it names a distinct stored
+// artifact — bentoml. On a hub the "version" is a git revision, so appending it
+// would publish a model as "Qwen/Qwen2.5-0.5B-Instruct:master", which is not a
+// name any client would ask for and differs from what the same model is called
+// when deployed from Hugging Face. Both hub kinds are excluded for that reason.
 func endpointModelServeName(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistry) string {
 	serveName := endpoint.Spec.Model.Name
 	if endpoint.Spec.Engine != nil && endpoint.Spec.Engine.Engine == v1.EngineNameSGLang {
@@ -64,7 +55,9 @@ func endpointModelServeName(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegist
 		return serveName
 	}
 
-	if endpoint.Spec.Model.Version != "" && endpoint.Spec.Model.Version != v1.LatestVersion && modelRegistry.Spec.Type != v1.HuggingFaceModelRegistryType {
+	if endpoint.Spec.Model.Version != "" && endpoint.Spec.Model.Version != v1.LatestVersion &&
+		modelRegistry.Spec.Type != v1.HuggingFaceModelRegistryType &&
+		modelRegistry.Spec.Type != v1.ModelScopeModelRegistryType {
 		serveName = endpoint.Spec.Model.Name + ":" + endpoint.Spec.Model.Version
 	}
 
@@ -454,6 +447,24 @@ func getDeployedModelRealVersion(modelRegistry *v1.ModelRegistry, modelName, mod
 		// For HuggingFace, return the version as-is (including empty string).
 		// Empty string will be converted to None by the Python downloader,
 		// which causes huggingface_hub to use the repository's default branch (main/master/etc).
+		return modelVersion, nil
+	}
+
+	if modelRegistry.Spec.Type == v1.ModelScopeModelRegistryType {
+		// Same shape as Hugging Face — the "version" is a git revision, not a
+		// stored artifact version, so there is nothing to look up.
+		//
+		// "latest" is normalised away rather than passed through. ModelScope's
+		// default branch is "master", not "main", and a wrong revision is not
+		// refused by the hub: it answers HTTP 200 with an empty file list. The
+		// downloader therefore omits the Revision parameter entirely for the
+		// default, letting the hub resolve the repository's own default branch,
+		// and "" is how that intent is spelled. This matches modelScope.revision()
+		// in internal/model_registry/model_scope.go.
+		if modelVersion == v1.LatestVersion {
+			return "", nil
+		}
+
 		return modelVersion, nil
 	}
 

--- a/internal/orchestrator/util_test.go
+++ b/internal/orchestrator/util_test.go
@@ -412,6 +412,87 @@ func TestGetDeployedModelRealVersion_Huggingface(t *testing.T) {
 	}
 }
 
+// ModelScope's "version" is a git revision, so there is nothing to look up —
+// but unlike Hugging Face, "latest" cannot be passed through. The hub's default
+// branch is "master", and it does not refuse a wrong revision: it answers HTTP
+// 200 with an empty file list, which a downloader would otherwise be free to
+// read as "this model has no files". Normalising to "" makes the downloader omit
+// the Revision parameter entirely and let the hub resolve its own default.
+func TestGetDeployedModelRealVersion_ModelScope(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputVersion string
+		expected     string
+	}{
+		{
+			name:         "latest is normalised away rather than sent as a branch name",
+			inputVersion: "latest",
+			expected:     "",
+		},
+		{
+			name:         "empty version already means the repository default",
+			inputVersion: "",
+			expected:     "",
+		},
+		{
+			name:         "an explicit revision is passed through untouched",
+			inputVersion: "v1.0.0",
+			expected:     "v1.0.0",
+		},
+		{
+			name:         "master is passed through; it is not special-cased here",
+			inputVersion: "master",
+			expected:     "master",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getDeployedModelRealVersion(&v1.ModelRegistry{
+				Spec: &v1.ModelRegistrySpec{
+					Type: v1.ModelScopeModelRegistryType,
+				},
+			}, "Qwen/Qwen3-8B", tt.inputVersion)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// The served model id is what a client puts in an OpenAI request. On a hub the
+// "version" is a git revision, so appending it would publish the model under a
+// name nobody would ask for, and under a different name than the identical model
+// deployed from the other hub.
+func TestEndpointModelServeName_HubRegistriesDoNotAppendTheRevision(t *testing.T) {
+	endpoint := func(version string) *v1.Endpoint {
+		return &v1.Endpoint{
+			Spec: &v1.EndpointSpec{
+				Engine: &v1.EndpointEngineSpec{Engine: v1.EngineNameVLLM},
+				Model:  &v1.ModelSpec{Name: "Qwen/Qwen3-8B", Version: version},
+			},
+		}
+	}
+	registry := func(kind v1.ModelRegistryType) *v1.ModelRegistry {
+		return &v1.ModelRegistry{Spec: &v1.ModelRegistrySpec{Type: kind}}
+	}
+
+	for _, kind := range []v1.ModelRegistryType{
+		v1.HuggingFaceModelRegistryType,
+		v1.ModelScopeModelRegistryType,
+	} {
+		t.Run(string(kind), func(t *testing.T) {
+			assert.Equal(t, "Qwen/Qwen3-8B",
+				endpointModelServeName(endpoint("master"), registry(kind)))
+		})
+	}
+
+	// BentoML is the contrast: there the version names a distinct stored
+	// artifact, so it belongs in the served name.
+	assert.Equal(t, "Qwen/Qwen3-8B:v3",
+		endpointModelServeName(endpoint("v3"), registry(v1.BentoMLModelRegistryType)))
+}
+
 func TestGetDeployedModelRealVersion_ModelRegistry(t *testing.T) {
 	test := []struct {
 		name          string

--- a/python/neutree/downloader/__init__.py
+++ b/python/neutree/downloader/__init__.py
@@ -1,6 +1,6 @@
 """neutree.downloader
 
-Simple downloader package supporting Hugging Face and Local backends.
+Simple downloader package supporting Hugging Face, ModelScope and Local backends.
 Run as module: python -m neutree.downloader
 """
 
@@ -10,6 +10,7 @@ from .utils import build_request_from_model_args, download_with_markers
 __all__ = [
     "base",
     "huggingface",
+    "model_scope",
     "local",
     "entity",
     "progress",

--- a/python/neutree/downloader/__main__.py
+++ b/python/neutree/downloader/__main__.py
@@ -18,7 +18,7 @@ def _build_parser():
     p.add_argument("--task", required=False, help="model task (informational)")
     p.add_argument("--registry_path", required=False, help="explicit registry path for the model")
     p.add_argument("--path", required=False, help="target path for the model")
-    p.add_argument("--registry_type", required=True, help="registry type (e.g., hugging-face, bentoml)")
+    p.add_argument("--registry_type", required=True, help="registry type (e.g., hugging-face, model-scope, bentoml)")
 
     return p
 

--- a/python/neutree/downloader/dispatcher.py
+++ b/python/neutree/downloader/dispatcher.py
@@ -24,6 +24,10 @@ def get_downloader(backend: str):
         from .huggingface import HuggingFaceDownloader as D
 
         return D()
+    if backend == "model-scope":
+        from .model_scope import ModelScopeDownloader as D
+
+        return D()
     if backend == "local":
         from .local import LocalDownloader as D
 

--- a/python/neutree/downloader/model_scope.py
+++ b/python/neutree/downloader/model_scope.py
@@ -1,0 +1,652 @@
+"""Downloader for ModelScope model repositories.
+
+Deliberately built on `urllib.request` from the standard library rather than on
+the `modelscope` SDK. That is not frugality, it is a constraint the repository
+already imposes: `cluster-image-builder/Dockerfile.engine-vllm` and
+`Dockerfile.engine-sglang` both copy this package's sources while explicitly
+refusing to `pip install downloader/requirements.txt`, because re-resolving the
+dependency set downgrades the `huggingface_hub` their bases ship and breaks the
+engine. Two of the three inference images therefore cannot take a new dependency
+at all. `modelscope` would pull in `requests`/`urllib3`/`tqdm` and, transitively,
+`huggingface_hub` — exactly the re-resolution those comments exist to prevent.
+
+Nothing is lost by it. Everything this downloader needs, ModelScope's REST API
+gives directly:
+
+  * list a repository's files, with size and SHA-256, at
+    GET /api/v1/models/<id>/repo/files?Recursive=True&Root=[&Revision=<rev>]
+  * read one file at
+    GET /api/v1/models/<id>/repo?FilePath=<path>[&Revision=<rev>]
+  * enumerate the revisions that exist at
+    GET /api/v1/models/<id>/revisions
+
+Large files answer 302 to a CDN host that honours `Range` (verified: a ranged
+request for a 988 MB weight file returns 206 with `content-range`), so resume is
+implementable here; and the file listing carries the real SHA-256 of every entry,
+LFS or not, so verification is a single algorithm rather than the LFS-sha256 /
+git-blob-sha1 pair the Hugging Face path has to juggle.
+
+Two behaviours of the hub shape the code and are worth stating up front:
+
+1. **A revision that does not exist answers 200, not 404.** Asking for
+   `Revision=main` or `Revision=zzz-not-a-branch` on a repository whose branch is
+   `master` yields `{"Code":200,"Message":"success","Data":{"Files":null}}`. An
+   empty file list is therefore never evidence that a repository is empty, and
+   `_no_files_error` refuses to treat it as such: it asks `/revisions` which of
+   the two it is, and says so. Silently producing an empty directory — which is
+   what a naive `for f in files:` loop would do — leaves the engine to fail later
+   on a directory with no weights in it.
+
+Concurrency is assumed, not exceptional: a neutree model cache is shared storage
+and an endpoint's replicas start together, so two processes fetch the same model
+into the same directory routinely. Two locks handle that, and are always taken in
+this order — `_download_lock` (per file, held across the whole fetch so the losing
+writer cannot share the winner's `.part`), then `_verify_record_lock` (the same
+lock file `huggingface.py` takes, around the same `.neutree/verify` store).
+
+2. **The default branch is `master`, not `main`.** Rather than hard-code either,
+   the `Revision` parameter is omitted entirely for the default version, which
+   makes the hub resolve the repository's own default. This mirrors
+   `internal/model_registry/model_scope.go`'s `revision()`. `DEFAULT_REVISION`
+   below is only ever used to *name* that version back to a caller.
+"""
+
+import fnmatch
+import json
+import logging
+import os
+import socket
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+
+from .base import Downloader
+from .progress import ProgressReporter, is_interactive
+from .utils import (
+    FileLock,
+    compute_sha256,
+    delete_verification_record,
+    ensure_dir,
+    is_offline_mode,
+    load_verification_record,
+    resolve_allow_pattern,
+    save_verification_record_with_algo,
+    should_keep_failed_files,
+    should_skip_verification,
+)
+
+logger = logging.getLogger(__name__)
+
+_log_level = os.environ.get("NEUTREE_LOG_LEVEL", "INFO").upper()
+try:
+    logger.setLevel(getattr(logging, _log_level))
+except (AttributeError, ValueError):
+    logger.setLevel(logging.INFO)
+
+if not logger.handlers:
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    ))
+    logger.addHandler(_handler)
+
+
+DEFAULT_ENDPOINT = "https://www.modelscope.cn"
+ENDPOINT_ENV = "MODELSCOPE_ENDPOINT"
+
+# What ModelScope calls a repository's default branch. Used to report a version
+# name, never to address one — see the module docstring.
+DEFAULT_REVISION = "master"
+
+# Version strings that mean "whatever the repository's default is". Kept in step
+# with modelScope.revision() in internal/model_registry/model_scope.go and with
+# v1.LatestVersion.
+_DEFAULT_VERSION_ALIASES = ("", "latest", DEFAULT_REVISION)
+
+_MODELS_PATH = "/api/v1/models"
+
+# Read timeout for a single socket operation, not for a whole download: a
+# multi-gigabyte weight file is many reads, each of which must make progress
+# within this window.
+_DEFAULT_TIMEOUT = 60.0
+
+_CHUNK_SIZE = 8 * 1024 * 1024
+
+# Suffix for the in-progress copy of a file. A download is only renamed onto its
+# final path after its checksum has been checked, so a half-written file is never
+# mistaken for a complete one by a later run or by the engine.
+_PART_SUFFIX = ".neutree-part"
+
+# Matches huggingface.py's timeout for the same lock over the same store.
+_VERIFY_LOCK_TIMEOUT = 600.0
+
+# The per-file lock is held for a whole download, so it has to outlast one. A
+# 600s cap would expire on any large weight file over a slow link and turn a
+# working download into a lock timeout.
+_DEFAULT_FILE_LOCK_TIMEOUT = 3600.0
+FILE_LOCK_TIMEOUT_ENV = "NEUTREE_DL_FILE_LOCK_TIMEOUT"
+
+
+def _file_lock_timeout() -> float:
+    raw = os.environ.get(FILE_LOCK_TIMEOUT_ENV)
+    if not raw:
+        return _DEFAULT_FILE_LOCK_TIMEOUT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_FILE_LOCK_TIMEOUT
+
+    return value if value > 0 else _DEFAULT_FILE_LOCK_TIMEOUT
+
+
+def _verify_record_lock(dest: str) -> FileLock:
+    """The lock huggingface.py takes around the verification-record store.
+
+    Deliberately the *same* lock file rather than a ModelScope-specific one:
+    both downloaders write `.neutree/verify/<path>.json` under the same names in
+    the same destination, so a private lock would exclude nothing that matters.
+    """
+    return FileLock(os.path.join(dest, ".neutree", "verify.lock"), timeout=_VERIFY_LOCK_TIMEOUT)
+
+
+def _download_lock(dest: str, rel_path: str) -> FileLock:
+    """Serialises one file's download into one destination.
+
+    A neutree model cache is shared storage and the replicas of an endpoint
+    start together, so two processes fetching the same model into the same
+    directory is the normal case. Without this they share a `.part` path, and
+    the losing writer keeps writing into the inode after the winner has renamed
+    it onto the final name — corrupting a file that has already been verified
+    and recorded as passing. Holding the lock across the whole fetch also means
+    the second process finds the finished file and skips it, instead of
+    downloading the same weights twice.
+
+    Lock ordering, wherever both are taken: this one first, then the verify
+    record lock. Never the other way round.
+    """
+    return FileLock(os.path.join(dest, ".neutree", "locks", rel_path + ".lock"),
+                    timeout=_file_lock_timeout())
+
+
+class ModelScopeDownloadUnavailable(RuntimeError):
+    """The hub could not be reached at all.
+
+    Distinct from every other failure on purpose: this is the one an air-gapped
+    deployment hits, and the message has to say that runtime download is
+    unavailable rather than surfacing a bare socket error or, worse, letting the
+    engine start against a directory with no model in it.
+    """
+
+
+def _endpoint(metadata: Optional[Dict[str, Any]] = None) -> str:
+    """Resolve the hub address.
+
+    The orchestrator passes the registry's own URL through the environment, so a
+    ModelScope mirror is reachable the same way `HF_ENDPOINT` makes a Hugging
+    Face mirror reachable.
+    """
+    url = os.environ.get(ENDPOINT_ENV) or ""
+    if not url and metadata:
+        url = metadata.get("registry_url") or ""
+    return (url or DEFAULT_ENDPOINT).rstrip("/")
+
+
+def _revision_param(version: Optional[str]) -> str:
+    """Map a version onto the hub's wire name for it.
+
+    Returns "" for "the repository's default", which is expressed by omitting the
+    parameter rather than by guessing a branch name.
+    """
+    if not version:
+        return ""
+    return "" if version.strip().lower() in _DEFAULT_VERSION_ALIASES else version
+
+
+def reported_revision(version: Optional[str]) -> str:
+    """The name to give a version back to a caller. Pairs with _revision_param."""
+    return _revision_param(version) or DEFAULT_REVISION
+
+
+class _NoAuthRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Follow redirects, but do not carry the hub token onto another host.
+
+    Weight files answer 302 to a CDN whose URL is already signed. urllib's stock
+    handler copies every header onto the redirected request, which would hand the
+    caller's ModelScope token to a host that neither needs nor should see it.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new is None:
+            return None
+
+        if urllib.parse.urlsplit(req.full_url).netloc != urllib.parse.urlsplit(newurl).netloc:
+            # Request.headers keys are capitalised by add_header/Request.__init__.
+            for key in list(new.headers):
+                if key.lower() == "authorization":
+                    del new.headers[key]
+
+        return new
+
+
+_opener = urllib.request.build_opener(_NoAuthRedirectHandler)
+
+
+def _open(url: str, token: Optional[str], timeout: float, extra_headers: Optional[Dict[str, str]] = None):
+    """Issue a GET and return the open response.
+
+    Raises ModelScopeDownloadUnavailable when the hub cannot be reached at all;
+    HTTP status codes come back as urllib.error.HTTPError for the caller to read.
+    """
+    req = urllib.request.Request(url, method="GET")
+    if token:
+        req.add_header("Authorization", "Bearer " + token)
+    for key, value in (extra_headers or {}).items():
+        req.add_header(key, value)
+
+    try:
+        return _opener.open(req, timeout=timeout)
+    except urllib.error.HTTPError:
+        raise
+    except (urllib.error.URLError, socket.timeout, OSError) as exc:
+        raise ModelScopeDownloadUnavailable(
+            f"runtime model download is unavailable: cannot reach the ModelScope endpoint "
+            f"{urllib.parse.urlsplit(url).scheme}://{urllib.parse.urlsplit(url).netloc} ({exc}). "
+            f"This deployment has no network path to the model hub, so the weights cannot be "
+            f"fetched at runtime."
+        ) from exc
+
+
+def _get_envelope(url: str, token: Optional[str], timeout: float, what: str) -> Dict[str, Any]:
+    """GET an endpoint that answers in ModelScope's JSON envelope, return its Data.
+
+    The hub's own Code/Message is finer-grained than the HTTP status and is what a
+    user needs to see, so it is carried into the error rather than replaced by it.
+    """
+    try:
+        with _open(url, token, timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            body = json.loads(exc.read().decode("utf-8", "replace"))
+            detail = f" (Code {body.get('Code')}: {body.get('Message')})" if isinstance(body, dict) else ""
+        except Exception:
+            detail = ""
+        raise RuntimeError(f"failed to {what}: HTTP {exc.code}{detail}") from exc
+
+    try:
+        envelope = json.loads(raw.decode("utf-8", "replace"))
+    except Exception as exc:
+        raise RuntimeError(f"failed to {what}: response was not JSON") from exc
+
+    if not isinstance(envelope, dict):
+        raise RuntimeError(f"failed to {what}: response was not a JSON object")
+
+    if not envelope.get("Success", True) or envelope.get("Code") not in (None, 200):
+        raise RuntimeError(
+            f"failed to {what}: ModelScope answered Code {envelope.get('Code')}: {envelope.get('Message')}"
+        )
+
+    data = envelope.get("Data")
+    return data if isinstance(data, dict) else {}
+
+
+def list_repo_files(endpoint: str, model_id: str, revision: str, token: Optional[str],
+                    timeout: float) -> List[Dict[str, Any]]:
+    """List every blob in a repository, recursively.
+
+    `Recursive=True` is not optional. Without it the hub returns a single level
+    and reports a subdirectory as one `Type: "tree"` entry with no contents, so a
+    repository that keeps weights under `original/` would download as its
+    top-level files alone — a partial model, not an error.
+
+    Returns [] both for "this revision does not exist" and for "this repository
+    is empty"; the caller must not treat that as success. See _no_files_error.
+    """
+    params = {"Root": "", "Recursive": "True"}
+    if revision:
+        params["Revision"] = revision
+
+    url = f"{endpoint}{_MODELS_PATH}/{model_id}/repo/files?{urllib.parse.urlencode(params)}"
+    data = _get_envelope(url, token, timeout, f"list files of ModelScope model {model_id!r}")
+
+    files = data.get("Files")
+    if not isinstance(files, list):
+        # Files is literally null for a nonexistent revision.
+        return []
+
+    return [f for f in files if isinstance(f, dict) and f.get("Type") != "tree"]
+
+
+def list_revisions(endpoint: str, model_id: str, token: Optional[str],
+                   timeout: float) -> Tuple[List[str], List[str]]:
+    """Return (branches, tags) for a repository."""
+    url = f"{endpoint}{_MODELS_PATH}/{model_id}/revisions"
+    data = _get_envelope(url, token, timeout, f"list revisions of ModelScope model {model_id!r}")
+
+    revision_map = data.get("RevisionMap")
+    if not isinstance(revision_map, dict):
+        return [], []
+
+    def names(key: str) -> List[str]:
+        entries = revision_map.get(key)
+        if not isinstance(entries, list):
+            return []
+        return [e.get("Revision") for e in entries if isinstance(e, dict) and e.get("Revision")]
+
+    return names("Branches"), names("Tags")
+
+
+def _no_files_error(endpoint: str, model_id: str, revision: str, token: Optional[str],
+                    timeout: float) -> RuntimeError:
+    """Turn an empty file list into a statement of which failure it actually was.
+
+    The hub answers 200 "success" with `Files: null` for a revision that does not
+    exist, which is indistinguishable from an empty repository at this endpoint.
+    `/revisions` can tell them apart, so it is asked rather than guessed at. If
+    that call itself fails, the ambiguity is reported as ambiguity — never
+    resolved in favour of "the repository is empty", which is the reading that
+    would let a caller proceed with nothing downloaded.
+    """
+    asked = revision or DEFAULT_REVISION
+
+    try:
+        branches, tags = list_revisions(endpoint, model_id, token, timeout)
+    except Exception as exc:
+        return RuntimeError(
+            f"ModelScope model {model_id!r} returned no files for revision {asked!r}, and the "
+            f"revision list could not be read to tell whether that revision exists ({exc}). "
+            f"Refusing to continue with an empty model directory."
+        )
+
+    known = branches + tags
+    if revision and revision not in known:
+        available = ", ".join(known) if known else "none"
+        return RuntimeError(
+            f"revision {revision!r} does not exist in ModelScope model {model_id!r} "
+            f"(available revisions: {available}). Note that ModelScope answers HTTP 200 with an "
+            f"empty file list for an unknown revision, and that its default branch is "
+            f"{DEFAULT_REVISION!r}, not 'main'."
+        )
+
+    return RuntimeError(
+        f"ModelScope model {model_id!r} lists no files at revision {asked!r}; there is nothing "
+        f"to download."
+    )
+
+
+def _select(files: List[Dict[str, Any]], allow_pattern: Optional[str],
+            model_id: str) -> List[Dict[str, Any]]:
+    """Apply the caller's file filter, refusing to match nothing silently."""
+    if not allow_pattern:
+        return files
+
+    selected = [f for f in files if fnmatch.fnmatch(f.get("Path") or "", allow_pattern)]
+    if not selected:
+        listed = ", ".join(sorted((f.get("Path") or "") for f in files)[:20])
+        raise RuntimeError(
+            f"file pattern {allow_pattern!r} matched none of the {len(files)} file(s) in "
+            f"ModelScope model {model_id!r} (files: {listed})"
+        )
+
+    return selected
+
+
+class ModelScopeDownloader(Downloader):
+    """Downloader for ModelScope repositories.
+
+    Accepts a credentials map (e.g. {"token": "ms-..."}); metadata carries the
+    high-level model_args (name, file, version, registry_path).
+    """
+
+    def download(self, source: str, dest: str, *, credentials: Optional[Dict[str, str]] = None,
+                 recursive: bool = True, overwrite: bool = False, retries: int = 3,
+                 timeout: Optional[float] = None, metadata: Optional[Dict[str, Any]] = None) -> None:
+        ensure_dir(dest)
+
+        model_id = (source or "").strip("/")
+        if not model_id:
+            raise RuntimeError("a ModelScope model id (\"<owner>/<name>\") is required")
+
+        endpoint = _endpoint(metadata)
+        token = (credentials or {}).get("token") or None
+        revision = _revision_param((metadata or {}).get("version"))
+        allow_pattern = resolve_allow_pattern(metadata)
+        request_timeout = timeout if timeout and timeout > 0 else _DEFAULT_TIMEOUT
+
+        if is_offline_mode():
+            self._assert_offline_copy_usable(model_id, dest)
+            return
+
+        logger.info(
+            f"Listing ModelScope model '{model_id}' at {endpoint} "
+            f"(revision={revision or 'default (' + DEFAULT_REVISION + ')'})"
+        )
+        files = list_repo_files(endpoint, model_id, revision, token, request_timeout)
+        if not files:
+            raise _no_files_error(endpoint, model_id, revision, token, request_timeout)
+
+        files = _select(files, allow_pattern, model_id)
+        total_bytes = sum(int(f.get("Size") or 0) for f in files)
+        logger.info(
+            f"ModelScope model '{model_id}': {len(files)} file(s) selected, "
+            f"{total_bytes} byte(s) total"
+        )
+
+        verify = not should_skip_verification()
+        interactive = is_interactive()
+
+        with ProgressReporter(dest, logger, label="ModelScope download",
+                              total_size=total_bytes, interactive=interactive):
+            for index, entry in enumerate(files, 1):
+                self._fetch_one(endpoint, model_id, revision, entry, dest, token,
+                                request_timeout, retries, overwrite, verify, index, len(files))
+
+    def _assert_offline_copy_usable(self, model_id: str, dest: str) -> None:
+        """Offline mode: use what is already on disk, or say why we cannot.
+
+        Offline is a legitimate configuration — the weights may have been staged
+        into the model cache out of band — so an already-populated destination is
+        honoured. What must not happen is proceeding with an empty one: the engine
+        would then fail somewhere inside itself on a missing model path, which is
+        the failure this whole refusal exists to replace with a reason.
+        """
+        existing = []
+        for root, _, names in os.walk(dest):
+            if os.path.basename(root) == ".neutree":
+                continue
+            existing.extend(os.path.join(root, n) for n in names if not n.endswith(_PART_SUFFIX))
+
+        if existing:
+            logger.info(
+                f"Offline mode: skipping ModelScope download of '{model_id}', using the "
+                f"{len(existing)} file(s) already present at {dest}"
+            )
+            return
+
+        raise ModelScopeDownloadUnavailable(
+            f"runtime model download is unavailable: offline mode is enabled, so the weights for "
+            f"ModelScope model {model_id!r} cannot be fetched from the hub, and none are present "
+            f"at {dest}. Stage the model into the cluster's model cache, or deploy from a "
+            f"registry this cluster can read offline."
+        )
+
+    def _fetch_one(self, endpoint: str, model_id: str, revision: str, entry: Dict[str, Any],
+                   dest: str, token: Optional[str], timeout: float, retries: int,
+                   overwrite: bool, verify: bool, index: int, total: int) -> None:
+        rel_path = entry.get("Path") or ""
+        if not rel_path or rel_path.startswith("/") or ".." in rel_path.split("/"):
+            # The destination is written from names the hub chose; a name that
+            # escapes it is refused rather than normalised, because there is no
+            # legitimate repository that needs one.
+            raise RuntimeError(f"ModelScope model {model_id!r} returned an unusable file path {rel_path!r}")
+
+        expected_size = int(entry.get("Size") or 0)
+        expected_hash = (entry.get("Sha256") or "").lower() or None
+
+        target = os.path.join(dest, rel_path)
+        ensure_dir(os.path.dirname(target) or dest)
+
+        # The presence check is inside the lock on purpose: a process that waited
+        # here re-checks afterwards and finds the file the winner just committed.
+        with _download_lock(dest, rel_path):
+            if not overwrite and self._already_have(target, dest, rel_path, expected_size,
+                                                    expected_hash, verify):
+                logger.info(f"[{index}/{total}] {rel_path}: already present, skipping")
+                return
+
+            logger.info(f"[{index}/{total}] {rel_path}: downloading ({expected_size} bytes)")
+            part = target + _PART_SUFFIX
+
+            last_error: Optional[BaseException] = None
+            for attempt in range(1, max(1, retries) + 1):
+                try:
+                    self._stream(endpoint, model_id, revision, rel_path, part, token, timeout, expected_size)
+                    self._commit(part, target, dest, rel_path, expected_size, expected_hash, verify)
+                    return
+                except ModelScopeDownloadUnavailable:
+                    # No network path: retrying cannot help, and the message is the
+                    # point of this class.
+                    raise
+                except Exception as exc:  # noqa: BLE001 - retried below, re-raised at the end
+                    last_error = exc
+                    logger.warning(f"{rel_path}: attempt {attempt}/{max(1, retries)} failed: {exc}")
+                    if attempt < max(1, retries):
+                        time.sleep(min(2 ** attempt, 30))
+
+        raise RuntimeError(f"failed to download {rel_path} of ModelScope model {model_id!r}: {last_error}")
+
+    def _already_have(self, target: str, dest: str, rel_path: str, expected_size: int,
+                      expected_hash: Optional[str], verify: bool) -> bool:
+        if not os.path.exists(target):
+            return False
+
+        try:
+            if expected_size and os.path.getsize(target) != expected_size:
+                return False
+        except OSError:
+            return False
+
+        if not verify or not expected_hash:
+            return True
+
+        verify_dir = os.path.join(dest, ".neutree", "verify")
+        with _verify_record_lock(dest):
+            cached = load_verification_record(verify_dir, rel_path)
+
+        if (cached and cached.get("expected_hash") == expected_hash
+                and cached.get("algorithm") == "sha256" and cached.get("passed")):
+            return True
+
+        try:
+            return compute_sha256(target).lower() == expected_hash
+        except OSError:
+            return False
+
+    def _stream(self, endpoint: str, model_id: str, revision: str, rel_path: str, part: str,
+                token: Optional[str], timeout: float, expected_size: int) -> None:
+        """Fetch one file into its .part, resuming an interrupted transfer.
+
+        Weight files are served by redirect to a CDN that honours Range, so an
+        attempt that died partway through does not restart from zero. A server
+        that ignores the Range header answers 200 rather than 206, which is
+        detected here and restarts the file cleanly instead of appending fresh
+        bytes onto stale ones.
+        """
+        params = {"FilePath": rel_path}
+        if revision:
+            params["Revision"] = revision
+        url = f"{endpoint}{_MODELS_PATH}/{model_id}/repo?{urllib.parse.urlencode(params)}"
+
+        have = 0
+        if os.path.exists(part):
+            try:
+                have = os.path.getsize(part)
+            except OSError:
+                have = 0
+
+        if expected_size and have >= expected_size:
+            # A .part at or past the full length is not resumable: a ranged
+            # request from there answers 416. Start it again rather than commit
+            # bytes whose provenance is unknown.
+            have = 0
+
+        headers = {"Range": f"bytes={have}-"} if have else None
+
+        try:
+            with _open(url, token, timeout, headers) as resp:
+                resumed = have > 0 and resp.status == 206
+                mode = "ab" if resumed else "wb"
+                if have and not resumed:
+                    logger.info(f"{rel_path}: server ignored the resume request, restarting")
+                    have = 0
+
+                with open(part, mode) as fh:
+                    while True:
+                        chunk = resp.read(_CHUNK_SIZE)
+                        if not chunk:
+                            break
+                        fh.write(chunk)
+        except urllib.error.HTTPError as exc:
+            detail = ""
+            try:
+                body = json.loads(exc.read().decode("utf-8", "replace"))
+                if isinstance(body, dict):
+                    detail = f" (Code {body.get('Code')}: {body.get('Message')})"
+            except Exception:
+                detail = ""
+            raise RuntimeError(f"HTTP {exc.code} fetching {rel_path}{detail}") from exc
+
+        if expected_size:
+            actual = os.path.getsize(part)
+            if actual != expected_size:
+                raise RuntimeError(
+                    f"{rel_path}: downloaded {actual} bytes but the repository lists {expected_size}"
+                )
+
+    def _commit(self, part: str, target: str, dest: str, rel_path: str, expected_size: int,
+                expected_hash: Optional[str], verify: bool) -> None:
+        """Verify the .part and move it onto the final path.
+
+        Verification happens before the rename, so a file that fails its checksum
+        never appears at its real name — a later run sees it as absent and fetches
+        it again, rather than seeing a corrupt file of the right size and
+        skipping it.
+
+        The hash is computed outside the record lock — it is the expensive part
+        and touches nothing shared — and only the write to the record store is
+        held under it, which is what huggingface.py's lock protects too.
+        """
+        if verify and expected_hash:
+            verify_dir = os.path.join(dest, ".neutree", "verify")
+            ensure_dir(verify_dir)
+
+            actual_hash = compute_sha256(part).lower()
+            passed = actual_hash == expected_hash
+
+            with _verify_record_lock(dest):
+                save_verification_record_with_algo(verify_dir, rel_path, "sha256",
+                                                   expected_hash, actual_hash, passed)
+                if not passed:
+                    delete_verification_record(verify_dir, rel_path)
+
+            if not passed:
+                if should_keep_failed_files():
+                    logger.error(f"{rel_path}: checksum mismatch, keeping {part} for inspection")
+                else:
+                    try:
+                        os.remove(part)
+                    except OSError:
+                        pass
+                raise RuntimeError(
+                    f"checksum mismatch for {rel_path}: expected sha256 {expected_hash[:16]}..., "
+                    f"got {actual_hash[:16]}..."
+                )
+        elif verify and not expected_hash:
+            logger.warning(f"{rel_path}: repository lists no Sha256, cannot verify")
+
+        os.replace(part, target)
+        logger.info(f"{rel_path}: done ({expected_size} bytes)")

--- a/python/neutree/downloader/test_model_scope.py
+++ b/python/neutree/downloader/test_model_scope.py
@@ -1,0 +1,575 @@
+"""Tests for ModelScopeDownloader.
+
+Run with (from project root):
+    PYTHONPATH=python python3 -m pytest python/neutree/downloader/test_model_scope.py -v
+
+These drive a real HTTP server over a real socket rather than mocking urllib.
+The behaviours that matter here are all protocol behaviours — a 302 to another
+host, a Range request that a server may or may not honour, an Authorization
+header that must not cross a host boundary, a 200 response that means "no such
+revision" — and none of them survive being mocked out. The server below is a
+deliberately faithful copy of what modelscope.cn was observed to do, including
+the parts that are unhelpful.
+"""
+
+import hashlib
+import http.server
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import types
+import unittest
+import urllib.parse
+from unittest import mock
+
+# Provide stub huggingface_hub modules when the real package is absent. utils.py
+# imports its hashing helpers from there; this downloader adds no dependency of
+# its own.
+_fake_sha = types.ModuleType("huggingface_hub.utils.sha")
+_fake_sha.git_hash = lambda data: ""
+_fake_sha.sha_fileobj = lambda stream, bufsize=0: hashlib.sha256(stream.read()).digest()
+sys.modules.setdefault("huggingface_hub", types.ModuleType("huggingface_hub"))
+sys.modules.setdefault("huggingface_hub.utils", types.ModuleType("huggingface_hub.utils"))
+sys.modules.setdefault("huggingface_hub.utils.sha", _fake_sha)
+_fake_hf_api = types.ModuleType("huggingface_hub.hf_api")
+_fake_hf_api.RepoFile = type("RepoFile", (), {})
+sys.modules.setdefault("huggingface_hub.hf_api", _fake_hf_api)
+
+from neutree.downloader.dispatcher import get_downloader  # noqa: E402
+from neutree.downloader import model_scope  # noqa: E402
+from neutree.downloader.model_scope import (  # noqa: E402
+    ModelScopeDownloader,
+    ModelScopeDownloadUnavailable,
+)
+from neutree.downloader.utils import build_request_from_model_args  # noqa: E402
+
+MODEL_ID = "test-owner/test-model"
+
+# Content is generated rather than literal so the "large" file can exercise a
+# multi-chunk read without a large fixture.
+_FILES = {
+    "config.json": b'{"architectures": ["TestForCausalLM"]}',
+    "README.md": b"# test model\n",
+    "nested/weights.bin": b"nested-payload" * 16,
+    "model-q2_k.gguf": bytes(range(256)) * 64,
+}
+
+# The file the fake hub serves by redirect to a "CDN" on a different host, the
+# way modelscope.cn serves LFS objects.
+_REDIRECTED = "model-q2_k.gguf"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+class _Hub(http.server.BaseHTTPRequestHandler):
+    """A stand-in for modelscope.cn's /api/v1 surface.
+
+    Class attributes carry the per-test knobs and the record of what was asked,
+    because BaseHTTPRequestHandler is instantiated per request.
+    """
+
+    revisions = ["master"]           # branches the repository has
+    files = dict(_FILES)             # path -> bytes
+    honour_range = True              # set False to model a server that ignores Range
+    corrupt_sha_for = None           # path whose advertised Sha256 is a lie
+    requests = []                    # (path, query dict, headers) for assertions
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_args):
+        pass
+
+    # -- helpers ---------------------------------------------------------
+
+    def _send(self, code, body: bytes, content_type="application/json", extra=None):
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        for key, value in (extra or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def _envelope(self, data, code=200, message="success", success=True):
+        return json.dumps({"Code": code, "Data": data, "Message": message,
+                           "RequestId": "test", "Success": success}).encode()
+
+    def _listing(self, revision):
+        # The behaviour this whole downloader is shaped around: an unknown
+        # revision is HTTP 200 with Files: null, not an error.
+        if revision and revision not in self.revisions:
+            return self._envelope({"Files": None, "IsVisual": 0, "LatestCommitter": None})
+
+        entries = []
+        seen_dirs = set()
+        for path, body in sorted(self.files.items()):
+            parent = os.path.dirname(path)
+            if parent and parent not in seen_dirs:
+                seen_dirs.add(parent)
+                entries.append({"Path": parent, "Name": parent, "Type": "tree", "Size": 0})
+            sha = _sha256(body)
+            if self.corrupt_sha_for == path:
+                sha = "0" * 64
+            entries.append({
+                "Path": path, "Name": os.path.basename(path), "Type": "blob",
+                "Size": len(body), "Sha256": sha, "IsLFS": path == _REDIRECTED,
+                "Revision": "deadbeef",
+            })
+        return self._envelope({"Files": entries, "IsVisual": 0})
+
+    def _blob(self, body: bytes):
+        rng = self.headers.get("Range")
+        if rng and self.honour_range and rng.startswith("bytes="):
+            start = int(rng[len("bytes="):].split("-")[0])
+            if start >= len(body):
+                self._send(416, b"", "text/plain")
+                return
+            chunk = body[start:]
+            self.send_response(206)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(chunk)))
+            self.send_header("Content-Range", f"bytes {start}-{len(body) - 1}/{len(body)}")
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+            self.wfile.write(chunk)
+            return
+
+        self._send(200, body, "application/octet-stream", {"Accept-Ranges": "bytes"})
+
+    # -- routes ----------------------------------------------------------
+
+    def do_GET(self):  # noqa: N802 - http.server's spelling
+        parsed = urllib.parse.urlsplit(self.path)
+        query = dict(urllib.parse.parse_qsl(parsed.query, keep_blank_values=True))
+        type(self).requests.append((parsed.path, query, dict(self.headers)))
+
+        # The "CDN": a different host from the caller's point of view, reached
+        # only by redirect.
+        if parsed.path.startswith("/cdn/"):
+            name = urllib.parse.unquote(parsed.path[len("/cdn/"):])
+            body = self.files.get(name)
+            if body is None:
+                self._send(404, b"", "text/plain")
+                return
+            self._blob(body)
+            return
+
+        prefix = f"/api/v1/models/{MODEL_ID}"
+        if parsed.path == prefix + "/repo/files":
+            self._send(200, self._listing(query.get("Revision", "")))
+            return
+
+        if parsed.path == prefix + "/revisions":
+            self._send(200, self._envelope({"RevisionMap": {
+                "Branches": [{"Revision": r} for r in self.revisions],
+                "Tags": [],
+            }}))
+            return
+
+        if parsed.path == prefix + "/repo":
+            name = query.get("FilePath", "")
+            body = self.files.get(name)
+            if body is None:
+                self._send(404, self._envelope(
+                    None, code=10990101007, message="file not found", success=False))
+                return
+            if name == _REDIRECTED:
+                host = f"127.0.0.1:{self.server.server_address[1]}"
+                # Different netloc than the caller used ("localhost:port"), so the
+                # Authorization-stripping path is genuinely exercised.
+                self._send(302, b"", "text/plain",
+                           {"Location": f"http://{host}/cdn/{urllib.parse.quote(name)}"})
+                return
+            self._blob(body)
+            return
+
+        self._send(404, self._envelope(
+            None, code=10010205001, message="record not found", success=False))
+
+
+class ModelScopeTestCase(unittest.TestCase):
+    def setUp(self):
+        _Hub.revisions = ["master"]
+        _Hub.files = dict(_FILES)
+        _Hub.honour_range = True
+        _Hub.corrupt_sha_for = None
+        _Hub.requests = []
+
+        self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Hub)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        # "localhost" here, "127.0.0.1" in the redirect Location: same machine,
+        # different netloc, which is what the header-stripping rule keys on.
+        self.endpoint = f"http://localhost:{self.server.server_address[1]}"
+
+        self.dest = tempfile.mkdtemp()
+        self.env = mock.patch.dict(os.environ, {"MODELSCOPE_ENDPOINT": self.endpoint}, clear=False)
+        self.env.start()
+
+    def tearDown(self):
+        self.env.stop()
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        shutil.rmtree(self.dest, ignore_errors=True)
+
+    def download(self, **metadata):
+        meta = {"name": MODEL_ID}
+        meta.update(metadata)
+        ModelScopeDownloader().download(MODEL_ID, self.dest, metadata=meta)
+
+    def listing_queries(self):
+        return [q for path, q, _ in _Hub.requests if path.endswith("/repo/files")]
+
+    def files_on_disk(self):
+        found = set()
+        for root, _, names in os.walk(self.dest):
+            if ".neutree" in root.split(os.sep):
+                continue
+            for name in names:
+                found.add(os.path.relpath(os.path.join(root, name), self.dest))
+        return found
+
+
+class TestHappyPath(ModelScopeTestCase):
+    def test_downloads_every_file_with_correct_bytes(self):
+        self.download()
+
+        self.assertEqual(self.files_on_disk(), set(_FILES))
+        for path, expected in _FILES.items():
+            with open(os.path.join(self.dest, path), "rb") as fh:
+                self.assertEqual(fh.read(), expected, path)
+
+    def test_no_part_files_are_left_behind(self):
+        self.download()
+        self.assertEqual([p for p in self.files_on_disk() if p.endswith(".neutree-part")], [])
+
+    def test_listing_asks_for_recursion(self):
+        """Without Recursive=True the hub reports a subdirectory as one tree
+        entry and never names the files inside it, so the weights under
+        nested/ would be silently skipped."""
+        self.download()
+
+        self.assertTrue(self.listing_queries())
+        for query in self.listing_queries():
+            self.assertEqual(query.get("Recursive"), "True")
+
+        self.assertIn("nested/weights.bin", self.files_on_disk())
+
+    def test_default_version_omits_the_revision_parameter(self):
+        """ModelScope's default branch is 'master', not 'main'. Rather than
+        hard-code either, the parameter is left off so the hub resolves the
+        repository's own default."""
+        for version in ("", None, "latest", "master"):
+            _Hub.requests = []
+            shutil.rmtree(self.dest, ignore_errors=True)
+            os.makedirs(self.dest)
+            self.download(version=version)
+            for query in self.listing_queries():
+                self.assertNotIn("Revision", query, f"version={version!r}")
+
+    def test_explicit_revision_is_sent(self):
+        _Hub.revisions = ["master", "v1.0"]
+        self.download(version="v1.0")
+        self.assertEqual([q.get("Revision") for q in self.listing_queries()], ["v1.0"])
+
+    def test_second_run_skips_files_already_present(self):
+        self.download()
+        _Hub.requests = []
+        self.download()
+
+        fetched = [q.get("FilePath") for path, q, _ in _Hub.requests if path.endswith("/repo")]
+        self.assertEqual(fetched, [], "already-verified files should not be re-fetched")
+
+
+class TestUnknownRevision(ModelScopeTestCase):
+    """The trap this downloader exists to defuse: the hub answers HTTP 200 with
+    Files: null for a revision that does not exist, which is indistinguishable
+    from an empty repository unless /revisions is consulted."""
+
+    def test_unknown_revision_raises_naming_the_revision(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.download(version="zzz-not-a-branch")
+
+        message = str(ctx.exception)
+        self.assertIn("zzz-not-a-branch", message)
+        self.assertIn("does not exist", message)
+        self.assertIn("master", message, "the available revisions should be named")
+
+    def test_unknown_revision_leaves_no_silent_empty_directory(self):
+        with self.assertRaises(RuntimeError):
+            self.download(version="main")
+
+        self.assertEqual(self.files_on_disk(), set(),
+                         "a nonexistent revision must not look like a successful empty download")
+
+    def test_main_is_reported_as_missing_not_as_the_default(self):
+        """'main' is the Hugging Face assumption; on ModelScope it is simply a
+        branch that is not there, and must be reported as such."""
+        with self.assertRaises(RuntimeError) as ctx:
+            self.download(version="main")
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_genuinely_empty_repository_says_so_instead(self):
+        _Hub.files = {}
+        with self.assertRaises(RuntimeError) as ctx:
+            self.download()
+
+        message = str(ctx.exception)
+        self.assertIn("lists no files", message)
+        self.assertNotIn("does not exist", message)
+
+
+class TestFileFilter(ModelScopeTestCase):
+    def test_gguf_pattern_selects_only_matching_files(self):
+        self.download(file="*q2_k.gguf")
+        self.assertEqual(self.files_on_disk(), {"model-q2_k.gguf"})
+
+    def test_non_gguf_pattern_is_ignored_like_the_hugging_face_path(self):
+        """resolve_allow_pattern only honours GGUF patterns, because a non-GGUF
+        model needs its whole directory."""
+        self.download(file="config.json")
+        self.assertEqual(self.files_on_disk(), set(_FILES))
+
+    def test_pattern_matching_nothing_is_an_error_not_an_empty_directory(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.download(file="*nonexistent.gguf")
+
+        self.assertIn("matched none", str(ctx.exception))
+        self.assertEqual(self.files_on_disk(), set())
+
+
+class TestRedirectAndResume(ModelScopeTestCase):
+    def test_redirected_file_is_downloaded_intact(self):
+        self.download(file="*q2_k.gguf")
+
+        with open(os.path.join(self.dest, _REDIRECTED), "rb") as fh:
+            self.assertEqual(fh.read(), _FILES[_REDIRECTED])
+        self.assertTrue(any(path.startswith("/cdn/") for path, _, _ in _Hub.requests),
+                        "the redirect should have been followed")
+
+    def test_resume_continues_from_a_partial_file(self):
+        body = _FILES[_REDIRECTED]
+        part = os.path.join(self.dest, _REDIRECTED + ".neutree-part")
+        with open(part, "wb") as fh:
+            fh.write(body[:100])
+
+        self.download(file="*q2_k.gguf")
+
+        ranges = [h.get("Range") for path, _, h in _Hub.requests if path.startswith("/cdn/")]
+        self.assertIn("bytes=100-", ranges)
+        with open(os.path.join(self.dest, _REDIRECTED), "rb") as fh:
+            self.assertEqual(fh.read(), body)
+
+    def test_a_server_ignoring_range_restarts_instead_of_appending(self):
+        """Appending a full 200 response onto existing bytes would produce a
+        file of the wrong length made of the right bytes twice over."""
+        _Hub.honour_range = False
+        body = _FILES[_REDIRECTED]
+        part = os.path.join(self.dest, _REDIRECTED + ".neutree-part")
+        with open(part, "wb") as fh:
+            fh.write(body[:100])
+
+        self.download(file="*q2_k.gguf")
+
+        with open(os.path.join(self.dest, _REDIRECTED), "rb") as fh:
+            self.assertEqual(fh.read(), body)
+
+    def test_token_is_sent_to_the_hub_but_not_to_the_redirect_target(self):
+        ModelScopeDownloader().download(
+            MODEL_ID, self.dest, credentials={"token": "ms-secret"},
+            metadata={"name": MODEL_ID, "file": "*q2_k.gguf"})
+
+        hub = [h for path, _, h in _Hub.requests if path.startswith("/api/")]
+        cdn = [h for path, _, h in _Hub.requests if path.startswith("/cdn/")]
+
+        self.assertTrue(hub and all(h.get("Authorization") == "Bearer ms-secret" for h in hub))
+        self.assertTrue(cdn)
+        self.assertTrue(all("Authorization" not in h for h in cdn),
+                        "the hub token must not follow a redirect onto another host")
+
+
+class TestVerification(ModelScopeTestCase):
+    def test_checksum_mismatch_fails_and_leaves_no_file_at_the_real_path(self):
+        _Hub.corrupt_sha_for = "config.json"
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.download()
+
+        self.assertIn("checksum mismatch", str(ctx.exception))
+        self.assertFalse(os.path.exists(os.path.join(self.dest, "config.json")),
+                         "a file that failed verification must not appear under its real name")
+
+    def test_verification_can_be_skipped(self):
+        _Hub.corrupt_sha_for = "config.json"
+        with mock.patch.dict(os.environ, {"NEUTREE_VERIFY_SKIP": "1"}):
+            self.download()
+        self.assertIn("config.json", self.files_on_disk())
+
+
+class TestOffline(ModelScopeTestCase):
+    """Acceptance criterion 2: an offline deployment must fail with a message
+    that points at runtime download being unavailable."""
+
+    def test_offline_with_nothing_cached_names_the_real_problem(self):
+        with mock.patch.dict(os.environ, {"HF_HUB_OFFLINE": "1"}):
+            with self.assertRaises(ModelScopeDownloadUnavailable) as ctx:
+                self.download()
+
+        self.assertIn("runtime model download is unavailable", str(ctx.exception))
+        self.assertEqual(_Hub.requests, [], "offline mode must not touch the network")
+
+    def test_offline_with_a_populated_cache_succeeds(self):
+        os.makedirs(os.path.join(self.dest, "nested"), exist_ok=True)
+        for path, body in _FILES.items():
+            with open(os.path.join(self.dest, path), "wb") as fh:
+                fh.write(body)
+
+        with mock.patch.dict(os.environ, {"NEUTREE_DL_OFFLINE": "1"}):
+            self.download()
+
+        self.assertEqual(_Hub.requests, [])
+
+    def test_unreachable_hub_names_the_real_problem(self):
+        with mock.patch.dict(os.environ, {"MODELSCOPE_ENDPOINT": "http://127.0.0.1:1"}):
+            with self.assertRaises(ModelScopeDownloadUnavailable) as ctx:
+                self.download()
+
+        self.assertIn("runtime model download is unavailable", str(ctx.exception))
+
+
+class TestUnknownModel(ModelScopeTestCase):
+    def test_unknown_model_surfaces_the_hubs_own_code_and_message(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            ModelScopeDownloader().download(
+                "no-such/model", self.dest, metadata={"name": "no-such/model"})
+
+        message = str(ctx.exception)
+        self.assertIn("404", message)
+        self.assertIn("10010205001", message)
+
+
+class TestWiring(unittest.TestCase):
+    """The backend is selected from the registry type, and the credential comes
+    from the hub-specific variable."""
+
+    def test_model_scope_registry_type_selects_the_model_scope_backend(self):
+        backend, request = build_request_from_model_args({
+            "registry_type": "model-scope", "name": MODEL_ID,
+            "registry_path": MODEL_ID, "path": "/models/x", "version": "",
+        })
+        self.assertEqual(backend, "model-scope")
+        self.assertEqual(request.source, MODEL_ID)
+        self.assertIsInstance(get_downloader(backend), ModelScopeDownloader)
+
+    def test_model_scope_reads_its_own_token_variable(self):
+        with mock.patch.dict(os.environ, {"MODELSCOPE_API_TOKEN": "ms-token", "HF_TOKEN": "hf-token"},
+                             clear=False):
+            _, request = build_request_from_model_args(
+                {"registry_type": "model-scope", "name": MODEL_ID})
+        self.assertEqual(request.credentials, {"token": "ms-token"})
+
+    def test_hugging_face_does_not_pick_up_the_model_scope_token(self):
+        """Regression guard for acceptance criterion 3: the Hugging Face path
+        must be untouched, and in particular must not start sending a
+        ModelScope credential to huggingface.co."""
+        env = {"MODELSCOPE_API_TOKEN": "ms-token"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            os.environ.pop("HF_TOKEN", None)
+            os.environ.pop("NEUTREE_DL_TOKEN", None)
+            backend, request = build_request_from_model_args(
+                {"registry_type": "hugging-face", "name": MODEL_ID})
+
+        self.assertEqual(backend, "hugging-face")
+        self.assertIsNone(request.credentials)
+
+
+class TestConcurrency(ModelScopeTestCase):
+    """A shared model cache with replicas starting together is the normal case,
+    not a corner, so two processes downloading the same file into the same
+    destination has to be safe."""
+
+    def _download_in_thread(self, errors, **metadata):
+        def run():
+            try:
+                self.download(**metadata)
+            except BaseException as exc:  # noqa: BLE001 - reported to the test
+                errors.append(exc)
+        return threading.Thread(target=run)
+
+    def test_two_concurrent_downloads_fetch_once_and_leave_a_correct_file(self):
+        """The loser must not share the winner's .part. If it did it would keep
+        writing into the inode after the winner renamed it onto the final name,
+        corrupting a file that had already been verified."""
+        errors = []
+        threads = [self._download_in_thread(errors, file="*q2_k.gguf") for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        self.assertEqual(errors, [])
+        self.assertFalse(any(t.is_alive() for t in threads), "a download thread deadlocked")
+
+        blob_fetches = [q.get("FilePath") for path, q, _ in _Hub.requests
+                        if path.endswith("/repo") and q.get("FilePath") == _REDIRECTED]
+        self.assertEqual(len(blob_fetches), 1,
+                         "the second process should have found the finished file, not re-fetched it")
+
+        with open(os.path.join(self.dest, _REDIRECTED), "rb") as fh:
+            self.assertEqual(fh.read(), _FILES[_REDIRECTED])
+        self.assertEqual([p for p in self.files_on_disk() if p.endswith(".neutree-part")], [])
+
+    def test_the_verification_record_survives_concurrent_writers(self):
+        """The record store is where two writers interleave; a torn record makes
+        a good file look unverified or a bad one look verified."""
+        errors = []
+        threads = [self._download_in_thread(errors) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+        self.assertEqual(errors, [])
+
+        verify_dir = os.path.join(self.dest, ".neutree", "verify")
+        records = [os.path.join(r, n) for r, _, ns in os.walk(verify_dir) for n in ns]
+        self.assertEqual(len(records), len(_FILES))
+        for path in records:
+            with open(path) as fh:
+                record = json.load(fh)          # torn JSON would raise here
+            self.assertTrue(record["passed"])
+            self.assertEqual(record["algorithm"], "sha256")
+            self.assertEqual(record["expected_hash"], record["actual_hash"])
+
+
+class TestLockIdentity(ModelScopeTestCase):
+    def test_the_record_store_is_guarded_by_the_lock_huggingface_uses(self):
+        """A ModelScope-private lock would exclude nothing: huggingface.py writes
+        the same records under the same names in the same directory, guarding
+        them with dest/.neutree/verify.lock."""
+        taken = []
+        real = model_scope.FileLock
+
+        def spy(lockfile, timeout=300.0):
+            taken.append(lockfile)
+            return real(lockfile, timeout=timeout)
+
+        with mock.patch.object(model_scope, "FileLock", spy):
+            self.download(file="*q2_k.gguf")
+
+        verify_lock = os.path.join(self.dest, ".neutree", "verify.lock")
+        self.assertIn(verify_lock, taken)
+        # And the same path huggingface.py builds, spelled the same way.
+        self.assertEqual(verify_lock, os.path.join(self.dest, ".neutree", "verify.lock"))
+        self.assertTrue(any(p.startswith(os.path.join(self.dest, ".neutree", "locks")) for p in taken),
+                        "the per-file download lock should also have been taken")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/neutree/downloader/utils.py
+++ b/python/neutree/downloader/utils.py
@@ -93,6 +93,8 @@ def build_request_from_model_args(model_args: Dict[str, Any]) -> Tuple[str, Down
         rt = (model_args.get("registry_type") or "")
         if isinstance(rt, str) and "hugging-face" in rt.lower():
             backend = "hugging-face"
+        elif isinstance(rt, str) and "model-scope" in rt.lower():
+            backend = "model-scope"
     if not backend:
         # infer from path/name heuristics
         candidate = model_args.get("registry_path") or model_args.get("name") or ""
@@ -109,7 +111,11 @@ def build_request_from_model_args(model_args: Dict[str, Any]) -> Tuple[str, Down
     dest = model_args.get("path") or "/models-cache"
 
     credentials = None
-    token = os.environ.get("NEUTREE_DL_TOKEN") or os.environ.get("HF_TOKEN")
+    # The hub-specific variable is chosen by backend rather than by falling
+    # through a shared chain, so a cluster that has both registries configured
+    # cannot send a Hugging Face token to ModelScope or the reverse.
+    hub_token_env = "MODELSCOPE_API_TOKEN" if backend == "model-scope" else "HF_TOKEN"
+    token = os.environ.get("NEUTREE_DL_TOKEN") or os.environ.get(hub_token_env)
     if token and token != "":
         credentials = {"token": token}
 
@@ -188,6 +194,21 @@ def compute_git_sha1(filepath: str) -> str:
         data = f.read()
 
     return git_hash(data)
+
+def is_offline_mode() -> bool:
+    """Whether this container is configured to do no network fetching at all.
+
+    `HF_HUB_OFFLINE` is honoured because it is what an air-gapped neutree
+    deployment already sets for the Hugging Face path, and an operator who has
+    declared the cluster offline means it for every hub, not just that one.
+    `NEUTREE_DL_OFFLINE` is the backend-neutral spelling.
+
+    Only new backends consult this. The Hugging Face path keeps deferring to
+    huggingface_hub's own handling of HF_HUB_OFFLINE, so its behaviour is
+    unchanged.
+    """
+    return env_bool("NEUTREE_DL_OFFLINE", False) or env_bool("HF_HUB_OFFLINE", False)
+
 
 def should_skip_verification() -> bool:
     """Check if file verification should be skipped.


### PR DESCRIPTION
## What this does

Endpoints can be deployed from a ModelScope model registry. A ModelScope downloader sits beside
the Hugging Face one, both orchestrators build a real Ray/Kubernetes application for
`model-scope` registries, and the placeholder refusal they used to return is gone.

No image change, no new Python dependency, no migration.

## Changes

| area | change |
|---|---|
| `python/neutree/downloader/model_scope.py` | new backend — list a revision's files, fetch each with resume, verify SHA-256, stage through `<name>.neutree-part` so a file appears under its real name only after its checksum passes |
| `dispatcher.py`, `utils.py`, `__init__.py`, `__main__.py` | `model-scope` registered; registry-type → backend mapping; `is_offline_mode()` |
| `api/v1/model_registry_types.go` | `MODELSCOPE_ENDPOINT` / `MODELSCOPE_API_TOKEN` env-var names |
| `internal/orchestrator/ray_orchestrator.go`, `kubernetes_orchestrator_resource.go` | the `ModelScopeModelRegistryType` case injects endpoint + credential and fills in the model args |
| `internal/orchestrator/util.go` | `errModelScopeDeployNotWiredYet` deleted; `latest` resolves to `""`; a hub revision is not appended to the served model id |

## Hub behaviours the code is written around

These are properties of the live hub, and each one has a branch that exists only because of it:

- **The REST API is `/api/v1/models/{id}/…`.** `/api/models/{id}` is the website's SPA route and
  answers HTML.
- **An unknown revision answers HTTP 200 with `Files: null`,** not an error. An empty listing is
  therefore never read as "empty repository": the downloader asks `/revisions`, which can tell the
  two apart, and reports which it was. Without this a wrong `version` produces an empty model
  directory and a container that dies later on a missing path.
- **The default branch is `master`, not `main`.** Neither name is hard-coded: the `Revision`
  parameter is *omitted* for the default version so the hub resolves the repository's own default.
  `getDeployedModelRealVersion` maps `latest` to `""` for the same reason, matching the convention
  `internal/model_registry/model_scope.go` already uses.
- **Listing is not recursive.** `Recursive=True` is always sent; without it a model that keeps
  weights in a subdirectory downloads partially and silently.
- **Weight files 302 to a CDN that honours `Range`,** so resume works — and because the redirect
  crosses a host boundary, the `Authorization` header is dropped when it does.
- **The listing carries a real SHA-256 for every file, LFS or not,** so verification is one
  algorithm rather than the LFS-sha256 / git-blob-sha1 pair `huggingface.py` juggles.

## Standard library only

`model_scope.py` uses `urllib.request`, not the `modelscope` SDK. `Dockerfile.engine-vllm` and
`Dockerfile.engine-sglang` copy the downloader sources and explicitly refuse to
`pip install downloader/requirements.txt`, because its `huggingface-hub<1.0` bound downgrades the
newer `huggingface_hub` those base images ship (the sglang comment names `is_offline_mode` as the
API that disappears and stops the backend starting). `modelscope` would pull in
`requests`/`urllib3`/`tqdm` and transitively `huggingface_hub` — the re-resolution those comments
exist to prevent. The three operations needed are plain GETs, so nothing is given up.

## Credentials and offline mode

The hub token variable is picked *by backend* (`MODELSCOPE_API_TOKEN` vs `HF_TOKEN`) rather than
by falling through a shared chain, so a cluster with both registries configured cannot hand one
hub the other's credential. `is_offline_mode()` honours `NEUTREE_DL_OFFLINE` and `HF_HUB_OFFLINE`;
with nothing staged, the failure names "runtime model download is unavailable" instead of
surfacing downstream as a missing model path. The Hugging Face path still defers to
`huggingface_hub`'s own offline handling and is untouched.

## Concurrency

A shared model cache with replicas starting together makes concurrent writers the normal case, so
two locks are taken, always in this order:

1. `_download_lock` — per file, held across the presence check *and* the whole fetch. It keeps two
   processes off one `.part` path; otherwise the loser goes on writing into that inode after the
   winner has `os.replace`d it onto the final name, corrupting a file that already passed its
   checksum. Covering the presence check too means a waiter finds the finished file instead of
   refetching it.
2. `_verify_record_lock` — deliberately the *same* lock file `huggingface.py` uses
   (`<dest>/.neutree/verify.lock`), not a ModelScope-private one: both downloaders write the same
   record names in the same directory, so a private lock would exclude nothing. The hash is
   computed outside the lock; only the store write is held under it.

## Tests

29 Python tests drive a real HTTP server over a real socket instead of mocking `urllib`, because
what matters here is protocol behaviour — a 302 to another host, a `Range` a server may ignore, an
`Authorization` header that must not cross a host boundary, a 200 that means "no such revision".
Three of them run real threads against the real locks. Go tests cover both orchestrators
separately, since each assembles its model args independently;
`TestEndpointToApplication_HuggingFaceUnchangedByModelScopeSupport` pins that the Hugging Face
branch still emits `HF_ENDPOINT`/`HF_TOKEN` and no ModelScope variables.

Verified end to end on a live control plane: a public ModelScope model reaches `Running` and
answers through the OpenAI-compatible gateway, and a Hugging Face endpoint deployed on the same
build immediately afterwards does too.

Closes NEU-689.
