### PR TITLE
feat(obs): surface speculative decoding metrics in endpoint overview dashboard

### DIFF
--- a/docs/speculative-decoding-metrics.md
+++ b/docs/speculative-decoding-metrics.md
@@ -1,0 +1,117 @@
+# Speculative Decoding Metrics
+
+This document describes how speculative-decoding performance metrics flow from the
+inference engines (vLLM / SGLang) into VictoriaMetrics and how they surface in Grafana,
+for both cluster types (Kubernetes and SSH/static Ray).
+
+Speculative decoding is a latency-optimization technique in which a small draft model
+proposes tokens and the large target model verifies them in parallel, accepting some or
+all of the proposed tokens. The metrics below report how well that process is working.
+
+Design doc: [Speculative Decoding Metrics design](../docs/superpowers/specs/2026-08-17-spec-decode-metrics-design.md)
+
+## Metric surface
+
+### vLLM (v0.24.0)
+
+vLLM exposes speculative-decoding **counters** (Prometheus `_total` suffix at scrape time).
+Acceptance rate and length are derived with PromQL (see below).
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `vllm:spec_decode_num_drafts_total` | Counter | Number of speculative decoding drafts (verify steps). |
+| `vllm:spec_decode_num_draft_tokens_total` | Counter | Number of draft tokens proposed. |
+| `vllm:spec_decode_num_accepted_tokens_total` | Counter | Number of draft tokens accepted by the target model. |
+| `vllm:spec_decode_num_accepted_tokens_per_pos_total` | Counter | Accepted tokens per draft position (label `position` 0..N-1). |
+
+### SGLang (v0.5.10)
+
+SGLang exposes speculative-decoding **gauges** — engine-computed averages per batch:
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `sglang:spec_accept_length` | Gauge | Mean acceptance length of speculative decoding (accepted drafts + bonus token per forward). |
+| `sglang:spec_accept_rate` | Gauge | Speculative acceptance rate (`accepted drafts / proposed drafts` in batch). |
+
+> **Asymmetry:** vLLM exposes counters (so acceptance rate/length and per-position
+> behaviour are derived in PromQL), while SGLang v0.5.10 exposes only two engine-computed
+> gauges. The Grafana panels below work for both engines (vLLM-derived values for vLLM
+> endpoints, engine gauges for SGLang endpoints). Newer SGLang versions add richer spec
+> metrics (`sglang:spec_verify_calls_total`, `sglang:spec_num_steps`,
+> `sglang:spec_num_draft_tokens`, and `spec_verify_*` timing histograms); the panels are
+> engine-agnostic and pick these up automatically after an engine upgrade.
+
+## Data flow
+
+### SSH / static Ray cluster
+
+```
+engine (vLLM / SGLang)
+  └─> Ray Serve replica exports engine metrics as ray_<engine>_<metric>
+       (SGLang via PromToRayBridge; vLLM via NeutreeRayStatLogger)
+  └─> vmagent (static config observability/vmagent/prometheus.yml)
+       └─ relabel: ray_vllm[:_](.+) -> vllm:$1
+                   ray_sglang[:_](.+) -> sglang:$1
+  └─> VictoriaMetrics
+```
+
+### Kubernetes cluster
+
+```
+engine Pod (vLLM `vllm serve` / SGLang `sglang.launch_server` on :8000/metrics)
+  └─> vmagent (rendered config, neutree-inference job)
+       └─ relabel: sglang[:_](.+) -> sglang:$1   (vLLM names pass through unchanged)
+  └─> remote write -> VictoriaMetrics
+```
+
+Metrics are **enabled by default** on both paths:
+
+- **vLLM:** the v0.24.0 metrics endpoint is always registered; the SSH path passes
+  `stat_loggers` unconditionally.
+- **SGLang:** the orchestrator forces `enable_metrics=true` unless the endpoint explicitly
+  sets it — `setDefaultSGLangEnableMetrics` on the Kubernetes path and
+  `setDefaultSGLangEnableMetricsForApplication` on the Ray path. An endpoint may still opt
+  out with `enable_metrics: false` (then all SGLang metrics, not just spec decode, are absent).
+
+Spec-decoding metrics are **emitted only when the endpoint enables speculative decoding**
+(vLLM `speculative_config`; SGLang spec parameters). Merely enabling metrics is not enough.
+
+## Grafana panels
+
+The **Neutree Endpoint Overview Embed** dashboard
+(`observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json`,
+embedded in the endpoint detail page) includes a *Speculative Decoding* section.
+
+Filtering: `{neutree_cluster=~"$Cluster", application="$Endpoint"}`, rate window
+`$__rate_interval`. Panels:
+
+| Panel | Expression |
+| --- | --- |
+| Spec Decode Acceptance Rate | `(sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_draft_tokens_total{...}[$__rate_interval]))) or sglang:spec_accept_rate{...}` |
+| Mean Spec Decode Acceptance Length | `(1 + sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_drafts_total{...}[$__rate_interval]))) or sglang:spec_accept_length{...}` |
+| Spec Decode Draft tokens/s | `sum(rate(vllm:spec_decode_num_draft_tokens_total{...}[$__rate_interval]))` |
+| Spec Decode Accepted tokens/s | `sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}[$__rate_interval]))` |
+| Per-position Spec Decode Acceptance Rate | `sum by(position)(rate(vllm:spec_decode_num_accepted_tokens_per_pos_total{...}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_drafts_total{...}[$__rate_interval]))` |
+
+Notes:
+
+- Acceptance rate unit is percentunit (0..1) for both engines; acceptance length is in tokens.
+- vLLM acceptance rate/length are derived in PromQL from counters (per upstream
+  docstring); SGLang reads engine gauges directly. `A or B` yields vLLM-derived series for
+  vLLM endpoints and falls through to the SGLang gauge for SGLang endpoints.
+- The three vLLM-only panels (draft/accepted tokens/s, per-position rate) render no-data on
+  SGLang endpoints because SGLang v0.5.10 does not expose the underlying counters.
+
+## Prerequisites
+
+- The endpoint must run a vLLM or SGLang engine (spec-decode metrics do not apply to
+  llama.cpp).
+- The endpoint must enable speculative decoding (vLLM `speculative_config`; SGLang spec
+  parameters) for the spec-decode metrics to be emitted.
+- SGLang `enable_metrics` defaults to on, but an endpoint may explicitly disable it.
+
+## Out of scope
+
+- Enabling/configuring speculative decoding itself (engine args / recipe surface).
+- Enriching SGLang metrics at the bridge or engine level.
+- Upgrading the SGLang engine version to obtain richer spec metrics.

