### PR TITLE
fix(model-registry): read the shape of composite and current checkpoints

### DIFF
--- a/internal/model_registry/modelmeta/modelmeta.go
+++ b/internal/model_registry/modelmeta/modelmeta.go
@@ -46,6 +46,11 @@ var configFields = allFields[:len(allFields)-1]
 // hfConfig is the subset of config.json this package reads. Every scalar is a
 // pointer so that a key present with value 0 is distinguishable from an absent
 // key — the difference between "the checkpoint says zero" and "we don't know".
+//
+// One value of it describes one model, which for a composite checkpoint means
+// the merge of the section describing the language model with the levels above
+// it — see decodeConfig. The rest of the package therefore reads a single flat
+// config and never has to know which layout it came from.
 type hfConfig struct {
 	Architectures         []string            `json:"architectures"`
 	NumHiddenLayers       *int                `json:"num_hidden_layers"`
@@ -55,10 +60,24 @@ type hfConfig struct {
 	HiddenSize            *int                `json:"hidden_size"`
 	MaxPositionEmbeddings *int                `json:"max_position_embeddings"`
 	TorchDtype            string              `json:"torch_dtype"`
+	Dtype                 string              `json:"dtype"`
 	NumLocalExperts       *int                `json:"num_local_experts"`
 	NumExperts            *int                `json:"num_experts"`
 	NumExpertsPerTok      *int                `json:"num_experts_per_tok"`
 	QuantizationConfig    *quantizationConfig `json:"quantization_config"`
+}
+
+// dtype reports the weight dtype the config states. transformers renamed the key
+// from torch_dtype to dtype in 4.56 and writes only the new spelling now, so a
+// parser that reads one of the two reports the precision of old checkpoints and
+// nothing about current ones. Both are read, the older spelling first, because
+// where a config carries both it is the one transformers itself still honours.
+func (c *hfConfig) dtype() string {
+	if c.TorchDtype != "" {
+		return c.TorchDtype
+	}
+
+	return c.Dtype
 }
 
 // quantizationConfig covers the shapes transformers writes for the quantizers
@@ -141,17 +160,124 @@ func ParseConfig(raw []byte) *v1.ModelInfo {
 	return info
 }
 
+// nestedConfigKeys names, in order, the keys a composite config.json puts the
+// language model's own config under. A multimodal or speech checkpoint is a
+// wrapper: architectures stays at the top while layers, heads and experts move a
+// level down, so reading only the top level reports a model whose name is known
+// and whose every shape parameter is not.
+//
+// This is a list of keys rather than of architectures on purpose. The file
+// states its own layout, and switching on the architecture string would be the
+// guessing this package refuses to do everywhere else — a new
+// "…ForConditionalGeneration" lands every few weeks, and each one would be
+// unreadable until someone added it here.
+var nestedConfigKeys = []string{"text_config", "thinker_config", "llm_config"}
+
+// maxNestedConfigDepth bounds the descent. Qwen3-Omni nests two deep
+// (thinker_config → text_config), which is the deepest layout in the wild; the
+// limit is what stops a hand-written or hostile config from recursing without
+// end.
+const maxNestedConfigDepth = 3
+
 func decodeConfig(raw []byte) *hfConfig {
 	if len(raw) == 0 {
 		return nil
 	}
 
-	var cfg hfConfig
-	if err := json.Unmarshal(raw, &cfg); err != nil {
+	var outer hfConfig
+	if err := json.Unmarshal(raw, &outer); err != nil {
 		return nil
 	}
 
-	return &cfg
+	merged := decodeNestedConfig(raw, 0)
+	if merged == nil {
+		return &outer
+	}
+
+	merged.fillFrom(&outer)
+
+	// The wrapper names the model that is actually served —
+	// Qwen3_5MoeForConditionalGeneration, not the plain causal-LM the text
+	// section names — and that is the name a reader is looking for. It is the one
+	// field the outer level wins outright.
+	if len(outer.Architectures) > 0 {
+		merged.Architectures = outer.Architectures
+	}
+
+	return merged
+}
+
+// decodeNestedConfig returns the language model's own config out of a composite
+// config.json, or nil when the file is flat and the top level is all there is.
+func decodeNestedConfig(raw []byte, depth int) *hfConfig {
+	if depth >= maxNestedConfigDepth {
+		return nil
+	}
+
+	var sections map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &sections); err != nil {
+		return nil
+	}
+
+	for _, key := range nestedConfigKeys {
+		section, ok := sections[key]
+		if !ok {
+			continue
+		}
+
+		var cfg hfConfig
+		if err := json.Unmarshal(section, &cfg); err != nil {
+			continue
+		}
+
+		if deeper := decodeNestedConfig(section, depth+1); deeper != nil {
+			deeper.fillFrom(&cfg)
+			cfg = *deeper
+		}
+
+		return &cfg
+	}
+
+	return nil
+}
+
+// fillFrom takes from the level above everything this config does not state
+// itself.
+//
+// The nested config wins wherever both state a key. A wrapper's own shape keys
+// describe the composite and can just as well belong to the vision tower, while
+// the section this was decoded from is unambiguously the language model — so it
+// is the authority on the language model's shape, and the outer level only fills
+// the gaps it leaves, as Qwen3-Omni's top-level dtype does.
+func (c *hfConfig) fillFrom(outer *hfConfig) {
+	fillPointer(&c.NumHiddenLayers, outer.NumHiddenLayers)
+	fillPointer(&c.NumAttentionHeads, outer.NumAttentionHeads)
+	fillPointer(&c.NumKeyValueHeads, outer.NumKeyValueHeads)
+	fillPointer(&c.HeadDim, outer.HeadDim)
+	fillPointer(&c.HiddenSize, outer.HiddenSize)
+	fillPointer(&c.MaxPositionEmbeddings, outer.MaxPositionEmbeddings)
+	fillPointer(&c.NumLocalExperts, outer.NumLocalExperts)
+	fillPointer(&c.NumExperts, outer.NumExperts)
+	fillPointer(&c.NumExpertsPerTok, outer.NumExpertsPerTok)
+	fillPointer(&c.QuantizationConfig, outer.QuantizationConfig)
+
+	if c.TorchDtype == "" {
+		c.TorchDtype = outer.TorchDtype
+	}
+
+	if c.Dtype == "" {
+		c.Dtype = outer.Dtype
+	}
+
+	if len(c.Architectures) == 0 {
+		c.Architectures = outer.Architectures
+	}
+}
+
+func fillPointer[T any](dst **T, src *T) {
+	if *dst == nil {
+		*dst = src
+	}
 }
 
 func applyConfig(info *v1.ModelInfo, cfg *hfConfig) {
@@ -185,8 +311,8 @@ func applyConfig(info *v1.ModelInfo, cfg *hfConfig) {
 
 	recordAuto(info, v1.ModelInfoFieldContextLength, cfg.MaxPositionEmbeddings != nil)
 
-	info.ParameterDtype = cfg.TorchDtype
-	recordAuto(info, v1.ModelInfoFieldParameterDtype, cfg.TorchDtype != "")
+	info.ParameterDtype = cfg.dtype()
+	recordAuto(info, v1.ModelInfoFieldParameterDtype, info.ParameterDtype != "")
 
 	applyExperts(info, cfg)
 	applyQuantization(info, cfg)

--- a/internal/model_registry/modelmeta/modelmeta_test.go
+++ b/internal/model_registry/modelmeta/modelmeta_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -251,6 +252,96 @@ func TestParse_NeverInfersFromNames(t *testing.T) {
 	}
 }
 
+// A composite config carries shape keys at more than one level. The section the
+// language model is described in is the one that has to win: a wrapper's own
+// keys can belong to the vision tower, and reading a head count off the wrong
+// tower produces a number that looks measured and is wrong.
+func TestParseConfig_CompositeConfigPrefersTheLanguageModelSection(t *testing.T) {
+	const config = `{
+		"architectures": ["Qwen3_5MoeForConditionalGeneration"],
+		"num_hidden_layers": 99,
+		"torch_dtype": "float32",
+		"text_config": {
+			"num_hidden_layers": 40,
+			"num_attention_heads": 16,
+			"head_dim": 256,
+			"max_position_embeddings": 262144,
+			"num_experts": 256
+		},
+		"vision_config": {"num_hidden_layers": 27, "hidden_size": 1152, "torch_dtype": "float16"}
+	}`
+
+	info := ParseConfig([]byte(config))
+
+	// From the text section, not from the wrapper's stray key.
+	assert.Equal(t, 40, *info.NumHiddenLayers)
+	// The wrapper names the model that is served, so the architecture stays its.
+	assert.Equal(t, "Qwen3_5MoeForConditionalGeneration", info.Architecture)
+	// Stated only by the wrapper: the outer level fills the gaps, it just does
+	// not overrule.
+	assert.Equal(t, "float32", info.ParameterDtype)
+	// vision_config is not a section the parser descends into at all.
+	assert.NotEqual(t, 1152, deref(info.HeadDim))
+	assert.Equal(t, 256, *info.HeadDim)
+	assert.True(t, *info.IsMoE)
+	assert.Equal(t, 256, *info.NumExperts)
+}
+
+// transformers renamed torch_dtype to dtype in 4.56, so both spellings are in
+// the wild and a checkpoint saved by a current release states only the new one.
+func TestParseConfig_ReadsBothDtypeSpellings(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{name: "torch_dtype", config: `{"torch_dtype":"bfloat16"}`, want: "bfloat16"},
+		{name: "dtype", config: `{"dtype":"bfloat16"}`, want: "bfloat16"},
+		{name: "both", config: `{"torch_dtype":"float16","dtype":"bfloat16"}`, want: "float16"},
+		{name: "neither", config: `{"num_hidden_layers":1}`, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := ParseConfig([]byte(tt.config))
+
+			assert.Equal(t, tt.want, info.ParameterDtype)
+
+			if tt.want == "" {
+				assert.Contains(t, info.MissingFields, v1.ModelInfoFieldParameterDtype)
+
+				return
+			}
+
+			assert.Equal(t, v1.ModelInfoSourceAuto, info.FieldSources[v1.ModelInfoFieldParameterDtype])
+		})
+	}
+}
+
+// Nesting is bounded, and a config that nests past the bound still parses into
+// whatever the levels above it stated rather than hanging or panicking.
+func TestParseConfig_NestingIsBounded(t *testing.T) {
+	config := `{"architectures":["Deep"],"num_hidden_layers":1`
+	for range 8 {
+		config += `,"text_config":{"num_hidden_layers":2`
+	}
+
+	config += strings.Repeat("}", 8) + "}"
+
+	info := ParseConfig([]byte(config))
+
+	assert.Equal(t, "Deep", info.Architecture)
+	assert.NotNil(t, info.NumHiddenLayers)
+}
+
+func deref(v *int) int {
+	if v == nil {
+		return 0
+	}
+
+	return *v
+}
+
 // backingKeys names the config.json keys a field may legitimately be read from.
 // A nil entry means the field does not come from a config key: is_moe is settled
 // by the config being readable at all, and parameter_count comes from the weight
