### PR TITLE
fix: stop requiring a model name and version from engines that ship their own model (NEU-633)

### DIFF
--- a/db/dbtest/validation_test.go
+++ b/db/dbtest/validation_test.go
@@ -853,3 +853,70 @@ func TestEndpointModelRegistryOptional(t *testing.T) {
 		}
 	})
 }
+
+// Migration 091: model name and version follow the registry out of the database.
+// The name *format* stays here -- it does not depend on the engine.
+func TestEndpointModelNameAndVersionOptional(t *testing.T) {
+	db := GetTestDB(t)
+	ctx := context.Background()
+
+	insert := func(name, version, suffix string) string {
+		return fmt.Sprintf(`
+			INSERT INTO api.endpoints (api_version, kind, spec, metadata)
+			VALUES (
+				'v1',
+				'Endpoint',
+				ROW(
+					'test-cluster',
+					ROW('', '%s', '', '%s', '', NULL)::api.model_spec,
+					ROW('flex', 'v1')::api.endpoint_engine_spec,
+					ROW('4', '2', NULL, '16')::api.resource_spec,
+					ROW(1)::api.replica_spec,
+					NULL,
+					NULL,
+					NULL
+				)::api.endpoint_spec,
+				ROW('test-ep-%s', NULL, 'test-workspace', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}'::json, '{}'::json)::api.metadata
+			)
+		`, name, version, suffix)
+	}
+
+	run := func(t *testing.T, stmt string) error {
+		t.Helper()
+
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("failed to begin transaction: %v", err)
+		}
+		defer func() {
+			_ = tx.Rollback()
+		}()
+
+		_, err = tx.ExecContext(ctx, stmt)
+
+		return err
+	}
+
+	t.Run("endpoint with no model name or version is accepted", func(t *testing.T) {
+		if err := run(t, insert("", "", "no-model")); err != nil {
+			t.Fatalf("expected an endpoint without model name/version to be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("a name that is given is still format-checked - error code 10105", func(t *testing.T) {
+		err := run(t, insert("Not A Valid Name", "", "bad-name"))
+		if err == nil {
+			t.Fatal("expected a format error for an invalid model name")
+		}
+
+		if !strings.Contains(err.Error(), `"code": "10105"`) {
+			t.Fatalf("expected error code 10105, got: %v", err)
+		}
+	})
+
+	t.Run("a well-formed name is accepted", func(t *testing.T) {
+		if err := run(t, insert("Qwen/Qwen3-8B", "v1", "good-name")); err != nil {
+			t.Fatalf("expected a well-formed model name to be accepted, got: %v", err)
+		}
+	})
+}

--- a/db/migrations/091_endpoint_model_name_version_optional.down.sql
+++ b/db/migrations/091_endpoint_model_name_version_optional.down.sql
@@ -1,0 +1,36 @@
+-- Restore the presence check alongside the format check (body from 017).
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_name()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.name IS NULL OR trim((NEW.spec).model.name) = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10007","message": "spec.model.name is required","hint": "Provide model name"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    IF NOT (NEW.spec).model.name ~ '^[A-Za-z0-9]+(?:[._\-A-Za-z0-9]*[A-Za-z0-9])?(?:/[A-Za-z0-9]+(?:[._\-A-Za-z0-9]*[A-Za-z0-9])?)*$' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10105","message": "Invalid model name format","hint": "Use alphanumeric, dots, underscores, hyphens, and optional slash-separated segments"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_version()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.version IS NULL OR trim((NEW.spec).model.version) = '' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10008","message": "spec.model.version is required","hint": "Provide model version"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER validate_endpoint_model_version_on_endpoints
+    BEFORE INSERT OR UPDATE ON api.endpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION api.validate_endpoint_model_version();

--- a/db/migrations/091_endpoint_model_name_version_optional.up.sql
+++ b/db/migrations/091_endpoint_model_name_version_optional.up.sql
@@ -1,0 +1,24 @@
+-- An engine that brings its own model has no model name or version to give:
+-- whether either is required depends on the engine, which a trigger cannot read.
+-- The requirement moves to internal/routes/proxies/endpoint_validation.go, next
+-- to the model registry check migration 090 moved there for the same reason.
+--
+-- The name format check stays here, because it applies to whatever name is
+-- given regardless of engine. Body based on 017, the latest definition.
+CREATE OR REPLACE FUNCTION api.validate_endpoint_model_name()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.spec).model.name IS NOT NULL AND trim((NEW.spec).model.name) <> ''
+       AND NOT (NEW.spec).model.name ~ '^[A-Za-z0-9]+(?:[._\-A-Za-z0-9]*[A-Za-z0-9])?(?:/[A-Za-z0-9]+(?:[._\-A-Za-z0-9]*[A-Za-z0-9])?)*$' THEN
+        RAISE sqlstate 'PGRST'
+            USING message = '{"code": "10105","message": "Invalid model name format","hint": "Use alphanumeric, dots, underscores, hyphens, and optional slash-separated segments"}',
+            detail = '{"status": 400, "headers": {"X-Powered-By": "Neutree"}}';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Version carried no format rule, only the presence check, so the whole trigger goes.
+DROP TRIGGER IF EXISTS validate_endpoint_model_version_on_endpoints ON api.endpoints;
+DROP FUNCTION IF EXISTS api.validate_endpoint_model_version();

