### PR TITLE
fix: stop requiring a model registry from engines that ship their own model (NEU-633)

### DIFF
--- a/db/dbtest/validation_test.go
+++ b/db/dbtest/validation_test.go
@@ -797,3 +797,59 @@ func TestEndpointAcceleratorValidation(t *testing.T) {
 		t.Log("NULL accelerator accepted successfully")
 	})
 }
+
+// Migration 090: the database no longer requires spec.model.registry. Whether an
+// endpoint needs one is decided by the API, not here.
+func TestEndpointModelRegistryOptional(t *testing.T) {
+	db := GetTestDB(t)
+	ctx := context.Background()
+
+	insert := func(registry string, name string) string {
+		return fmt.Sprintf(`
+			INSERT INTO api.endpoints (api_version, kind, spec, metadata)
+			VALUES (
+				'v1',
+				'Endpoint',
+				ROW(
+					'test-cluster',
+					ROW('%s', '%s', '', 'v1', '', NULL)::api.model_spec,
+					ROW('flex', 'v1')::api.endpoint_engine_spec,
+					ROW('4', '2', NULL, '16')::api.resource_spec,
+					ROW(1)::api.replica_spec,
+					NULL,
+					NULL,
+					NULL
+				)::api.endpoint_spec,
+				ROW('test-ep-%s', NULL, 'test-workspace', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata
+			)
+		`, registry, name, name)
+	}
+
+	t.Run("endpoint without a model registry is accepted", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("failed to begin transaction: %v", err)
+		}
+		defer func() {
+			_ = tx.Rollback()
+		}()
+
+		if _, err = tx.ExecContext(ctx, insert("", "builtin-model")); err != nil {
+			t.Fatalf("expected registry-less endpoint to be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("endpoint with a model registry is still accepted", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("failed to begin transaction: %v", err)
+		}
+		defer func() {
+			_ = tx.Rollback()
+		}()
+
+		if _, err = tx.ExecContext(ctx, insert("test-registry", "registry-model")); err != nil {
+			t.Fatalf("expected registry-backed endpoint to be accepted, got: %v", err)
+		}
+	})
+}

--- a/db/migrations/090_endpoint_model_registry_optional.down.sql
+++ b/db/migrations/090_endpoint_model_registry_optional.down.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_registry()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.registry IS NULL OR trim((NEW.spec).model.registry) = ''
+    THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10011","message": "spec.model.registry is required","hint": "Provide model registry"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_endpoint_model_registry_on_endpoints
+    BEFORE INSERT OR UPDATE ON api.endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_endpoint_model_registry();

--- a/db/migrations/090_endpoint_model_registry_optional.up.sql
+++ b/db/migrations/090_endpoint_model_registry_optional.up.sql
@@ -1,0 +1,5 @@
+-- Whether an endpoint needs a model registry depends on the engine (does Neutree
+-- download the model?) and on the caller's workspace, neither of which a trigger
+-- can read. The check lives in internal/routes/proxies/endpoint_validation.go.
+DROP TRIGGER IF EXISTS validate_endpoint_model_registry_on_endpoints ON api.endpoints;
+DROP FUNCTION IF EXISTS api.validate_endpoint_model_registry();

--- a/internal/orchestrator/kubernetes_orchestrator.go
+++ b/internal/orchestrator/kubernetes_orchestrator.go
@@ -74,7 +74,7 @@ func (k *kubernetesOrchestrator) prepareOrchestratorContext(endpoint *v1.Endpoin
 		return nil, errors.Wrap(err, "failed to get engine")
 	}
 
-	modelRegistry, err := getEndpointModelRegistry(k.storage, endpoint)
+	modelRegistry, err := resolveEndpointModelRegistry(k.storage, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get model registry")
 	}
@@ -114,8 +114,9 @@ func (k *kubernetesOrchestrator) validateDependencies(ctx *OrchestratorContext) 
 		return errors.Errorf("engine %s not ready", ctx.Engine.Metadata.WorkspaceName())
 	}
 
