### PR TITLE
fix(cli): print command errors once (NEU-673)

### DIFF
--- a/cmd/neutree-cli/app/cmd/apply/apply.go
+++ b/cmd/neutree-cli/app/cmd/apply/apply.go
@@ -34,8 +34,7 @@ Examples:
 
   # Apply with force update for existing resources
   neutree-cli apply -f resources.yaml --server-url https://api.neutree.ai --api-key sk_xxx --force-update`,
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runApply(opts)
 		},

--- a/cmd/neutree-cli/app/cmd/cleanup/cleanup.go
+++ b/cmd/neutree-cli/app/cmd/cleanup/cleanup.go
@@ -48,9 +48,8 @@ Examples:
 
   # Skip confirmation (for automation)
   neutree-cli cleanup neutree-core --force`,
-		Args:          cobra.ExactArgs(1),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCleanup(&command.OSExecutor{}, opts, args[0])
 		},

--- a/cmd/neutree-cli/app/cmd/cmd.go
+++ b/cmd/neutree-cli/app/cmd/cmd.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -69,9 +68,9 @@ Examples:
 }
 
 func Execute() {
-	err := NewNeutreeCliCommand().Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+	// Cobra already prints the error to stderr (see Command.ExecuteC); printing
+	// it again here would duplicate every failure message.
+	if err := NewNeutreeCliCommand().Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/neutree-cli/app/cmd/delete/delete.go
+++ b/cmd/neutree-cli/app/cmd/delete/delete.go
@@ -51,8 +51,7 @@ Examples:
 
   # Ignore resources that don't exist
   neutree-cli delete Endpoint my-ep -w default --ignore-not-found --server-url https://api.neutree.ai --api-key sk_xxx`,
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDelete(opts, args)
 		},

--- a/cmd/neutree-cli/app/cmd/engine/remove_version.go
+++ b/cmd/neutree-cli/app/cmd/engine/remove_version.go
@@ -44,8 +44,7 @@ Examples:
   # Force remove the last remaining version
   neutree-cli engine remove-version --name vllm --version v0.6.0 --force
 `,
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemoveVersion(opts)
 		},

--- a/cmd/neutree-cli/app/cmd/export/export.go
+++ b/cmd/neutree-cli/app/cmd/export/export.go
@@ -88,9 +88,8 @@ Examples:
 
   # Export everything for one API key over the last week
   neutree-cli export access-log -w default --api-key-id <uuid> --since 2026-07-07 --limit 0`,
-		Args:          cobra.NoArgs,
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAccessLogExport(cmd, opts)
 		},

--- a/cmd/neutree-cli/app/cmd/export/model_usage.go
+++ b/cmd/neutree-cli/app/cmd/export/model_usage.go
@@ -74,9 +74,8 @@ Examples:
 
   # One API key, JSON Lines piped to jq
   neutree-cli export model-usage --api-key-id <uuid> --format jsonl | jq -c .`,
-		Args:          cobra.NoArgs,
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runModelUsageExport(opts)
 		},

--- a/cmd/neutree-cli/app/cmd/get/get.go
+++ b/cmd/neutree-cli/app/cmd/get/get.go
@@ -53,9 +53,8 @@ Examples:
 
   # Watch with custom interval
   neutree-cli get endpoint my-ep -w default --watch --interval 10s`,
-		Args:          cobra.RangeArgs(1, 2),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Args:         cobra.RangeArgs(1, 2),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGet(opts, args)
 		},

