### PR TITLE
feat: import package cluster profiles

### DIFF
--- a/cmd/neutree-api/app/factory.go
+++ b/cmd/neutree-api/app/factory.go
@@ -118,7 +118,7 @@ func ClustersRouteFactory(register ClustersRegisterFunc) RouteFactory {
 	return func(deps *RouteOptions) error {
 		register(deps.Group, deps.Middlewares, &clusters.Dependencies{
 			Storage:             deps.Config.Storage,
-			ReleaseInfoProvider: releaseprofile.NewReleaseInfoProvider(deps.Config.Storage, deps.Config.Version),
+			ReleaseInfoProvider: releaseprofile.NewProvider(deps.Config.Storage, deps.Config.Storage),
 			ImageService:        registry.NewImageService(),
 		})
 

--- a/cmd/neutree-api/app/factory.go
+++ b/cmd/neutree-api/app/factory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/neutree-ai/neutree/internal/routes/proxies"
 	"github.com/neutree-ai/neutree/internal/routes/system"
 	"github.com/neutree-ai/neutree/internal/util"
+	"github.com/neutree-ai/neutree/pkg/releaseprofile"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
@@ -116,8 +117,9 @@ type ClustersRegisterFunc func(group *gin.RouterGroup, middlewares []gin.Handler
 func ClustersRouteFactory(register ClustersRegisterFunc) RouteFactory {
 	return func(deps *RouteOptions) error {
 		register(deps.Group, deps.Middlewares, &clusters.Dependencies{
-			Storage:      deps.Config.Storage,
-			ImageService: registry.NewImageService(),
+			Storage:             deps.Config.Storage,
+			ReleaseInfoProvider: releaseprofile.NewReleaseInfoProvider(deps.Config.Storage, deps.Config.Version),
+			ImageService:        registry.NewImageService(),
 		})
 
 		return nil

--- a/cmd/neutree-cli/app/cmd/packageimport/cluster.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/cluster.go
@@ -7,7 +7,9 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
+	"github.com/neutree-ai/neutree/cmd/neutree-cli/app/cmd/global"
 	"github.com/neutree-ai/neutree/internal/cli/packageimport"
+	"github.com/neutree-ai/neutree/pkg/client"
 )
 
 type ClusterImportOptions struct {
@@ -15,6 +17,19 @@ type ClusterImportOptions struct {
 	extractPath string
 	importLocal bool
 }
+
+type clusterPackageImporter interface {
+	Import(context.Context, *packageimport.ImportOptions) (*packageimport.ImportResult, error)
+}
+
+var (
+	clusterImportNewAPIClient = func() (*client.Client, error) {
+		return global.NewClient()
+	}
+	clusterImportNewImporter = func(apiClientFactory packageimport.APIClientFactory) clusterPackageImporter {
+		return packageimport.NewImporterWithAPIClientFactory(apiClientFactory)
+	}
+)
 
 func NewClusterImportCmd() *cobra.Command {
 	opts := &ClusterImportOptions{}
@@ -66,12 +81,12 @@ images:
 func runClusterImport(opts *ClusterImportOptions) error {
 	ctx := context.Background()
 
-	// Cluster no need to create apiclient
-	importer := packageimport.NewImporter(nil)
+	importer := clusterImportNewImporter(clusterImportNewAPIClient)
 
 	// Prepare import options
 	importOpts := &packageimport.ImportOptions{
 		PackagePath: opts.packagePath,
+		Workspace:   workspace,
 		ExtractPath: opts.extractPath,
 	}
 

--- a/cmd/neutree-cli/app/cmd/packageimport/cluster_test.go
+++ b/cmd/neutree-cli/app/cmd/packageimport/cluster_test.go
@@ -1,0 +1,56 @@
+package packageimport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	internalpackageimport "github.com/neutree-ai/neutree/internal/cli/packageimport"
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+func TestClusterImportDefersControlPlaneClientUntilManifestRequiresIt(t *testing.T) {
+	oldNewClient := clusterImportNewAPIClient
+	oldNewImporter := clusterImportNewImporter
+	t.Cleanup(func() {
+		clusterImportNewAPIClient = oldNewClient
+		clusterImportNewImporter = oldNewImporter
+	})
+
+	createdClient := false
+	clusterImportNewAPIClient = func() (*client.Client, error) {
+		createdClient = true
+		return client.NewClient("http://example.invalid"), nil
+	}
+	importer := &recordingClusterPackageImporter{}
+	clusterImportNewImporter = func(apiClientFactory internalpackageimport.APIClientFactory) clusterPackageImporter {
+		assert.NotNil(t, apiClientFactory)
+		return importer
+	}
+
+	err := runClusterImport(&ClusterImportOptions{
+		packagePath: "cluster-package.tar.gz",
+		importLocal: true,
+	})
+
+	require.NoError(t, err)
+	assert.False(t, createdClient)
+	require.NotNil(t, importer.options)
+	assert.True(t, importer.options.SkipImagePush)
+	assert.Equal(t, workspace, importer.options.Workspace)
+}
+
+func TestClusterImportCommandDoesNotExposeForceUpdateFlag(t *testing.T) {
+	assert.Nil(t, NewClusterImportCmd().Flags().Lookup("force-update"))
+}
+
+type recordingClusterPackageImporter struct {
+	options *internalpackageimport.ImportOptions
+}
+
+func (importer *recordingClusterPackageImporter) Import(_ context.Context, options *internalpackageimport.ImportOptions) (*internalpackageimport.ImportResult, error) {
+	importer.options = options
+	return &internalpackageimport.ImportResult{}, nil
+}

--- a/internal/cli/packageimport/cluster_profile_test.go
+++ b/internal/cli/packageimport/cluster_profile_test.go
@@ -1,0 +1,260 @@
+package packageimport
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/client"
+)
+
+func TestParseManifestFileAcceptsClusterProfile(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), ManifestFileName)
+	manifest := `
+manifest_version: "1.0"
+cluster_profile:
+  version: v1.2.0
+  components:
+    ssh:
+      ray_runtime: {image: neutree/neutree-serve, tag: v1.2.0}
+      node_agent: {image: neutree/neutree-node-agent, tag: v1.2.0}
+      node_exporter: {image: prom/node-exporter, tag: v1.9.1}
+      vmagent: {image: victoriametrics/vmagent, tag: v1.115.0}
+    kubernetes:
+      kubernetes_runtime: {image: neutree/neutree-runtime, tag: v1.2.0}
+      router: {image: neutree/neutree-router, tag: v1.2.0}
+      node_agent: {image: neutree/neutree-node-agent, tag: v1.2.0}
+      node_exporter: {image: prom/node-exporter, tag: v1.9.1}
+      vmagent: {image: victoriametrics/vmagent, tag: v1.115.0}
+      kube_state_metrics: {image: registry.k8s.io/kube-state-metrics/kube-state-metrics, tag: v2.15.0}
+`
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o600))
+
+	parsed, err := NewParser().ParseManifestFile(manifestPath)
+
+	require.NoError(t, err)
+	require.NotNil(t, parsed.ClusterProfile)
+	assert.Equal(t, "v1.2.0", parsed.ClusterProfile.Version)
+	assert.Equal(t, "neutree/neutree-serve", parsed.ClusterProfile.Components[v1.SSHClusterType].RayRuntime.Image)
+	assert.Equal(t, "v1.2.0", parsed.ClusterProfile.Components[v1.KubernetesClusterType].Router.Tag)
+}
+
+func TestClusterProfileToAPIClusterProfile(t *testing.T) {
+	profile := completePackageClusterProfile("v1.2.0")
+
+	converted := profile.ToAPIClusterProfile()
+
+	require.NotNil(t, converted)
+	assert.Equal(t, "v1", converted.APIVersion)
+	assert.Equal(t, v1.ClusterProfileKind, converted.Kind)
+	assert.Equal(t, "v1.2.0", converted.GetName())
+	require.NotNil(t, converted.Spec)
+	assert.Equal(t, v1.ImageRef{Image: "neutree/neutree-serve", Tag: "v1.2.0"},
+		converted.Spec.Components[v1.SSHClusterType].RayRuntime)
+	assert.Equal(t, v1.ImageRef{Image: "neutree/neutree-runtime", Tag: "v1.2.0"},
+		converted.Spec.Components[v1.KubernetesClusterType].KubernetesRuntime)
+}
+
+func TestRegisterManifestRegistersClusterProfileAfterEngines(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+
+		switch request.Method + " " + request.URL.Path {
+		case http.MethodGet + " /api/v1/engines":
+			_, err := writer.Write([]byte(`[]`))
+			require.NoError(t, err)
+		case http.MethodPost + " /api/v1/engines":
+			writer.WriteHeader(http.StatusCreated)
+		case http.MethodPost + " /api/v1/clusters/profile_upsert":
+			var payload struct {
+				Profile *v1.ClusterProfile `json:"profile"`
+			}
+			require.NoError(t, json.NewDecoder(request.Body).Decode(&payload))
+			require.NotNil(t, payload.Profile)
+			assert.Equal(t, "v1.2.0", payload.Profile.GetName())
+			assert.Equal(t, "neutree/neutree-serve", payload.Profile.Spec.Components[v1.SSHClusterType].RayRuntime.Image)
+			_, err := writer.Write([]byte(`{"operation":"created"}`))
+			require.NoError(t, err)
+		default:
+			http.Error(writer, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	importer := NewImporter(client.NewClient(server.URL))
+	manifest := &PackageManifest{
+		Engines: []*EngineMetadata{{
+			Name:           "vllm",
+			EngineVersions: []*v1.EngineVersion{{Version: "v0.10.2"}},
+		}},
+		ClusterProfile: completePackageClusterProfile("v1.2.0"),
+	}
+
+	result, err := importer.registerManifest(context.Background(), &ImportOptions{Workspace: "default"}, manifest, &ImportResult{})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, []string{
+		http.MethodGet + " /api/v1/engines",
+		http.MethodPost + " /api/v1/engines",
+		http.MethodPost + " /api/v1/clusters/profile_upsert",
+	}, requests)
+}
+
+func TestRegisterManifestDefersOrRequiresClusterProfileClient(t *testing.T) {
+	tests := []struct {
+		name           string
+		manifest       *PackageManifest
+		importer       *Importer
+		wantFactoryUse int
+		wantError      string
+	}{
+		{
+			name:     "profile does not construct client when absent",
+			manifest: &PackageManifest{},
+		},
+		{
+			name:           "profile constructs client when present",
+			manifest:       &PackageManifest{ClusterProfile: completePackageClusterProfile("v1.2.0")},
+			wantFactoryUse: 1,
+			wantError:      "API client is required to register cluster profile",
+		},
+		{
+			name:      "profile requires a client",
+			manifest:  &PackageManifest{ClusterProfile: completePackageClusterProfile("v1.2.0")},
+			importer:  NewImporter(nil),
+			wantError: "API client is required to register cluster profile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factoryCalls := 0
+			importer := tt.importer
+			if importer == nil {
+				importer = NewImporterWithAPIClientFactory(func() (*client.Client, error) {
+					factoryCalls++
+					return nil, nil
+				})
+			}
+
+			_, err := importer.registerManifest(context.Background(), &ImportOptions{}, tt.manifest, &ImportResult{})
+
+			if tt.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantError)
+			}
+			assert.Equal(t, tt.wantFactoryUse, factoryCalls)
+		})
+	}
+}
+
+func TestClusterProfileMaterialHandlingValidation(t *testing.T) {
+	profileManifest := &PackageManifest{ClusterProfile: completePackageClusterProfile("v1.2.0")}
+
+	tests := []struct {
+		name       string
+		manifest   *PackageManifest
+		opts       *ImportOptions
+		standalone bool
+		wantError  string
+	}{
+		{
+			name:       "standalone profile requires package URL",
+			manifest:   profileManifest,
+			opts:       &ImportOptions{},
+			standalone: true,
+			wantError:  "cluster profile import requires package_url material handling",
+		},
+		{
+			name: "profile cannot skip image load",
+			manifest: &PackageManifest{
+				Metadata:       &PackageMetadata{PackageURL: "https://example.test/cluster.tar.gz"},
+				ClusterProfile: completePackageClusterProfile("v1.2.0"),
+			},
+			opts:      &ImportOptions{SkipImageLoad: true},
+			wantError: "cluster profile import cannot skip image handling",
+		},
+		{
+			name: "archive profile processes image material",
+			manifest: &PackageManifest{
+				ClusterProfile: completePackageClusterProfile("v1.2.0"),
+			},
+			opts: &ImportOptions{},
+		},
+		{
+			name:       "engine-only manifest keeps existing skip behavior",
+			manifest:   &PackageManifest{},
+			opts:       &ImportOptions{SkipImageLoad: true},
+			standalone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateClusterProfileMaterialHandling(tt.manifest, tt.opts, tt.standalone)
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.EqualError(t, err, tt.wantError)
+		})
+	}
+}
+
+func TestImportRejectsStandaloneClusterProfileBeforeRegistration(t *testing.T) {
+	manifestPath := filepath.Join(t.TempDir(), ManifestFileName)
+	manifest := `
+manifest_version: "1.0"
+cluster_profile:
+  version: v1.2.0
+`
+	require.NoError(t, os.WriteFile(manifestPath, []byte(manifest), 0o600))
+
+	factoryCalls := 0
+	importer := NewImporterWithAPIClientFactory(func() (*client.Client, error) {
+		factoryCalls++
+		return client.NewClient("http://example.invalid"), nil
+	})
+
+	_, err := importer.Import(context.Background(), &ImportOptions{
+		PackagePath:   manifestPath,
+		SkipImagePush: true,
+	})
+
+	require.EqualError(t, err, "cluster profile import requires package_url material handling")
+	assert.Zero(t, factoryCalls)
+}
+
+func completePackageClusterProfile(version string) *ClusterProfile {
+	return &ClusterProfile{
+		Version: version,
+		Components: map[string]ClusterProfileComponents{
+			v1.SSHClusterType: {
+				RayRuntime:   ClusterImageRef{Image: "neutree/neutree-serve", Tag: version},
+				NodeAgent:    ClusterImageRef{Image: "neutree/neutree-node-agent", Tag: version},
+				NodeExporter: ClusterImageRef{Image: "prom/node-exporter", Tag: "v1.9.1"},
+				VMAgent:      ClusterImageRef{Image: "victoriametrics/vmagent", Tag: "v1.115.0"},
+			},
+			v1.KubernetesClusterType: {
+				KubernetesRuntime: ClusterImageRef{Image: "neutree/neutree-runtime", Tag: version},
+				Router:            ClusterImageRef{Image: "neutree/neutree-router", Tag: version},
+				NodeAgent:         ClusterImageRef{Image: "neutree/neutree-node-agent", Tag: version},
+				NodeExporter:      ClusterImageRef{Image: "prom/node-exporter", Tag: "v1.9.1"},
+				VMAgent:           ClusterImageRef{Image: "victoriametrics/vmagent", Tag: "v1.115.0"},
+				KubeStateMetrics:  ClusterImageRef{Image: "registry.k8s.io/kube-state-metrics/kube-state-metrics", Tag: "v2.15.0"},
+			},
+		},
+	}
+}

