### PR TITLE
build: support mirror registry for engine packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,9 +433,10 @@ ENGINE_VLLM_IMAGE_TAG = $(ENGINE_VLLM_IMAGE_VERSION)-ray2.53.0
 ENGINE_IMAGES ?= nvidia_gpu:neutree/engine-vllm:$(ENGINE_VLLM_IMAGE_TAG)
 ENGINE_TASKS ?= text-generation,text-embedding,text-rerank
 ENGINE_DESCRIPTION ?= $(ENGINE_NAME) inference engine
+ENGINE_PACKAGE_MIRROR_REGISTRY ?=
 
 .PHONY: build-engine-package
-build-engine-package: ## Build engine package (configurable via ENGINE_NAME, ENGINE_VERSION, ENGINE_IMAGES, ENGINE_TASKS, ENGINE_DESCRIPTION)
+build-engine-package: ## Build engine package (configurable via ENGINE_NAME, ENGINE_VERSION, ENGINE_IMAGES, ENGINE_TASKS, ENGINE_DESCRIPTION, ENGINE_PACKAGE_MIRROR_REGISTRY)
 	@mkdir -p $(ENGINE_PACKAGE_OUTPUT_DIR)
 	bash $(ENGINE_PACKAGE_SCRIPT) \
 		-n $(ENGINE_NAME) \
@@ -444,6 +445,7 @@ build-engine-package: ## Build engine package (configurable via ENGINE_NAME, ENG
 		-s "$(ENGINE_TASKS)" \
 		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/schema.json),-c $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/schema.json) \
 		$(if $(wildcard $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/templates),-t $(ENGINE_BASE_DIR)/$(ENGINE_NAME)/$(ENGINE_DIR_VERSION)/templates) \
+		$(if $(ENGINE_PACKAGE_MIRROR_REGISTRY),--mirror-registry $(ENGINE_PACKAGE_MIRROR_REGISTRY)) \
 		-o $(ENGINE_NAME)-$(ENGINE_VERSION).tar.gz \
 		-d "$(ENGINE_DESCRIPTION)"
 