--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -237,30 +237,46 @@ func endpointPatchMayAffectModelSourceValidation(endpoint *v1.Endpoint) bool {
 	return endpoint.Spec.Model != nil || endpoint.Spec.Engine != nil
 }
 
-// validateEndpointModelSource decides whether an endpoint has to name a model
-// registry, and checks the one it names is real.
+// validateEndpointModelSource decides which parts of spec.model an endpoint has
+// to fill in, and checks that the registry it names is real.
 //
-// A registry is required exactly when Neutree downloads the model itself, which
-// v1.IsBuiltInModelDownloaderEngine answers and the orchestrator keys its
-// download step off as well -- keep the two on the same predicate, or validation
-// and deployment will disagree about which endpoints need a registry.
+// Registry, model name and version are required exactly when Neutree downloads
+// the model itself, which v1.IsBuiltInModelDownloaderEngine answers and the
+// orchestrator keys its download step off as well -- keep the two on the same
+// predicate, or validation and deployment will disagree about which endpoints
+// need a model at all. An engine that brings its own model has none of these to
+// give, and the database no longer demands them.
 //
 // A registry that *is* named is resolved against the endpoint's own workspace
 // whichever engine is in play: deps.Storage runs as the service role and does
 // not apply RLS, so a spec naming another workspace's registry would otherwise
-// be honoured.
+// be honoured. The name *format*, when a name is given, stays a database
+// concern -- it does not depend on the engine.
 func validateEndpointModelSource(store storage.Storage, endpoint *v1.Endpoint) *validationError {
 	if endpoint == nil || endpoint.Spec == nil || endpoint.Spec.Model == nil {
 		return nil
 	}
 
-	if endpoint.Spec.Model.Registry == "" {
-		if endpointDownloadsModel(endpoint) {
-			return endpointModelSourceError(fmt.Sprintf(
-				"spec.model.registry is required for engine %s, which downloads its own model",
-				endpoint.Spec.Engine.Engine))
-		}
+	model := endpoint.Spec.Model
 
+	if endpointDownloadsModel(endpoint) {
+		for _, required := range []struct {
+			field string
+			value string
+		}{
+			{"spec.model.registry", model.Registry},
+			{"spec.model.name", model.Name},
+			{"spec.model.version", model.Version},
+		} {
+			if required.value == "" {
+				return endpointModelSourceError(fmt.Sprintf(
+					"%s is required for engine %s, which downloads its own model",
+					required.field, endpoint.Spec.Engine.Engine))
+			}
+		}
+	}
+
+	if model.Registry == "" {
 		return nil
 	}
 

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -2305,29 +2305,41 @@ func TestValidateEndpointModelSource(t *testing.T) {
 		}
 	})
 
