### PR TITLE
feat(cluster): integrate release profile availability

### DIFF
--- a/cmd/neutree-api/app/factory.go
+++ b/cmd/neutree-api/app/factory.go
@@ -118,7 +118,7 @@ func ClustersRouteFactory(register ClustersRegisterFunc) RouteFactory {
 	return func(deps *RouteOptions) error {
 		register(deps.Group, deps.Middlewares, &clusters.Dependencies{
 			Storage:             deps.Config.Storage,
-			ReleaseInfoProvider: releaseprofile.NewReleaseInfoProvider(deps.Config.Storage, deps.Config.Version),
+			ReleaseInfoProvider: releaseprofile.NewProvider(deps.Config.Storage, deps.Config.Storage),
 			ImageService:        registry.NewImageService(),
 		})
 

--- a/cmd/neutree-api/app/factory.go
+++ b/cmd/neutree-api/app/factory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/neutree-ai/neutree/internal/routes/proxies"
 	"github.com/neutree-ai/neutree/internal/routes/system"
 	"github.com/neutree-ai/neutree/internal/util"
+	"github.com/neutree-ai/neutree/pkg/releaseprofile"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
@@ -116,8 +117,9 @@ type ClustersRegisterFunc func(group *gin.RouterGroup, middlewares []gin.Handler
 func ClustersRouteFactory(register ClustersRegisterFunc) RouteFactory {
 	return func(deps *RouteOptions) error {
 		register(deps.Group, deps.Middlewares, &clusters.Dependencies{
-			Storage:      deps.Config.Storage,
-			ImageService: registry.NewImageService(),
+			Storage:             deps.Config.Storage,
+			ReleaseInfoProvider: releaseprofile.NewReleaseInfoProvider(deps.Config.Storage, deps.Config.Version),
+			ImageService:        registry.NewImageService(),
 		})
 
 		return nil

--- a/internal/registry/image.go
+++ b/internal/registry/image.go
@@ -12,7 +12,7 @@ import (
 )
 
 type ImageService interface {
-	CheckImageExists(image string, auth authn.Authenticator) (bool, error)
+	CheckImageExists(image string, auth authn.Authenticator, useHTTP bool) (bool, error)
 	// CheckPullPermission checks if the provided auth has pull permission for the image
 	CheckPullPermission(image string, auth authn.Authenticator, useHTTP bool) (bool, error)
 	ListImageTags(imageRepo string, auth authn.Authenticator, useHTTP bool) ([]string, error)
@@ -32,18 +32,16 @@ func NewImageService() ImageService {
 	}
 }
 
-func (svc *imageService) CheckImageExists(image string, auth authn.Authenticator) (bool, error) {
-	ref, err := name.ParseReference(image)
+func (svc *imageService) CheckImageExists(image string, auth authn.Authenticator, useHTTP bool) (bool, error) {
+	ref, err := name.ParseReference(image, registryNameOptions(useHTTP)...)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to parse image "+image)
 	}
 
-	_, err = remote.Head(ref, remote.WithAuth(auth), remote.WithTransport(svc.transport))
+	_, err = remote.Head(ref, remote.WithAuth(auth), remote.WithTransport(svc.registryTransport(ref.Context().Registry.RegistryStr(), useHTTP)))
 	if err != nil {
-		if transportErr, ok := err.(*transport.Error); ok {
-			if transportErr.StatusCode == http.StatusNotFound {
-				return false, nil
-			}
+		if isNotFoundTransportError(err) {
+			return false, nil
 		}
 
 		return false, errors.Wrap(err, "failed to request image "+image)
@@ -85,6 +83,10 @@ func (svc *imageService) GetImageLabels(image string, auth authn.Authenticator, 
 
 	img, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(svc.registryTransport(ref.Context().Registry.RegistryStr(), useHTTP)))
 	if err != nil {
+		if isNotFoundTransportError(err) {
+			return map[string]string{}, nil
+		}
+
 		return nil, errors.Wrap(err, "failed to fetch image "+image)
 	}
 
@@ -108,10 +110,8 @@ func (svc *imageService) ListImageTags(imageRepo string, auth authn.Authenticato
 
 	tags, err := remote.List(repo, remote.WithAuth(auth), remote.WithTransport(svc.registryTransport(repo.Registry.RegistryStr(), useHTTP)))
 	if err != nil {
-		if transportErr, ok := err.(*transport.Error); ok {
-			if transportErr.StatusCode == http.StatusNotFound {
-				return nil, nil
-			}
+		if isNotFoundTransportError(err) {
+			return nil, nil
 		}
 
 		return nil, errors.Wrap(err, "failed to list the image tags of image repo "+imageRepo)
@@ -126,6 +126,12 @@ func registryNameOptions(useHTTP bool) []name.Option {
 	}
 
 	return nil
+}
+
+func isNotFoundTransportError(err error) bool {
+	var transportErr *transport.Error
+
+	return errors.As(err, &transportErr) && transportErr.StatusCode == http.StatusNotFound
 }
 
 func (svc *imageService) registryTransport(registry string, useHTTP bool) http.RoundTripper {

--- a/internal/registry/image_test.go
+++ b/internal/registry/image_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,6 +38,46 @@ func TestImageService_CheckPullPermissionUsesConfiguredScheme(t *testing.T) {
 			require.True(t, allowed)
 		})
 	}
+}
+
+func TestImageService_CheckImageExistsUsesConfiguredScheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		newServer func(http.Handler) *httptest.Server
+		useHTTP   bool
+		scheme    string
+	}{
+		{name: "explicit HTTP", newServer: httptest.NewServer, useHTTP: true, scheme: "http"},
+		{name: "HTTPS by default", newServer: httptest.NewTLSServer, scheme: "https"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.newServer(testRegistryHandler())
+			t.Cleanup(server.Close)
+
+			image := strings.TrimPrefix(server.URL, tt.scheme+"://") + "/neutree/router:v1.2.0"
+			exists, err := NewImageService().CheckImageExists(image, authn.Anonymous, tt.useHTTP)
+
+			require.NoError(t, err)
+			require.True(t, exists)
+		})
+	}
+}
+
+func TestImageService_CheckImageExistsTreatsMissingTagAsUnavailable(t *testing.T) {
+	server := httptest.NewServer(testRegistryHandler())
+	t.Cleanup(server.Close)
+
+	registryHost := strings.TrimPrefix(server.URL, "http://")
+	exists, err := NewImageService().CheckImageExists(
+		registryHost+"/neutree/router:missing",
+		authn.Anonymous,
+		true,
+	)
+
+	require.NoError(t, err)
+	require.False(t, exists)
 }
 
 func TestImageService_ListImageTagsUsesConfiguredScheme(t *testing.T) {
@@ -89,6 +130,21 @@ func TestImageService_GetImageLabelsUsesConfiguredScheme(t *testing.T) {
 	}
 }
 
+func TestImageService_GetImageLabelsTreatsMissingTagAsEmpty(t *testing.T) {
+	server := httptest.NewServer(testRegistryHandler())
+	t.Cleanup(server.Close)
+
+	registryHost := strings.TrimPrefix(server.URL, "http://")
+	labels, err := NewImageService().GetImageLabels(
+		registryHost+"/neutree/router:missing",
+		authn.Anonymous,
+		true,
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, labels)
+}
+
 func TestImageService_DefaultHTTPSDoesNotDowngradeToHTTP(t *testing.T) {
 	server := httptest.NewServer(testRegistryHandler())
 	t.Cleanup(server.Close)
@@ -99,6 +155,10 @@ func TestImageService_DefaultHTTPSDoesNotDowngradeToHTTP(t *testing.T) {
 	allowed, err := service.CheckPullPermission(registryHost+"/neutree/router:v1.2.0", authn.Anonymous, false)
 	require.Error(t, err)
 	require.False(t, allowed)
+
+	exists, err := service.CheckImageExists(registryHost+"/neutree/router:v1.2.0", authn.Anonymous, false)
+	require.Error(t, err)
+	require.False(t, exists)
 
 	_, err = service.ListImageTags(registryHost+"/neutree/router", authn.Anonymous, false)
 	require.Error(t, err)

--- a/internal/registry/mocks/mock_image_service.go
+++ b/internal/registry/mocks/mock_image_service.go
@@ -20,9 +20,9 @@ func (_m *MockImageService) EXPECT() *MockImageService_Expecter {
 	return &MockImageService_Expecter{mock: &_m.Mock}
 }
 
-// CheckImageExists provides a mock function with given fields: image, auth
-func (_m *MockImageService) CheckImageExists(image string, auth authn.Authenticator) (bool, error) {
-	ret := _m.Called(image, auth)
+// CheckImageExists provides a mock function with given fields: image, auth, useHTTP
+func (_m *MockImageService) CheckImageExists(image string, auth authn.Authenticator, useHTTP bool) (bool, error) {
+	ret := _m.Called(image, auth, useHTTP)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CheckImageExists")
@@ -30,17 +30,17 @@ func (_m *MockImageService) CheckImageExists(image string, auth authn.Authentica
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, authn.Authenticator) (bool, error)); ok {
-		return rf(image, auth)
+	if rf, ok := ret.Get(0).(func(string, authn.Authenticator, bool) (bool, error)); ok {
+		return rf(image, auth, useHTTP)
 	}
-	if rf, ok := ret.Get(0).(func(string, authn.Authenticator) bool); ok {
-		r0 = rf(image, auth)
+	if rf, ok := ret.Get(0).(func(string, authn.Authenticator, bool) bool); ok {
+		r0 = rf(image, auth, useHTTP)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(string, authn.Authenticator) error); ok {
-		r1 = rf(image, auth)
+	if rf, ok := ret.Get(1).(func(string, authn.Authenticator, bool) error); ok {
+		r1 = rf(image, auth, useHTTP)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -56,13 +56,14 @@ type MockImageService_CheckImageExists_Call struct {
 // CheckImageExists is a helper method to define mock.On call
 //   - image string
 //   - auth authn.Authenticator
-func (_e *MockImageService_Expecter) CheckImageExists(image interface{}, auth interface{}) *MockImageService_CheckImageExists_Call {
-	return &MockImageService_CheckImageExists_Call{Call: _e.mock.On("CheckImageExists", image, auth)}
+//   - useHTTP bool
+func (_e *MockImageService_Expecter) CheckImageExists(image interface{}, auth interface{}, useHTTP interface{}) *MockImageService_CheckImageExists_Call {
+	return &MockImageService_CheckImageExists_Call{Call: _e.mock.On("CheckImageExists", image, auth, useHTTP)}
 }
 
-func (_c *MockImageService_CheckImageExists_Call) Run(run func(image string, auth authn.Authenticator)) *MockImageService_CheckImageExists_Call {
+func (_c *MockImageService_CheckImageExists_Call) Run(run func(image string, auth authn.Authenticator, useHTTP bool)) *MockImageService_CheckImageExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(authn.Authenticator))
+		run(args[0].(string), args[1].(authn.Authenticator), args[2].(bool))
 	})
 	return _c
 }
@@ -72,7 +73,7 @@ func (_c *MockImageService_CheckImageExists_Call) Return(_a0 bool, _a1 error) *M
 	return _c
 }
 
-func (_c *MockImageService_CheckImageExists_Call) RunAndReturn(run func(string, authn.Authenticator) (bool, error)) *MockImageService_CheckImageExists_Call {
+func (_c *MockImageService_CheckImageExists_Call) RunAndReturn(run func(string, authn.Authenticator, bool) (bool, error)) *MockImageService_CheckImageExists_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/routes/clusters/cluster.go
+++ b/internal/routes/clusters/cluster.go
@@ -3,13 +3,21 @@ package clusters
 import (
 	"github.com/gin-gonic/gin"
 
+	v1 "github.com/neutree-ai/neutree/api/v1"
 	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
+// ReleaseInfoProvider is the narrow policy dependency needed by cluster API
+// operations that select versions from the current control-plane baseline.
+type ReleaseInfoProvider interface {
+	Current() (*v1.ReleaseInfo, error)
+}
+
 type Dependencies struct {
-	Storage      storage.Storage
-	ImageService registry.ImageService
+	Storage             storage.Storage
+	ReleaseInfoProvider ReleaseInfoProvider
+	ImageService        registry.ImageService
 }
 
 func RegisterClusterRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc, deps *Dependencies) {

--- a/internal/routes/clusters/cluster_versions.go
+++ b/internal/routes/clusters/cluster_versions.go
@@ -4,198 +4,399 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"sync"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-containerregistry/pkg/authn"
-	"k8s.io/klog/v2"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/registry"
 	"github.com/neutree-ai/neutree/internal/util"
+	"github.com/neutree-ai/neutree/pkg/releaseprofile"
 	"github.com/neutree-ai/neutree/pkg/storage"
 )
 
 type availableClusterVersionsResponse struct {
-	AvailableVersions []string `json:"available_versions"`
+	AvailableVersions     []string `json:"available_versions"`
+	DefaultClusterVersion *string  `json:"default_cluster_version"`
 }
 
-// getAvailableClusterVersions handles GET /clusters/available_versions
-// Query params: image_registry (required), workspace (required), cluster_type (required), accelerator_type (optional)
+type availableClusterVersionsRequest struct {
+	workspace    string
+	registryName string
+	clusterType  string
+}
+
+type availableClusterVersionsTarget struct {
+	releaseInfo *v1.ReleaseInfo
+	profiles    []v1.ClusterProfile
+	imagePrefix string
+	auth        authn.Authenticator
+	useHTTP     bool
+}
+
+type availableClusterVersion struct {
+	name    string
+	version *semver.Version
+}
+
+type availableClusterVersionsError struct {
+	status  int
+	message string
+}
+
+func (err *availableClusterVersionsError) Error() string {
+	return err.message
+}
+
+// getAvailableClusterVersions returns exact Profiles whose declared material
+// is available in the caller-selected target registry.
 func getAvailableClusterVersions(deps *Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		workspace := c.Query("workspace")
-		if workspace == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "workspace is required"})
-			return
-		}
-
-		imageRegistryName := c.Query("image_registry")
-		if imageRegistryName == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "image_registry is required"})
-			return
-		}
-
-		clusterType := c.Query("cluster_type")
-		if clusterType == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "cluster_type is required"})
-			return
-		}
-
-		acceleratorType := c.Query("accelerator_type")
-
-		// Get image registry
-		imageRegistries, err := deps.Storage.ListImageRegistry(storage.ListOption{
-			Filters: []storage.Filter{
-				{Column: "metadata->name", Operator: "eq", Value: fmt.Sprintf(`"%s"`, imageRegistryName)},
-				{Column: "metadata->workspace", Operator: "eq", Value: fmt.Sprintf(`"%s"`, workspace)},
-			},
-		})
+		request, err := parseAvailableClusterVersionsRequest(c)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get image registry: %v", err)})
+			writeAvailableClusterVersionsError(c, err)
+
 			return
 		}
 
-		if len(imageRegistries) == 0 {
-			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("image registry %s/%s not found", workspace, imageRegistryName)})
-			return
-		}
-
-		imageRegistry := &imageRegistries[0]
-		useHTTP := util.IsHTTPRegistryURL(imageRegistry.Spec.URL)
-
-		imagePrefix, err := util.GetImagePrefix(imageRegistry)
+		response, err := resolveAvailableClusterVersions(deps, request)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get image prefix: %v", err)})
+			writeAvailableClusterVersionsError(c, err)
+
 			return
 		}
 