-	// validate model registry status
-	if ctx.ModelRegistry.Status == nil || ctx.ModelRegistry.Status.Phase != v1.ModelRegistryPhaseCONNECTED {
+	// An endpoint that names no registry has nothing to validate here.
+	if ctx.ModelRegistry != nil &&
+		(ctx.ModelRegistry.Status == nil || ctx.ModelRegistry.Status.Phase != v1.ModelRegistryPhaseCONNECTED) {
 		return errors.Errorf("model registry %s not ready", ctx.ModelRegistry.Metadata.WorkspaceName())
 	}
 

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -384,7 +384,7 @@ func (k *kubernetesOrchestrator) setModelArgs(data *DeploymentManifestVariables,
 		"file":          endpoint.Spec.Model.File,
 		"task":          endpoint.Spec.Model.Task,
 		"path":          endpoint.Spec.Model.Name, // default to model name
-		"registry_type": string(modelRegistry.Spec.Type),
+		"registry_type": endpointModelRegistryType(modelRegistry),
 	}
 
 	modelArgs["serve_name"] = endpointModelServeName(endpoint, modelRegistry)
@@ -407,8 +407,10 @@ func (k *kubernetesOrchestrator) setModelRegistryVariables(data *DeploymentManif
 		modelCacheRelativePath = modelCaches[0].Name
 	}
 
-	switch modelRegistry.Spec.Type {
-	case v1.BentoMLModelRegistryType:
+	// With no registry there is nothing to place from: the model args keep the
+	// bare name / version the spec carries.
+	switch endpointModelRegistryType(modelRegistry) {
+	case string(v1.BentoMLModelRegistryType):
 		url, _ := url.Parse(modelRegistry.Spec.Url) // nolint: errcheck
 		if url != nil && url.Scheme == v1.BentoMLModelRegistryConnectTypeNFS {
 			modelRealVersion, err := getDeployedModelRealVersion(modelRegistry, endpoint.Spec.Model.Name, endpoint.Spec.Model.Version)
@@ -439,7 +441,7 @@ func (k *kubernetesOrchestrator) setModelRegistryVariables(data *DeploymentManif
 			})
 		}
 
-	case v1.HuggingFaceModelRegistryType:
+	case string(v1.HuggingFaceModelRegistryType):
 		data.Env[v1.HFEndpoint] = strings.TrimSuffix(modelRegistry.Spec.Url, "/")
 		if modelRegistry.Spec.Credentials != "" {
 			data.Env[v1.HFTokenEnv] = modelRegistry.Spec.Credentials

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -111,7 +111,7 @@ func (o *RayOrchestrator) prepareOrchestratorContext(endpoint *v1.Endpoint) (*Or
 		return nil, errors.Wrap(err, "failed to get engine")
 	}
 
-	modelRegistry, err := getEndpointModelRegistry(o.storage, endpoint)
+	modelRegistry, err := resolveEndpointModelRegistry(o.storage, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get model registry")
 	}
@@ -152,8 +152,9 @@ func (o *RayOrchestrator) validateDependencies(ctx *OrchestratorContext) error {
 		return errors.Errorf("engine %s not ready", ctx.Engine.Metadata.WorkspaceName())
 	}
 
-	// validate model registry status
-	if ctx.ModelRegistry.Status == nil || ctx.ModelRegistry.Status.Phase != v1.ModelRegistryPhaseCONNECTED {
+	// An endpoint that names no registry has nothing to validate here.
+	if ctx.ModelRegistry != nil &&
+		(ctx.ModelRegistry.Status == nil || ctx.ModelRegistry.Status.Phase != v1.ModelRegistryPhaseCONNECTED) {
 		return errors.Errorf("model registry %s not ready", ctx.ModelRegistry.Metadata.WorkspaceName())
 	}
 
@@ -185,7 +186,7 @@ func (o *RayOrchestrator) CreateEndpoint(endpoint *v1.Endpoint) error {
 		return err
 	}
 
-	if !isNew {
+	if !isNew && ctx.ModelRegistry != nil {
 		// always exec connect model to cluster, for cluster may dynamic scale, we need ensure model exists on all cluster nodes.
 		// todo: In order to reduce model connection actions, a new controller may be created in the future to uniformly manage model connections on the cluster.
 		err = o.connectSSHClusterEndpointModel(*ctx.ModelRegistry, *ctx.Endpoint, connect)
@@ -913,7 +914,7 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 	}
 
 	modelArgs := map[string]interface{}{
-		"registry_type": modelRegistry.Spec.Type,
+		"registry_type": endpointModelRegistryType(modelRegistry),
 		"name":          endpoint.Spec.Model.Name,
 		"file":          endpoint.Spec.Model.File,
 		"version":       endpoint.Spec.Model.Version,
@@ -934,8 +935,10 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 		modelCacheRelativePath = modelCaches[0].Name
 	}
 
-	switch modelRegistry.Spec.Type {
-	case v1.BentoMLModelRegistryType:
+	// With no registry there is nothing to place from: modelArgs keeps the bare
+	// name / version the spec carries.
+	switch endpointModelRegistryType(modelRegistry) {
+	case string(v1.BentoMLModelRegistryType):
 		registryURL, _ := url.Parse(modelRegistry.Spec.Url) // nolint: errcheck
 		if registryURL != nil && registryURL.Scheme == v1.BentoMLModelRegistryConnectTypeNFS {
 			modelRealVersion, err := getDeployedModelRealVersion(modelRegistry, endpoint.Spec.Model.Name, endpoint.Spec.Model.Version)
@@ -951,7 +954,7 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 			modelArgs["registry_path"] = filepath.Join(nfsMountPath, "models", endpoint.Spec.Model.Name, modelRealVersion)
 			modelArgs["path"] = filepath.Join(v1.DefaultSSHClusterModelCacheMountPath, modelCacheRelativePath, endpoint.Spec.Model.Name, modelRealVersion)
 		}
-	case v1.HuggingFaceModelRegistryType:
+	case string(v1.HuggingFaceModelRegistryType):
 		applicationEnv[v1.HFEndpoint] = strings.TrimSuffix(modelRegistry.Spec.Url, "/")
 		if modelRegistry.Spec.Credentials != "" {
 			applicationEnv[v1.HFTokenEnv] = modelRegistry.Spec.Credentials

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -4113,3 +4113,33 @@ func TestRayOrchestrator_prepareOrchestratorContextForPauseDelete_NoDashboardURL
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "dashboard URL")
 }
+
+// The API admits endpoints that name no model registry, so the deploy path has to
+// render one. Every registry-shaped step below would otherwise nil-deref, leaving
+// such an endpoint permanently stuck in reconcile.
+func TestEndpointToApplication_WithoutModelRegistry(t *testing.T) {
+	endpoint := &v1.Endpoint{
+		Metadata: &v1.Metadata{Workspace: "production", Name: "ocr"},
+		Spec: &v1.EndpointSpec{
+			Engine:            &v1.EndpointEngineSpec{Engine: "flex", Version: "1.0.0"},
+			Resources:         &v1.ResourceSpec{Accelerator: map[string]string{}},
+			DeploymentOptions: map[string]interface{}{},
+			Model:             &v1.ModelSpec{Name: "packaged-ocr", Version: "v2"},
+		},
+	}
+
+	app, err := EndpointToApplication(endpoint, &v1.Cluster{}, nil, nil, nil, &acceleratormocks.MockManager{})
+
+	require.NoError(t, err)
+
+	modelArgs, ok := app.Args["model"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "packaged-ocr", modelArgs["name"])
+	// No registry type to branch on, and no version suffix to disambiguate
+	// against: the engine serves the bare name.
+	assert.Equal(t, "", modelArgs["registry_type"])
+	assert.Equal(t, "packaged-ocr", modelArgs["serve_name"])
+	// Registry-specific placement never ran, so no path was invented.
+	assert.NotContains(t, modelArgs, "registry_path")
+}

--- a/internal/orchestrator/util.go
+++ b/internal/orchestrator/util.go
@@ -58,6 +58,12 @@ func endpointModelServeName(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegist
 		return serveName
 	}
 
+	// No registry means no registry-side version to disambiguate against, so the
+	// bare model name is the served name.
+	if modelRegistry == nil || modelRegistry.Spec == nil {
+		return serveName
+	}
+
 	if endpoint.Spec.Model.Version != "" && endpoint.Spec.Model.Version != v1.LatestVersion && modelRegistry.Spec.Type != v1.HuggingFaceModelRegistryType {
 		serveName = endpoint.Spec.Model.Name + ":" + endpoint.Spec.Model.Version
 	}
@@ -135,6 +141,30 @@ func getUsedEngine(s storage.Storage, endpoint *v1.Endpoint) (*v1.Engine, error)
 	}
 
 	return &engine[0], nil
+}
+
+// resolveEndpointModelRegistry returns the model registry an endpoint deploys
+// from, or nil when it names none.
+//
+// nil is a legitimate state, not a lookup failure: an engine that ships its own
+// weights has nothing to fetch. Callers must handle it.
+func resolveEndpointModelRegistry(s storage.Storage, endpoint *v1.Endpoint) (*v1.ModelRegistry, error) {
+	if endpoint.Spec == nil || endpoint.Spec.Model == nil || endpoint.Spec.Model.Registry == "" {
+		return nil, nil
+	}
+
+	return getEndpointModelRegistry(s, endpoint)
+}
+
+// endpointModelRegistryType renders the registry type for the deploy template,
+// empty when the endpoint names no registry. The templates branch on this value,
+// so an absent registry has to read as "none" rather than crash the render.
+func endpointModelRegistryType(modelRegistry *v1.ModelRegistry) string {
+	if modelRegistry == nil || modelRegistry.Spec == nil {
+		return ""
+	}
+
+	return string(modelRegistry.Spec.Type)
 }
 
 func getEndpointModelRegistry(s storage.Storage, endpoint *v1.Endpoint) (*v1.ModelRegistry, error) {

--- a/internal/orchestrator/util_test.go
+++ b/internal/orchestrator/util_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stretchr/testify/mock"
+
 	acceleratormocks "github.com/neutree-ai/neutree/internal/accelerator/mocks"
 	"github.com/neutree-ai/neutree/internal/model_registry"
 	modelregistrymocks "github.com/neutree-ai/neutree/internal/model_registry/mocks"
+	storagemocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
 func TestConverterManager_ConvertToRay_NVIDIA(t *testing.T) {
@@ -447,4 +450,49 @@ func TestGetDeployedModelRealVersion_ModelRegistry(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.expectedErr)
 		})
 	}
+}
+
+// A nil model registry is a normal state, not a lookup failure, so every
+// registry-shaped helper in the deploy path has to tolerate it.
+func TestModelRegistryOptionalInDeployPath(t *testing.T) {
+	t.Run("resolve returns nil, not an error, when no registry is named", func(t *testing.T) {
+		store := storagemocks.NewMockStorage(t)
+
+		for _, endpoint := range []*v1.Endpoint{
+			{Spec: &v1.EndpointSpec{Model: &v1.ModelSpec{Name: "packaged-ocr"}}},
+			{Spec: &v1.EndpointSpec{Model: nil}},
+			{Spec: nil},
+		} {
+			registry, err := resolveEndpointModelRegistry(store, endpoint)
+
+			require.NoError(t, err)
+			assert.Nil(t, registry)
+		}
+
+		// The store is never consulted for an endpoint that names no registry.
+		store.AssertNotCalled(t, "ListModelRegistry", mock.Anything)
+	})
+
+	t.Run("registry type renders empty rather than crashing the template", func(t *testing.T) {
+		assert.Equal(t, "", endpointModelRegistryType(nil))
+		assert.Equal(t, "", endpointModelRegistryType(&v1.ModelRegistry{}))
+		assert.Equal(t, string(v1.HuggingFaceModelRegistryType), endpointModelRegistryType(
+			&v1.ModelRegistry{Spec: &v1.ModelRegistrySpec{Type: v1.HuggingFaceModelRegistryType}},
+		))
+	})
+
+	t.Run("serve name falls back to the bare model name", func(t *testing.T) {
+		// The version suffix exists to disambiguate versions held by a registry.
+		// With no registry there is nothing to disambiguate against, so appending
+		// it would invent a name the engine does not serve.
+		endpoint := &v1.Endpoint{
+			Spec: &v1.EndpointSpec{
+				Model:  &v1.ModelSpec{Name: "packaged-ocr", Version: "v2"},
+				Engine: &v1.EndpointEngineSpec{Engine: "flex"},
+			},
+		}
+
+		assert.Equal(t, "packaged-ocr", endpointModelServeName(endpoint, nil))
+		assert.Equal(t, "packaged-ocr", endpointModelServeName(endpoint, &v1.ModelRegistry{}))
+	})
 }

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -47,12 +47,14 @@ type endpointValidationConfig struct {
 var endpointValidationConfigs = map[endpointValidationOperation]endpointValidationConfig{
 	endpointValidationCreate: {
 		Validators: []endpointValidator{
+			validateEndpointCreateModelSource,
 			validateEndpointCreateResourceShape,
 		},
 	},
 	endpointValidationPatch: {
 		Validators: []endpointValidator{
 			validateEndpointPatchClusterImmutable,
+			validateEndpointPatchModelSource,
 			validateEndpointPatchResourceShape,
 		},
 	},
@@ -201,6 +203,108 @@ func endpointPatchIsSoftDelete(payload map[string]json.RawMessage) (bool, error)
 	}
 
 	return metadata.DeletionTimestamp != "", nil
+}
+
+func validateEndpointCreateModelSource(store storage.Storage, input *endpointValidationInput) *validationError {
+	if input == nil || input.Patch.GetDeletionTimestamp() != "" {
+		return nil
+	}
+
+	return validateEndpointModelSource(store, input.New)
+}
+
+func validateEndpointPatchModelSource(store storage.Storage, input *endpointValidationInput) *validationError {
+	if input == nil || input.New == nil {
+		return nil
+	}
+
+	if !endpointPatchMayAffectModelSourceValidation(&input.Patch) {
+		return nil
+	}
+
+	return validateEndpointModelSource(store, input.New)
+}
+
+// endpointPatchMayAffectModelSourceValidation reports whether a PATCH can change
+// the answer. spec.engine counts alongside spec.model: the engine decides whether
+// a registry is required at all, so repointing an endpoint at another engine has
+// to be re-checked even when spec.model is untouched.
+func endpointPatchMayAffectModelSourceValidation(endpoint *v1.Endpoint) bool {
+	if endpoint == nil || endpoint.Spec == nil {
+		return false
+	}
+
+	return endpoint.Spec.Model != nil || endpoint.Spec.Engine != nil
+}
+
+// validateEndpointModelSource decides whether an endpoint has to name a model
+// registry, and checks the one it names is real.
+//
+// A registry is required exactly when Neutree downloads the model itself, which
+// v1.IsBuiltInModelDownloaderEngine answers and the orchestrator keys its
+// download step off as well -- keep the two on the same predicate, or validation
+// and deployment will disagree about which endpoints need a registry.
+//
+// A registry that *is* named is resolved against the endpoint's own workspace
+// whichever engine is in play: deps.Storage runs as the service role and does
+// not apply RLS, so a spec naming another workspace's registry would otherwise
+// be honoured.
+func validateEndpointModelSource(store storage.Storage, endpoint *v1.Endpoint) *validationError {
+	if endpoint == nil || endpoint.Spec == nil || endpoint.Spec.Model == nil {
+		return nil
+	}
+
+	if endpoint.Spec.Model.Registry == "" {
+		if endpointDownloadsModel(endpoint) {
+			return endpointModelSourceError(fmt.Sprintf(
+				"spec.model.registry is required for engine %s, which downloads its own model",
+				endpoint.Spec.Engine.Engine))
+		}
+
+		return nil
+	}
+
+	return validateEndpointModelRegistryVisible(store, endpoint)
+}
+
+// endpointDownloadsModel reports whether Neutree fetches this endpoint's model
+// itself, which is what makes a model registry mandatory.
+func endpointDownloadsModel(endpoint *v1.Endpoint) bool {
+	return endpoint.Spec.Engine != nil &&
+		v1.IsBuiltInModelDownloaderEngine(endpoint.Spec.Engine.Engine)
+}
+
+func validateEndpointModelRegistryVisible(store storage.Storage, endpoint *v1.Endpoint) *validationError {
+	if store == nil {
+		return internalServerValidationError()
+	}
+
+	workspace := endpointValidationWorkspace(endpoint)
+	registry := endpoint.Spec.Model.Registry
+
+	registries, err := store.ListModelRegistry(storage.ListOption{
+		Filters: []storage.Filter{
+			{Column: "metadata->name", Operator: "eq", Value: strconv.Quote(registry)},
+			{Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote(workspace)},
+		},
+	})
+	if err != nil {
+		return internalServerValidationError()
+	}
+
+	if len(registries) == 0 {
+		return endpointModelSourceError(fmt.Sprintf("model registry %s/%s not found", workspace, registry))
+	}
+
+	return nil
+}
+
+func endpointValidationWorkspace(endpoint *v1.Endpoint) string {
+	if endpoint != nil && endpoint.Metadata != nil && endpoint.Metadata.Workspace != "" {
+		return endpoint.Metadata.Workspace
+	}
+
+	return defaultWorkspace
 }
 
 func validateEndpointCreateResourceShape(store storage.Storage, input *endpointValidationInput) *validationError {
@@ -520,10 +624,7 @@ func resolveEndpointCluster(store storage.Storage, endpoint *v1.Endpoint) (*v1.C
 		return nil, endpointAcceleratorResourceError(errors.New("spec.cluster is required"))
 	}
 
-	workspace := defaultWorkspace
-	if endpoint.Metadata != nil && endpoint.Metadata.Workspace != "" {
-		workspace = endpoint.Metadata.Workspace
-	}
+	workspace := endpointValidationWorkspace(endpoint)
 
 	clusters, err := store.ListCluster(storage.ListOption{
 		Filters: endpointClusterLookupFilters(clusterName, workspace),
@@ -848,6 +949,14 @@ func endpointResourceValueError(err error) *validationError {
 		Code:    "10216",
 		Message: "invalid endpoint accelerator virtualization resources",
 		Hint:    err.Error(),
+	}
+}
+
+func endpointModelSourceError(hint string) *validationError {
+	return &validationError{
+		Code:    "10229",
+		Message: "invalid endpoint model source",
+		Hint:    hint,
 	}
 }
 

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -2244,3 +2244,136 @@ func TestEndpointPatchMayAffectResourceValidation(t *testing.T) {
 		assert.False(t, endpointPatchMayAffectResourceValidation(&v1.Endpoint{}))
 	})
 }
+
+type fakeModelRegistryStorage struct {
+	*storagemocks.MockStorage
+
+	registries []v1.ModelRegistry
+	listErr    error
+	options    []storage.ListOption
+}
+
+func (s *fakeModelRegistryStorage) ListModelRegistry(option storage.ListOption) ([]v1.ModelRegistry, error) {
+	s.options = append(s.options, option)
+
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+
+	return s.registries, nil
+}
+
+func modelSourceEndpoint(workspace string, model *v1.ModelSpec, engine string) *v1.Endpoint {
+	return &v1.Endpoint{
+		Metadata: &v1.Metadata{Name: "ep", Workspace: workspace},
+		Spec: &v1.EndpointSpec{
+			Cluster: "c1",
+			Model:   model,
+			Engine:  &v1.EndpointEngineSpec{Engine: engine, Version: "v1"},
+		},
+	}
+}
+
+func TestValidateEndpointModelSource(t *testing.T) {
+	visible := []v1.ModelRegistry{{Metadata: &v1.Metadata{Name: "hf", Workspace: "ws-a"}}}
+
+	t.Run("accepts a registry-backed model visible in the endpoint workspace", func(t *testing.T) {
+		store := &fakeModelRegistryStorage{registries: visible}
+
+		err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a",
+			&v1.ModelSpec{Registry: "hf", Name: "qwen3", Version: "latest"}, v1.EngineNameVLLM))
+
+		assert.Nil(t, err)
+		if assert.Len(t, store.options, 1) {
+			assert.Contains(t, store.options[0].Filters, storage.Filter{
+				Column: "metadata->workspace", Operator: "eq", Value: strconv.Quote("ws-a"),
+			})
+		}
+	})
+
+	t.Run("rejects a registry that lives in another workspace", func(t *testing.T) {
+		// The registry exists, just not in ws-a: the lookup is workspace-scoped,
+		// which is the whole point — deps.Storage bypasses RLS.
+		store := &fakeModelRegistryStorage{}
+
+		err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a",
+			&v1.ModelSpec{Registry: "other-ws-registry", Name: "qwen3", Version: "latest"}, v1.EngineNameVLLM))
+
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "10229", err.Code)
+			assert.Contains(t, err.Hint, "ws-a/other-ws-registry")
+		}
+	})
+
+	t.Run("requires a registry for an engine Neutree downloads for", func(t *testing.T) {
+		for _, engine := range []string{v1.EngineNameVLLM, v1.EngineNameLlamaCpp, v1.EngineNameSGLang} {
+			store := &fakeModelRegistryStorage{registries: visible}
+
+			err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a",
+				&v1.ModelSpec{Name: "qwen3", Version: "latest"}, engine))
+
+			if assert.NotNilf(t, err, "engine %s", engine) {
+				assert.Equal(t, "10229", err.Code)
+				assert.Contains(t, err.Hint, "spec.model.registry is required")
+			}
+		}
+	})
+
+	t.Run("accepts no registry for an engine that ships its own model", func(t *testing.T) {
+		// The Flex case: nothing for Neutree to fetch, so nothing to name. The
+		// store is never consulted.
+		store := &fakeModelRegistryStorage{}
+
+		err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a",
+			&v1.ModelSpec{Name: "packaged-ocr"}, "flex"))
+
+		assert.Nil(t, err)
+		assert.Empty(t, store.options)
+	})
+
+	t.Run("still checks a registry a self-contained engine does name", func(t *testing.T) {
+		// Optional does not mean unchecked: naming another workspace's registry
+		// is refused whichever engine asks.
+		store := &fakeModelRegistryStorage{}
+
+		err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a",
+			&v1.ModelSpec{Registry: "other-ws-registry", Name: "m"}, "flex"))
+
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "10229", err.Code)
+		}
+	})
+
+	t.Run("ignores an endpoint that carries no model spec", func(t *testing.T) {
+		store := &fakeModelRegistryStorage{}
+
+		err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a", nil, "flex"))
+
+		assert.Nil(t, err)
+		assert.Empty(t, store.options)
+	})
+}
+
+func TestEndpointPatchMayAffectModelSourceValidation(t *testing.T) {
+	t.Run("skips a patch that touches neither model nor engine", func(t *testing.T) {
+		replicas := 3
+
+		assert.False(t, endpointPatchMayAffectModelSourceValidation(&v1.Endpoint{
+			Spec: &v1.EndpointSpec{Replicas: v1.ReplicaSpec{Num: &replicas}},
+		}))
+	})
+
+	t.Run("re-checks a patch that repoints the engine", func(t *testing.T) {
+		// Whether a registry is required at all is the engine's answer, so an
+		// engine change has to be re-checked even with spec.model untouched.
+		assert.True(t, endpointPatchMayAffectModelSourceValidation(&v1.Endpoint{
+			Spec: &v1.EndpointSpec{Engine: &v1.EndpointEngineSpec{Engine: v1.EngineNameVLLM}},
+		}))
+	})
+
+	t.Run("re-checks a patch that changes the model", func(t *testing.T) {
+		assert.True(t, endpointPatchMayAffectModelSourceValidation(&v1.Endpoint{
+			Spec: &v1.EndpointSpec{Model: &v1.ModelSpec{Name: "other"}},
+		}))
+	})
+}