--- a/internal/cli/packageimport/importer.go
+++ b/internal/cli/packageimport/importer.go
@@ -18,11 +18,16 @@ import (
 
 // Importer handles importing packages
 type Importer struct {
-	apiClient *client.Client
-	extractor *Extractor
-	parser    *Parser
-	validator *Validator
+	apiClient        *client.Client
+	apiClientFactory APIClientFactory
+	extractor        *Extractor
+	parser           *Parser
+	validator        *Validator
 }
+
+// APIClientFactory builds an API client only when a package needs to register
+// a ClusterProfile with the control plane.
+type APIClientFactory func() (*client.Client, error)
 
 // NewImporter creates a new Importer
 func NewImporter(apiClient *client.Client) *Importer {
@@ -31,6 +36,17 @@ func NewImporter(apiClient *client.Client) *Importer {
 		extractor: NewExtractor(),
 		parser:    NewParser(),
 		validator: NewValidator(),
+	}
+}
+
+// NewImporterWithAPIClientFactory creates an Importer that defers
+// control-plane client construction until a manifest includes a ClusterProfile.
+func NewImporterWithAPIClientFactory(apiClientFactory APIClientFactory) *Importer {
+	return &Importer{
+		apiClientFactory: apiClientFactory,
+		extractor:        NewExtractor(),
+		parser:           NewParser(),
+		validator:        NewValidator(),
 	}
 }
 
@@ -67,11 +83,14 @@ func (i *Importer) importFromManifest(ctx context.Context, opts *ImportOptions, 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse manifest file")
 	}
+	if err := validateClusterProfileMaterialHandling(manifest, opts, true); err != nil {
+		return nil, err
+	}
 
 	// If skip image load, just register engine metadata
 	if opts.SkipImageLoad {
 		klog.Info("Skipping image handling as per configuration")
-		return i.registerEngines(ctx, opts, manifest, result)
+		return i.registerManifest(ctx, opts, manifest, result)
 	}
 
 	// If package_url is present, stream-extract and push images
@@ -118,13 +137,13 @@ func (i *Importer) importFromManifest(ctx context.Context, opts *ImportOptions, 
 
 		result.ImagesImported = pushedImages
 
-		return i.registerEngines(ctx, opts, manifest, result)
+		return i.registerManifest(ctx, opts, manifest, result)
 	}
 
 	// No package_url and not skipping images — register metadata only
 	klog.Info("No package URL specified, registering engine metadata only (no images to process)")
 
-	return i.registerEngines(ctx, opts, manifest, result)
+	return i.registerManifest(ctx, opts, manifest, result)
 }
 
 // importFromArchive handles the traditional tar.gz archive import flow.
@@ -162,6 +181,9 @@ func (i *Importer) importFromArchive(ctx context.Context, opts *ImportOptions, r
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse manifest")
 	}
+	if err := validateClusterProfileMaterialHandling(manifest, opts, false); err != nil {
+		return nil, err
+	}
 
 	// Push images
 	klog.Info("Pushing images to registry")