-		var imageName string
-
-		switch clusterType {
-		case string(v1.SSHClusterType):
-			imageName = v1.NeutreeServeImageName
-		case string(v1.KubernetesClusterType):
-			imageName = v1.NeutreeRouterImageName
-		default:
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("unsupported cluster_type: %s, must be 'ssh' or 'kubernetes'", clusterType)})
-			return
-		}
-
-		imageRepo := imagePrefix + "/" + imageName
-
-		// Build auth
-		username, password, err := util.GetImageRegistryAuthInfo(imageRegistry)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get auth info: %v", err)})
-			return
-		}
-
-		var auth authn.Authenticator
-		if username != "" || password != "" {
-			auth = authn.FromConfig(authn.AuthConfig{
-				Username: username,
-				Password: password,
-			})
-		} else {
-			auth = authn.Anonymous
-		}
-
-		// List tags, then read image labels to discover available versions.
-		// Only images with the "neutree.ai/cluster-version" label are included;
-		// images without the label (dev/nightly builds) are skipped.
-		// Labeled images are deduplicated by version and filtered by accelerator type.
-		imageSvc := deps.ImageService
-
-		tags, err := imageSvc.ListImageTags(imageRepo, auth, useHTTP)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list image tags: %v", err)})
-			return
-		}
-
-		minClusterVersion, err := semver.NewVersion(v1.MinimumSelectableClusterVersionGate)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("invalid minimum cluster version: %v", err)})
-			return
-		}
-
-		// Fetch labels concurrently for all tags
-		type tagResult struct {
-			version *semver.Version
-		}
-
-		results := make([]tagResult, len(tags))
-
-		var wg sync.WaitGroup
-
-		for i, tag := range tags {
-			wg.Add(1)
-
-			go func(idx int, t string) {
-				defer wg.Done()
-
-				imageRef := imageRepo + ":" + t
-
-				labels, labelErr := imageSvc.GetImageLabels(imageRef, auth, useHTTP)
-				if labelErr != nil {
-					klog.V(4).Infof("skipping tag %s: failed to get labels: %v", t, labelErr)
-					return
-				}
-
-				versionStr := labels[v1.ImageLabelVersion]
-				if versionStr == "" {
-					return
-				}
-
-				if acceleratorType != "" {
-					if labels[v1.ImageLabelAcceleratorType] != acceleratorType {
-						return
-					}
-				}
-
-				v, parseErr := semver.NewVersion(versionStr)
-				if parseErr != nil {
-					return
-				}
-
-				if !minClusterVersion.LessThan(v) {
-					return
-				}
-
-				results[idx] = tagResult{version: v}
-			}(i, tag)
-		}
-
-		wg.Wait()
-
-		// Deduplicate and collect versions
-		seen := make(map[string]struct{})
-		var versions []*semver.Version
-
-		for _, r := range results {
-			if r.version == nil {
-				continue
-			}
-
-			key := r.version.String()
-			if _, ok := seen[key]; ok {
-				continue
-			}
-
-			seen[key] = struct{}{}
-
-			versions = append(versions, r.version)
-		}
-
-		sort.Sort(semver.Collection(versions))
-
-		availableVersions := make([]string, 0, len(versions))
-		for _, v := range versions {
-			availableVersions = append(availableVersions, "v"+v.String())
-		}
-
-		c.JSON(http.StatusOK, availableClusterVersionsResponse{
-			AvailableVersions: availableVersions,
-		})
+		c.JSON(http.StatusOK, response)
 	}