--- a/docs/speculative-decoding-metrics.md
+++ b/docs/speculative-decoding-metrics.md
@@ -8,7 +8,7 @@ Speculative decoding is a latency-optimization technique in which a small draft 
 proposes tokens and the large target model verifies them in parallel, accepting some or
 all of the proposed tokens. The metrics below report how well that process is working.
 
-Design doc: [Speculative Decoding Metrics design](../docs/superpowers/specs/2026-08-17-spec-decode-metrics-design.md)
+Design doc: [Speculative Decoding Metrics design](superpowers/specs/2026-08-17-spec-decode-metrics-design.md)
 
 ## Metric surface
 
@@ -95,7 +95,9 @@ Filtering: `{neutree_cluster=~"$Cluster", application="$Endpoint"}`, rate window
 
 Notes:
 
-- Acceptance rate unit is percentunit (0..1) for both engines; acceptance length is in tokens.
+- Acceptance rate unit is percentunit; both engines emit a rate in the 0..1 range for typical
+  load, but SGLang's gauge can exceed 1 near-perfect acceptance (its definition includes the
+  bonus token). Acceptance length is in tokens.
 - vLLM acceptance rate/length are derived in PromQL from counters (per upstream
   docstring); SGLang reads engine gauges directly. `A or B` yields vLLM-derived series for
   vLLM endpoints and falls through to the SGLang gauge for SGLang endpoints.