@@ -173,7 +195,70 @@ func (i *Importer) importFromArchive(ctx context.Context, opts *ImportOptions, r
 
 	result.ImagesImported = pushedImages
 
-	return i.registerEngines(ctx, opts, manifest, result)
+	return i.registerManifest(ctx, opts, manifest, result)
+}
+
+// registerManifest completes metadata registration after all package material
+// processing has succeeded. Cluster Profile semantics are validated by the API.
+func (i *Importer) registerManifest(ctx context.Context, opts *ImportOptions, manifest *PackageManifest, result *ImportResult) (*ImportResult, error) {
+	result, err := i.registerEngines(ctx, opts, manifest, result)
+	if err != nil {
+		return result, err
+	}
+
+	if manifest.ClusterProfile == nil {
+		return result, nil
+	}
+
+	apiClient, err := i.clusterProfileAPIClient()
+	if err != nil {
+		return result, err
+	}
+
+	if _, err := apiClient.Clusters.UpsertClusterProfile(manifest.ClusterProfile.ToAPIClusterProfile()); err != nil {
+		return result, errors.Wrap(err, "failed to register cluster profile")
+	}
+
+	return result, nil
+}
+
+func (i *Importer) clusterProfileAPIClient() (*client.Client, error) {
+	if i.apiClient != nil {
+		return i.apiClient, nil
+	}
+
+	if i.apiClientFactory == nil {
+		return nil, errors.New("API client is required to register cluster profile")
+	}
+
+	apiClient, err := i.apiClientFactory()
+	if err != nil {
+		return nil, errors.Wrap(err, "create API client for cluster profile")
+	}
+
+	if apiClient == nil {
+		return nil, errors.New("API client is required to register cluster profile")
+	}
+
+	return apiClient, nil
+}
+
+// validateClusterProfileMaterialHandling keeps Profile registration behind the
+// package material workflow. Semantic Profile validation remains at the API.
+func validateClusterProfileMaterialHandling(manifest *PackageManifest, opts *ImportOptions, standalone bool) error {
+	if manifest.ClusterProfile == nil {
+		return nil
+	}
+
+	if opts.SkipImageLoad {
+		return errors.New("cluster profile import cannot skip image handling")
+	}
+
+	if standalone && (manifest.Metadata == nil || strings.TrimSpace(manifest.Metadata.PackageURL) == "") {
+		return errors.New("cluster profile import requires package_url material handling")
+	}
+
+	return nil
 }
 
 // registerEngines registers engine metadata from manifest.

--- a/internal/cli/packageimport/parser.go
+++ b/internal/cli/packageimport/parser.go
@@ -108,8 +108,8 @@ func (p *Parser) ParseManifestFile(path string) (*PackageManifest, error) {
 		return nil, errors.New("manifest_version is required")
 	}
 