+}
+
+func parseAvailableClusterVersionsRequest(c *gin.Context) (availableClusterVersionsRequest, error) {
+	request := availableClusterVersionsRequest{
+		workspace:    strings.TrimSpace(c.Query("workspace")),
+		registryName: strings.TrimSpace(c.Query("image_registry")),
+		clusterType:  strings.TrimSpace(c.Query("cluster_type")),
+	}
+	if request.workspace == "" || request.registryName == "" {
+		return availableClusterVersionsRequest{}, newAvailableClusterVersionsError(
+			http.StatusBadRequest,
+			"workspace and image_registry are required",
+		)
+	}
+
+	if !v1.IsSupportedClusterType(request.clusterType) {
+		return availableClusterVersionsRequest{}, newAvailableClusterVersionsError(
+			http.StatusBadRequest,
+			fmt.Sprintf("cluster_type must be one of %q or %q", v1.SSHClusterType, v1.KubernetesClusterType),
+		)
+	}
+
+	return request, nil
+}
+
+func resolveAvailableClusterVersions(
+	deps *Dependencies,
+	request availableClusterVersionsRequest,
+) (availableClusterVersionsResponse, error) {
+	target, err := loadAvailableClusterVersionsTarget(deps, request)
+	if err != nil {
+		return availableClusterVersionsResponse{}, err
+	}
+
+	sshVersionsByRepo := map[string]map[string]struct{}{}
+
+	versions := make([]availableClusterVersion, 0, len(target.profiles))
+	defaultAvailable := false
+	for index := range target.profiles {
+		profile := &target.profiles[index]
+		if err := releaseprofile.ValidateClusterProfile(profile); err != nil {
+			return availableClusterVersionsResponse{}, newAvailableClusterVersionsError(
+				http.StatusInternalServerError,
+				fmt.Sprintf("invalid stored cluster profile %q: %v", profile.GetName(), err),
+			)
+		}
+
+		if err := releaseprofile.ValidateClusterVersionEligibility(target.releaseInfo, profile.GetName()); err != nil {
+			continue
+		}
+
+		components, _ := profile.Spec.ComponentsFor(request.clusterType)
+		available, err := profileImagesAvailable(
+			deps.ImageService,
+			target,
+			request.clusterType,
+			profile.GetName(),
+			components,
+			sshVersionsByRepo,
+		)
+		if err != nil {
+			return availableClusterVersionsResponse{}, newAvailableClusterVersionsError(
+				http.StatusInternalServerError,
+				fmt.Sprintf("failed to check images for %s: %v", profile.GetName(), err),
+			)
+		}
+		if !available {
+			continue
+		}
+
+		version, err := semver.StrictNewVersion(strings.TrimPrefix(profile.GetName(), "v"))
+		if err != nil {
+			return availableClusterVersionsResponse{}, newAvailableClusterVersionsError(
+				http.StatusInternalServerError,
+				fmt.Sprintf("invalid stored cluster profile version %q: %v", profile.GetName(), err),
+			)
+		}
+
+		versions = append(versions, availableClusterVersion{name: profile.GetName(), version: version})
+		defaultAvailable = defaultAvailable || profile.GetName() == target.releaseInfo.Spec.DefaultClusterVersion
+	}
+
+	return availableClusterVersionsResponse{
+		AvailableVersions:     sortedAvailableClusterVersions(versions),
+		DefaultClusterVersion: availableDefaultClusterVersion(target.releaseInfo, defaultAvailable),
+	}, nil
+}
+
+func loadAvailableClusterVersionsTarget(
+	deps *Dependencies,
+	request availableClusterVersionsRequest,
+) (*availableClusterVersionsTarget, error) {
+	if deps == nil || deps.Storage == nil || deps.ImageService == nil || deps.ReleaseInfoProvider == nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			"storage, image service, and release info provider are required",
+		)
+	}
+
+	info, err := deps.ReleaseInfoProvider.Current()
+	if err != nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to get release info: %v", err),
+		)
+	}
+	if err := releaseprofile.ValidateReleaseInfo(info); err != nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			fmt.Sprintf("invalid current release info: %v", err),
+		)
+	}
+
+	registries, err := deps.Storage.ListImageRegistry(storage.ListOption{Filters: []storage.Filter{
+		{Column: "metadata->>workspace", Operator: "eq", Value: request.workspace},
+		{Column: "metadata->>name", Operator: "eq", Value: request.registryName},
+	}})
+	if err != nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to list image registries: %v", err),
+		)
+	}
+	if len(registries) == 0 {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusNotFound,
+			fmt.Sprintf("image registry %s/%s not found", request.workspace, request.registryName),
+		)
+	}
+	if len(registries) != 1 || registries[0].Spec == nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			"expected one valid image registry",
+		)
+	}
+
+	imageRegistry := &registries[0]
+	imagePrefix, err := util.GetImagePrefix(imageRegistry)
+	if err != nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to resolve image registry: %v", err),
+		)
+	}
+
+	username, password, err := util.GetImageRegistryAuthInfo(imageRegistry)
+	if err != nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to resolve image registry auth: %v", err),
+		)
+	}
+
+	auth := authn.Anonymous
+	if username != "" || password != "" {
+		auth = authn.FromConfig(authn.AuthConfig{Username: username, Password: password})
+	}
+
+	profiles, err := deps.Storage.ListClusterProfile(storage.ListOption{})
+	if err != nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to list cluster profiles: %v", err),
+		)
+	}
+
+	return &availableClusterVersionsTarget{
+		releaseInfo: info,
+		profiles:    profiles,
+		imagePrefix: imagePrefix,
+		auth:        auth,
+		useHTTP:     util.IsHTTPRegistryURL(imageRegistry.Spec.URL),
+	}, nil
+}
+
+func availableSSHAcceleratorVersions(
+	target *availableClusterVersionsTarget,
+	rayRuntimeImage string,
+	service registry.ImageService,
+) (map[string]struct{}, error) {
+	// RayRuntime is the SSH accelerator-semantic component. Its labels map an
+	// accelerator-specific artifact back to the Profile's exact version.
+	runtimeRepository := util.RewriteImageRef(target.imagePrefix, strings.TrimSpace(rayRuntimeImage))
+	tags, err := service.ListImageTags(runtimeRepository, target.auth, target.useHTTP)
+	if err != nil {
+		return nil, newAvailableClusterVersionsError(
+			http.StatusInternalServerError,
+			fmt.Sprintf("failed to check SSH accelerator images: %v", err),
+		)
+	}
+
+	versions := make(map[string]struct{})
+	for _, tag := range tags {
+		labels, err := service.GetImageLabels(runtimeRepository+":"+tag, target.auth, target.useHTTP)
+		if err != nil {
+			return nil, newAvailableClusterVersionsError(
+				http.StatusInternalServerError,
+				fmt.Sprintf("failed to read SSH accelerator image labels: %v", err),
+			)
+		}
+
+		version := strings.TrimSpace(labels[v1.ImageLabelVersion])
+		acceleratorType := strings.TrimSpace(labels[v1.ImageLabelAcceleratorType])
+		if version == "" || acceleratorType == "" {
+			continue
+		}
+
+		versions[version] = struct{}{}
+	}
+
+	return versions, nil
+}
+
+func profileImagesAvailable(
+	service registry.ImageService,
+	target *availableClusterVersionsTarget,
+	clusterType string,
+	clusterVersion string,
+	components v1.ClusterProfileComponents,
+	sshVersionsByRepo map[string]map[string]struct{},
+) (bool, error) {
+	switch clusterType {
+	case v1.SSHClusterType:
+		runtimeRepository := util.RewriteImageRef(target.imagePrefix, strings.TrimSpace(components.RayRuntime.Image))
+		sshVersions, found := sshVersionsByRepo[runtimeRepository]
+		if !found {
+			var err error
+			sshVersions, err = availableSSHAcceleratorVersions(target, components.RayRuntime.Image, service)
+			if err != nil {
+				return false, err
+			}
+			sshVersionsByRepo[runtimeRepository] = sshVersions
+		}
+
+		if _, found := sshVersions[clusterVersion]; !found {
+			return false, nil
+		}
+
+		return exactImagesAvailable(service, target, []v1.ImageRef{
+			components.NodeAgent,
+			components.NodeExporter,
+			components.VMAgent,
+		})
+	case v1.KubernetesClusterType:
+		return exactImagesAvailable(service, target, []v1.ImageRef{
+			components.KubernetesRuntime,
+			components.Router,
+			components.NodeAgent,
+			components.NodeExporter,
+			components.VMAgent,
+			components.KubeStateMetrics,
+		})
+	default:
+		return false, fmt.Errorf("unsupported cluster type %q", clusterType)
+	}
+}
+
+func exactImagesAvailable(
+	service registry.ImageService,
+	target *availableClusterVersionsTarget,
+	refs []v1.ImageRef,
+) (bool, error) {
+	for _, ref := range refs {
+		image := strings.TrimSpace(ref.Image)
+		tag := strings.TrimSpace(ref.Tag)
+		if image == "" || tag == "" {
+			return false, fmt.Errorf("cluster profile image and tag are required")
+		}
+
+		exists, err := service.CheckImageExists(
+			util.RewriteImageRef(target.imagePrefix, image+":"+tag),
+			target.auth,
+			target.useHTTP,
+		)
+		if err != nil {
+			return false, err
+		}
+		if !exists {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func sortedAvailableClusterVersions(versions []availableClusterVersion) []string {
+	sort.Slice(versions, func(left, right int) bool {
+		if versions[left].version.Equal(versions[right].version) {
+			return versions[left].name < versions[right].name
+		}
+
+		return versions[left].version.LessThan(versions[right].version)
+	})
+
+	available := make([]string, 0, len(versions))
+	for _, version := range versions {
+		available = append(available, version.name)
+	}
+
+	return available
+}
+
+func availableDefaultClusterVersion(info *v1.ReleaseInfo, defaultAvailable bool) *string {
+	if !defaultAvailable {
+		return nil
+	}
+
+	value := info.Spec.DefaultClusterVersion
+
+	return &value
+}
+
+func newAvailableClusterVersionsError(status int, message string) *availableClusterVersionsError {
+	return &availableClusterVersionsError{status: status, message: message}
+}
+
+func writeAvailableClusterVersionsError(c *gin.Context, err error) {
+	response := &availableClusterVersionsError{
+		status:  http.StatusInternalServerError,
+		message: "internal server error",
+	}
+	if typed, ok := err.(*availableClusterVersionsError); ok {
+		response = typed
+	}
+	if response.status >= http.StatusInternalServerError {
+		response.message = "internal server error"
+	}
+
+	c.JSON(response.status, gin.H{"error": response.message})
 }

--- a/internal/routes/clusters/cluster_versions.go
+++ b/internal/routes/clusters/cluster_versions.go
@@ -110,13 +110,6 @@ func resolveAvailableClusterVersions(
 	defaultAvailable := false
 	for index := range target.profiles {
 		profile := &target.profiles[index]
-		if err := releaseprofile.ValidateClusterProfile(profile); err != nil {
-			return availableClusterVersionsResponse{}, newAvailableClusterVersionsError(
-				http.StatusInternalServerError,
-				fmt.Sprintf("invalid stored cluster profile %q: %v", profile.GetName(), err),
-			)
-		}
-
 		if err := releaseprofile.ValidateClusterVersionEligibility(target.releaseInfo, profile.GetName()); err != nil {
 			continue
 		}
@@ -174,12 +167,6 @@ func loadAvailableClusterVersionsTarget(
 		return nil, newAvailableClusterVersionsError(
 			http.StatusInternalServerError,
 			fmt.Sprintf("failed to get release info: %v", err),
-		)
-	}
-	if err := releaseprofile.ValidateReleaseInfo(info); err != nil {
-		return nil, newAvailableClusterVersionsError(
-			http.StatusInternalServerError,
-			fmt.Sprintf("invalid current release info: %v", err),
 		)
 	}
 

--- a/internal/routes/clusters/cluster_versions.go
+++ b/internal/routes/clusters/cluster_versions.go
@@ -110,7 +110,7 @@ func resolveAvailableClusterVersions(
 	defaultAvailable := false
 	for index := range target.profiles {
 		profile := &target.profiles[index]
-		if err := releaseprofile.ValidateClusterVersionEligibility(target.releaseInfo, profile.GetName()); err != nil {
+		if err := releaseprofile.ValidateClusterVersionCompatibility(target.releaseInfo, profile.GetName()); err != nil {
 			continue
 		}
 

--- a/internal/routes/clusters/cluster_versions_test.go
+++ b/internal/routes/clusters/cluster_versions_test.go
@@ -8,246 +8,436 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
-	registryMocks "github.com/neutree-ai/neutree/internal/registry/mocks"
+	"github.com/neutree-ai/neutree/internal/util"
+	"github.com/neutree-ai/neutree/pkg/storage"
 	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
 )
 
-func createTestContextWithQuery(queryParams map[string]string) (*gin.Context, *httptest.ResponseRecorder) {
-	gin.SetMode(gin.TestMode)
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	q := req.URL.Query()
-	for k, v := range queryParams {
-		q.Set(k, v)
-	}
-	req.URL.RawQuery = q.Encode()
-	c.Request = req
-
-	return c, w
-}
-
-func TestGetAvailableClusterVersionsPassesHTTPRegistryScheme(t *testing.T) {
-	tests := []struct {
-		name    string
-		url     string
-		useHTTP bool
-	}{
-		{name: "explicit HTTP", url: "http://registry.example.com:5000", useHTTP: true},
-		{name: "explicit HTTPS", url: "https://registry.example.com:5000"},
-		{name: "URL without scheme", url: "registry.example.com:5000"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			storage := storageMocks.NewMockStorage(t)
-			imageService := registryMocks.NewMockImageService(t)
-			storage.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{{
-				Spec: &v1.ImageRegistrySpec{URL: tt.url},
-			}}, nil)
-			imageService.
-				On("ListImageTags", "registry.example.com:5000/"+v1.NeutreeRouterImageName, mock.Anything, tt.useHTTP).
-				Return([]string{"v1.2.0"}, nil)
-			imageService.
-				On("GetImageLabels", "registry.example.com:5000/neutree/router:v1.2.0", mock.Anything, tt.useHTTP).
-				Return(map[string]string{v1.ImageLabelVersion: "v1.2.0"}, nil)
-
-			context, recorder := createTestContextWithQuery(map[string]string{
-				"workspace":      "default",
-				"image_registry": "registry",
-				"cluster_type":   "kubernetes",
-			})
-			getAvailableClusterVersions(&Dependencies{Storage: storage, ImageService: imageService})(context)
-
-			assert.Equal(t, http.StatusOK, recorder.Code)
-			imageService.AssertExpectations(t)
-		})
-	}
-}
+const availableVersionsImagePrefix = "registry.example.com/project"
 
 func TestGetAvailableClusterVersions(t *testing.T) {
 	tests := []struct {
-		name               string
-		queryParams        map[string]string
-		setupMock          func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService)
-		expectedStatusCode int
-		expectedResponse   *availableClusterVersionsResponse
-		expectedError      string
+		name         string
+		clusterType  string
+		profiles     []v1.ClusterProfile
+		registryURL  string
+		configure    func(*availableVersionsImageService, []v1.ClusterProfile)
+		wantStatus   int
+		wantVersions []string
+		wantDefault  *string
+		verifyCalls  func(*testing.T, *availableVersionsImageService)
 	}{
 		{
-			name: "success - filters by nvidia accelerator type",
-			queryParams: map[string]string{
-				"workspace":        "default",
-				"image_registry":   "my-registry",
-				"cluster_type":     "ssh",
-				"accelerator_type": "nvidia_gpu",
+			name:        "SSH returns eligible profiles with base images and accelerator labels",
+			clusterType: v1.SSHClusterType,
+			profiles: []v1.ClusterProfile{
+				availableVersionsProfile("v1.1.1"),
+				availableVersionsProfile("v1.2.0"),
+				availableVersionsProfile("v1.2.1"),
 			},
-			setupMock: func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService) {
-				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{
-					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
-				}, nil)
-				imgSvc.On("ListImageTags", mock.Anything, mock.Anything, false).Return([]string{
-					"v1.0.0", "v1.0.0-rocm", "v1.0.1", "v1.0.1-rc.1", "v1.0.2", "v1.1.0",
-					"v1.0.1-nightly-20260313", "latest",
-				}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0-rocm" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1-rc.1" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1-rc.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.1.0" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.1.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				// Unlabeled tags — skipped
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.1-nightly-20260313" }), mock.Anything, false).
-					Return(map[string]string{}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:latest" }), mock.Anything, false).
-					Return(map[string]string{}, nil)
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableSSHProfile(images, profiles[0], true)
+				configureAvailableSSHProfile(images, profiles[1], true)
 			},
-			expectedStatusCode: http.StatusOK,
-			expectedResponse: &availableClusterVersionsResponse{
-				AvailableVersions: []string{"v1.0.2", "v1.1.0"},
+			wantStatus:   http.StatusOK,
+			wantVersions: []string{"v1.1.1", "v1.2.0"},
+			wantDefault:  stringPointer("v1.2.0"),
+			verifyCalls: func(t *testing.T, images *availableVersionsImageService) {
+				assert.Len(t, images.tagCalls, 1)
+				assert.Len(t, images.labelCalls, 2)
 			},
 		},
 		{
-			name: "success - no accelerator_type deduplicates shared versions after minimum filter",
-			queryParams: map[string]string{
-				"workspace":      "default",
-				"image_registry": "my-registry",
-				"cluster_type":   "ssh",
+			name:        "missing default material leaves compatible lower version and null default",
+			clusterType: v1.SSHClusterType,
+			profiles: []v1.ClusterProfile{
+				availableVersionsProfile("v1.1.1"),
+				availableVersionsProfile("v1.2.0"),
 			},
-			setupMock: func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService) {
-				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{
-					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
-				}, nil)
-				imgSvc.On("ListImageTags", mock.Anything, mock.Anything, false).Return([]string{
-					"v1.0.0", "v1.0.0-rocm", "v1.0.2", "v1.0.2-rocm",
-				}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.0-rocm" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/neutree-serve:v1.0.2-rocm" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.2", v1.ImageLabelAcceleratorType: "amd_gpu"}, nil)
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableSSHProfile(images, profiles[0], true)
+				configureAvailableSSHProfile(images, profiles[1], true)
+				ssh, _ := profiles[1].Spec.ComponentsFor(v1.SSHClusterType)
+				images.existence[availableVersionsImageRef(ssh.NodeAgent)] = availableVersionsExistenceResult{}
 			},
-			expectedStatusCode: http.StatusOK,
-			expectedResponse: &availableClusterVersionsResponse{
-				AvailableVersions: []string{"v1.0.2"},
+			wantStatus:   http.StatusOK,
+			wantVersions: []string{"v1.1.1"},
+		},
+		{
+			name:        "SSH requires a nonempty accelerator label",
+			clusterType: v1.SSHClusterType,
+			profiles:    []v1.ClusterProfile{availableVersionsProfile("v1.2.0")},
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableSSHProfile(images, profiles[0], false)
+			},
+			wantStatus:   http.StatusOK,
+			wantVersions: []string{},
+		},
+		{
+			name:        "SSH ignores accelerator labels for another cluster version",
+			clusterType: v1.SSHClusterType,
+			profiles:    []v1.ClusterProfile{availableVersionsProfile("v1.2.0")},
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableSSHProfile(images, profiles[0], true)
+				ssh, _ := profiles[0].Spec.ComponentsFor(v1.SSHClusterType)
+				runtimeRepository := util.RewriteImageRef(availableVersionsImagePrefix, ssh.RayRuntime.Image)
+				tag := "accelerator-" + profiles[0].GetName()
+				images.labels[runtimeRepository+":"+tag] = availableVersionsLabelsResult{labels: map[string]string{
+					v1.ImageLabelVersion:         "v1.1.1",
+					v1.ImageLabelAcceleratorType: "cuda",
+				}}
+			},
+			wantStatus:   http.StatusOK,
+			wantVersions: []string{},
+		},
+		{
+			name:        "SSH uses the profile ray runtime repository for accelerator labels",
+			clusterType: v1.SSHClusterType,
+			profiles: []v1.ClusterProfile{
+				func() v1.ClusterProfile {
+					profile := availableVersionsProfile("v1.2.0")
+					ssh, _ := profile.Spec.ComponentsFor(v1.SSHClusterType)
+					ssh.RayRuntime.Image = "enterprise/neutree-serve"
+					profile.Spec.Components[v1.SSHClusterType] = ssh
+
+					return profile
+				}(),
+			},
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableSSHProfile(images, profiles[0], true)
+			},
+			wantStatus:   http.StatusOK,
+			wantVersions: []string{"v1.2.0"},
+			wantDefault:  stringPointer("v1.2.0"),
+		},
+		{
+			name:        "Kubernetes requires its complete base matrix but no accelerator query",
+			clusterType: v1.KubernetesClusterType,
+			profiles:    []v1.ClusterProfile{availableVersionsProfile("v1.2.0")},
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableKubernetesProfile(images, profiles[0])
+			},
+			wantStatus:   http.StatusOK,
+			wantVersions: []string{"v1.2.0"},
+			wantDefault:  stringPointer("v1.2.0"),
+			verifyCalls: func(t *testing.T, images *availableVersionsImageService) {
+				assert.Empty(t, images.tagCalls)
+				assert.Empty(t, images.labelCalls)
 			},
 		},
 		{
-			name: "success - k8s cluster type uses router image",
-			queryParams: map[string]string{
-				"workspace":        "default",
-				"image_registry":   "my-registry",
-				"cluster_type":     "kubernetes",
-				"accelerator_type": "nvidia_gpu",
+			name:        "Kubernetes registry error fails instead of becoming an empty result",
+			clusterType: v1.KubernetesClusterType,
+			profiles:    []v1.ClusterProfile{availableVersionsProfile("v1.2.0")},
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableKubernetesProfile(images, profiles[0])
+				components, _ := profiles[0].Spec.ComponentsFor(v1.KubernetesClusterType)
+				images.existence[availableVersionsImageRef(components.Router)] = availableVersionsExistenceResult{
+					err: errors.New("registry unavailable"),
+				}
 			},
-			setupMock: func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService) {
-				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{
-					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
-				}, nil)
-				imgSvc.On("ListImageTags", "registry.example.com/"+v1.NeutreeRouterImageName, mock.Anything, false).Return([]string{
-					"v1.0.0", "v1.0.1", "v1.1.0",
-				}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.0.0" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.0.1" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.0.1", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-				imgSvc.On("GetImageLabels", mock.MatchedBy(func(s string) bool { return s == "registry.example.com/neutree/router:v1.1.0" }), mock.Anything, false).
-					Return(map[string]string{v1.ImageLabelVersion: "v1.1.0", v1.ImageLabelAcceleratorType: "nvidia_gpu"}, nil)
-			},
-			expectedStatusCode: http.StatusOK,
-			expectedResponse: &availableClusterVersionsResponse{
-				AvailableVersions: []string{"v1.1.0"},
-			},
+			wantStatus: http.StatusInternalServerError,
 		},
 		{
-			name:               "missing workspace",
-			queryParams:        map[string]string{"image_registry": "r", "cluster_type": "ssh"},
-			setupMock:          func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService) {},
-			expectedStatusCode: http.StatusBadRequest,
-			expectedError:      "workspace is required",
+			name:        "SSH label lookup failure fails instead of excluding the candidate",
+			clusterType: v1.SSHClusterType,
+			profiles:    []v1.ClusterProfile{availableVersionsProfile("v1.2.0")},
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableSSHProfile(images, profiles[0], true)
+				ssh, _ := profiles[0].Spec.ComponentsFor(v1.SSHClusterType)
+				runtimeRepository := util.RewriteImageRef(availableVersionsImagePrefix, ssh.RayRuntime.Image)
+				tag := "accelerator-" + profiles[0].GetName()
+				images.labels[runtimeRepository+":"+tag] = availableVersionsLabelsResult{
+					err: errors.New("registry label lookup failed"),
+				}
+			},
+			wantStatus: http.StatusInternalServerError,
 		},
 		{
-			name:               "missing image_registry",
-			queryParams:        map[string]string{"workspace": "default", "cluster_type": "ssh"},
-			setupMock:          func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService) {},
-			expectedStatusCode: http.StatusBadRequest,
-			expectedError:      "image_registry is required",
-		},
-		{
-			name:               "missing cluster_type",
-			queryParams:        map[string]string{"workspace": "default", "image_registry": "r"},
-			setupMock:          func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService) {},
-			expectedStatusCode: http.StatusBadRequest,
-			expectedError:      "cluster_type is required",
-		},
-		{
-			name: "image registry not found",
-			queryParams: map[string]string{
-				"workspace": "default", "image_registry": "missing", "cluster_type": "ssh",
+			name:        "eligible prerelease remains distinct from default identity",
+			clusterType: v1.KubernetesClusterType,
+			profiles:    []v1.ClusterProfile{availableVersionsProfile("v1.2.0-alpha.1")},
+			registryURL: "http://registry.example.com",
+			configure: func(images *availableVersionsImageService, profiles []v1.ClusterProfile) {
+				configureAvailableKubernetesProfile(images, profiles[0])
 			},
-			setupMock: func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService) {
-				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{}, nil)
+			wantStatus:   http.StatusOK,
+			wantVersions: []string{"v1.2.0-alpha.1"},
+			verifyCalls: func(t *testing.T, images *availableVersionsImageService) {
+				require.NotEmpty(t, images.existenceCalls)
+				for _, call := range images.existenceCalls {
+					assert.True(t, call.useHTTP)
+				}
 			},
-			expectedStatusCode: http.StatusNotFound,
-			expectedError:      "image registry default/missing not found",
-		},
-		{
-			name: "list tags error",
-			queryParams: map[string]string{
-				"workspace": "default", "image_registry": "my-registry", "cluster_type": "ssh",
-			},
-			setupMock: func(s *storageMocks.MockStorage, imgSvc *registryMocks.MockImageService) {
-				s.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{
-					{Spec: &v1.ImageRegistrySpec{URL: "registry.example.com"}},
-				}, nil)
-				imgSvc.On("ListImageTags", mock.Anything, mock.Anything, false).Return(nil, errors.New("registry unreachable"))
-			},
-			expectedStatusCode: http.StatusInternalServerError,
-			expectedError:      "failed to list image tags",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockStorage := storageMocks.NewMockStorage(t)
-			mockImgSvc := registryMocks.NewMockImageService(t)
-			tt.setupMock(mockStorage, mockImgSvc)
-
-			deps := &Dependencies{Storage: mockStorage, ImageService: mockImgSvc}
-			c, w := createTestContextWithQuery(tt.queryParams)
-
-			handler := getAvailableClusterVersions(deps)
-			handler(c)
-
-			assert.Equal(t, tt.expectedStatusCode, w.Code)
-
-			if tt.expectedResponse != nil {
-				var resp availableClusterVersionsResponse
-				err := json.Unmarshal(w.Body.Bytes(), &resp)
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedResponse.AvailableVersions, resp.AvailableVersions)
+			images := newAvailableVersionsImageService()
+			if tt.configure != nil {
+				tt.configure(images, tt.profiles)
 			}
 
