### PR TITLE
fix: restore migration 087 upgrade path

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,7 +5,7 @@
 #   2. gofmt                       — format check
 #   3. go vet                      — static analysis
 #   4. architecture boundaries     — import-direction rules (scripts/check-boundaries.sh)
-#   5. migration hygiene           — up/down pairs + unique version numbers (scripts/check-migrations.sh)
+#   5. migration hygiene           — immutable history, pairs, unique versions, seed-owned reload (scripts/check-migrations.sh)
 #   6. golangci-lint (full)        — CI-equivalent lint for non-test/non-mock files
 #   7. go test -short              — affected packages only
 #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,13 @@ jobs:
           TOKEN: ${{ secrets.CI_ACCESS_TOKEN }}
           USERNAME: ${{ secrets.CI_USERNAME }}
         run: git config --global url."https://${USERNAME}:${TOKEN}@github.com".insteadOf "https://github.com"
+
+      - name: Migration hygiene (PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          bash scripts/check-migrations.sh "origin/${{ github.base_ref }}"
+
       - name: Prepare for lint
         run: make prepare-build-cli
       - name: Run golangci-lint
@@ -46,12 +53,6 @@ jobs:
 
       - name: Architecture boundaries
         run: bash scripts/check-boundaries.sh
-
-      - name: Migration hygiene (PR only)
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch origin "${{ github.base_ref }}" --depth=50
-          bash scripts/check-migrations.sh "origin/${{ github.base_ref }}"
 
       - name: Upload Coverage report to CodeCov
         uses: codecov/codecov-action@v1.0.15

--- a/contributing/database.md
+++ b/contributing/database.md
@@ -15,8 +15,10 @@
 - Numbering: each `NNN` must be unique across the branch. Read the highest number in use rather than trusting a number written down here — `ls db/migrations | sed -E 's/_.*//' | sort -n | tail -1` — and start at the next one.
 - Any migration that touches RLS or permissions must ship with an integration test under `db/dbtest/`.
 - **Redefining an existing function**: `CREATE OR REPLACE` replaces the whole body, so base it on the *latest* migration that defines the function, not the first one you find. `grep -l 'FUNCTION api.<name>' db/migrations/*.up.sql` lists them all — copying an older body silently reverts every change made in between.
+- **Released migrations are immutable**: once a migration file exists on the base branch, do not modify, rename, or delete it. If deployed SQL must be undone, add a later reversible migration instead of rewriting history.
+- **Schema reload belongs to seed SQL**: `db/seed/999_notify_pgrst.sql` sends the PostgREST schema reload notification. New migrations must not add `NOTIFY pgrst, 'reload schema'`.
 
-> ⚠️ **Pair rule (new migrations)**: every new migration must ship `.up.sql` and `.down.sql` together; a missing `.down.sql` breaks rollback. The pre-commit hook (P0-2) enforces this.
+> ⚠️ **Pair rule (new migrations)**: every new migration must ship `.up.sql` and `.down.sql` together; a missing `.down.sql` breaks rollback. `scripts/check-migrations.sh` enforces this together with historical-file immutability, version uniqueness, and the seed-owned schema-reload rule.
 >
 > **Historical exception**: migrations `001_rbac`, `002_user-extend`, `003_resources`, and `005_kong` are bootstrap SQL without rollback files. These pre-date the rule and are grandfathered in; the hook ignores them.
 

--- a/db/migrations/087_oem_config_custom_css.down.sql
+++ b/db/migrations/087_oem_config_custom_css.down.sql
@@ -1,0 +1,2 @@
+ALTER TYPE api.oem_config_spec
+    DROP ATTRIBUTE custom_css;

--- a/db/migrations/087_oem_config_custom_css.up.sql
+++ b/db/migrations/087_oem_config_custom_css.up.sql
@@ -1,0 +1,2 @@
+ALTER TYPE api.oem_config_spec
+    ADD ATTRIBUTE custom_css TEXT;

--- a/db/migrations/089_oem_config_remove_custom_css.down.sql
+++ b/db/migrations/089_oem_config_remove_custom_css.down.sql
@@ -1,0 +1,3 @@
+-- Restore the field definition only; values removed by 089 up cannot be recovered.
+ALTER TYPE api.oem_config_spec
+    ADD ATTRIBUTE custom_css TEXT;

--- a/db/migrations/089_oem_config_remove_custom_css.up.sql
+++ b/db/migrations/089_oem_config_remove_custom_css.up.sql
@@ -1,0 +1,5 @@
+-- A database initialized while the released 087 source pair was absent can be
+-- at version 88 without this attribute. Removing it when present discards its
+-- stored values; the down migration restores only the field definition.
+ALTER TYPE api.oem_config_spec
+    DROP ATTRIBUTE IF EXISTS custom_css;

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Migration hygiene gates for db/migrations/:
-#   1. pair rule        — every new *.up.sql ships a matching *.down.sql
-#   2. version uniqueness — every NNN_ prefix is claimed by exactly one migration
+#   1. historical migrations are immutable once they land on the base branch
+#   2. pair rule        — every new migration ships matching *.up.sql and *.down.sql files
+#   3. version uniqueness — every NNN_ prefix is claimed by exactly one migration
+#   4. new migrations must not duplicate seed-owned PostgREST reload NOTIFY
 #
-# Gate 2 exists because git cannot see the collision: 085_a.up.sql and
+# Gate 3 exists because git cannot see the collision: 085_a.up.sql and
 # 085_b.up.sql are two unrelated new files, so two PRs adding the same number
 # both merge green. golang-migrate is what rejects the duplicate, when the
 # deploy runs the migrations — so the breakage lands far from the change.
@@ -13,22 +15,49 @@
 #   <ref>             — CI mode: inspects additions on HEAD since merge-base with <ref>
 #                       (e.g. 'origin/main' for PR-against-main)
 #
-# Both gates only fault files this branch adds; pre-existing state is grandfathered.
+# Gate 1 faults modifications, deletions, and renames of migrations that
+# already exist on the base branch.
+#
+# Gate 4 only inspects new migration files. Historical releases may already
+# contain the notification and are left untouched.
 #
 # See contributing/database.md#migration-rules
-set -e
+set -euo pipefail
 
 FAIL=0
 BASE="${1:-}"
 if [ -n "$BASE" ]; then
-  ADDED=$(git diff --name-only --diff-filter=A "$BASE"...HEAD 2>/dev/null || true)
-  TREE=$(git ls-tree -r --name-only HEAD -- db/migrations/ 2>/dev/null || true)
+  if ! git rev-parse --verify --quiet "$BASE^{commit}" >/dev/null 2>&1; then
+    echo "❌ Migration guard cannot resolve base ref: $BASE" >&2
+    echo "   ✅ FIX: fetch the PR base branch before running this guard" >&2
+    exit 2
+  fi
+  if ! git merge-base "$BASE" HEAD >/dev/null; then
+    echo "❌ Migration guard cannot find a merge base for: $BASE" >&2
+    echo "   ✅ FIX: fetch enough history for the PR base branch before running this guard" >&2
+    exit 2
+  fi
+
+  CHANGED=$(git diff --name-status --find-renames "$BASE"...HEAD -- db/migrations/)
+  ADDED=$(git diff --name-only --diff-filter=A "$BASE"...HEAD -- db/migrations/)
+  # A long-lived branch can claim a version that the base branch gained after
+  # the branch point. Compare both current trees, not just HEAD.
+  TREE=$(
+    {
+      git ls-tree -r --name-only "$BASE" -- db/migrations/
+      git ls-tree -r --name-only HEAD -- db/migrations/
+    } | sort -u
+  )
+  CONTENT_REF="HEAD"
 else
-  ADDED=$(git diff --cached --name-only --diff-filter=A 2>/dev/null || true)
-  TREE=$(git ls-files --cached -- db/migrations/ 2>/dev/null || true)
+  CHANGED=$(git diff --cached --name-status --find-renames -- db/migrations/)
+  ADDED=$(git diff --cached --name-only --diff-filter=A -- db/migrations/)
+  TREE=$(git ls-files --cached -- db/migrations/)
+  CONTENT_REF=":"
 fi
 
 MIGRATION_FILE_RE='^db/migrations/[0-9]+_.*\.(up|down)\.sql$'
+PGRST_NOTIFY_RE="NOTIFY[[:space:]]+pgrst[[:space:]]*,[[:space:]]*['\"]reload[[:space:]]+schema['\"]"
 
 # Migration name ("085_foo") for every path in a newline-separated file list.
 migration_names() {
@@ -37,7 +66,53 @@ migration_names() {
     | sort -u
 }
 
-# ── Gate 1: up/down pairs ──
+show_migration() {
+  local path="$1"
+  if [ "$CONTENT_REF" = ":" ]; then
+    git show ":$path"
+  else
+    git show "HEAD:$path"
+  fi
+}
+
+# ── Gate 1: historical migrations are immutable ──
+while IFS=$'\t' read -r status source target; do
+  [ -z "$status" ] && continue
+
+  case "$status" in
+    M|T)
+      if [[ "$source" =~ $MIGRATION_FILE_RE ]]; then
+        echo "❌ Historical migration file cannot be modified: $source"
+        echo "   ✅ FIX: keep released migration files unchanged and add a later migration to reverse them"
+        echo "   📖 See: contributing/database.md#migration-rules"
+        echo
+        FAIL=1
+      fi
+      ;;
+    D)
+      if [[ "$source" =~ $MIGRATION_FILE_RE ]]; then
+        echo "❌ Historical migration file cannot be deleted: $source"
+        echo "   ✅ FIX: restore the released file and add a later migration to reverse it"
+        echo "   📖 See: contributing/database.md#migration-rules"
+        echo
+        FAIL=1
+      fi
+      ;;
+    R*)
+      if [[ "$source" =~ $MIGRATION_FILE_RE ]] || [[ "$target" =~ $MIGRATION_FILE_RE ]]; then
+        echo "❌ Historical migration file cannot be renamed: $source -> $target"
+        echo "   ✅ FIX: keep released migration files unchanged and add a new migration instead"
+        echo "   📖 See: contributing/database.md#migration-rules"
+        echo
+        FAIL=1
+      fi
+      ;;
+  esac
+done <<EOF
+$CHANGED
+EOF
+
+# ── Gate 2: up/down pairs ──
 # Historical exceptions (001, 002, 003, 005) are grandfathered — only newly
 # added files are inspected.
 while IFS= read -r up; do