-	t.Run("requires a registry for an engine Neutree downloads for", func(t *testing.T) {
-		for _, engine := range []string{v1.EngineNameVLLM, v1.EngineNameLlamaCpp, v1.EngineNameSGLang} {
-			store := &fakeModelRegistryStorage{registries: visible}
+	t.Run("requires registry, name and version for an engine Neutree downloads for", func(t *testing.T) {
+		for _, tc := range []struct {
+			missing string
+			model   *v1.ModelSpec
+		}{
+			{"spec.model.registry", &v1.ModelSpec{Name: "qwen3", Version: "latest"}},
+			{"spec.model.name", &v1.ModelSpec{Registry: "hf", Version: "latest"}},
+			{"spec.model.version", &v1.ModelSpec{Registry: "hf", Name: "qwen3"}},
+		} {
+			for _, engine := range []string{v1.EngineNameVLLM, v1.EngineNameLlamaCpp, v1.EngineNameSGLang} {
+				store := &fakeModelRegistryStorage{registries: visible}
 
-			err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a",
-				&v1.ModelSpec{Name: "qwen3", Version: "latest"}, engine))
+				err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a", tc.model, engine))
 
-			if assert.NotNilf(t, err, "engine %s", engine) {
-				assert.Equal(t, "10229", err.Code)
-				assert.Contains(t, err.Hint, "spec.model.registry is required")
+				if assert.NotNilf(t, err, "engine %s missing %s", engine, tc.missing) {
+					assert.Equal(t, "10229", err.Code)
+					assert.Contains(t, err.Hint, tc.missing+" is required")
+				}
 			}
 		}
 	})
 
-	t.Run("accepts no registry for an engine that ships its own model", func(t *testing.T) {
-		// The Flex case: nothing for Neutree to fetch, so nothing to name. The
-		// store is never consulted.
+	t.Run("accepts an empty model spec for an engine that ships its own model", func(t *testing.T) {
+		// The Flex case: Neutree fetches nothing, so there is no registry, name
+		// or version to give. The store is never consulted.
 		store := &fakeModelRegistryStorage{}
 
-		err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a",
-			&v1.ModelSpec{Name: "packaged-ocr"}, "flex"))
+		for _, model := range []*v1.ModelSpec{
+			{},
+			{Name: "packaged-ocr"},
+			{Name: "packaged-ocr", Version: "v2"},
+		} {
+			assert.Nil(t, validateEndpointModelSource(store, modelSourceEndpoint("ws-a", model, "flex")))
+		}
 
-		assert.Nil(t, err)
 		assert.Empty(t, store.options)
 	})
 


### PR DESCRIPTION
## Issue

NEU-633 — the remaining half of #574.

## Summary

#574 moved the `spec.model.registry` requirement out of the database because whether an endpoint needs one depends on the engine, which a trigger cannot read. Model name and version are the same case and were left behind, so a Flex endpoint — whose model is baked into its image — still had to invent both.

Migration `091` finishes the move. The requirement is now stated once, next to the registry check and on the same predicate the orchestrator keys its download step off: **registry, name and version are required exactly when Neutree downloads the model itself.**

## Changes

- `091_endpoint_model_name_version_optional` redefines `validate_endpoint_model_name` to drop the presence check and drops the `validate_endpoint_model_version` trigger outright.
- `endpoint_validation.go` takes over both, alongside the registry check added by #574.

The name **format** check stays in the database. It applies to whatever name is given regardless of engine, so it does not belong with the engine-dependent rules — and keeping it there avoids duplicating the regex. The version trigger carried no format rule, only the presence check, so nothing is left to keep.

`validate_endpoint_model_name` is redefined from `017`'s body, the latest definition, per the migration rules.

## Test Plan

- [x] E2E (if affected): not affected
- [x] DB integration (`make db-test`): pass — full suite green with migrations `001..091` applied to a fresh database. `TestEndpointModelNameAndVersionOptional` covers the migration on three axes: an endpoint with no model name or version inserts; a malformed name is still refused with `10105`; a well-formed name is accepted.

`go test ./...` green, `make lint` clean.

Validation is covered on both sides of the predicate: each of the three fields is demanded individually from vLLM / llama-cpp / SGLang, and a Flex endpoint is accepted with an empty model spec, with a name only, and with a name and version.

## Risk & Rollback

`091_endpoint_model_name_version_optional.down.sql` restores both triggers with the bodies they had. The same caveat as #574 applies and is worth repeating: the restored triggers fire on UPDATE as well as INSERT, so endpoints created without a model name or version while they were absent could no longer be updated. Rolling back means rolling back those endpoints too.

Existing endpoints all carry a name and version and validate exactly as before. One behaviour change for existing clients: a downloader-engine endpoint missing any of the three fields is now refused by the API with `10229` rather than by the database with `10007` / `10008`, so the error code and message differ while the outcome does not.

## Unblocks

ui#385 — the console can now stop asking for these fields on a Flex endpoint.