--- a/scripts/builder/build-engine-package.sh
+++ b/scripts/builder/build-engine-package.sh
@@ -27,6 +27,49 @@ print_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
+normalize_registry() {
+    local registry="$1"
+    registry="${registry#http://}"
+    registry="${registry#https://}"
+    registry="${registry%/}"
+    echo "$registry"
+}
+
+strip_image_registry() {
+    local image="$1"
+
+    if [[ "$image" =~ ^((localhost)|([^/]*[.:][^/]*))/(.+)$ ]]; then
+        echo "${BASH_REMATCH[4]}"
+    else
+        echo "$image"
+    fi
+}
+
+image_exists_for_platform() {
+    local image="$1"
+    local platform="$2"
+    local image_platform
+    local requested_os
+    local requested_arch
+    local requested_platform
+
+    requested_os="${platform%%/*}"
+    requested_arch="${platform#*/}"
+    requested_arch="${requested_arch%%/*}"
+    requested_platform="${requested_os}/${requested_arch}"
+
+    if ! image_platform=$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "$image" 2>/dev/null); then
+        return 1
+    fi
+
+    if [ "$image_platform" = "$requested_platform" ]; then
+        return 0
+    fi
+
+    print_warn "Image $image found locally for $image_platform, but $platform was requested."
+    return 1
+}
+
 # Function to read and format deploy template
 read_deploy_template() {
     local template_file="$1"
@@ -173,6 +216,7 @@ Options:
     -o, --output FILE         Output package file path (default: ENGINE-VERSION.tar.gz)
     -d, --description TEXT    Engine version description
     -p, --platform PLATFORM   Image platform used for pull and manifest (default: linux/amd64)
+    --mirror-registry URL     Mirror registry for missing images (e.g., registry.example.com)
     --manifest-only           Generate only the manifest file (skip Docker image export and packaging)
     -h, --help                Show this help message
 
@@ -255,6 +299,7 @@ SCHEMA_FILE=""
 OUTPUT_FILE=""
 DESCRIPTION=""
 PLATFORM="linux/amd64"
+MIRROR_REGISTRY=""
 MANIFEST_ONLY=""
 # Capability declarations. Empty means "undeclared", which is not the same as
 # declaring false: an engine version with no capabilities block keeps the
@@ -332,6 +377,10 @@ while [[ $# -gt 0 ]]; do
             PLATFORM="$2"
             shift 2
             ;;
+        --mirror-registry)
+            MIRROR_REGISTRY="$2"
+            shift 2
+            ;;
         --manifest-only)
             MANIFEST_ONLY="true"
             shift
@@ -384,6 +433,10 @@ mkdir -p "$IMAGES_DIR"
 
 print_info "Building engine version package: $ENGINE_NAME $ENGINE_VERSION"
 print_info "Temporary directory: $TEMP_DIR"
+if [ -n "$MIRROR_REGISTRY" ]; then
+    MIRROR_REGISTRY=$(normalize_registry "$MIRROR_REGISTRY")
+    print_info "Mirror registry: $MIRROR_REGISTRY"
+fi
 
 IFS=',' read -ra IMAGE_SPECS <<< "$IMAGES"
 IMAGE_ENTRIES=""
@@ -402,12 +455,36 @@ if [ -z "$MANIFEST_ONLY" ]; then
 
         FULL_IMAGE="$IMAGE_NAME:$IMAGE_TAG"
 
-        print_info "Pulling latest $PLATFORM image: $FULL_IMAGE"
-        if ! docker pull --platform "$PLATFORM" "$FULL_IMAGE"; then
-            print_error "Failed to pull image $FULL_IMAGE for platform $PLATFORM"
-            exit 1
+        if image_exists_for_platform "$FULL_IMAGE" "$PLATFORM"; then
+            print_info "Image $FULL_IMAGE found locally. Skipping pull."
+        elif [ -n "$MIRROR_REGISTRY" ]; then
+            IMAGE_WITHOUT_REGISTRY=$(strip_image_registry "$FULL_IMAGE")
+            MIRROR_IMAGE="${MIRROR_REGISTRY}/${IMAGE_WITHOUT_REGISTRY}"
+
+            if image_exists_for_platform "$MIRROR_IMAGE" "$PLATFORM"; then
+                print_info "Mirror image $MIRROR_IMAGE found locally. Skipping pull."
+            else
+                print_info "Pulling latest $PLATFORM image from mirror: $MIRROR_IMAGE"
+                if ! docker pull --platform "$PLATFORM" "$MIRROR_IMAGE"; then
+                    print_error "Failed to pull image $MIRROR_IMAGE for platform $PLATFORM"
+                    exit 1
+                fi
+                print_info "Successfully pulled $MIRROR_IMAGE for platform $PLATFORM"
+            fi
+
+            print_info "Retagging $MIRROR_IMAGE to $FULL_IMAGE"
+            if ! docker tag "$MIRROR_IMAGE" "$FULL_IMAGE"; then
+                print_error "Failed to tag image: $MIRROR_IMAGE -> $FULL_IMAGE"
+                exit 1
+            fi
+        else
+            print_info "Pulling latest $PLATFORM image: $FULL_IMAGE"
+            if ! docker pull --platform "$PLATFORM" "$FULL_IMAGE"; then
+                print_error "Failed to pull image $FULL_IMAGE for platform $PLATFORM"
+                exit 1
+            fi
+            print_info "Successfully pulled $FULL_IMAGE for platform $PLATFORM"
         fi
-        print_info "Successfully pulled $FULL_IMAGE for platform $PLATFORM"
 
         ALL_IMAGES+=("$FULL_IMAGE")
     done


### PR DESCRIPTION
## Issue

N/A

## Summary

Allow engine package builds to source missing images from a configured mirror registry while reusing locally cached images that match the requested platform.

## Changes

- Add `--mirror-registry` to `scripts/builder/build-engine-package.sh`.
- Reuse a local source or mirror image when its OS and architecture match `--platform`; otherwise pull the requested platform and retag mirror images to the source reference.
- Normalize mirror registry URLs and remove an existing source registry before composing the mirror image reference.
- Add `ENGINE_PACKAGE_MIRROR_REGISTRY` to the Makefile target.

## Test Plan

### Unit test

- No persistent script test added, as requested.
- Verified script syntax, CLI help, and Makefile dry-run argument forwarding.
- Temporary Docker-stub and platform-decision validation covered local source reuse, local mirror reuse, mirror pull and retag, direct upstream pull, `linux/arm64/v8` cache reuse, and cross-architecture cache rejection.

### DB test

- Not applicable.

### E2E test

- Not applicable: this only changes the package builder script and Makefile wiring.
- Manual validation was used because runtime E2E does not exercise image-fetch selection in this packaging script.

## Risk & Rollback

- A configured mirror must preserve the expected image repository path; mirror images are retagged to the source reference before export.
- Omit `ENGINE_PACKAGE_MIRROR_REGISTRY` to retain direct pulls, or revert this commit to roll back.