### PR TITLE
chore: upgrade bundled Grafana to 12.4.9

### DIFF
--- a/cmd/neutree-cli/app/cmd/launch/obs_stack_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/obs_stack_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/constants"
+	"github.com/neutree-ai/neutree/internal/componentversion"
 	"github.com/neutree-ai/neutree/pkg/command/mocks"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -140,6 +141,60 @@ func TestPrepareObsStackDeployConfig(t *testing.T) {
 				assert.FileExists(t, filepath.Join(tempDir, "obs-stack", "grafana", "provisioning", "datasources", "cluster.yml"))
 			}
 		})
+	}
+}
+
+// The version reaches the Compose stack through a template variable, so what the
+// CLI actually deploys is only visible after a real render.
+func TestPrepareObsStackDeployConfig_PinsGrafanaVersion(t *testing.T) {
+	tempDir := t.TempDir()
+
+	options := &obsStackInstallOptions{
+		commonOptions: &commonOptions{
+			workDir:    tempDir,
+			nodeIP:     "192.168.1.1",
+			deployType: constants.DeployTypeLocal,
+			deployMode: constants.DeployModeSingle,
+		},
+	}
+
+	require.NoError(t, prepareObsStackDeployConfig(options))
+
+	rendered, err := os.ReadFile(filepath.Join(tempDir, "obs-stack", "docker-compose.yml"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "grafana/grafana:"+componentversion.Grafana)
+	// The template variable itself must be gone: an unrendered `{{ }}` reaches
+	// Docker verbatim and fails at pull time rather than here.
+	assert.NotContains(t, string(rendered), "{{")
+}
+
+// Grafana is pinned in three places that are only correct together. A bump that
+// lands in one of them produces a deployment pulling an image the offline package
+// does not carry, which only shows up at install time on a machine with no
+// registry to fall back to.
+func TestGrafanaVersionPinsAgree(t *testing.T) {
+	// From this package back to the repository root.
+	root := filepath.Join("..", "..", "..", "..", "..")
+
+	for _, tc := range []struct {
+		path string
+		want string
+	}{
+		{
+			path: filepath.Join(root, "scripts", "builder", "image-lists", "controlplane", "images.txt"),
+			want: "grafana/grafana:" + componentversion.Grafana,
+		},
+		{
+			path: filepath.Join(root, "deploy", "chart", "neutree", "values.yaml"),
+			want: `tag: "` + componentversion.Grafana + `"`,
+		},
+	} {
+		content, err := os.ReadFile(tc.path)
+		require.NoError(t, err)
+
+		assert.Containsf(t, string(content), tc.want,
+			"%s does not pin Grafana %s", tc.path, componentversion.Grafana)
 	}
 }
 

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -372,7 +372,7 @@ grafana:
     # -- Docker image repository
     repository: grafana/grafana
     # Overrides the Grafana image tag whose default is the chart appVersion
-    tag: "11.5.3"
+    tag: "12.4.9"
 
   testFramework:
     enabled: false

--- a/internal/componentversion/componentversion.go
+++ b/internal/componentversion/componentversion.go
@@ -22,7 +22,15 @@ const NodeExporter = "v1.8.2"
 const NeutreeNodeAgent = "v1.1.0-rc.1"
 
 // Grafana image version.
-const Grafana = "11.5.3"
+//
+// Do not go below 12.1.0: the AppWrapper crash on boot over plain HTTP
+// (`window.caches` is undefined outside a secure context) was fixed there and
+// never backported to 11.5.x, 11.6.x or 12.0.x, and the 11.5 line is EOL.
+//
+// Grafana 12 removes AngularJS. Bundled dashboards still carrying `graph` /
+// `singlestat` panels are core visualizations and are force-migrated on load,
+// which is why their JSON is unchanged.
+const Grafana = "12.4.9"
 
 // Vector image version.
 const Vector = "0.47.0-debian"

--- a/scripts/builder/image-lists/controlplane/images.txt
+++ b/scripts/builder/image-lists/controlplane/images.txt
@@ -1,5 +1,5 @@
 ghcr.io/groundnuty/k8s-wait-for:v2.0
-grafana/grafana:11.5.3
+grafana/grafana:12.4.9
 kong/kong:3.9
 migrate/migrate:v4.18.3
 neutree/jwt-cli:6.2.0


### PR DESCRIPTION
## Issue

Related to NEU-593 — but see **Risk & Rollback**: this does **not** fix it.

## Summary

We ship Grafana 11.5.3. That line is dead upstream — its last release was 11.5.10 — and we sit seven patches behind even that. It also carries an unhandled exception on boot over plain HTTP: `AppWrapper` calls `window.caches.keys()` without checking the Cache API exists, and outside a secure context it does not. Upstream fixed it in [grafana/grafana#105646](https://github.com/grafana/grafana/pull/105646) and never backported it.

I checked `public/app/AppWrapper.tsx` at each tag rather than trusting release notes:

| tag | guarded |
|---|---|
| v11.5.3 (ours) / v11.5.9 / v11.5.10 *(last 11.5)* | ❌ |
| v11.6.16 *(latest 11.6)* | ❌ |
| v12.0.6 | ❌ |
| **v12.1.0** and later — v12.3.11, v12.4.9, v13.1.4 | ✅ |

So there is no patch-level or 11.x escape; 12.1.0 is the floor. 12.4.x is the landing point because 12.1 itself stopped receiving releases in March.

## Changes

Grafana is pinned in three places that are only correct together:

- `internal/componentversion/componentversion.go` — the constant the CLI renders into the Compose stack
- `deploy/chart/neutree/values.yaml` — the Helm image tag
- `scripts/builder/image-lists/controlplane/images.txt` — the offline control-plane image list

Plus two tests:

- `TestGrafanaVersionPinsAgree` asserts the three agree. A bump landing in one alone produces a deployment that pulls an image the offline package does not carry — which only surfaces at install time, on a machine with no registry to fall back to. Verified it fails when one pin is reverted.
- `TestPrepareObsStackDeployConfig_PinsGrafanaVersion` renders the obs-stack Compose file through the real CLI path and asserts the pin survives templating (the version arrives via `{{ .GrafanaVersion }}`, so it is only observable after a render).

Dashboard JSON is untouched — see below.

## Test Plan

- [x] E2E (if affected): not affected
- [x] DB integration (`make db-test`): not affected

Verified against a real deployment, not release notes. Both versions were run over plain HTTP with this repo's `obs-stack` `grafana.ini`, provisioning and all 19 dashboards mounted, then driven with a headless browser at the embed URL `buildGrafanaDashboardUrl` produces:

- **The exception is gone.** 11.5.3 threw `Cannot read properties of undefined (reading 'keys')` on 8/8 dashboards; 12.4.9 on 0/8. `isSecureContext === false` and `window.caches === undefined` on both, so the precondition was genuinely met.
- **All 19 dashboards provisioned on both**, including the four `schemaVersion: 27` ones — 12.4.9 did not reject them.
- **The five `neutree_*_embed_*` dashboards the console iframes render identically** on both.
- **Anonymous auth and `allow_embedding` still work.** A cross-origin iframe on an HTTP page rendered the dashboard on 12.4.9 with no login redirect and no frame refusal — the two config behaviours the console depends on.
- **AngularJS removal is absorbed.** Grafana 12 drops Angular; seven bundled dashboards still carry 110 `graph` + 10 `singlestat` panels. All are core visualizations, so Grafana force-migrates them on load. `rayDefaultDashboard` (23 `graph` panels, and the dashboard `default_home_dashboard_path` points at), `node-exporter` and `nvidia-dcgm-dashboard` all rendered with titles, template variables and layout intact — no "panel plugin not found".

Also `go test ./...` green and `make lint` clean, and `helm template` renders `docker.io/grafana/grafana:12.4.9`.

## Risk & Rollback

**This does not fix NEU-593, and the PR should not be merged as if it does.** The exception it removes is real but is not what blanks the embedded dashboard. In v11.5.3:

```js
async componentDidMount() {
  await loadAndInitAngularIfEnabled();
  this.setState({ ready: true });                 // app renders here
  $('.preloader').remove();
  const cacheKeys = await window.caches.keys();   // throws here
}
```

`render()` gates on `ready`, which is set *before* the throw, and the throw is an unhandled rejection that does not unmount React. Observed behaviour matches: 11.5.3 rendered all 11 panels — both top-level and inside a cross-origin HTTP iframe — while throwing. NEU-593's blank still needs a root cause; the likely candidates are frame refusal (`X-Frame-Options` / CSP `frame-ancestors`), mixed content, a wrong `root_url`, or Grafana being unreachable. The console-side gap (no health probe, no error placeholder, iframe revealed unconditionally after an 8s timeout) is unaffected by this PR and worth fixing separately.

Rollback is reverting the three pins. Grafana state lives in a volume; the dashboards are provisioned read-only from files, so no dashboard is rewritten on disk by the migration and a downgrade finds them exactly as they were.

Two follow-ups deliberately left out to keep this to one change:

1. The seven Angular dashboards are migrated at load, every load, and cannot be saved because they are provisioned. Persisting the migrated JSON is worth doing, and is a diff large enough to review on its own.
2. The upstream Helm subchart stays at `8.11.0` (appVersion 11.6.0). It templates a plain Deployment plus ConfigMap, renders cleanly with the new tag, and the rendered pod uses only `GF_PATHS_*` env and `/api/health` probes — all still valid in Grafana 12. Moving it to `10.5.x` crosses two major chart versions with its own values-schema risk.

The Helm path is verified by rendering only; the Compose path is the one exercised end to end above. A smoke test on a real cluster before release would be worth it.