### PR TITLE
fix: percent-decode the endpoint name in the Kong access log pipeline (NEU-690) (#579)

### DIFF
--- a/cmd/neutree-cli/app/cmd/launch/core_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/core_test.go
@@ -244,6 +244,35 @@ func TestPrepareNeutreeCoreDeployConfig_PreservesVRLOperators(t *testing.T) {
 	assert.Contains(t, string(vector), "<= 1572864")
 }
 
+// The decode only exists in the template, and a template that renders wrong fails
+// at Vector startup rather than in CI — same reason as the NEU-583 guard above.
+func TestPrepareNeutreeCoreDeployConfig_DecodesEndpointName(t *testing.T) {
+	tempDir := t.TempDir()
+
+	options := neutreeCoreInstallOptions{
+		commonOptions: &commonOptions{
+			workDir:    tempDir,
+			nodeIP:     "192.168.1.1",
+			deployType: constants.DeployTypeLocal,
+			deployMode: constants.DeployModeSingle,
+		},
+		jwtSecret: "test-secret",
+		version:   "v1.0.0",
+	}
+
+	require.NoError(t, prepareNeutreeCoreDeployConfig(options))
+
+	vector, err := os.ReadFile(filepath.Join(tempDir, "neutree-core", "vector", "vector.yml"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(vector),
+		"decode_percent(.extracted_data.url_split[4]) ?? .extracted_data.url_split[4]")
+	// The fallback is the point: without it an absent segment or an invalid
+	// escape aborts the remap instead of keeping the raw value.
+	assert.NotContains(t, string(vector),
+		"endpoint_name = .extracted_data.url_split[4]")
+}
+
 func TestValidateNeutreeCoreVersionCompatibility(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/deploy/chart/neutree/templates/vector-install.yaml
+++ b/deploy/chart/neutree/templates/vector-install.yaml
@@ -36,7 +36,11 @@ data:
               .extracted_data.url_split = split!(.request.uri, "/")
               .extracted_data.workspace = .extracted_data.url_split[2]      # workspace name from /workspace/{workspace}/...
               .extracted_data.endpoint_type = .extracted_data.url_split[3]  # "endpoint" or "external-endpoint"
-              .extracted_data.endpoint_name = .extracted_data.url_split[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
+              # The name comes from the raw request URI, so a non-ASCII endpoint name
+              # (external endpoint names are not restricted to ASCII) arrives encoded.
+              # decode_percent is fallible on an `any` argument, and the fallback also
+              # covers a missing segment and an invalid escape -- do not drop it.
+              .extracted_data.endpoint_name = decode_percent(.extracted_data.url_split[4]) ?? .extracted_data.url_split[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
           }
 
           if exists(.ai) && exists(.ai."statistics") && exists(.ai."statistics".usage) {

--- a/deploy/docker/neutree-core/vector/vector.yml
+++ b/deploy/docker/neutree-core/vector/vector.yml
@@ -22,7 +22,11 @@ transforms:
           .extracted_data.url_split = split!(.request.uri, "/")
           .extracted_data.workspace = .extracted_data.url_split[2]      # workspace name from /workspace/{workspace}/...
           .extracted_data.endpoint_type = .extracted_data.url_split[3]  # "endpoint" or "external-endpoint"
-          .extracted_data.endpoint_name = .extracted_data.url_split[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
+          # The name comes from the raw request URI, so a non-ASCII endpoint name
+          # (external endpoint names are not restricted to ASCII) arrives encoded.
+          # decode_percent is fallible on an `any` argument, and the fallback also
+          # covers a missing segment and an invalid escape -- do not drop it.
+          .extracted_data.endpoint_name = decode_percent(.extracted_data.url_split[4]) ?? .extracted_data.url_split[4]  # endpoint name from /workspace/{workspace}/{type}/{endpoint_name}
       }
 
       if exists(.ai) && exists(.ai."statistics") && exists(.ai."statistics".usage) {


### PR DESCRIPTION
## Issue

NEU-690

## Summary

The endpoint name is lifted out of Kong's raw `request.uri` by splitting on `/`, and `request.uri` is what the client sent — so a non-ASCII name arrives percent-encoded and was stored that way. An endpoint whose name contains non-ASCII characters reads as `%E4%B8%AD%E6%96%87...` everywhere downstream.

This is reachable because `api.external_endpoints` is the one resource table without the `metadata.name` trigger, so external endpoint names are not restricted to ASCII. Internal endpoints are: `validate_name_on_endpoints` pins them to `^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$`, so contrary to the report's impact note, a non-ASCII internal endpoint name cannot exist. Workspaces carry the same trigger, which is why only `endpoint_name` is decoded here — `workspace` is lowercase ASCII by construction and `endpoint_type` is a fixed literal.

## Changes

One line, in the two copies of the transform:

- `deploy/docker/neutree-core/vector/vector.yml`
- `deploy/chart/neutree/templates/vector-install.yaml`

The fallback is load-bearing, not decoration: `decode_percent` is fallible **here** because the indexed segment is `any` rather than a string, and the fallback also covers a path with no name segment and an invalid escape — both keep today's behaviour instead of aborting the remap.

A test asserts the decode survives templating, for the same reason as the NEU-583 guard beside it: a template that renders wrong fails at Vector startup, not in CI.

## Wider than the report

The report describes this as an AI Trace display problem. `endpoint_name` has three consumers, and one decode fixes all of them because they all read `.extracted_data.endpoint_name`:

| consumer | impact today |
|---|---|
| AI Trace list | renders the encoded name |
| AI Trace endpoint filter | `internal/routes/logs/trace_store.go` matches `endpoint_name:=` **exactly**, so filtering by the real name returns nothing at all |
| `api.api_usage_records.endpoint_name` | `get_usage_by_dimension` groups and filters on it, so Model Usage shows the encoded name and its endpoint filter never matches |

## Test Plan

- [x] E2E (if affected): not affected
- [x] DB integration (`make db-test`): not affected

Verified against the pinned Vector (`0.47.0-debian`) rather than by reading docs, and on **rendered** output rather than the templates — the CLI-rendered Compose config and the Helm-rendered ConfigMap. Both pass `vector validate`:

```
√ Loaded ["/w/rendered-vector.yml"]     Validated
√ Loaded ["/w/helm-vector.yml"]         Validated
```

Decoding was exercised over the cases that actually reach this line:

| segment | result |
|---|---|
| `%E4%B8%AD%E6%96%87%E6%B5%8B%E8%AF%95` | the 4-character UTF-8 name it encodes |
| `plain-name` | `plain-name` (unchanged) |
| `%ZZbad` (invalid escape) | `%ZZbad` (falls back) |
| path with fewer than 5 segments | `null` (unchanged) |

`go test ./...` green and `make lint` clean.

## Risk & Rollback

Rollback is reverting the line. No schema change, no API change.

**Historical rows are not rewritten.** Records already in VictoriaLogs and `api_usage_records` keep the encoded value, so both forms coexist for the retention window — and, for usage records, indefinitely. `endpoint_name` is also a VictoriaLogs stream field (`_stream_fields=workspace,endpoint_type,endpoint_name`), so the new value starts a new stream rather than continuing the old one. Backfill, if wanted, is a separate change; this PR assumes we accept the split.

## Left out on purpose

- **A name containing `/`.** `a%2Fb` decodes to `a/b`, and an unencoded `/` in a name would break the `split!` segmentation outright. That is a symptom of the missing name validation, not of the decode.
- **Query string leaking into the name.** `request.uri` carries the query string, so a request that ends at the name segment yields `<name>?x=1`. This is pre-existing and unaffected by the decode (the raw value is equally wrong); real inference requests always have `/v1/...` after the name.
- **Both point at the same root cause** — external endpoint names accept anything. Worth its own ticket: constrain the name to ASCII and let `display_name` carry the non-ASCII label.
- **The durable fix** is not to reconstruct identity from a URL at all. Kong already knows it: `internal/gateway/kong.go` puts `endpoint_name` in the ai-gateway plugin config and the handler stashes it in `kong.ctx.shared`; emitting it via `kong.log.set_serialize_value` would remove the encoding and the segmentation problems together. That means a plugin change and an image rebuild, so it is a direction, not this PR.

## Draft because

The behaviour is verified at the config layer (rendered + `vector validate` + the decode itself against the pinned Vector), but not yet end to end on a running stack — no Kong request against a non-ASCII-named external endpoint has been pushed through to VictoriaLogs and the Model Usage page. Worth doing before this leaves draft.