--- a/cmd/neutree-cli/app/cmd/wait/wait.go
+++ b/cmd/neutree-cli/app/cmd/wait/wait.go
@@ -46,9 +46,8 @@ Examples:
 
   # Wait with custom timeout and poll interval
   neutree-cli wait endpoint my-ep -w default --for jsonpath=.status.phase=Running --timeout 5m --interval 10s`,
-		Args:          cobra.ExactArgs(2),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runWait(opts, args)
 		},

--- a/tests/e2e/cli_test.go
+++ b/tests/e2e/cli_test.go
@@ -289,7 +289,7 @@ spec: {}
 				"--timeout", "5s",
 			)
 			ExpectFailed(r)
-			Expect(r.Stdout).To(ContainSubstring("timeout"))
+			Expect(r.Stdout + r.Stderr).To(ContainSubstring("timeout"))
 		})
 	})
 


### PR DESCRIPTION
## Issue

NEU-673

## Summary

Every failing `neutree-cli` command printed the same error twice — once from cobra's own `Error: <msg>` in `ExecuteC`, once from an extra `Fprintln` in `Execute()`. This was global, not specific to any subcommand.

The fix lets cobra own error printing and drops the duplicate `Fprintln`. The per-command `SilenceErrors: true` flags were local workarounds for this same duplication, so they go away with it. `SilenceUsage` is untouched, so usage-dump behavior is unchanged.

The alternative — silencing cobra and keeping `Execute()` as the single printer — was rejected because root-level `SilenceErrors` also swallows cobra's `Run '... --help' for usage.` hint on the unknown-command path, and drops the `Error: ` prefix everywhere.

## Changes

- `Execute()` no longer prints the error; it only sets the exit code
- Drop the now-redundant `SilenceErrors` from `apply`, `cleanup`, `delete`, `get`, `wait`, `export access-log`, `export model-usage`, `engine remove-version`
- All commands now report failures uniformly as `Error: <msg>`
- Fix the wait-timeout e2e assertion, which checked stdout for a message that only ever goes to stderr

## Test Plan

- [x] Unit tests: `go test ./cmd/neutree-cli/...` passes; `go vet` clean
- [ ] E2E: not run (needs a live control plane); assertions reviewed for regressions — the stderr checks in `cp_deploy_test.go`, `cp_cleanup_test.go`, `model_test.go` and `image_registry_test.go` all match on message substrings, not on the prefix, so they are unaffected
- Built the CLI before and after the change and diffed stderr across 13 failure paths (unknown command, unknown flag, missing required flag, wrong arg count, connection refused, business errors): each error now appears exactly once, exit codes are identical, error wording is unchanged, and `launch` still dumps usage as before

## Prior art: why the `Fprintln` was there

`git log -L` on `Execute()` turns up two commits. The print dates back to the first CLI commit (#29), where it was `fmt.Println` — straight to stdout. #500 later moved it to stderr, for a reason worth restating:

> `export access-log` documents that data goes to stdout and all diagnostics go to stderr, so an argument-parse error (e.g. an unknown flag) would land in redirected JSONL/JSON/CSV output. Since the export subcommands set SilenceUsage/SilenceErrors, this stdout print was the only place the error surfaced.

That last clause is the point: the print had to stay only *because* `SilenceErrors` had closed cobra's own path. #500 fixed a single exit pointing at the wrong stream — it did not call for a second exit.

This PR reopens cobra's path and removes the extra one, so the invariant #500 established still holds: cobra's `PrintErrln` writes to `ErrOrStderr()` and its usage dump to `OutOrStderr()`, and this CLI never calls `SetOut`/`SetErr`, so both land on stderr. Verified against six `export` failure paths (unknown flag, extra arg, bad `--format`, bad `--since`, bad `--api-key-id`, missing `--server-url`): stdout is 0 bytes before and after, exit code 1 in both, the only delta being the `Error: ` prefix on stderr.

For the record, the `SilenceErrors` flags being removed were never about the stdout contract either — `get`/`apply`/`wait` picked theirs up in #276, the two `export` commands in #489 and #498, each suppressing the duplicate print locally.

## Risk & Rollback

CLI-only, no API or database changes. The visible change is the shape of every command's error line: the eight commands listed above gain the `Error: ` prefix they previously lacked. Anything parsing CLI stderr by exact prefix would need updating; no such parsing exists in this repo. Rollback by reverting the branch.