### PR DESCRIPTION
## Issue

NEU-633

## Summary

`spec.model.registry` was required by a database trigger on every endpoint. Engines that ship their own weights — the Flex engine bakes its model into the image — have nothing for Neutree to fetch, so they carried a registry that meant nothing.

The requirement now follows what it was standing in for: **a model registry is required exactly when Neutree downloads the model itself.** `v1.IsBuiltInModelDownloaderEngine` answers that, and the orchestrator keys its download step off the same predicate, so validation and deployment cannot disagree about which endpoints need a registry.

## Changes

**Admission** — migration `090` drops the trigger; `internal/routes/proxies/endpoint_validation.go` takes over on create, and on any PATCH touching `spec.model` or `spec.engine`:

- an engine Neutree downloads for must still name a registry;
- a registry that *is* named is checked against the endpoint's own workspace **whichever engine asks** — `deps.Storage` runs as the service role and does not apply RLS. Optional does not mean unchecked;
- `spec.model.name` / `version` / `task` stay required for every engine. They are equally meaningless for a self-contained engine, but removing them is the next step of NEU-633 and touches a different set of triggers.

**Deployment** — both orchestrators resolved the registry unconditionally and failed when the lookup came back empty, so relaxing admission alone would have produced endpoints that are accepted and then stuck in reconcile. The registry is now resolved only when the spec names one, and `nil` is handled everywhere it flows: the readiness check, the SSH NFS connect, the serve name, the deploy-template `registry_type`, and registry-specific model placement, in both the Ray and Kubernetes paths.

