### PR TITLE
feat: support custom CSS in OEM config

### DIFF
--- a/api/v1/api_gen.go
+++ b/api/v1/api_gen.go
@@ -335,6 +335,7 @@ type ApiModelRegistriesUpdate struct {
 type ApiOemConfigSelect struct {
 	BrandName           sql.NullString `json:"brand_name"`
 	CreatedAt           sql.NullString `json:"created_at"`
+	CustomCSS           sql.NullString `json:"custom_css"`
 	Id                  int32          `json:"id"`
 	LogoBase64          sql.NullString `json:"logo_base64"`
 	LogoCollapsedBase64 sql.NullString `json:"logo_collapsed_base64"`
@@ -344,6 +345,7 @@ type ApiOemConfigSelect struct {
 type ApiOemConfigInsert struct {
 	BrandName           sql.NullString `json:"brand_name"`
 	CreatedAt           sql.NullString `json:"created_at"`
+	CustomCSS           sql.NullString `json:"custom_css"`
 	Id                  sql.NullInt32  `json:"id"`
 	LogoBase64          sql.NullString `json:"logo_base64"`
 	LogoCollapsedBase64 sql.NullString `json:"logo_collapsed_base64"`
@@ -353,6 +355,7 @@ type ApiOemConfigInsert struct {
 type ApiOemConfigUpdate struct {
 	BrandName           sql.NullString `json:"brand_name"`
 	CreatedAt           sql.NullString `json:"created_at"`
+	CustomCSS           sql.NullString `json:"custom_css"`
 	Id                  sql.NullInt32  `json:"id"`
 	LogoBase64          sql.NullString `json:"logo_base64"`
 	LogoCollapsedBase64 sql.NullString `json:"logo_collapsed_base64"`
@@ -615,6 +618,7 @@ type ApiModelCatalogStatus struct {
 
 type ApiOemConfigSpec struct {
 	BrandName           string `json:"brand_name"`
+	CustomCSS           string `json:"custom_css"`
 	LogoBase64          string `json:"logo_base64"`
 	LogoCollapsedBase64 string `json:"logo_collapsed_base64"`
 }

--- a/api/v1/oem_config_types.go
+++ b/api/v1/oem_config_types.go
@@ -10,6 +10,7 @@ type OEMConfigSpec struct {
 	BrandName           string `json:"brand_name,omitempty"`
 	LogoBase64          string `json:"logo_base64,omitempty"`
 	LogoCollapsedBase64 string `json:"logo_collapsed_base64,omitempty"`
+	CustomCSS           string `json:"custom_css,omitempty"`
 }
 
 type OEMConfig struct {

--- a/db/migrations/087_oem_config_custom_css.down.sql
+++ b/db/migrations/087_oem_config_custom_css.down.sql
@@ -1,0 +1,2 @@
+ALTER TYPE api.oem_config_spec
+    DROP ATTRIBUTE custom_css;

--- a/db/migrations/087_oem_config_custom_css.up.sql
+++ b/db/migrations/087_oem_config_custom_css.up.sql
@@ -1,0 +1,2 @@
+ALTER TYPE api.oem_config_spec
+    ADD ATTRIBUTE custom_css TEXT;


### PR DESCRIPTION
## Issue

n/a

## Summary

Refines the endpoint detail and playground surfaces, removes redundant endpoint metadata, and improves Grafana embed loading so the Neutree loader does not overlap with Grafana's own loading state, especially for cross-origin embeds.

## Changes

- Remove the redundant `MetadataDisclosure` from the endpoint detail page
- Refine the Chat Playground card and background boundaries
- Wrap the Grafana iframe in a Neutree-styled overlay loader while keeping the iframe rendered
- Detect cross-origin Grafana embeds and reveal the dashboard after the next paint without attempting CSS injection
- Prevent duplicate or overlapping loading states during Grafana initialization
- Update the i18n tracker lock

## Test Plan

- [ ] E2E (if affected): not run
- [ ] Unit tests: not affected; no test code changed
- Manually verified endpoint detail, playground, and Grafana embed loading in preview environments
- Manually checked both same-origin and cross-origin Grafana embeds

## Risk & Rollback

Frontend-only change with no database or API contract changes. Rollback can be performed by reverting the branch. The main behavioral risk is the Grafana loading reveal timing, which is isolated by cross-origin detection.