-			if tt.expectedError != "" {
-				var errResp map[string]string
-				err := json.Unmarshal(w.Body.Bytes(), &errResp)
-				assert.NoError(t, err)
-				assert.Contains(t, errResp["error"], tt.expectedError)
+			deps := availableVersionsDependencies(t, tt.profiles, tt.registryURL, images)
+			response := executeAvailableVersions(
+				t,
+				deps,
+				"workspace=default&image_registry=registry&cluster_type="+tt.clusterType,
+			)
+
+			assert.Equal(t, tt.wantStatus, response.Code)
+			if tt.wantStatus == http.StatusOK {
+				var body availableClusterVersionsResponse
+				require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+				assert.Equal(t, tt.wantVersions, body.AvailableVersions)
+				assert.Equal(t, tt.wantDefault, body.DefaultClusterVersion)
+			}
+			if tt.wantStatus >= http.StatusInternalServerError {
+				assert.Contains(t, response.Body.String(), "internal server error")
+				assert.NotContains(t, response.Body.String(), "registry")
+			}
+
+			if tt.verifyCalls != nil {
+				tt.verifyCalls(t, images)
 			}
 		})
 	}
+}
+
+func TestGetAvailableClusterVersionsRejectsIncompleteTarget(t *testing.T) {
+	for _, query := range []string{
+		"cluster_type=ssh",
+		"workspace=default&cluster_type=ssh",
+		"workspace=default&image_registry=registry",
+		"workspace=default&image_registry=registry&cluster_type=invalid",
+	} {
+		t.Run(query, func(t *testing.T) {
+			response := executeAvailableVersions(t, &Dependencies{}, query)
+			assert.Equal(t, http.StatusBadRequest, response.Code)
+		})
+	}
+}
+
+func availableVersionsDependencies(
+	t *testing.T,
+	profiles []v1.ClusterProfile,
+	registryURL string,
+	images *availableVersionsImageService,
+) *Dependencies {
+	t.Helper()
+	if registryURL == "" {
+		registryURL = "https://registry.example.com"
+	}
+
+	store := storageMocks.NewMockStorage(t)
+	store.On("ListImageRegistry", mock.MatchedBy(matchesAvailableVersionsRegistryFilter)).
+		Return([]v1.ImageRegistry{availableVersionsImageRegistry(registryURL)}, nil).Once()
+	store.On("ListClusterProfile", mock.Anything).Return(profiles, nil).Once()
+
+	return &Dependencies{
+		Storage:             store,
+		ReleaseInfoProvider: availableVersionsReleaseInfoProvider{info: availableVersionsReleaseInfo()},
+		ImageService:        images,
+	}
+}
+
+func executeAvailableVersions(t *testing.T, deps *Dependencies, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodGet, "/clusters/available_versions?"+query, nil)
+	getAvailableClusterVersions(deps)(context)
+
+	return recorder
+}
+
+func matchesAvailableVersionsRegistryFilter(option storage.ListOption) bool {
+	if len(option.Filters) != 2 {
+		return false
+	}
+
+	return option.Filters[0] == (storage.Filter{Column: "metadata->>workspace", Operator: "eq", Value: "default"}) &&
+		option.Filters[1] == (storage.Filter{Column: "metadata->>name", Operator: "eq", Value: "registry"})
+}
+
+func availableVersionsReleaseInfo() *v1.ReleaseInfo {
+	return &v1.ReleaseInfo{
+		APIVersion: "v1",
+		Kind:       v1.ReleaseInfoKind,
+		Metadata:   &v1.Metadata{Name: "v1.2.0"},
+		Spec: &v1.ReleaseInfoSpec{
+			DefaultClusterVersion:      "v1.2.0",
+			CompatibleClusterBaselines: []string{"v1.1", "v1.2"},
+		},
+	}
+}
+
+func availableVersionsProfile(version string) v1.ClusterProfile {
+	return v1.ClusterProfile{
+		APIVersion: "v1",
+		Kind:       v1.ClusterProfileKind,
+		Metadata:   &v1.Metadata{Name: version},
+		Spec: &v1.ClusterProfileSpec{Components: map[string]v1.ClusterProfileComponents{
+			v1.SSHClusterType: {
+				RayRuntime:   v1.ImageRef{Image: v1.NeutreeServeImageName, Tag: version},
+				NodeAgent:    v1.ImageRef{Image: "neutree/node-agent", Tag: version},
+				NodeExporter: v1.ImageRef{Image: "prometheus/node-exporter", Tag: "v1.8.2"},
+				VMAgent:      v1.ImageRef{Image: "victoriametrics/vmagent", Tag: "v1.111.0"},
+			},
+			v1.KubernetesClusterType: {
+				KubernetesRuntime: v1.ImageRef{Image: "neutree/kubernetes-runtime", Tag: version},
+				Router:            v1.ImageRef{Image: v1.NeutreeRouterImageName, Tag: version},
+				NodeAgent:         v1.ImageRef{Image: "neutree/node-agent", Tag: version},
+				NodeExporter:      v1.ImageRef{Image: "prometheus/node-exporter", Tag: "v1.8.2"},
+				VMAgent:           v1.ImageRef{Image: "victoriametrics/vmagent", Tag: "v1.111.0"},
+				KubeStateMetrics:  v1.ImageRef{Image: "kubernetes/kube-state-metrics", Tag: "v2.15.0"},
+			},
+		}},
+	}
+}
+
+func availableVersionsImageRegistry(url string) v1.ImageRegistry {
+	return v1.ImageRegistry{
+		Metadata: &v1.Metadata{Name: "registry", Workspace: "default"},
+		Spec: &v1.ImageRegistrySpec{
+			URL:        url,
+			Repository: "project",
+		},
+	}
+}
+
+func configureAvailableSSHProfile(images *availableVersionsImageService, profile v1.ClusterProfile, accelerator bool) {
+	components, _ := profile.Spec.ComponentsFor(v1.SSHClusterType)
+	for _, ref := range []v1.ImageRef{components.NodeAgent, components.NodeExporter, components.VMAgent} {
+		images.existence[availableVersionsImageRef(ref)] = availableVersionsExistenceResult{exists: true}
+	}
+
+	serveRepository := util.RewriteImageRef(availableVersionsImagePrefix, components.RayRuntime.Image)
+	tag := "accelerator-" + profile.GetName()
+	images.tags[serveRepository] = availableVersionsTagsResult{tags: append(images.tags[serveRepository].tags, tag)}
+	labels := map[string]string{v1.ImageLabelVersion: profile.GetName()}
+	if accelerator {
+		labels[v1.ImageLabelAcceleratorType] = "cuda"
+	}
+	images.labels[serveRepository+":"+tag] = availableVersionsLabelsResult{labels: labels}
+}
+
+func configureAvailableKubernetesProfile(images *availableVersionsImageService, profile v1.ClusterProfile) {
+	components, _ := profile.Spec.ComponentsFor(v1.KubernetesClusterType)
+	for _, ref := range []v1.ImageRef{
+		components.KubernetesRuntime,
+		components.Router,
+		components.NodeAgent,
+		components.NodeExporter,
+		components.VMAgent,
+		components.KubeStateMetrics,
+	} {
+		images.existence[availableVersionsImageRef(ref)] = availableVersionsExistenceResult{exists: true}
+	}
+}
+
+func availableVersionsImageRef(ref v1.ImageRef) string {
+	return util.RewriteImageRef(availableVersionsImagePrefix, ref.Image+":"+ref.Tag)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+type availableVersionsReleaseInfoProvider struct {
+	info *v1.ReleaseInfo
+	err  error
+}
+
+func (provider availableVersionsReleaseInfoProvider) Current() (*v1.ReleaseInfo, error) {
+	return provider.info, provider.err
+}
+
+type availableVersionsImageService struct {
+	existence      map[string]availableVersionsExistenceResult
+	tags           map[string]availableVersionsTagsResult
+	labels         map[string]availableVersionsLabelsResult
+	existenceCalls []availableVersionsImageCall
+	tagCalls       []availableVersionsImageCall
+	labelCalls     []availableVersionsImageCall
+}
+
+type availableVersionsExistenceResult struct {
+	exists bool
+	err    error
+}
+
+type availableVersionsTagsResult struct {
+	tags []string
+	err  error
+}
+
+type availableVersionsLabelsResult struct {
+	labels map[string]string
+	err    error
+}
+
+type availableVersionsImageCall struct {
+	image   string
+	useHTTP bool
+}
+
+func newAvailableVersionsImageService() *availableVersionsImageService {
+	return &availableVersionsImageService{
+		existence: map[string]availableVersionsExistenceResult{},
+		tags:      map[string]availableVersionsTagsResult{},
+		labels:    map[string]availableVersionsLabelsResult{},
+	}
+}
+
+func (service *availableVersionsImageService) CheckImageExists(
+	image string,
+	_ authn.Authenticator,
+	useHTTP bool,
+) (bool, error) {
+	service.existenceCalls = append(service.existenceCalls, availableVersionsImageCall{image: image, useHTTP: useHTTP})
+	result, found := service.existence[image]
+	if !found {
+		return true, nil
+	}
+
+	return result.exists, result.err
+}
+
+func (service *availableVersionsImageService) CheckPullPermission(
+	_ string,
+	_ authn.Authenticator,
+	_ bool,
+) (bool, error) {
+	return true, nil
+}
+
+func (service *availableVersionsImageService) ListImageTags(
+	image string,
+	_ authn.Authenticator,
+	useHTTP bool,
+) ([]string, error) {
+	service.tagCalls = append(service.tagCalls, availableVersionsImageCall{image: image, useHTTP: useHTTP})
+	result := service.tags[image]
+
+	return result.tags, result.err
+}
+
+func (service *availableVersionsImageService) GetImageLabels(
+	image string,
+	_ authn.Authenticator,
+	useHTTP bool,
+) (map[string]string, error) {
+	service.labelCalls = append(service.labelCalls, availableVersionsImageCall{image: image, useHTTP: useHTTP})
+	result := service.labels[image]
+
+	return result.labels, result.err
 }


### PR DESCRIPTION
## Summary

- combine D6 registry-aware `available_versions` with the D7 exact Profile package-artifact chain
- preserve the middleware-validated, domain-checked package Profile import route
- provide one exact community commit for the Enterprise companion branch

## Test Plan

### Unit test

- `go test ./internal/routes/clusters ./internal/registry ./pkg/releaseprofile ./internal/cli/packageimport ./cmd/neutree-cli/app/cmd/packageimport ./cmd/neutree-api/app -count=1`

### DB test

- Not run: this integration introduces no new migration or DB-only behavior.

### E2E test

- Not run per the user-directed Unit-only staged workflow.