@@ -263,7 +354,7 @@ var backingKeys = map[string][]string{
 	v1.ModelInfoFieldHeadDim:               {"head_dim", "hidden_size"},
 	v1.ModelInfoFieldMaxPositionEmbeddings: {"max_position_embeddings"},
 	v1.ModelInfoFieldContextLength:         {"max_position_embeddings"},
-	v1.ModelInfoFieldParameterDtype:        {"torch_dtype"},
+	v1.ModelInfoFieldParameterDtype:        {"torch_dtype", "dtype"},
 	v1.ModelInfoFieldNumExperts:            {"num_local_experts", "num_experts"},
 	v1.ModelInfoFieldNumExpertsPerToken:    {"num_experts_per_tok"},
 	v1.ModelInfoFieldQuantizationBits:      {"quantization_config"},
@@ -311,9 +402,21 @@ func TestParse_FixturesOnlyPopulateWhatTheConfigStates(t *testing.T) {
 	}
 }
 
+// A composite checkpoint states the language model's shape one level down, so
+// the search follows the same nesting the parser does. Only the sections the
+// parser descends into count: a value that could only have come from
+// vision_config is a value read off the wrong tower, and this has to keep
+// catching that.
 func statesAnyKey(stated map[string]any, keys []string) bool {
 	for _, key := range keys {
 		if _, ok := stated[key]; ok {
+			return true
+		}
+	}
+
+	for _, section := range nestedConfigKeys {
+		nested, ok := stated[section].(map[string]any)
+		if ok && statesAnyKey(nested, keys) {
 			return true
 		}
 	}

--- a/internal/model_registry/modelmeta/testdata/dtype-alias/config.json
+++ b/internal/model_registry/modelmeta/testdata/dtype-alias/config.json
@@ -1,0 +1,9 @@
+{
+  "architectures": ["LlamaForCausalLM"],
+  "dtype": "bfloat16",
+  "hidden_size": 4096,
+  "max_position_embeddings": 131072,
+  "num_attention_heads": 32,
+  "num_hidden_layers": 32,
+  "num_key_value_heads": 8
+}

--- a/internal/model_registry/modelmeta/testdata/dtype-alias/expected.json
+++ b/internal/model_registry/modelmeta/testdata/dtype-alias/expected.json
@@ -1,0 +1,25 @@
+{
+  "context_length": "131072",
+  "architecture": "LlamaForCausalLM",
+  "num_hidden_layers": 32,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 8,
+  "head_dim": 128,
+  "max_position_embeddings": 131072,
+  "is_moe": false,
+  "parameter_dtype": "bfloat16",
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "derived",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/nested-llm-config/config.json
+++ b/internal/model_registry/modelmeta/testdata/nested-llm-config/config.json
@@ -1,0 +1,19 @@
+{
+  "architectures": ["InternVLChatModel"],
+  "hidden_size": 3584,
+  "llm_config": {
+    "architectures": ["Qwen2ForCausalLM"],
+    "hidden_size": 3584,
+    "max_position_embeddings": 32768,
+    "num_attention_heads": 28,
+    "num_hidden_layers": 28,
+    "num_key_value_heads": 4,
+    "torch_dtype": "bfloat16"
+  },
+  "model_type": "internvl_chat",
+  "torch_dtype": "bfloat16",
+  "vision_config": {
+    "hidden_size": 1024,
+    "num_hidden_layers": 24
+  }
+}

--- a/internal/model_registry/modelmeta/testdata/nested-llm-config/expected.json
+++ b/internal/model_registry/modelmeta/testdata/nested-llm-config/expected.json
@@ -1,0 +1,25 @@
+{
+  "context_length": "32768",
+  "architecture": "InternVLChatModel",
+  "num_hidden_layers": 28,
+  "num_attention_heads": 28,
+  "num_key_value_heads": 4,
+  "head_dim": 128,
+  "max_position_embeddings": 32768,
+  "is_moe": false,
+  "parameter_dtype": "bfloat16",
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "derived",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/nested-text-config/config.json
+++ b/internal/model_registry/modelmeta/testdata/nested-text-config/config.json
@@ -1,0 +1,23 @@
+{
+  "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+  "image_token_id": 151655,
+  "model_type": "qwen3_5_moe",
+  "text_config": {
+    "dtype": "bfloat16",
+    "head_dim": 256,
+    "hidden_size": 4096,
+    "max_position_embeddings": 262144,
+    "num_attention_heads": 16,
+    "num_experts": 256,
+    "num_experts_per_tok": 8,
+    "num_hidden_layers": 40,
+    "num_key_value_heads": 2,
+    "vocab_size": 151936
+  },
+  "tie_word_embeddings": false,
+  "vision_config": {
+    "depth": 27,
+    "hidden_size": 1152,
+    "num_heads": 16
+  }
+}

--- a/internal/model_registry/modelmeta/testdata/nested-text-config/expected.json
+++ b/internal/model_registry/modelmeta/testdata/nested-text-config/expected.json
@@ -1,0 +1,29 @@
+{
+  "context_length": "262144",
+  "architecture": "Qwen3_5MoeForConditionalGeneration",
+  "num_hidden_layers": 40,
+  "num_attention_heads": 16,
+  "num_key_value_heads": 2,
+  "head_dim": 256,
+  "max_position_embeddings": 262144,
+  "is_moe": true,
+  "num_experts": 256,
+  "num_experts_per_token": 8,
+  "parameter_dtype": "bfloat16",
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "auto",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_experts": "auto",
+    "num_experts_per_token": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}

--- a/internal/model_registry/modelmeta/testdata/nested-thinker/config.json
+++ b/internal/model_registry/modelmeta/testdata/nested-thinker/config.json
@@ -1,0 +1,28 @@
+{
+  "architectures": ["Qwen3OmniMoeForConditionalGeneration"],
+  "dtype": "bfloat16",
+  "model_type": "qwen3_omni_moe",
+  "talker_config": {
+    "model_type": "qwen3_omni_moe_talker"
+  },
+  "thinker_config": {
+    "audio_config": {
+      "d_model": 1280,
+      "encoder_layers": 32
+    },
+    "text_config": {
+      "head_dim": 128,
+      "hidden_size": 2048,
+      "max_position_embeddings": 65536,
+      "num_attention_heads": 32,
+      "num_experts": 128,
+      "num_experts_per_tok": 8,
+      "num_hidden_layers": 48,
+      "num_key_value_heads": 4
+    },
+    "vision_config": {
+      "depth": 27,
+      "hidden_size": 1152
+    }
+  }
+}

--- a/internal/model_registry/modelmeta/testdata/nested-thinker/expected.json
+++ b/internal/model_registry/modelmeta/testdata/nested-thinker/expected.json
@@ -1,0 +1,29 @@
+{
+  "context_length": "65536",
+  "architecture": "Qwen3OmniMoeForConditionalGeneration",
+  "num_hidden_layers": 48,
+  "num_attention_heads": 32,
+  "num_key_value_heads": 4,
+  "head_dim": 128,
+  "max_position_embeddings": 65536,
+  "is_moe": true,
+  "num_experts": 128,
+  "num_experts_per_token": 8,
+  "parameter_dtype": "bfloat16",
+  "field_sources": {
+    "architecture": "auto",
+    "context_length": "auto",
+    "head_dim": "auto",
+    "is_moe": "auto",
+    "max_position_embeddings": "auto",
+    "num_attention_heads": "auto",
+    "num_experts": "auto",
+    "num_experts_per_token": "auto",
+    "num_hidden_layers": "auto",
+    "num_key_value_heads": "auto",
+    "parameter_dtype": "auto"
+  },
+  "missing_fields": [
+    "parameter_count"
+  ]
+}


### PR DESCRIPTION
A multimodal or speech checkpoint states its language model's shape one level down — `text_config`, `thinker_config` or `llm_config` — while only `architectures` stays at the top. The parser read the top level alone, so `Qwen3.5-35B-A3B` reported its architecture and parameter count and reported every layer, head and expert count as unknown, plus a flat `is_moe: false` for a checkpoint whose experts it had simply not looked at.

`decodeConfig` now descends into the nested section and merges it with the levels above into one flat config, so the rest of the package reads a single shape and never has to know which layout it came from.

Sections are found by key, not by architecture. The file states its own layout, and a list of architecture names would be stale the week after it was written — a new `…ForConditionalGeneration` lands every few weeks, and each one would be unreadable until someone added it. Adding a layout is adding a string to `nestedConfigKeys`.

The merge:

- shape parameters — the nested section wins. A wrapper's own `hidden_size` can just as well belong to the vision tower, while the text/llm section is unambiguously the language model. The outer level only fills the gaps it leaves, as Qwen3-Omni's top-level `dtype` does.
- `architectures` — the outer level wins. It names the model that is actually served (`Qwen3_5MoeForConditionalGeneration`), which is the name a reader is looking for, not the plain causal-LM the text section names.

Also reads `dtype` beside `torch_dtype`. transformers renamed that key in 4.56 and writes only the new spelling, which left the precision unknown on any recently saved checkpoint, composite or not.

## Tests

Four golden fixtures taken from the real config layouts — Qwen3.5 (`text_config`), Qwen3-Omni (`thinker_config` → `text_config`, two levels), InternVL (`llm_config`), and a flat config using `dtype` — plus cases pinning that the nested section wins over the wrapper, that `vision_config` is never descended into, both `dtype` spellings, and the depth bound.

The nine existing goldens are unchanged, byte for byte.

`statesAnyKey` in the fixture sweep follows the same nesting the parser does, so it still fails a field populated from a section the parser has no business reading.