-	if len(manifest.Engines) == 0 {
-		return nil, errors.New("at least one engine entry is required in manifest")
+	if len(manifest.Engines) == 0 && manifest.ClusterProfile == nil {
+		return nil, errors.New("at least one engine entry is required when cluster_profile is not set")
 	}
 
 	for idx := range manifest.Engines {

--- a/internal/cli/packageimport/types.go
+++ b/internal/cli/packageimport/types.go
@@ -16,6 +16,59 @@ type PackageManifest struct {
 
 	// Engines contains the list of engines need to be imported
 	Engines []*EngineMetadata `json:"engines" yaml:"engines"`
+
+	// ClusterProfile is the exact dual-type Cluster component image matrix
+	// carried by a cluster image package.
+	ClusterProfile *ClusterProfile `json:"cluster_profile,omitempty" yaml:"cluster_profile,omitempty"`
+}
+
+// ClusterProfile is the package representation of one exact Cluster Profile.
+// Semantic validation remains at the API boundary.
+type ClusterProfile struct {
+	Version    string                              `json:"version" yaml:"version"`
+	Components map[string]ClusterProfileComponents `json:"components" yaml:"components"`
+}
+
+type ClusterProfileComponents struct {
+	RayRuntime        ClusterImageRef `json:"ray_runtime" yaml:"ray_runtime"`
+	KubernetesRuntime ClusterImageRef `json:"kubernetes_runtime" yaml:"kubernetes_runtime"`
+	Router            ClusterImageRef `json:"router" yaml:"router"`
+	NodeAgent         ClusterImageRef `json:"node_agent" yaml:"node_agent"`
+	NodeExporter      ClusterImageRef `json:"node_exporter" yaml:"node_exporter"`
+	VMAgent           ClusterImageRef `json:"vmagent" yaml:"vmagent"`
+	KubeStateMetrics  ClusterImageRef `json:"kube_state_metrics" yaml:"kube_state_metrics"`
+}
+
+type ClusterImageRef struct {
+	Image string `json:"image" yaml:"image"`
+	Tag   string `json:"tag" yaml:"tag"`
+}
+
+// ToAPIClusterProfile converts a package payload to the internal API object.
+func (profile *ClusterProfile) ToAPIClusterProfile() *v1.ClusterProfile {
+	if profile == nil {
+		return nil
+	}
+
+	components := make(map[string]v1.ClusterProfileComponents, len(profile.Components))
+	for clusterType, value := range profile.Components {
+		components[clusterType] = v1.ClusterProfileComponents{
+			RayRuntime:        v1.ImageRef{Image: value.RayRuntime.Image, Tag: value.RayRuntime.Tag},
+			KubernetesRuntime: v1.ImageRef{Image: value.KubernetesRuntime.Image, Tag: value.KubernetesRuntime.Tag},
+			Router:            v1.ImageRef{Image: value.Router.Image, Tag: value.Router.Tag},
+			NodeAgent:         v1.ImageRef{Image: value.NodeAgent.Image, Tag: value.NodeAgent.Tag},
+			NodeExporter:      v1.ImageRef{Image: value.NodeExporter.Image, Tag: value.NodeExporter.Tag},
+			VMAgent:           v1.ImageRef{Image: value.VMAgent.Image, Tag: value.VMAgent.Tag},
+			KubeStateMetrics:  v1.ImageRef{Image: value.KubeStateMetrics.Image, Tag: value.KubeStateMetrics.Tag},
+		}
+	}
+
+	return &v1.ClusterProfile{
+		APIVersion: "v1",
+		Kind:       v1.ClusterProfileKind,
+		Metadata:   &v1.Metadata{Name: profile.Version},
+		Spec:       &v1.ClusterProfileSpec{Components: components},
+	}
 }
 
 type EngineMetadata struct {

--- a/internal/middleware/cluster_profile_import_validation.go
+++ b/internal/middleware/cluster_profile_import_validation.go
@@ -11,19 +11,14 @@ import (
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
-	"github.com/neutree-ai/neutree/pkg/releaseprofile"
 )
 
 const clusterProfileImportContextKey = "cluster-profile-import"
 
-// ReleaseInfoProvider resolves the policy that gates cluster package imports.
-type ReleaseInfoProvider interface {
-	Current() (*v1.ReleaseInfo, error)
-}
-
-// ClusterProfileImportValidation rejects invalid package Profile requests before
-// they reach storage. Semantic checks stay in releaseprofile instead of SQL.
-func ClusterProfileImportValidation(provider ReleaseInfoProvider) gin.HandlerFunc {
+// ClusterProfileImportValidation rejects malformed package Profile requests
+// before they reach the API handler. Domain eligibility stays with the handler
+// and releaseprofile instead of SQL.
+func ClusterProfileImportValidation() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Method != http.MethodPost {
 			c.Next()
@@ -38,32 +33,13 @@ func ClusterProfileImportValidation(provider ReleaseInfoProvider) gin.HandlerFun
 			return
 		}
 
-		if provider == nil {
-			writeClusterProfileImportError(c, http.StatusInternalServerError, "internal server error")
-
-			return
-		}
-
-		info, err := provider.Current()
-		if err != nil {
-			writeClusterProfileImportError(c, http.StatusInternalServerError, "internal server error")
-
-			return
-		}
-
-		if err := releaseprofile.ValidateProfileEligibility(info, profile); err != nil {
-			writeClusterProfileImportError(c, http.StatusBadRequest, err.Error())
-
-			return
-		}
-
 		c.Set(clusterProfileImportContextKey, profile)
 		c.Next()
 	}
 }
 
-// ClusterProfileImportFromContext returns the Profile validated by the import
-// middleware. Handlers must not re-decode or re-validate the request payload.
+// ClusterProfileImportFromContext returns the Profile whose request shape was
+// validated by the import middleware. Handlers own domain validation.
 func ClusterProfileImportFromContext(c *gin.Context) (*v1.ClusterProfile, bool) {
 	value, found := c.Get(clusterProfileImportContextKey)
 	if !found {

--- a/internal/middleware/cluster_profile_import_validation.go
+++ b/internal/middleware/cluster_profile_import_validation.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
@@ -88,8 +91,99 @@ func readClusterProfileImport(c *gin.Context) (*v1.ClusterProfile, error) {
 	if request.Profile == nil {
 		return nil, errors.New("profile is required")
 	}
+	if err := validateClusterProfileImport(request.Profile); err != nil {
+		return nil, err
+	}
 
 	return request.Profile, nil
+}
+
+func validateClusterProfileImport(profile *v1.ClusterProfile) error {
+	if profile.Metadata == nil || profile.Spec == nil {
+		return errors.New("cluster profile metadata and spec are required")
+	}
+	if profile.APIVersion != "v1" {
+		return errors.New("cluster profile api version must be v1")
+	}
+	if profile.Kind != v1.ClusterProfileKind {
+		return fmt.Errorf("cluster profile kind must be %s", v1.ClusterProfileKind)
+	}
+	if profile.Metadata.Workspace != "" {
+		return errors.New("cluster profile metadata.workspace must be empty")
+	}
+	if err := validateClusterProfileVersion(profile.Metadata.Name); err != nil {
+		return err
+	}
+
+	for clusterType := range profile.Spec.Components {
+		if !v1.IsSupportedClusterType(clusterType) {
+			return fmt.Errorf("unsupported component matrix type %q", clusterType)
+		}
+	}
+
+	for _, clusterType := range []string{v1.SSHClusterType, v1.KubernetesClusterType} {
+		components, found := profile.Spec.ComponentsFor(clusterType)
+		if !found {
+			return fmt.Errorf("%s component matrix is required", clusterType)
+		}
+
+		for _, component := range requiredClusterProfileImages(clusterType, components) {
+			if invalidClusterProfileImageValue(component.ref.Image) {
+				return fmt.Errorf("%s image is required", component.name)
+			}
+			if invalidClusterProfileImageValue(component.ref.Tag) {
+				return fmt.Errorf("%s tag is required", component.name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateClusterProfileVersion(version string) error {
+	if !strings.HasPrefix(version, "v") {
+		return fmt.Errorf("invalid cluster profile version %q", version)
+	}
+	if _, err := semver.StrictNewVersion(strings.TrimPrefix(version, "v")); err != nil {
+		return fmt.Errorf("invalid cluster profile version %q: %w", version, err)
+	}
+
+	return nil
+}
+
+func invalidClusterProfileImageValue(value string) bool {
+	return strings.TrimSpace(value) == "" || strings.TrimSpace(value) != value
+}
+
+type requiredClusterProfileImage struct {
+	name string
+	ref  v1.ImageRef
+}
+
+func requiredClusterProfileImages(
+	clusterType string,
+	components v1.ClusterProfileComponents,
+) []requiredClusterProfileImage {
+	switch clusterType {
+	case v1.SSHClusterType:
+		return []requiredClusterProfileImage{
+			{name: "ray runtime", ref: components.RayRuntime},
+			{name: "node agent", ref: components.NodeAgent},
+			{name: "node exporter", ref: components.NodeExporter},
+			{name: "vmagent", ref: components.VMAgent},
+		}
+	case v1.KubernetesClusterType:
+		return []requiredClusterProfileImage{
+			{name: "kubernetes runtime", ref: components.KubernetesRuntime},
+			{name: "router", ref: components.Router},
+			{name: "node agent", ref: components.NodeAgent},
+			{name: "node exporter", ref: components.NodeExporter},
+			{name: "vmagent", ref: components.VMAgent},
+			{name: "kube state metrics", ref: components.KubeStateMetrics},
+		}
+	default:
+		return nil
+	}
 }
 
 func writeClusterProfileImportError(c *gin.Context, status int, message string) {

--- a/internal/middleware/cluster_profile_import_validation.go
+++ b/internal/middleware/cluster_profile_import_validation.go
@@ -1,0 +1,122 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/pkg/releaseprofile"
+)
+
+const clusterProfileImportContextKey = "cluster-profile-import"
+
+// ReleaseInfoProvider resolves the policy that gates cluster package imports.
+type ReleaseInfoProvider interface {
+	Current() (*v1.ReleaseInfo, error)
+}
+
+// ClusterProfileImportValidation rejects invalid package Profile requests before
+// they reach storage. Semantic checks stay in releaseprofile instead of SQL.
+func ClusterProfileImportValidation(provider ReleaseInfoProvider) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodPost {
+			c.Next()
+
+			return
+		}
+
+		profile, err := readClusterProfileImport(c)
+		if err != nil {
+			writeClusterProfileImportError(c, http.StatusBadRequest, err.Error())
+
+			return
+		}
+
+		if provider == nil {
+			writeClusterProfileImportError(c, http.StatusInternalServerError, "internal server error")
+
+			return
+		}
+
+		info, err := provider.Current()
+		if err != nil {
+			writeClusterProfileImportError(c, http.StatusInternalServerError, "internal server error")
+
+			return
+		}
+
+		if err := releaseprofile.ValidateProfileEligibility(info, profile); err != nil {
+			writeClusterProfileImportError(c, http.StatusBadRequest, err.Error())
+
+			return
+		}
+
+		c.Set(clusterProfileImportContextKey, profile)
+		c.Next()
+	}
+}
+
+// ClusterProfileImportFromContext returns the Profile validated by the import
+// middleware. Handlers must not re-decode or re-validate the request payload.
+func ClusterProfileImportFromContext(c *gin.Context) (*v1.ClusterProfile, bool) {
+	value, found := c.Get(clusterProfileImportContextKey)
+	if !found {
+		return nil, false
+	}
+
+	profile, ok := value.(*v1.ClusterProfile)
+
+	return profile, ok
+}
+
+func readClusterProfileImport(c *gin.Context) (*v1.ClusterProfile, error) {
+	if c.Request.Body == nil {
+		return nil, errors.New("cluster profile payload is required")
+	}
+
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return nil, errors.New("invalid cluster profile payload")
+	}
+
+	if err := c.Request.Body.Close(); err != nil {
+		return nil, errors.New("invalid cluster profile payload")
+	}
+
+	c.Request.Body = io.NopCloser(bytes.NewReader(body))
+	c.Request.ContentLength = int64(len(body))
+	c.Request.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	var rawPayload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &rawPayload); err != nil {
+		return nil, errors.New("invalid cluster profile payload")
+	}
+
+	if _, found := rawPayload["force_update"]; found {
+		return nil, errors.New("force_update is not supported for cluster profiles")
+	}
+
+	var request struct {
+		Profile *v1.ClusterProfile `json:"profile"`
+	}
+	if err := json.Unmarshal(body, &request); err != nil {
+		return nil, errors.New("invalid cluster profile payload")
+	}
+
+	if request.Profile == nil {
+		return nil, errors.New("profile is required")
+	}
+
+	return request.Profile, nil
+}
+
+func writeClusterProfileImportError(c *gin.Context, status int, message string) {
+	c.JSON(status, gin.H{"error": message})
+	c.Abort()
+}

--- a/internal/middleware/cluster_profile_import_validation_test.go
+++ b/internal/middleware/cluster_profile_import_validation_test.go
@@ -1,0 +1,160 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+type releaseInfoProviderFunc func() (*v1.ReleaseInfo, error)
+
+func (fn releaseInfoProviderFunc) Current() (*v1.ReleaseInfo, error) {
+	return fn()
+}
+
+func TestClusterProfileImportValidation(t *testing.T) {
+	profile := completeClusterProfile("v1.1.1")
+	validReleaseInfo := currentReleaseInfo()
+
+	tests := []struct {
+		name         string
+		payload      any
+		provider     releaseInfoProviderFunc
+		wantStatus   int
+		wantContinue bool
+		wantCalls    int
+	}{
+		{
+			name:         "allows eligible profile and restores body",
+			payload:      map[string]any{"profile": profile},
+			provider:     func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
+			wantStatus:   http.StatusNoContent,
+			wantContinue: true,
+			wantCalls:    1,
+		},
+		{
+			name:       "rejects force update true",
+			payload:    map[string]any{"profile": profile, "force_update": true},
+			provider:   func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "rejects force update false",
+			payload:    map[string]any{"profile": profile, "force_update": false},
+			provider:   func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "rejects force update null",
+			payload:    map[string]any{"profile": profile, "force_update": nil},
+			provider:   func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "rejects invalid profile through domain validation",
+			payload: map[string]any{"profile": &v1.ClusterProfile{
+				APIVersion: "v1",
+				Kind:       v1.ClusterProfileKind,
+				Metadata:   &v1.Metadata{Name: "v1.1.1"},
+				Spec:       &v1.ClusterProfileSpec{Components: map[string]v1.ClusterProfileComponents{}},
+			}},
+			provider:   func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
+			wantStatus: http.StatusBadRequest,
+			wantCalls:  1,
+		},
+		{
+			name:       "hides current release provider failure",
+			payload:    map[string]any{"profile": profile},
+			provider:   func() (*v1.ReleaseInfo, error) { return nil, errors.New("database unavailable") },
+			wantStatus: http.StatusInternalServerError,
+			wantCalls:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(tt.payload)
+			require.NoError(t, err)
+
+			providerCalls := 0
+			provider := releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
+				providerCalls++
+				return tt.provider()
+			})
+
+			continued := false
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			router.POST("/profiles", ClusterProfileImportValidation(provider), func(c *gin.Context) {
+				continued = true
+
+				validated, found := ClusterProfileImportFromContext(c)
+				require.True(t, found)
+				assert.Equal(t, profile.GetName(), validated.GetName())
+
+				restoredBody, readErr := io.ReadAll(c.Request.Body)
+				require.NoError(t, readErr)
+				assert.JSONEq(t, string(body), string(restoredBody))
+				c.Status(http.StatusNoContent)
+			})
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/profiles", bytes.NewReader(body))
+			request.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(recorder, request)
+
+			assert.Equal(t, tt.wantStatus, recorder.Code)
+			assert.Equal(t, tt.wantContinue, continued)
+			assert.Equal(t, tt.wantCalls, providerCalls)
+			if tt.wantStatus == http.StatusInternalServerError {
+				assert.NotContains(t, recorder.Body.String(), "database unavailable")
+			}
+		})
+	}
+}
+
+func currentReleaseInfo() *v1.ReleaseInfo {
+	return &v1.ReleaseInfo{
+		APIVersion: "v1",
+		Kind:       v1.ReleaseInfoKind,
+		Metadata:   &v1.Metadata{Name: "v1.2.0"},
+		Spec: &v1.ReleaseInfoSpec{
+			DefaultClusterVersion:      "v1.2.0",
+			CompatibleClusterBaselines: []string{"v1.1", "v1.2"},
+		},
+	}
+}
+
+func completeClusterProfile(version string) *v1.ClusterProfile {
+	return &v1.ClusterProfile{
+		APIVersion: "v1",
+		Kind:       v1.ClusterProfileKind,
+		Metadata:   &v1.Metadata{Name: version},
+		Spec: &v1.ClusterProfileSpec{Components: map[string]v1.ClusterProfileComponents{
+			v1.SSHClusterType: {
+				RayRuntime:   v1.ImageRef{Image: "neutree/neutree-serve", Tag: version},
+				NodeAgent:    v1.ImageRef{Image: "neutree/neutree-node-agent", Tag: version},
+				NodeExporter: v1.ImageRef{Image: "quay.io/prometheus/node-exporter", Tag: "v1.8.2"},
+				VMAgent:      v1.ImageRef{Image: "victoriametrics/vmagent", Tag: "v1.115.0"},
+			},
+			v1.KubernetesClusterType: {
+				KubernetesRuntime: v1.ImageRef{Image: "neutree/neutree-runtime", Tag: version},
+				Router:            v1.ImageRef{Image: "neutree/router", Tag: version},
+				NodeAgent:         v1.ImageRef{Image: "neutree/neutree-node-agent", Tag: version},
+				NodeExporter:      v1.ImageRef{Image: "quay.io/prometheus/node-exporter", Tag: "v1.8.2"},
+				VMAgent:           v1.ImageRef{Image: "victoriametrics/vmagent", Tag: "v1.115.0"},
+				KubeStateMetrics:  v1.ImageRef{Image: "registry.k8s.io/kube-state-metrics/kube-state-metrics", Tag: "v2.15.0"},
+			},
+		}},
+	}
+}

--- a/internal/middleware/cluster_profile_import_validation_test.go
+++ b/internal/middleware/cluster_profile_import_validation_test.go
@@ -62,16 +62,36 @@ func TestClusterProfileImportValidation(t *testing.T) {
 			wantProfile: "",
 		},
 		{
-			name: "allows domain-invalid profile for API validation",
+			name: "rejects incomplete profile",
 			payload: map[string]any{"profile": &v1.ClusterProfile{
 				APIVersion: "v1",
 				Kind:       v1.ClusterProfileKind,
 				Metadata:   &v1.Metadata{Name: "v1.1.1"},
 				Spec:       &v1.ClusterProfileSpec{Components: map[string]v1.ClusterProfileComponents{}},
 			}},
-			wantStatus:   http.StatusNoContent,
-			wantContinue: true,
-			wantProfile:  "v1.1.1",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "rejects unsupported component matrix type",
+			payload: map[string]any{"profile": func() *v1.ClusterProfile {
+				profile := completeClusterProfile("v1.1.1")
+				profile.Spec.Components["docker"] = v1.ClusterProfileComponents{}
+
+				return profile
+			}()},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "rejects blank required component tag",
+			payload: map[string]any{"profile": func() *v1.ClusterProfile {
+				profile := completeClusterProfile("v1.1.1")
+				ssh := profile.Spec.Components[v1.SSHClusterType]
+				ssh.RayRuntime.Tag = " "
+				profile.Spec.Components[v1.SSHClusterType] = ssh
+
+				return profile
+			}()},
+			wantStatus: http.StatusBadRequest,
 		},
 	}
 

--- a/internal/middleware/cluster_profile_import_validation_test.go
+++ b/internal/middleware/cluster_profile_import_validation_test.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,91 +15,84 @@ import (
 	v1 "github.com/neutree-ai/neutree/api/v1"
 )
 
-type releaseInfoProviderFunc func() (*v1.ReleaseInfo, error)
-
-func (fn releaseInfoProviderFunc) Current() (*v1.ReleaseInfo, error) {
-	return fn()
-}
-
 func TestClusterProfileImportValidation(t *testing.T) {
 	profile := completeClusterProfile("v1.1.1")
-	validReleaseInfo := currentReleaseInfo()
 
 	tests := []struct {
 		name         string
 		payload      any
-		provider     releaseInfoProviderFunc
+		rawBody      string
 		wantStatus   int
 		wantContinue bool
-		wantCalls    int
+		wantProfile  string
 	}{
 		{
 			name:         "allows eligible profile and restores body",
 			payload:      map[string]any{"profile": profile},
-			provider:     func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
 			wantStatus:   http.StatusNoContent,
 			wantContinue: true,
-			wantCalls:    1,
+			wantProfile:  profile.GetName(),
 		},
 		{
-			name:       "rejects force update true",
-			payload:    map[string]any{"profile": profile, "force_update": true},
-			provider:   func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
+			name:       "rejects malformed JSON",
+			rawBody:    `{"profile":`,
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "rejects force update false",
-			payload:    map[string]any{"profile": profile, "force_update": false},
-			provider:   func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
+			name:       "rejects missing profile",
+			payload:    map[string]any{},
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "rejects force update null",
-			payload:    map[string]any{"profile": profile, "force_update": nil},
-			provider:   func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
-			wantStatus: http.StatusBadRequest,
+			name:        "rejects force update true",
+			payload:     map[string]any{"profile": profile, "force_update": true},
+			wantStatus:  http.StatusBadRequest,
+			wantProfile: "",
 		},
 		{
-			name: "rejects invalid profile through domain validation",
+			name:        "rejects force update false",
+			payload:     map[string]any{"profile": profile, "force_update": false},
+			wantStatus:  http.StatusBadRequest,
+			wantProfile: "",
+		},
+		{
+			name:        "rejects force update null",
+			payload:     map[string]any{"profile": profile, "force_update": nil},
+			wantStatus:  http.StatusBadRequest,
+			wantProfile: "",
+		},
+		{
+			name: "allows domain-invalid profile for API validation",
 			payload: map[string]any{"profile": &v1.ClusterProfile{
 				APIVersion: "v1",
 				Kind:       v1.ClusterProfileKind,
 				Metadata:   &v1.Metadata{Name: "v1.1.1"},
 				Spec:       &v1.ClusterProfileSpec{Components: map[string]v1.ClusterProfileComponents{}},
 			}},
-			provider:   func() (*v1.ReleaseInfo, error) { return validReleaseInfo, nil },
-			wantStatus: http.StatusBadRequest,
-			wantCalls:  1,
-		},
-		{
-			name:       "hides current release provider failure",
-			payload:    map[string]any{"profile": profile},
-			provider:   func() (*v1.ReleaseInfo, error) { return nil, errors.New("database unavailable") },
-			wantStatus: http.StatusInternalServerError,
-			wantCalls:  1,
+			wantStatus:   http.StatusNoContent,
+			wantContinue: true,
+			wantProfile:  "v1.1.1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body, err := json.Marshal(tt.payload)
-			require.NoError(t, err)
-
-			providerCalls := 0
-			provider := releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
-				providerCalls++
-				return tt.provider()
-			})
+			body := []byte(tt.rawBody)
+			if tt.rawBody == "" {
+				var err error
+				body, err = json.Marshal(tt.payload)
+				require.NoError(t, err)
+			}
 
 			continued := false
 			gin.SetMode(gin.TestMode)
 			router := gin.New()
-			router.POST("/profiles", ClusterProfileImportValidation(provider), func(c *gin.Context) {
+			router.POST("/profiles", ClusterProfileImportValidation(), func(c *gin.Context) {
 				continued = true
 
 				validated, found := ClusterProfileImportFromContext(c)
 				require.True(t, found)
-				assert.Equal(t, profile.GetName(), validated.GetName())
+				assert.Equal(t, tt.wantProfile, validated.GetName())
 
 				restoredBody, readErr := io.ReadAll(c.Request.Body)
 				require.NoError(t, readErr)
@@ -115,23 +107,7 @@ func TestClusterProfileImportValidation(t *testing.T) {
 
 			assert.Equal(t, tt.wantStatus, recorder.Code)
 			assert.Equal(t, tt.wantContinue, continued)
-			assert.Equal(t, tt.wantCalls, providerCalls)
-			if tt.wantStatus == http.StatusInternalServerError {
-				assert.NotContains(t, recorder.Body.String(), "database unavailable")
-			}
 		})
-	}
-}
-
-func currentReleaseInfo() *v1.ReleaseInfo {
-	return &v1.ReleaseInfo{
-		APIVersion: "v1",
-		Kind:       v1.ReleaseInfoKind,
-		Metadata:   &v1.Metadata{Name: "v1.2.0"},
-		Spec: &v1.ReleaseInfoSpec{
-			DefaultClusterVersion:      "v1.2.0",
-			CompatibleClusterBaselines: []string{"v1.1", "v1.2"},
-		},
 	}
 }
 

--- a/internal/routes/clusters/cluster.go
+++ b/internal/routes/clusters/cluster.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"github.com/gin-gonic/gin"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/middleware"
 	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/pkg/storage"
@@ -10,7 +11,9 @@ import (
 
 // ReleaseInfoProvider is the narrow policy dependency needed for cluster
 // package Profile imports.
-type ReleaseInfoProvider = middleware.ReleaseInfoProvider
+type ReleaseInfoProvider interface {
+	Current() (*v1.ReleaseInfo, error)
+}
 
 type Dependencies struct {
 	Storage             storage.Storage
@@ -25,6 +28,6 @@ func RegisterClusterRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc
 	clusterGroup.GET("/available_versions", getAvailableClusterVersions(deps))
 	clusterGroup.POST("/profile_upsert",
 		middleware.RequirePermission("system:admin", middleware.PermissionDependencies{Storage: deps.Storage}),
-		middleware.ClusterProfileImportValidation(deps.ReleaseInfoProvider),
+		middleware.ClusterProfileImportValidation(),
 		upsertClusterProfile(deps))
 }

--- a/internal/routes/clusters/cluster.go
+++ b/internal/routes/clusters/cluster.go
@@ -3,13 +3,19 @@ package clusters
 import (
 	"github.com/gin-gonic/gin"
 
+	"github.com/neutree-ai/neutree/internal/middleware"
 	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
+// ReleaseInfoProvider is the narrow policy dependency needed for cluster
+// package Profile imports.
+type ReleaseInfoProvider = middleware.ReleaseInfoProvider
+
 type Dependencies struct {
-	Storage      storage.Storage
-	ImageService registry.ImageService
+	Storage             storage.Storage
+	ReleaseInfoProvider ReleaseInfoProvider
+	ImageService        registry.ImageService
 }
 
 func RegisterClusterRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc, deps *Dependencies) {
@@ -17,4 +23,8 @@ func RegisterClusterRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc
 	clusterGroup.Use(middlewares...)
 
 	clusterGroup.GET("/available_versions", getAvailableClusterVersions(deps))
+	clusterGroup.POST("/profile_upsert",
+		middleware.RequirePermission("system:admin", middleware.PermissionDependencies{Storage: deps.Storage}),
+		middleware.ClusterProfileImportValidation(deps.ReleaseInfoProvider),
+		upsertClusterProfile(deps))
 }

--- a/internal/routes/clusters/profile_upsert.go
+++ b/internal/routes/clusters/profile_upsert.go
@@ -2,7 +2,9 @@ package clusters
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -19,8 +21,8 @@ type profileUpsertResponse struct {
 	Operation string `json:"operation"`
 }
 
-// upsertClusterProfile validates the Profile against current domain policy,
-// then creates absent versions or permits exact replay. It never updates a
+// upsertClusterProfile checks the Profile version against current policy, then
+// creates absent versions or permits exact replay. It never updates a
 // stored Profile because component drift would change deployed runtime behavior.
 func upsertClusterProfile(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -44,7 +46,7 @@ func upsertClusterProfile(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		if err := releaseprofile.ValidateProfileEligibility(info, profile); err != nil {
+		if err := releaseprofile.ValidateClusterVersionEligibility(info, profile.GetName()); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 
 			return
@@ -97,7 +99,7 @@ func findClusterProfile(s storage.Storage, version string) (*v1.ClusterProfile, 
 }
 
 func respondExistingClusterProfile(c *gin.Context, existing, incoming *v1.ClusterProfile) {
-	if releaseprofile.ClusterProfilesSemanticallyEqual(existing, incoming) {
+	if clusterProfilesSemanticallyEqual(existing, incoming) {
 		c.JSON(http.StatusOK, profileUpsertResponse{Operation: "unchanged"})
 
 		return
@@ -106,6 +108,20 @@ func respondExistingClusterProfile(c *gin.Context, existing, incoming *v1.Cluste
 	c.JSON(http.StatusConflict, gin.H{
 		"error": fmt.Sprintf("cluster profile %s already exists with different content", incoming.GetName()),
 	})
+}
+
+func clusterProfilesSemanticallyEqual(left, right *v1.ClusterProfile) bool {
+	if left == nil || right == nil || left.Metadata == nil || right.Metadata == nil {
+		return left == right
+	}
+
+	return left.APIVersion == right.APIVersion &&
+		left.Kind == right.Kind &&
+		left.Metadata.Name == right.Metadata.Name &&
+		left.Metadata.Workspace == right.Metadata.Workspace &&
+		maps.Equal(left.Metadata.Labels, right.Metadata.Labels) &&
+		maps.Equal(left.Metadata.Annotations, right.Metadata.Annotations) &&
+		reflect.DeepEqual(left.Spec, right.Spec)
 }
 
 func isUniqueViolation(err error) bool {

--- a/internal/routes/clusters/profile_upsert.go
+++ b/internal/routes/clusters/profile_upsert.go
@@ -19,14 +19,33 @@ type profileUpsertResponse struct {
 	Operation string `json:"operation"`
 }
 
-// upsertClusterProfile persists a middleware-validated package Profile. It
-// creates absent versions and permits exact replay, but never updates a stored
-// Profile because component drift would change deployed runtime behavior.
+// upsertClusterProfile validates the Profile against current domain policy,
+// then creates absent versions or permits exact replay. It never updates a
+// stored Profile because component drift would change deployed runtime behavior.
 func upsertClusterProfile(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		profile, found := middleware.ClusterProfileImportFromContext(c)
 		if !found {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+
+			return
+		}
+
+		if deps.ReleaseInfoProvider == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+
+			return
+		}
+
+		info, err := deps.ReleaseInfoProvider.Current()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+
+			return
+		}
+
+		if err := releaseprofile.ValidateProfileEligibility(info, profile); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 
 			return
 		}

--- a/internal/routes/clusters/profile_upsert.go
+++ b/internal/routes/clusters/profile_upsert.go
@@ -1,0 +1,94 @@
+package clusters
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/middleware"
+	"github.com/neutree-ai/neutree/pkg/releaseprofile"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+const uniqueViolationCode = "23505"
+
+type profileUpsertResponse struct {
+	Operation string `json:"operation"`
+}
+
+// upsertClusterProfile persists a middleware-validated package Profile. It
+// creates absent versions and permits exact replay, but never updates a stored
+// Profile because component drift would change deployed runtime behavior.
+func upsertClusterProfile(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		profile, found := middleware.ClusterProfileImportFromContext(c)
+		if !found {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+
+			return
+		}
+
+		existing, err := findClusterProfile(deps.Storage, profile.GetName())
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+
+			return
+		}
+
+		if existing != nil {
+			respondExistingClusterProfile(c, existing, profile)
+			return
+		}
+
+		if err := deps.Storage.CreateClusterProfile(profile); err != nil {
+			if isUniqueViolation(err) {
+				existing, reloadErr := findClusterProfile(deps.Storage, profile.GetName())
+				if reloadErr == nil && existing != nil {
+					respondExistingClusterProfile(c, existing, profile)
+
+					return
+				}
+			}
+
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+
+			return
+		}
+
+		c.JSON(http.StatusOK, profileUpsertResponse{Operation: "created"})
+	}
+}
+
+func findClusterProfile(s storage.Storage, version string) (*v1.ClusterProfile, error) {
+	profiles, err := s.ListClusterProfile(storage.ListOption{})
+	if err != nil {
+		return nil, err
+	}
+
+	for index := range profiles {
+		if profiles[index].GetName() == version {
+			return &profiles[index], nil
+		}
+	}
+
+	return nil, nil
+}
+
+func respondExistingClusterProfile(c *gin.Context, existing, incoming *v1.ClusterProfile) {
+	if releaseprofile.ClusterProfilesSemanticallyEqual(existing, incoming) {
+		c.JSON(http.StatusOK, profileUpsertResponse{Operation: "unchanged"})
+
+		return
+	}
+
+	c.JSON(http.StatusConflict, gin.H{
+		"error": fmt.Sprintf("cluster profile %s already exists with different content", incoming.GetName()),
+	})
+}
+
+func isUniqueViolation(err error) bool {
+	return err != nil && strings.Contains(err.Error(), uniqueViolationCode)
+}

--- a/internal/routes/clusters/profile_upsert.go
+++ b/internal/routes/clusters/profile_upsert.go
@@ -46,7 +46,7 @@ func upsertClusterProfile(deps *Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		if err := releaseprofile.ValidateClusterVersionEligibility(info, profile.GetName()); err != nil {
+		if err := releaseprofile.ValidateClusterVersionCompatibility(info, profile.GetName()); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 
 			return

--- a/internal/routes/clusters/profile_upsert_test.go
+++ b/internal/routes/clusters/profile_upsert_test.go
@@ -111,6 +111,15 @@ func TestProfileUpsertRejectsInvalidRequestsBeforeStorage(t *testing.T) {
 			name:    "force update null",
 			payload: map[string]any{"profile": completeProfile("v1.1.1"), "force_update": nil},
 		},
+		{
+			name: "incomplete profile",
+			payload: map[string]any{"profile": &v1.ClusterProfile{
+				APIVersion: "v1",
+				Kind:       v1.ClusterProfileKind,
+				Metadata:   &v1.Metadata{Name: "v1.1.1"},
+				Spec:       &v1.ClusterProfileSpec{Components: map[string]v1.ClusterProfileComponents{}},
+			}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/routes/clusters/profile_upsert_test.go
+++ b/internal/routes/clusters/profile_upsert_test.go
@@ -1,0 +1,300 @@
+package clusters
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+type releaseInfoProviderFunc func() (*v1.ReleaseInfo, error)
+
+func (fn releaseInfoProviderFunc) Current() (*v1.ReleaseInfo, error) {
+	return fn()
+}
+
+func TestProfileUpsertCreatesOrReplaysExactProfile(t *testing.T) {
+	tests := []struct {
+		name             string
+		stored           []v1.ClusterProfile
+		request          *v1.ClusterProfile
+		wantStatus       int
+		wantOperation    string
+		wantCreate       bool
+		wantConflictBody bool
+	}{
+		{
+			name:          "creates absent profile",
+			request:       completeProfile("v1.1.1"),
+			wantStatus:    http.StatusOK,
+			wantOperation: "created",
+			wantCreate:    true,
+		},
+		{
+			name: "replays semantically identical profile",
+			stored: []v1.ClusterProfile{func() v1.ClusterProfile {
+				profile := completeProfile("v1.1.1")
+				profile.ID = 42
+				profile.Metadata.CreationTimestamp = "2026-08-01T00:00:00Z"
+				profile.Metadata.UpdateTimestamp = "2026-08-02T00:00:00Z"
+				return *profile
+			}()},
+			request:       completeProfile("v1.1.1"),
+			wantStatus:    http.StatusOK,
+			wantOperation: "unchanged",
+		},
+		{
+			name:   "rejects same version with component drift",
+			stored: []v1.ClusterProfile{*completeProfile("v1.1.1")},
+			request: func() *v1.ClusterProfile {
+				profile := completeProfile("v1.1.1")
+				ssh := profile.Spec.Components[v1.SSHClusterType]
+				ssh.RayRuntime.Tag = "v1.1.1-rocm"
+				profile.Spec.Components[v1.SSHClusterType] = ssh
+				return profile
+			}(),
+			wantStatus:       http.StatusConflict,
+			wantConflictBody: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := storageMocks.NewMockStorage(t)
+			allowSystemAdmin(store, "administrator")
+			store.On("ListClusterProfile", mock.Anything).Return(tt.stored, nil).Once()
+			if tt.wantCreate {
+				store.On("CreateClusterProfile", mock.MatchedBy(func(profile *v1.ClusterProfile) bool {
+					return profile.GetName() == tt.request.GetName()
+				})).Return(nil).Once()
+			}
+
+			response := executeProfileUpsert(t, store, releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
+				return validReleaseInfo(), nil
+			}), map[string]any{"profile": tt.request}, "administrator")
+
+			assert.Equal(t, tt.wantStatus, response.Code)
+			if tt.wantOperation != "" {
+				assert.Contains(t, response.Body.String(), tt.wantOperation)
+			}
+			if tt.wantConflictBody {
+				assert.Contains(t, response.Body.String(), "different content")
+			}
+		})
+	}
+}
+
+func TestProfileUpsertRejectsInvalidRequestsBeforeStorage(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload any
+	}{
+		{
+			name:    "invalid matrix",
+			payload: map[string]any{"profile": &v1.ClusterProfile{APIVersion: "v1", Kind: v1.ClusterProfileKind, Metadata: &v1.Metadata{Name: "v1.1.1"}, Spec: &v1.ClusterProfileSpec{}}},
+		},
+		{
+			name:    "force update true",
+			payload: map[string]any{"profile": completeProfile("v1.1.1"), "force_update": true},
+		},
+		{
+			name:    "force update false",
+			payload: map[string]any{"profile": completeProfile("v1.1.1"), "force_update": false},
+		},
+		{
+			name:    "force update null",
+			payload: map[string]any{"profile": completeProfile("v1.1.1"), "force_update": nil},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := storageMocks.NewMockStorage(t)
+			allowSystemAdmin(store, "administrator")
+
+			response := executeProfileUpsert(t, store, releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
+				return validReleaseInfo(), nil
+			}), tt.payload, "administrator")
+
+			assert.Equal(t, http.StatusBadRequest, response.Code)
+			store.AssertNotCalled(t, "ListClusterProfile", mock.Anything)
+			store.AssertNotCalled(t, "CreateClusterProfile", mock.Anything)
+		})
+	}
+}
+
+func TestProfileUpsertMapsProviderFailureAndPermission(t *testing.T) {
+	t.Run("provider failure is internal", func(t *testing.T) {
+		store := storageMocks.NewMockStorage(t)
+		allowSystemAdmin(store, "administrator")
+
+		response := executeProfileUpsert(t, store, releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
+			return nil, errors.New("database unavailable")
+		}), map[string]any{"profile": completeProfile("v1.1.1")}, "administrator")
+
+		assert.Equal(t, http.StatusInternalServerError, response.Code)
+		assert.NotContains(t, response.Body.String(), "database unavailable")
+		store.AssertNotCalled(t, "ListClusterProfile", mock.Anything)
+	})
+
+	t.Run("requires system admin", func(t *testing.T) {
+		store := storageMocks.NewMockStorage(t)
+		allowSystemAdminResult(store, "member", false)
+
+		response := executeProfileUpsert(t, store, releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
+			return validReleaseInfo(), nil
+		}), map[string]any{"profile": completeProfile("v1.1.1")}, "member")
+
+		assert.Equal(t, http.StatusForbidden, response.Code)
+		store.AssertNotCalled(t, "ListClusterProfile", mock.Anything)
+	})
+}
+
+func TestProfileUpsertResolvesConcurrentCreateAgainstPersistedProfile(t *testing.T) {
+	tests := []struct {
+		name          string
+		persisted     *v1.ClusterProfile
+		wantStatus    int
+		wantOperation string
+	}{
+		{
+			name:          "identical profile becomes unchanged",
+			persisted:     completeProfile("v1.1.1"),
+			wantStatus:    http.StatusOK,
+			wantOperation: "unchanged",
+		},
+		{
+			name: "different profile remains conflict",
+			persisted: func() *v1.ClusterProfile {
+				profile := completeProfile("v1.1.1")
+				ssh := profile.Spec.Components[v1.SSHClusterType]
+				ssh.RayRuntime.Tag = "v1.1.1-rocm"
+				profile.Spec.Components[v1.SSHClusterType] = ssh
+				return profile
+			}(),
+			wantStatus: http.StatusConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := storageMocks.NewMockStorage(t)
+			allowSystemAdmin(store, "administrator")
+			store.On("ListClusterProfile", mock.Anything).
+				Return([]v1.ClusterProfile{}, nil).Once()
+			store.On("CreateClusterProfile", mock.Anything).
+				Return(errors.New(`{"code":"23505","message":"duplicate key value violates unique constraint"}`)).Once()
+			store.On("ListClusterProfile", mock.Anything).
+				Return([]v1.ClusterProfile{*tt.persisted}, nil).Once()
+
+			response := executeProfileUpsert(t, store, releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
+				return validReleaseInfo(), nil
+			}), map[string]any{"profile": completeProfile("v1.1.1")}, "administrator")
+
+			assert.Equal(t, tt.wantStatus, response.Code)
+			if tt.wantOperation != "" {
+				assert.Contains(t, response.Body.String(), tt.wantOperation)
+			}
+		})
+	}
+}
+
+func TestProfileUpsertDoesNotMaskNonUniqueCreateFailure(t *testing.T) {
+	store := storageMocks.NewMockStorage(t)
+	allowSystemAdmin(store, "administrator")
+	store.On("ListClusterProfile", mock.Anything).Return([]v1.ClusterProfile{}, nil).Once()
+	store.On("CreateClusterProfile", mock.Anything).Return(errors.New("database unavailable")).Once()
+
+	response := executeProfileUpsert(t, store, releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
+		return validReleaseInfo(), nil
+	}), map[string]any{"profile": completeProfile("v1.1.1")}, "administrator")
+
+	assert.Equal(t, http.StatusInternalServerError, response.Code)
+	assert.NotContains(t, response.Body.String(), "database unavailable")
+	store.AssertNumberOfCalls(t, "ListClusterProfile", 1)
+}
+
+func executeProfileUpsert(
+	t *testing.T,
+	store *storageMocks.MockStorage,
+	provider ReleaseInfoProvider,
+	payload any,
+	userID string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(func(c *gin.Context) { c.Set("user_id", userID) })
+	RegisterClusterRoutes(router.Group("/api/v1"), nil, &Dependencies{
+		Storage:             store,
+		ReleaseInfoProvider: provider,
+	})
+
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/clusters/profile_upsert", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, request)
+
+	return recorder
+}
+
+func allowSystemAdmin(store *storageMocks.MockStorage, userID string) {
+	allowSystemAdminResult(store, userID, true)
+}
+
+func allowSystemAdminResult(store *storageMocks.MockStorage, userID string, allowed bool) {
+	store.On("CallDatabaseFunction", "has_permission", mock.MatchedBy(func(params map[string]interface{}) bool {
+		return params["user_uuid"] == userID && params["required_permission"] == "system:admin" && params["workspace"] == nil
+	}), mock.Anything).Run(func(args mock.Arguments) {
+		result := args.Get(2).(*bool)
+		*result = allowed
+	}).Return(nil).Once()
+}
+
+func validReleaseInfo() *v1.ReleaseInfo {
+	return &v1.ReleaseInfo{
+		APIVersion: "v1",
+		Kind:       v1.ReleaseInfoKind,
+		Metadata:   &v1.Metadata{Name: "v1.2.0"},
+		Spec: &v1.ReleaseInfoSpec{
+			DefaultClusterVersion:      "v1.2.0",
+			CompatibleClusterBaselines: []string{"v1.1", "v1.2"},
+		},
+	}
+}
+
+func completeProfile(version string) *v1.ClusterProfile {
+	return &v1.ClusterProfile{
+		APIVersion: "v1",
+		Kind:       v1.ClusterProfileKind,
+		Metadata:   &v1.Metadata{Name: version},
+		Spec: &v1.ClusterProfileSpec{Components: map[string]v1.ClusterProfileComponents{
+			v1.SSHClusterType: {
+				RayRuntime:   v1.ImageRef{Image: "neutree/neutree-serve", Tag: version},
+				NodeAgent:    v1.ImageRef{Image: "neutree/neutree-node-agent", Tag: version},
+				NodeExporter: v1.ImageRef{Image: "quay.io/prometheus/node-exporter", Tag: "v1.8.2"},
+				VMAgent:      v1.ImageRef{Image: "victoriametrics/vmagent", Tag: "v1.115.0"},
+			},
+			v1.KubernetesClusterType: {
+				KubernetesRuntime: v1.ImageRef{Image: "neutree/neutree-runtime", Tag: version},
+				Router:            v1.ImageRef{Image: "neutree/router", Tag: version},
+				NodeAgent:         v1.ImageRef{Image: "neutree/neutree-node-agent", Tag: version},
+				NodeExporter:      v1.ImageRef{Image: "quay.io/prometheus/node-exporter", Tag: "v1.8.2"},
+				VMAgent:           v1.ImageRef{Image: "victoriametrics/vmagent", Tag: "v1.115.0"},
+				KubeStateMetrics:  v1.ImageRef{Image: "registry.k8s.io/kube-state-metrics/kube-state-metrics", Tag: "v2.15.0"},
+			},
+		}},
+	}
+}