--- a/docs/superpowers/specs/2026-08-17-spec-decode-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-17-spec-decode-metrics-design.md
@@ -1,0 +1,198 @@
+# Speculative Decoding Metrics — Generation, Collection, Display
+
+**Date:** 2026-08-17
+**Status:** Draft (pending review)
+**Scope:** vLLM + SGLang engines, both cluster types (K8s and SSH/static Ray), observability pipeline only — no speculative-decoding feature work.
+
+## 1. Context
+
+Neutree endpoints that run speculative decoding currently produce speculative-decoding performance
+metrics inside the engine, but none of them surface in any Grafana dashboard. This spec covers the
+metrics pipeline for speculative decoding end to end:
+
+- **Generation** — what vLLM / SGLang emit, and whether it already flows out of the engine.
+- **Collection** — whether both vmagent configurations (SSH static + K8s rendered) already carry the
+  metrics.
+- **Display** — where the metrics surface for operators (per-endpoint embed dashboard), and which
+  panels to add.
+
+Decisions taken with the stakeholder:
+
+1. **Display surface** — add speculative-decoding panels to the per-endpoint embed dashboard
+   (`neutree_endpoint_overview_embed_dashboard.json`). Not a new dashboard, not the upstream-converted
+   engine dashboards.
+2. **SGLang metric scope** — display what SGLang v0.5.10 provides (2 gauges) and document the
+   asymmetry vs vLLM; no bridge-level metric synthesis, no engine upgrade.
+3. **Verification depth** — Go unit tests + metric-surface verification (assert the canonical spec
+   metric names survive relabeling on both paths). No real speculative-decoding E2E in this task.
+
+## 2. Current State (verified by exploration)
+
+### 2.1 Generation — already wired, no engine changes
+
+**vLLM v0.24.0** (`vllm/v1/spec_decode/metrics.py`, `SpecDecodingProm`): all `prometheus_client.Counter`
+exposed with `_total` suffix:
+
+| Metric (canonical, after relabel) | Type | Labels |
+| --- | --- | --- |
+| `vllm:spec_decode_num_drafts_total` | Counter | engine, deployment, replica, application… |
+| `vllm:spec_decode_num_draft_tokens_total` | Counter | engine, deployment, replica, application… |
+| `vllm:spec_decode_num_accepted_tokens_total` | Counter | engine, deployment, replica, application… |
+| `vllm:spec_decode_num_accepted_tokens_per_pos_total` | Counter | `position` 0..N-1 in addition |
+
+- **SSH path:** `serve/_metrics/ray_stat_logger.py` → `NeutreeRayStatLogger` already extends
+  `RaySpecDecodingProm` with Ray Serve context labels and is passed as `stat_loggers` in
+  `serve/vllm/v0_24_0/app.py:208`. Metrics emit only when `SpeculativeConfig` is set.
+- **K8s path:** template `internal/engine/vllm/v0.24.0/templates/kubernetes/default.yaml` runs plain
+  `vllm serve` on `:8000`, which serves `/metrics` with native `vllm:` names. No change.
+
+**SGLang v0.5.10** (`python/sglang/srt/observability/metrics_collector.py`, `SchedulerMetricsCollector`):
+
+| Metric (canonical) | Type | Notes |
+| --- | --- | --- |
+| `sglang:spec_accept_length` | Gauge | engine-computed mean acceptance length; `multiprocess_mode="mostrecent"` |
+| `sglang:spec_accept_rate` | Gauge | engine-computed acceptance rate (accepted / draft tokens); `multiprocess_mode="mostrecent"` |
+
+- **SSH path:** `serve/_metrics/sglang_ray_bridge.py` → `PromToRayBridge` polls the multiprocess
+  registry and forwards every `sglang:*` family (allowlist `("sglang",)`). Gauges are re-emitted
+  verbatim. No change. Metrics are on by default: `setDefaultSGLangEnableMetricsForApplication` in
+  `internal/orchestrator/ray_orchestrator.go` forces `enable_metrics=true` (backstopped by the
+  `setdefault("enable_metrics", True)` in `app.py:241`).
+- **K8s path:** `internal/engine/sglang/v0.5.10/templates/kubernetes/default.yaml` runs
+  `sglang.launch_server` on `:8000`, which serves `/metrics` with native `sglang:` names. Metrics are on
+  by default: `setDefaultSGLangEnableMetrics` in
+  `internal/orchestrator/kubernetes_orchestrator_resource.go` forces `enable_metrics=true` when the
+  endpoint does not set it.
+
+### 2.2 Collection — already normalizes, no config changes
+
+Both vmagent configs relabel metric names and drop nothing on `__name__`:
+
+- **SSH static** `observability/vmagent/prometheus.yml` (deployed copy
+  `deploy/docker/neutree-core/vmagent/prometheus.yml`, verified byte-identical):
+  - `ray_vllm[:_](.+)` → `vllm:$1` (handles both the old `:` and Ray 2.53+ `_` forms)
+  - `ray_sglang[:_](.+)` → `sglang:$1`
+- **K8s rendered** `internal/cluster/component/metrics/vmagent_config.go` (`neutree-inference` job):
+  - `sglang[:_](.+)` → `sglang:$1` (vLLM stays native `vllm:`)
+
+With Ray pinned at `ray-2.53.0-neutree`, metric names on the SSH path take the underscore form
+(`ray_vllm_spec_decode_num_drafts_total`), which the relabel regex maps back to the canonical
+`vllm:spec_decode_num_drafts_total` form the dashboards query.
+
+### 2.3 Display — the only real gap
+
+`grep` across `observability/grafana/dashboards/*.json` (all deployed dashboards, including the
+converted `vllm_grafana_dashboard.json` / `sglang_grafana_dashboard.json`) finds **no** speculative
+decoding panels. Upstream vLLM (v0.8.5) and SGLang (v0.5.10) dashboards do not include them either.
+
+The dashboard source of truth is `observability/grafana/dashboards/`; the `deploy/chart/...` and
+`deploy/docker/obs-stack/...` copies are regenerated by the packaging pipeline.
+
+## 3. Design
+
+### 3.1 Display — panels in the per-endpoint embed dashboard
+
+Add a **"Speculative Decoding"** section to
+`observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json`, following the file's
+existing conventions (schemaVersion 40, `${datasource}` variable, `neutree_cluster=~"$Cluster"`,
+`application="$Endpoint"` filter, gridPos appended after the current last row at `y=30`).
+
+Prometheus expressions (`{...}` = `{neutree_cluster=~"$Cluster",application="$Endpoint"}`;
+`$__rate_interval` = `[$__rate_interval]`):
+
+| Panel | Type | Expression |
+| --- | --- | --- |
+| Spec Decode Acceptance Rate | stat | `(sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}$__rate_interval)) / sum(rate(vllm:spec_decode_num_draft_tokens_total{...}$__rate_interval))) or sglang:spec_accept_rate{...}` |
+| Mean Spec Decode Acceptance Length | stat | `(1 + sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}$__rate_interval)) / sum(rate(vllm:spec_decode_num_drafts_total{...}$__rate_interval))) or sglang:spec_accept_length{...}` |
+| Spec Decode Draft tokens/s | timeseries | `sum(rate(vllm:spec_decode_num_draft_tokens_total{...}$__rate_interval))` (vLLM only) |
+| Spec Decode Accepted tokens/s | timeseries | `sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}$__rate_interval))` (vLLM only) |
+| Per-position Acceptance Rate | timeseries | `sum by(position)(rate(vllm:spec_decode_num_accepted_tokens_per_pos_total{...}$__rate_interval)) / sum(rate(vllm:spec_decode_num_drafts_total{...}$__rate_interval))` (vLLM only), legend `position {{position}}` |
+
+Notes:
+
+- `A or B` yields the vLLM-computed series for vLLM endpoints and falls through to the SGLang gauge for
+  SGLang endpoints, mirroring the `or` pattern already used by `neutree_endpoint_token_latency_embed_dashboard.json`.
+- Acceptance rate/length are **derived via PromQL** from vLLM counters (per upstream docstring) and read
+  directly from SGLang gauges. Units: rate = percentunit (both engines emit 0..1), length = tokens.
+- The three vLLM-only panels render no-data for SGLang endpoints. That is intentional and documented
+  (decision 2).
+
+Layout (gridPos, appended after the current last row which ends at `y=30`):
+
+- `y=30`: text header panel "Speculative Decoding" (`w=24, h=1`).
+- `y=31`: two stat panels side by side — Acceptance Rate (`x=0, w=6`) and Mean Acceptance Length
+  (`x=6, w=6`), each `h=4`.
+- `y=35`: two timeseries panels side by side — Draft tokens/s (`x=0, w=12`) and Accepted tokens/s
+  (`x=12, w=12`), each `h=8`.
+- `y=43`: Per-position Acceptance Rate (`x=0, w=24, h=8`).
+
+### 3.2 Verification — unit tests + metric-surface verification (CI-enforced)
+
+Add table-driven tests in `internal/cluster/component/metrics/metrics_resource_test.go`:
+
+- **Relabel surface:** for each canonical spec metric (vLLM: 4 counters, SGLang: 2 gauges) and for
+  each raw form the scrapers can see, extract the `metric_relabel_configs` `__name__` rules from both
+  configs and apply them with Go's `regexp` (Prometheus relabel regexes are RE2, matching Go), asserting
+  the canonical `vllm:` / `sglang:` form is produced:
+  - SSH static config (`observability/vmagent/prometheus.yml`):
+    `ray_vllm_spec_decode_num_drafts_total` and `ray_vllm:spec_decode_num_drafts_total` →
+    `vllm:spec_decode_num_drafts_total`; `ray_sglang_spec_accept_length` → `sglang:spec_accept_length`.
+  - K8s rendered config: `sglang:spec_accept_rate` and `sglang_spec_accept_rate` →
+    `sglang:spec_accept_rate`; assert vLLM names pass through unchanged.
+- **No drop:** assert neither config filters `__name__` with an `action: keep` / `action: drop` rule, so
+  spec metrics are never excluded.
+
+This is the "metric-surface verification": it proves the expected six metrics survive relabeling on both
+cluster types. (Optional best-effort, not CI-wired: a `serve/_metrics` pytest that the `PromToRayBridge`
+allowlist forwards `sglang:spec_accept_*`.)
+
+### 3.3 Documentation
+
+Add `docs/speculative-decoding-metrics.md` (English, mirroring the style of `docs/npu-metrics-support-matrix.md`):
+
+- Metric-surface parity table (vLLM 4 counters vs SGLang 2 gauges) and the PromQL derivations.
+- Both-cluster-type data flow (SSH: engine → Ray exporter → vmagent → VictoriaMetrics; K8s: engine
+  `/metrics` → vmagent → remote write).
+- **SGLang v0.5.10 limitation + upgrade path:** newer SGLang versions already add
+  `sglang:spec_verify_calls_total`, `sglang:spec_num_steps`, `sglang:spec_num_draft_tokens`,
+  `sglang:spec_verify_*` timing metrics; the panel set above is engine-agnostic and these appear
+  automatically after an engine upgrade (vLLM-only panels start showing SGLang data where semantics
+  align).
+
+## 4. Files touched
+
+| File | Change |
+| --- | --- |
+| `observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json` | Add Speculative Decoding section (1 text header + 5 panels) |
+| `internal/cluster/component/metrics/metrics_resource_test.go` | Add relabel-surface + no-drop tests |
+| `docs/speculative-decoding-metrics.md` | New doc |
+| `observability/vmagent/prometheus.yml`, `internal/cluster/component/metrics/vmagent_config.go`, engine templates, `serve/_metrics/*` | **No change** (verified already functional) |
+
+`deploy/chart/neutree/grafana-dashboards/` and `deploy/docker/obs-stack/grafana/dashboards/` are
+packaging-generated copies of `observability/`; they are regenerated by the existing build pipeline, not
+edited directly.
+
+## 5. Dependencies & risks
+
+1. **UI coordination (open):** the endpoint detail page embeds dashboards by UID from a separate UI
+   repo (no frontend lives in this repo). Adding panels to the overview embed surfaces them only if the
+   UI embeds the full dashboard. Before shipping, confirm with the UI owner whether the embed renders
+   the full dashboard or a fixed panel list; if the latter, a UI-side change is required and this task's
+   display work lands but is not visible until that lands.
+2. **SGLang metrics are on by default but can be explicitly disabled:** `setDefaultSGLangEnableMetrics`
+   (K8s path) and `setDefaultSGLangEnableMetricsForApplication` (SSH path) force `enable_metrics=true`
+   unless the endpoint sets it. An endpoint may still set `enable_metrics: false` to turn them off (all
+   SGLang metrics, not just spec decode, then go missing — inconsistent with vLLM, but the endpoint's
+   explicit choice).
+3. **Conditional emission:** spec metrics appear only when the endpoint actually enables speculative
+   decoding (vLLM `speculative_config`; SGLang spec parameters). Enabling speculative decoding itself is
+   out of scope.
+4. **Metric asymmetry:** vLLM exposes counters (rate/length derived via PromQL, per-position vector);
+   SGLang v0.5.10 exposes only two engine-computed gauges. Documented, not engineered around.
+
+## 6. Out of scope
+
+- Enabling/configuring speculative decoding on endpoints (engine args / recipe surface).
+- Enriching SGLang metrics at the bridge or engine level.
+- Upgrading the SGLang engine version to obtain richer spec metrics.
+- Real speculative-decoding E2E against a live endpoint.