Unchanged on purpose: the delete path already tolerates a missing registry, and model-reference lookup filters on `spec->model->>registry`, which a registry-less endpoint correctly never matches.

No new API surface — `api/v1` is untouched.

## Test Plan

- [x] E2E (if affected): not affected
- [x] DB integration (`make db-test`): pass — full suite green against a fresh postgres with migrations `001..090`. `TestEndpointModelRegistryOptional` covers the migration: a registry-less endpoint now inserts, a registry-backed one still does.

`go test ./...` green, `make lint` clean.

`TestEndpointToApplication_WithoutModelRegistry` renders a Ray application for a registry-less endpoint end to end and asserts the model args — bare name, empty `registry_type`, no invented `registry_path`. Reverting the nil handling turns it into a nil-pointer panic, so it guards the deploy path rather than restating it.

Validation is covered on both sides of the predicate: a registry is still demanded from vLLM / llama-cpp / SGLang, omitted freely for a self-contained engine, and a cross-workspace registry is refused whichever engine names it.

## Risk & Rollback

Rollback is reverting the migration, which `090_endpoint_model_registry_optional.down.sql` recreates verbatim — with one caveat: the restored trigger fires on UPDATE as well as INSERT, so endpoints created without a registry while it was absent could no longer be updated. Rolling back means rolling back those endpoints too.

Existing endpoints all carry a registry and validate exactly as before. One behaviour change for existing clients: a write naming a registry that does not exist in the endpoint's workspace is now refused at the API instead of reaching the database — that write was already broken at deploy time.

Writers that bypass the proxy (controllers writing through `storage`) are no longer covered by the dropped trigger. Deliberate, and consistent with how cluster and resource-shape validation already work.