--- a/internal/routes/clusters/profile_upsert_test.go
+++ b/internal/routes/clusters/profile_upsert_test.go
@@ -129,7 +129,7 @@ func TestProfileUpsertRejectsInvalidRequestsBeforeStorage(t *testing.T) {
 	}
 }
 
-func TestProfileUpsertRejectsDomainInvalidProfileBeforeStorage(t *testing.T) {
+func TestProfileUpsertRejectsIneligibleVersionBeforeStorage(t *testing.T) {
 	store := storageMocks.NewMockStorage(t)
 	allowSystemAdmin(store, "administrator")
 
@@ -138,12 +138,7 @@ func TestProfileUpsertRejectsDomainInvalidProfileBeforeStorage(t *testing.T) {
 		providerCalls++
 
 		return validReleaseInfo(), nil
-	}), map[string]any{"profile": &v1.ClusterProfile{
-		APIVersion: "v1",
-		Kind:       v1.ClusterProfileKind,
-		Metadata:   &v1.Metadata{Name: "v1.1.1"},
-		Spec:       &v1.ClusterProfileSpec{},
-	}}, "administrator")
+	}), map[string]any{"profile": completeProfile("v1.2.1")}, "administrator")
 
 	assert.Equal(t, http.StatusBadRequest, response.Code)
 	assert.Equal(t, 1, providerCalls)