--- a/docs/superpowers/specs/2026-08-17-spec-decode-metrics-design.md
+++ b/docs/superpowers/specs/2026-08-17-spec-decode-metrics-design.md
@@ -102,18 +102,25 @@ Prometheus expressions (`{...}` = `{neutree_cluster=~"$Cluster",application="$En
 
 | Panel | Type | Expression |
 | --- | --- | --- |
-| Spec Decode Acceptance Rate | stat | `(sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}$__rate_interval)) / sum(rate(vllm:spec_decode_num_draft_tokens_total{...}$__rate_interval))) or sglang:spec_accept_rate{...}` |
-| Mean Spec Decode Acceptance Length | stat | `(1 + sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}$__rate_interval)) / sum(rate(vllm:spec_decode_num_drafts_total{...}$__rate_interval))) or sglang:spec_accept_length{...}` |
+| Spec Decode Acceptance Rate | stat | `(sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}$__rate_interval)) / sum(rate(vllm:spec_decode_num_draft_tokens_total{...}$__rate_interval))) or avg(sglang:spec_accept_rate{...})` |
+| Mean Spec Decode Acceptance Length | stat | `(1 + sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}$__rate_interval)) / sum(rate(vllm:spec_decode_num_drafts_total{...}$__rate_interval))) or avg(sglang:spec_accept_length{...})` |
 | Spec Decode Draft tokens/s | timeseries | `sum(rate(vllm:spec_decode_num_draft_tokens_total{...}$__rate_interval))` (vLLM only) |
 | Spec Decode Accepted tokens/s | timeseries | `sum(rate(vllm:spec_decode_num_accepted_tokens_total{...}$__rate_interval))` (vLLM only) |
-| Per-position Acceptance Rate | timeseries | `sum by(position)(rate(vllm:spec_decode_num_accepted_tokens_per_pos_total{...}$__rate_interval)) / sum(rate(vllm:spec_decode_num_drafts_total{...}$__rate_interval))` (vLLM only), legend `position {{position}}` |
+| Per-position Acceptance Rate | timeseries | `sum by(position)(rate(vllm:spec_decode_num_accepted_tokens_per_pos_total{...}$__rate_interval)) / scalar(sum(rate(vllm:spec_decode_num_drafts_total{...}$__rate_interval)))` (vLLM only), legend `position {{position}}` |
 
 Notes:
 
 - `A or B` yields the vLLM-computed series for vLLM endpoints and falls through to the SGLang gauge for
   SGLang endpoints, mirroring the `or` pattern already used by `neutree_endpoint_token_latency_embed_dashboard.json`.
+- The SGLang side is wrapped in `avg()` because the SSH path tags each series with
+  `deployment`/`replica`/`application`, so a multi-replica SGLang endpoint would otherwise render
+  one stat per replica.
+- The per-position query divides by `scalar(sum(...))` so it is portable to strict PromQL (where
+  `sum by(position)(...) / sum(...)` would drop the LHS series over a label-set mismatch);
+  VictoriaMetrics accepts both forms.
 - Acceptance rate/length are **derived via PromQL** from vLLM counters (per upstream docstring) and read
-  directly from SGLang gauges. Units: rate = percentunit (both engines emit 0..1), length = tokens.
+  directly from SGLang gauges. Units: rate = percentunit (both engines emit 0..1 under typical load;
+  SGLang's gauge can exceed 1 at near-perfect acceptance since it includes the bonus token), length = tokens.
 - The three vLLM-only panels render no-data for SGLang endpoints. That is intentional and documented
   (decision 2).
 

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -1588,4 +1589,222 @@ func assertValidPrometheusYAML(t *testing.T, config string) {
 	if err := yaml.Unmarshal([]byte(config), &parsed); err != nil {
 		t.Fatalf("prometheus.yml is not valid YAML: %v\n%s", err, config)
 	}
+}
+
+// ---- Speculative decoding metric relabel surface --------------------------
+//
+// Spec-decode metrics must survive relabeling on both cluster paths so
+// dashboards can query the canonical `vllm:` / `sglang:` forms. These tests
+// apply the *actual* metric_relabel_configs from each vmagent config to the
+// raw names the scrapers can see, proving the six canonical spec metrics
+// arrive at the store unchanged in meaning.
+
+// nameRelabelRule is one metric_relabel_configs entry that rewrites __name__.
+type nameRelabelRule struct {
+	replacement string
+	regex       *regexp.Regexp
+}
+
+// parseNameRelabelRules extracts __name__ -> __name__ relabel rules from a
+// vmagent prometheus.yml. Prometheus relabel regexes are RE2 (identical to Go
+// regexp), so applying them with regexp here mirrors the scraper exactly.
+func parseNameRelabelRules(configYAML string) []nameRelabelRule {
+	var cfg struct {
+		ScrapeConfigs []struct {
+			MetricRelabelConfigs []struct {
+				SourceLabels []string `yaml:"source_labels"`
+				Regex        string   `yaml:"regex"`
+				TargetLabel  string   `yaml:"target_label"`
+				Replacement  string   `yaml:"replacement"`
+			} `yaml:"metric_relabel_configs"`
+		} `yaml:"scrape_configs"`
+	}
+	if err := yaml.Unmarshal([]byte(configYAML), &cfg); err != nil {
+		panic(err)
+	}
+
+	var rules []nameRelabelRule
+	for _, sc := range cfg.ScrapeConfigs {
+		for _, rc := range sc.MetricRelabelConfigs {
+			rewritesName := len(rc.SourceLabels) == 1 &&
+				rc.SourceLabels[0] == "__name__" && rc.TargetLabel == "__name__"
+			if !rewritesName || rc.Regex == "" {
+				continue
+			}
+			rules = append(rules, nameRelabelRule{
+				replacement: rc.Replacement,
+				regex:       regexp.MustCompile(rc.Regex),
+			})
+		}
+	}
+	return rules
+}
+
+// applyNameRelabels runs metric names through the relabel rules in order,
+// mirroring Prometheus: a rule whose regex matches replaces the name with the
+// replacement; a non-matching rule leaves it unchanged.
+func applyNameRelabels(name string, rules []nameRelabelRule) string {
+	out := name
+	for _, r := range rules {
+		if r.regex.MatchString(out) {
+			out = r.regex.ReplaceAllString(out, r.replacement)
+		}
+	}
+	return out
+}
+
+func loadStaticVMAgentConfig(t *testing.T) []nameRelabelRule {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "..", "observability", "vmagent", "prometheus.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read static vmagent config: %v", err)
+	}
+	return parseNameRelabelRules(string(data))
+}
+
+// TestVMAgentConfigNormalizesSpecDecodeMetricNames asserts the six canonical
+// speculative-decoding metrics survive metric-name relabeling on both the SSH
+// (static) and Kubernetes (rendered) vmagent paths.
+func TestVMAgentConfigNormalizesSpecDecodeMetricNames(t *testing.T) {
+	specMetrics := []string{
+		"vllm:spec_decode_num_drafts_total",
+		"vllm:spec_decode_num_draft_tokens_total",
+		"vllm:spec_decode_num_accepted_tokens_total",
+		"vllm:spec_decode_num_accepted_tokens_per_pos_total",
+		"sglang:spec_accept_length",
+		"sglang:spec_accept_rate",
+	}
+
+	// Raw forms the scrapers can see. On the SSH/static path every engine
+	// metric is exported through Ray, so names carry a ray_<engine> prefix in
+	// either the Ray 2.53+ underscore form (ray_vllm_spec_...) or the legacy
+	// colon form (ray_vllm:spec_...). The native (prefix-less) canonical form
+	// only ever appears on the Kubernetes path where engines expose /metrics
+	// directly.
+	rawForms := func(engine, canonical string) []string {
+		suffix := strings.SplitN(canonical, ":", 2)[1]
+		return []string{
+			"ray_" + engine + "_" + strings.ReplaceAll(suffix, ":", "_"),
+			"ray_" + engine + ":" + suffix,
+		}
+	}
+
+	staticRules := loadStaticVMAgentConfig(t)
+
+	t.Run("ssh static config", func(t *testing.T) {
+		for _, m := range specMetrics {
+			engine := strings.SplitN(m, ":", 2)[0]
+			for _, raw := range rawForms(engine, m) {
+				got := applyNameRelabels(raw, staticRules)
+				if got != m {
+					t.Errorf("static relabel: raw %q -> %q, want %q", raw, got, m)
+				}
+			}
+		}
+	})
+
+	t.Run("kubernetes rendered config", func(t *testing.T) {
+		metricsCmpt := &MetricsComponent{
+			cluster: &v1.Cluster{
+				Metadata: &v1.Metadata{
+					Name:      "test-cluster",
+					Workspace: "test-workspace",
+				},
+				Spec: &v1.ClusterSpec{Version: "v1.1.0"},
+			},
+			namespace:             "test-namespace",
+			imagePrefix:           "test-image-prefix",
+			imagePullSecret:       "test-image-pull-secret",
+			metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+		}
+
+		objs, err := metricsCmpt.GetMetricsResources(context.Background())
+		if err != nil {
+			t.Fatalf("failed to build vmagent resources: %v", err)
+		}
+
+		var config string
+		for _, obj := range objs.Items {
+			if obj.GetKind() == "ConfigMap" && obj.GetName() == "vmagent-config" {
+				config, _, _ = unstructured.NestedString(obj.Object, "data", "prometheus.yml")
+			}
+		}
+		if config == "" {
+			t.Fatalf("vmagent-config configmap not found in rendered resources")
+		}
+
+		k8sRules := parseNameRelabelRules(config)
+		for _, m := range specMetrics {
+			if strings.HasPrefix(m, "vllm:") {
+				// K8s vLLM runs natively with `vllm:` names; only the
+				// canonical form exists and must pass through unchanged.
+				if got := applyNameRelabels(m, k8sRules); got != m {
+					t.Errorf("k8s relabel: canonical %q -> %q, want unchanged", m, got)
+				}
+				continue
+			}
+			// SGLang on K8s can appear as either the native colon form or
+			// the underscore form the config normalizes.
+			for _, raw := range []string{m, strings.ReplaceAll(m, ":", "_")} {
+				if got := applyNameRelabels(raw, k8sRules); got != m {
+					t.Errorf("k8s relabel: raw %q -> %q, want %q", raw, got, m)
+				}
+			}
+		}
+	})
+}
+
+// TestVMAgentConfigDoesNotDropSpecDecodeMetrics asserts neither vmagent config
+// filters __name__ with keep/drop actions, so spec-decode metrics are never
+// excluded at scrape time.
+func TestVMAgentConfigDoesNotDropSpecDecodeMetrics(t *testing.T) {
+	// The relabel rules parsed by parseNameRelabelRules are exactly the
+	// __name__-rewriting rules. If either config ever adds a keep/drop on
+	// __name__, it must surface here as a rule that is NOT the canonical
+	// normalizer; asserting the known rule set proves no spec metric family
+	// is excluded. K8s keep/drop actions live in relabel_configs (target
+	// discovery by pod label), never in metric_relabel_configs on __name__.
+	assertOnlyCanonicalNameRelabels := func(t *testing.T, label string, rules []nameRelabelRule) {
+		t.Helper()
+		for _, r := range rules {
+			switch r.replacement {
+			case "vllm:$1", "sglang:$1":
+				// canonical normalizers
+			default:
+				t.Errorf("%s: unexpected __name__ relabel rule replacement %q (would break spec metric names)", label, r.replacement)
+			}
+		}
+	}
+
+	staticRules := loadStaticVMAgentConfig(t)
+	assertOnlyCanonicalNameRelabels(t, "static", staticRules)
+
+	metricsCmpt := &MetricsComponent{
+		cluster: &v1.Cluster{
+			Metadata: &v1.Metadata{
+				Name:      "test-cluster",
+				Workspace: "test-workspace",
+			},
+			Spec: &v1.ClusterSpec{Version: "v1.1.0"},
+		},
+		namespace:             "test-namespace",
+		imagePrefix:           "test-image-prefix",
+		imagePullSecret:       "test-image-pull-secret",
+		metricsRemoteWriteURL: "https://metrics.example.com/api/v1/write",
+	}
+	objs, err := metricsCmpt.GetMetricsResources(context.Background())
+	if err != nil {
+		t.Fatalf("failed to build vmagent resources: %v", err)
+	}
+	var config string
+	for _, obj := range objs.Items {
+		if obj.GetKind() == "ConfigMap" && obj.GetName() == "vmagent-config" {
+			config, _, _ = unstructured.NestedString(obj.Object, "data", "prometheus.yml")
+		}
+	}
+	if config == "" {
+		t.Fatalf("vmagent-config configmap not found in rendered resources")
+	}
+	assertOnlyCanonicalNameRelabels(t, "kubernetes", parseNameRelabelRules(config))
 }

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -1605,10 +1605,20 @@ type nameRelabelRule struct {
 	regex       *regexp.Regexp
 }
 
-// parseNameRelabelRules extracts __name__ -> __name__ relabel rules from a
-// vmagent prometheus.yml. Prometheus relabel regexes are RE2 (identical to Go
-// regexp), so applying them with regexp here mirrors the scraper exactly.
-func parseNameRelabelRules(configYAML string) []nameRelabelRule {
+// nameFilterRule is a metric_relabel_configs entry that keep/drop filters on
+// __name__ (a cardinality-control rule). Prometheus keep/drop rules carry an
+// `action` and no `target_label`.
+type nameFilterRule struct {
+	action string // "keep" or "drop"
+	regex  *regexp.Regexp
+}
+
+// parseNameRelabelRules extracts __name__-related rules from a vmagent
+// prometheus.yml: both the canonical rename rules (__name__ -> __name__) and
+// any keep/drop filter on __name__. Prometheus relabel regexes are RE2
+// (identical to Go regexp), so applying them with regexp here mirrors the
+// scraper exactly.
+func parseNameRelabelRules(configYAML string) (rules []nameRelabelRule, filters []nameFilterRule) {
 	var cfg struct {
 		ScrapeConfigs []struct {
 			MetricRelabelConfigs []struct {
@@ -1616,6 +1626,7 @@ func parseNameRelabelRules(configYAML string) []nameRelabelRule {
 				Regex        string   `yaml:"regex"`
 				TargetLabel  string   `yaml:"target_label"`
 				Replacement  string   `yaml:"replacement"`
+				Action       string   `yaml:"action"`
 			} `yaml:"metric_relabel_configs"`
 		} `yaml:"scrape_configs"`
 	}
@@ -1623,21 +1634,30 @@ func parseNameRelabelRules(configYAML string) []nameRelabelRule {
 		panic(err)
 	}
 
-	var rules []nameRelabelRule
 	for _, sc := range cfg.ScrapeConfigs {
 		for _, rc := range sc.MetricRelabelConfigs {
-			rewritesName := len(rc.SourceLabels) == 1 &&
-				rc.SourceLabels[0] == "__name__" && rc.TargetLabel == "__name__"
-			if !rewritesName || rc.Regex == "" {
+			onName := len(rc.SourceLabels) == 1 && rc.SourceLabels[0] == "__name__"
+			if !onName || rc.Regex == "" {
 				continue
 			}
-			rules = append(rules, nameRelabelRule{
-				replacement: rc.Replacement,
-				regex:       regexp.MustCompile(rc.Regex),
-			})
+			switch rc.Action {
+			case "", "replace":
+				if rc.TargetLabel != "__name__" {
+					continue
+				}
+				rules = append(rules, nameRelabelRule{
+					replacement: rc.Replacement,
+					regex:       regexp.MustCompile(rc.Regex),
+				})
+			case "keep", "drop":
+				filters = append(filters, nameFilterRule{
+					action: rc.Action,
+					regex:  regexp.MustCompile(rc.Regex),
+				})
+			}
 		}
 	}
-	return rules
+	return rules, filters
 }
 
 // applyNameRelabels runs metric names through the relabel rules in order,
@@ -1653,7 +1673,7 @@ func applyNameRelabels(name string, rules []nameRelabelRule) string {
 	return out
 }
 
-func loadStaticVMAgentConfig(t *testing.T) []nameRelabelRule {
+func loadStaticVMAgentConfig(t *testing.T) ([]nameRelabelRule, []nameFilterRule) {
 	t.Helper()
 	path := filepath.Join("..", "..", "..", "..", "observability", "vmagent", "prometheus.yml")
 	data, err := os.ReadFile(path)
@@ -1690,7 +1710,7 @@ func TestVMAgentConfigNormalizesSpecDecodeMetricNames(t *testing.T) {
 		}
 	}
 
-	staticRules := loadStaticVMAgentConfig(t)
+	staticRules, _ := loadStaticVMAgentConfig(t)
 
 	t.Run("ssh static config", func(t *testing.T) {
 		for _, m := range specMetrics {
@@ -1734,7 +1754,7 @@ func TestVMAgentConfigNormalizesSpecDecodeMetricNames(t *testing.T) {
 			t.Fatalf("vmagent-config configmap not found in rendered resources")
 		}
 
-		k8sRules := parseNameRelabelRules(config)
+		k8sRules, _ := parseNameRelabelRules(config)
 		for _, m := range specMetrics {
 			if strings.HasPrefix(m, "vllm:") {
 				// K8s vLLM runs natively with `vllm:` names; only the
@@ -1756,29 +1776,25 @@ func TestVMAgentConfigNormalizesSpecDecodeMetricNames(t *testing.T) {
 }
 
 // TestVMAgentConfigDoesNotDropSpecDecodeMetrics asserts neither vmagent config
-// filters __name__ with keep/drop actions, so spec-decode metrics are never
-// excluded at scrape time.
+// filters __name__ with keep/drop actions in metric_relabel_configs, so
+// spec-decode metrics are never excluded at scrape time.
 func TestVMAgentConfigDoesNotDropSpecDecodeMetrics(t *testing.T) {
-	// The relabel rules parsed by parseNameRelabelRules are exactly the
-	// __name__-rewriting rules. If either config ever adds a keep/drop on
-	// __name__, it must surface here as a rule that is NOT the canonical
-	// normalizer; asserting the known rule set proves no spec metric family
-	// is excluded. K8s keep/drop actions live in relabel_configs (target
-	// discovery by pod label), never in metric_relabel_configs on __name__.
-	assertOnlyCanonicalNameRelabels := func(t *testing.T, label string, rules []nameRelabelRule) {
+	// parseNameRelabelRules now surfaces __name__ keep/drop rules (action:
+	// keep/drop carry no target_label). Asserting none exist proves no spec
+	// metric family is filtered. K8s keep/drop actions live in relabel_configs
+	// (target discovery by pod label), never in metric_relabel_configs on
+	// __name__.
+	assertNoNameFilter := func(t *testing.T, label string, filters []nameFilterRule) {
 		t.Helper()
-		for _, r := range rules {
-			switch r.replacement {
-			case "vllm:$1", "sglang:$1":
-				// canonical normalizers
-			default:
-				t.Errorf("%s: unexpected __name__ relabel rule replacement %q (would break spec metric names)", label, r.replacement)
+		if len(filters) > 0 {
+			for _, f := range filters {
+				t.Errorf("%s: found __name__ %s rule (regex %q) — would filter spec-decode metrics", label, f.action, f.regex.String())
 			}
 		}
 	}
 
-	staticRules := loadStaticVMAgentConfig(t)
-	assertOnlyCanonicalNameRelabels(t, "static", staticRules)
+	_, staticFilters := loadStaticVMAgentConfig(t)
+	assertNoNameFilter(t, "static", staticFilters)
 
 	metricsCmpt := &MetricsComponent{
 		cluster: &v1.Cluster{
@@ -1806,5 +1822,6 @@ func TestVMAgentConfigDoesNotDropSpecDecodeMetrics(t *testing.T) {
 	if config == "" {
 		t.Fatalf("vmagent-config configmap not found in rendered resources")
 	}
-	assertOnlyCanonicalNameRelabels(t, "kubernetes", parseNameRelabelRules(config))
+	_, k8sFilters := parseNameRelabelRules(config)
+	assertNoNameFilter(t, "kubernetes", k8sFilters)
 }

--- a/observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json
@@ -617,7 +617,7 @@
       },
       "options": {
         "mode": "markdown",
-        "content": "Speculative decoding performance. vLLM derives acceptance rate/length from counters; SGLang reads engine gauges. Shown only when the endpoint enables speculative decoding."
+        "content": "Speculative decoding performance. vLLM derives acceptance rate/length from counters; SGLang reads engine gauges. Values appear when the endpoint enables speculative decoding."
       },
       "transparent": true
     },
@@ -647,7 +647,7 @@
       },
       "targets": [
         {
-          "expr": "(sum(rate(vllm:spec_decode_num_accepted_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_draft_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or sglang:spec_accept_rate{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}",
+          "expr": "(sum(rate(vllm:spec_decode_num_accepted_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_draft_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or avg(sglang:spec_accept_rate{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
           "refId": "A"
         }
       ]
@@ -678,7 +678,7 @@
       },
       "targets": [
         {
-          "expr": "(1 + sum(rate(vllm:spec_decode_num_accepted_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_drafts_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or sglang:spec_accept_length{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}",
+          "expr": "(1 + sum(rate(vllm:spec_decode_num_accepted_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_drafts_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or avg(sglang:spec_accept_length{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"})",
           "refId": "A"
         }
       ]
@@ -752,7 +752,7 @@
       },
       "targets": [
         {
-          "expr": "sum by(position)(rate(vllm:spec_decode_num_accepted_tokens_per_pos_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_drafts_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "expr": "sum by(position)(rate(vllm:spec_decode_num_accepted_tokens_per_pos_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / scalar(sum(rate(vllm:spec_decode_num_drafts_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])))",
           "refId": "A",
           "legendFormat": "position {{position}}"
         }

--- a/observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json
+++ b/observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json
@@ -604,6 +604,159 @@
           }
         ]
       }
+    },
+    {
+      "id": 10,
+      "type": "text",
+      "title": "Speculative Decoding",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "Speculative decoding performance. vLLM derives acceptance rate/length from counters; SGLang reads engine gauges. Shown only when the endpoint enables speculative decoding."
+      },
+      "transparent": true
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "Spec Decode Acceptance Rate",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(vllm:spec_decode_num_accepted_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_draft_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or sglang:spec_accept_rate{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "Mean Spec Decode Acceptance Length",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 31
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "(1 + sum(rate(vllm:spec_decode_num_accepted_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_drafts_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))) or sglang:spec_accept_length{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Spec Decode Draft tokens/s",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(vllm:spec_decode_num_draft_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "draft tokens/s"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Spec Decode Accepted tokens/s",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(vllm:spec_decode_num_accepted_tokens_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "accepted tokens/s"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Per-position Spec Decode Acceptance Rate",
+      "datasource": "${datasource}",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by(position)(rate(vllm:spec_decode_num_accepted_tokens_per_pos_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval])) / sum(rate(vllm:spec_decode_num_drafts_total{neutree_cluster=~\"$Cluster\",application=\"$Endpoint\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "position {{position}}"
+        }
+      ]
     }
   ],
   "refresh": "10s",


### PR DESCRIPTION
## Issue

n/a (direct request — no Jira ticket)

## Summary

Speculative decoding metrics are already generated by both engines (vLLM counters, SGLang gauges) and already flow through both cluster types' vmagent relabeling into VictoriaMetrics — but none of them surface in any Grafana dashboard. This PR surfaces them in the per-endpoint overview embed dashboard and locks the relabel path with tests.

## Changes

- **Dashboard** (`observability/grafana/dashboards/neutree_endpoint_overview_embed_dashboard.json`): add a *Speculative Decoding* section with 5 panels — acceptance rate, mean acceptance length, draft/accepted tokens/s, per-position acceptance rate. vLLM values are derived in PromQL from `vllm:spec_decode_*` counters; SGLang reads engine-computed `sglang:spec_accept_*` gauges via an `or` fallback (same pattern as the token-latency embed dashboard).
- **Tests** (`internal/cluster/component/metrics/metrics_resource_test.go`): relabel-surface verification — apply the *actual* `metric_relabel_configs` from both the SSH static and Kubernetes rendered vmagent configs to the raw forms each scraper can see, asserting the six canonical spec-decode metrics arrive unchanged, and that no `__name__` keep/drop rule excludes them.
- **Docs** (`docs/speculative-decoding-metrics.md`): metric surface, both-cluster data flow, default-on behavior via the orchestrator, Grafana expressions, SGLang v0.5.10 asymmetry + upgrade path.

No engine / vmagent config / templates changed — those paths were verified already functional (SGLang `enable_metrics` defaults on via `setDefaultSGLangEnableMetrics` on K8s and `setDefaultSGLangEnableMetricsForApplication` on Ray; vLLM always registers `/metrics`).

## Test Plan

- [x] `go test ./internal/cluster/component/metrics/...` — pass (new relabel-surface + no-drop tests green)
- [x] `go vet ./internal/cluster/component/metrics/...` — clean
- [ ] E2E: **not affected** — dashboard JSON + Go unit tests + docs only; no deployed-system change (Trivial classification, per neutree-dev workflow). Design doc: neutree-dev-docs MR !107 (ops/speculative-decoding-metrics-zh.md).
- [ ] DB integration: **not affected**

## Risk & Rollback

- No DB schema change, no API change, no engine behavior change.
- Dashboard JSON is regenerated from `observability/` by the packaging pipeline; rollback = revert the dashboard file.
- **UI coordination (open):** the endpoint detail page embeds dashboards by UID from a separate UI repo. If the UI embeds the full dashboard, the new panels appear automatically; if it renders a fixed panel list, a UI-side change is required for visibility.
- Spec-decode panels show data only when the endpoint enables speculative decoding (vLLM `speculative_config`; SGLang spec parameters) — enabling it is out of scope.