@@ -54,7 +129,21 @@ done <<EOF
 $(echo "$ADDED" | grep -E '^db/migrations/[0-9]+_.*\.up\.sql$' || true)
 EOF
 
-# ── Gate 2: version uniqueness ──
+while IFS= read -r down; do
+  [ -z "$down" ] && continue
+  up="${down%.down.sql}.up.sql"
+  if ! echo "$ADDED" | grep -qxF "$up"; then
+    echo "❌ New down migration without matching up: $down"
+    echo "   ✅ FIX: create $up in the same commit"
+    echo "   📖 See: contributing/database.md#migration-rules"
+    echo
+    FAIL=1
+  fi
+done <<EOF
+$(echo "$ADDED" | grep -E '^db/migrations/[0-9]+_.*\.down\.sql$' || true)
+EOF
+
+# ── Gate 3: version uniqueness ──
 ALL_NAMES=$(echo "$TREE" | migration_names || true)
 NEW_NAMES=$(echo "$ADDED" | migration_names || true)
 
@@ -92,5 +181,23 @@ for version in $DUP_VERSIONS; do
   echo
   FAIL=1
 done
+
+# ── Gate 4: seed owns the PostgREST reload NOTIFY ──
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  if ! [[ "$path" =~ $MIGRATION_FILE_RE ]]; then
+    continue
+  fi
+
+  if show_migration "$path" | tr '\n' ' ' | grep -Eiq "$PGRST_NOTIFY_RE"; then
+    echo "❌ New migration duplicates the seed-owned PostgREST reload NOTIFY: $path"
+    echo "   ✅ FIX: remove the NOTIFY and keep schema reload in db/seed/999_notify_pgrst.sql"
+    echo "   📖 See: contributing/database.md#migration-rules"
+    echo
+    FAIL=1
+  fi
+done <<EOF
+$ADDED
+EOF
 
 exit $FAIL