--- a/internal/routes/clusters/profile_upsert_test.go
+++ b/internal/routes/clusters/profile_upsert_test.go
@@ -100,10 +100,6 @@ func TestProfileUpsertRejectsInvalidRequestsBeforeStorage(t *testing.T) {
 		payload any
 	}{
 		{
-			name:    "invalid matrix",
-			payload: map[string]any{"profile": &v1.ClusterProfile{APIVersion: "v1", Kind: v1.ClusterProfileKind, Metadata: &v1.Metadata{Name: "v1.1.1"}, Spec: &v1.ClusterProfileSpec{}}},
-		},
-		{
 			name:    "force update true",
 			payload: map[string]any{"profile": completeProfile("v1.1.1"), "force_update": true},
 		},
@@ -131,6 +127,28 @@ func TestProfileUpsertRejectsInvalidRequestsBeforeStorage(t *testing.T) {
 			store.AssertNotCalled(t, "CreateClusterProfile", mock.Anything)
 		})
 	}
+}
+
+func TestProfileUpsertRejectsDomainInvalidProfileBeforeStorage(t *testing.T) {
+	store := storageMocks.NewMockStorage(t)
+	allowSystemAdmin(store, "administrator")
+
+	providerCalls := 0
+	response := executeProfileUpsert(t, store, releaseInfoProviderFunc(func() (*v1.ReleaseInfo, error) {
+		providerCalls++
+
+		return validReleaseInfo(), nil
+	}), map[string]any{"profile": &v1.ClusterProfile{
+		APIVersion: "v1",
+		Kind:       v1.ClusterProfileKind,
+		Metadata:   &v1.Metadata{Name: "v1.1.1"},
+		Spec:       &v1.ClusterProfileSpec{},
+	}}, "administrator")
+
+	assert.Equal(t, http.StatusBadRequest, response.Code)
+	assert.Equal(t, 1, providerCalls)
+	store.AssertNotCalled(t, "ListClusterProfile", mock.Anything)
+	store.AssertNotCalled(t, "CreateClusterProfile", mock.Anything)
 }
 
 func TestProfileUpsertMapsProviderFailureAndPermission(t *testing.T) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,6 +17,7 @@ type Client struct {
 	// Service endpoints
 	Models          *ModelsService
 	Engines         *EnginesService
+	Clusters        *ClustersService
 	ImageRegistries *ImageRegistriesService
 	ModelRegistries *ModelRegistriesService
 	Generic         *GenericService
@@ -102,6 +103,7 @@ func NewClient(baseURL string, options ...ClientOption) *Client {
 	// Initialize services
 	client.Models = NewModelsService(client)
 	client.Engines = NewEnginesService(client)
+	client.Clusters = NewClustersService(client)
 	client.ImageRegistries = NewImageRegistriesService(client)
 	client.ModelRegistries = NewModelRegistriesService(client)
 	client.Traces = NewTracesService(client)

--- a/pkg/client/cluster.go
+++ b/pkg/client/cluster.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+type ClusterProfileUpsertResult struct {
+	Operation string `json:"operation"`
+}
+
+// ClustersService owns calls to Cluster-specific helper endpoints.
+type ClustersService struct {
+	client *Client
+}
+
+func NewClustersService(client *Client) *ClustersService {
+	return &ClustersService{client: client}
+}
+
+// UpsertClusterProfile sends the internal immutable ClusterProfile import
+// request. The control plane permits creation and exact-content replay only.
+func (service *ClustersService) UpsertClusterProfile(profile *v1.ClusterProfile) (*ClusterProfileUpsertResult, error) {
+	payload, err := json.Marshal(struct {
+		Profile *v1.ClusterProfile `json:"profile"`
+	}{Profile: profile})
+	if err != nil {
+		return nil, err
+	}
+
+	requestURL := fmt.Sprintf("%s/api/v1/clusters/profile_upsert", service.client.baseURL)
+	req, err := http.NewRequest(http.MethodPost, requestURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := service.client.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err = expectStatus(resp, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	result := &ClusterProfileUpsertResult{}
+	if err = json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/pkg/client/cluster_test.go
+++ b/pkg/client/cluster_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+func TestClusterProfileUpsert(t *testing.T) {
+	profile := &v1.ClusterProfile{
+		APIVersion: "v1",
+		Kind:       v1.ClusterProfileKind,
+		Metadata:   &v1.Metadata{Name: "v1.2.0-alpha.1"},
+		Spec: &v1.ClusterProfileSpec{Components: map[string]v1.ClusterProfileComponents{
+			v1.SSHClusterType:        {},
+			v1.KubernetesClusterType: {},
+		}},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "/api/v1/clusters/profile_upsert", request.URL.Path)
+		assert.Equal(t, "test-api-key", request.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", request.Header.Get("Content-Type"))
+
+		var payload struct {
+			Profile *v1.ClusterProfile `json:"profile"`
+		}
+		require.NoError(t, json.NewDecoder(request.Body).Decode(&payload))
+		require.NotNil(t, payload.Profile)
+		assert.Equal(t, profile.GetName(), payload.Profile.GetName())
+		assert.Equal(t, profile.Spec.Components, payload.Profile.Spec.Components)
+		_, err := writer.Write([]byte(`{"operation":"created"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	result, err := NewClient(server.URL, WithAPIKey("test-api-key")).Clusters.UpsertClusterProfile(profile)
+
+	require.NoError(t, err)
+	assert.Equal(t, "created", result.Operation)
+}


### PR DESCRIPTION
## Issue

NEU-605

## Summary

Import the exact `cluster_profile` carried by a cluster package through a restricted API path. Keep semantic validation in API middleware and `pkg/releaseprofile`, and register the profile only after package material handling completes.

## Changes

- Add `POST /api/v1/clusters/profile_upsert` with system-admin permission, middleware validation, immutable create-or-identical-replay semantics, and current `ReleaseInfo` eligibility checks.
- Extend cluster package import to parse `cluster_profile`, lazily construct an API client only when profile registration is required, and register the profile after engine/image handling.
- Add a `Clusters` API client helper and focused unit coverage for middleware, route behavior, parser/importer ordering, lazy client behavior, and CLI wiring.

## Test Plan

### Unit test

- `go test ./internal/middleware ./internal/routes/clusters ./cmd/neutree-api/app ./internal/cli/packageimport ./pkg/client ./cmd/neutree-cli/app/cmd/packageimport ./pkg/releaseprofile -count=1`
- `go vet ./internal/middleware ./internal/routes/clusters ./cmd/neutree-api/app ./internal/cli/packageimport ./pkg/client ./cmd/neutree-cli/app/cmd/packageimport ./pkg/releaseprofile`

### DB test

- Not applicable. No migration or DB schema behavior changed in this slice.

### E2E test

- Skipped in this staged workflow by user instruction. Manual testing is not required at this stage.

## Risk & Rollback

The main risk is rejecting package profile payloads that previously would have been silently accepted. Rollback is to revert commit `94dce1b0`, which removes the restricted endpoint and restores cluster package import to image-only behavior.