### PR DESCRIPTION
## Issue

n/a

## Summary

Restores the released migration 087 source pair so databases recorded at version 87 can upgrade again, then removes the obsolete attribute through a later schema-reversible migration. The fix also supports the valid version-88 state created while the 087 source pair was temporarily absent.

## Changes

- Restore the exact released 087 up/down migration files and add schema-reversible migration 089 to remove `custom_css`.
- Make 089 tolerate the known version-88 state without `custom_css`, while preserving schema-only rollback disclosure.
- Enforce immutable released migrations, symmetric new migration pairs, and seed-owned PostgREST reload notifications.
- Run migration hygiene directly in CI; do not add standalone migration test scripts.

## Test Plan

### Unit test

- N/A: per user direction, no standalone migration-script test files are added. CI executes migration hygiene directly.
- [x] `bash scripts/check-migrations.sh origin/main`, shell syntax, ShellCheck, and CI YAML parsing passed.

### DB test

- N/A: no committed version-87 DB test script is added.

### E2E test

- [x] Isolated Compose database validation created the historical `88:false` state with no `custom_css`, switched to the task source, and upgraded successfully to `89:false`.
- [x] The same isolated environment completed the restored `87:false` with `custom_css` to `89:false` without it round trip, with project-scoped cleanup.
- [x] Manual Compose seed-repeat: an isolated task-CLI-rendered Compose chain upgraded from 87 to 89, restarted `post-migration-hook` twice, logged `999_notify_pgrst.sql` twice, and returned HTTP 200 from PostgREST.
- [x] Enterprise compatibility: a clean Enterprise worktree synced community assets pinned to the validated migration source, retained both 087/089 migration pairs, and built the affected API and Core binaries.

## Risk & Rollback

Migration 089 intentionally discards stored `custom_css` values when the attribute exists. Its `IF EXISTS` was added for the known version-88 state created while the released 087 source pair was absent; PostgreSQL will also no-op when the attribute is absent for another schema state, which is not an endorsement of arbitrary schema drift. Rolling back 089 restores only the field definition for schema compatibility; it cannot recover values discarded by 089. Historical migration 088 remains unchanged.