### PR TITLE
feat(api): list the tags a repository holds in an image registry (NEU-634)

### DIFF
--- a/cmd/neutree-api/app/builder.go
+++ b/cmd/neutree-api/app/builder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/neutree-ai/neutree/internal/routes/auth"
 	"github.com/neutree-ai/neutree/internal/routes/clusters"
 	"github.com/neutree-ai/neutree/internal/routes/credentials"
+	"github.com/neutree-ai/neutree/internal/routes/images"
 	"github.com/neutree-ai/neutree/internal/routes/logs"
 	"github.com/neutree-ai/neutree/internal/routes/models"
 	"github.com/neutree-ai/neutree/internal/routes/proxies"
@@ -60,6 +61,7 @@ func NewBuilder() *Builder {
 		"rest/user-profiles":        ProxiesRouteFactory(proxies.RegisterUserProfileRoutes),
 		"rest/clusters":             ProxiesRouteFactory(proxies.RegisterClusterRoutes),
 		"clusters":                  ClustersRouteFactory(clusters.RegisterClusterRoutes),
+		"images":                    ImagesRouteFactory(images.RegisterImageRoutes),
 		"rest/static-node-clusters": ProxiesRouteFactory(proxies.RegisterStaticNodeClusterRoutes),
 		"rest/static-nodes":         ProxiesRouteFactory(proxies.RegisterStaticNodeRoutes),
 		"rest/image-registries":     ProxiesRouteFactory(proxies.RegisterImageRegistryRoutes),
@@ -102,6 +104,7 @@ func NewBuilder() *Builder {
 		"rest/user-profiles":        {"auth"},
 		"rest/clusters":             {"auth"},
 		"clusters":                  {"auth"},
+		"images":                    {"auth"},
 		"rest/static-node-clusters": {"auth"},
 		"rest/static-nodes":         {"auth"},
 		"rest/image-registries":     {"auth"},

--- a/cmd/neutree-api/app/factory.go
+++ b/cmd/neutree-api/app/factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/neutree-ai/neutree/internal/routes/auth"
 	"github.com/neutree-ai/neutree/internal/routes/clusters"
 	"github.com/neutree-ai/neutree/internal/routes/credentials"
+	"github.com/neutree-ai/neutree/internal/routes/images"
 	"github.com/neutree-ai/neutree/internal/routes/logs"
 	"github.com/neutree-ai/neutree/internal/routes/models"
 	"github.com/neutree-ai/neutree/internal/routes/proxies"
@@ -112,6 +113,19 @@ func CredentialsRouteFactory(register CredentialsRegisterFunc) RouteFactory {
 }
 
 type ClustersRegisterFunc func(group *gin.RouterGroup, middlewares []gin.HandlerFunc, deps *clusters.Dependencies)
+
+type ImagesRegisterFunc func(group *gin.RouterGroup, middlewares []gin.HandlerFunc, deps *images.Dependencies)
+
+func ImagesRouteFactory(register ImagesRegisterFunc) RouteFactory {
+	return func(deps *RouteOptions) error {
+		register(deps.Group, deps.Middlewares, &images.Dependencies{
+			Storage:      deps.Config.Storage,
+			ImageService: registry.NewImageService(),
+		})
+
+		return nil
+	}
+}
 
 func ClustersRouteFactory(register ClustersRegisterFunc) RouteFactory {
 	return func(deps *RouteOptions) error {

--- a/internal/routes/images/image_tags.go
+++ b/internal/routes/images/image_tags.go
@@ -1,0 +1,100 @@
+package images
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/go-containerregistry/pkg/authn"
+
+	"github.com/neutree-ai/neutree/internal/util"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// ImageTagsResponse lists the tags one repository holds in an image registry.
+type ImageTagsResponse struct {
+	// Repository echoed as the caller named it, so a client rendering several
+	// answers can tell them apart without tracking its own requests.
+	Repository string   `json:"repository"`
+	Tags       []string `json:"tags"`
+}
+
+// getImageTags handles
+// GET /workspaces/:workspace/image_registries/:registry/repositories/:repository/tags.
+//
+// It answers "which tags does this repository have?", not "which repositories
+// does this registry have?". Enumerating repositories needs the registry's
+// catalog endpoint, which Docker Hub does not implement at all and which
+// self-hosted registries commonly restrict to a wider scope than pulling -- a
+// pull-scoped credential, the only kind a working deployment is guaranteed to
+// hold, is refused there. Tags come back with the same scope pulls use, so this
+// answer is available wherever deploying already works.
+//
+// The repository is named relative to the registry's own repository prefix.
+func getImageTags(deps *Dependencies) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		workspace := c.Param("workspace")
+		imageRegistryName := c.Param("registry")
+
+		repository := strings.Trim(strings.TrimSpace(c.Param("repository")), "/")
+		if repository == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "repository is required"})
+			return
+		}
+
+		imageRegistries, err := deps.Storage.ListImageRegistry(storage.ListOption{
+			Filters: []storage.Filter{
+				{Column: "metadata->name", Operator: "eq", Value: fmt.Sprintf(`"%s"`, imageRegistryName)},
+				{Column: "metadata->workspace", Operator: "eq", Value: fmt.Sprintf(`"%s"`, workspace)},
+			},
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get image registry: %v", err)})
+			return
+		}
+
+		if len(imageRegistries) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("image registry %s/%s not found", workspace, imageRegistryName)})
+			return
+		}
+
+		imageRegistry := &imageRegistries[0]
+
+		imagePrefix, err := util.GetImagePrefix(imageRegistry)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get image prefix: %v", err)})
+			return
+		}
+
+		username, password, err := util.GetImageRegistryAuthInfo(imageRegistry)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get auth info: %v", err)})
+			return
+		}
+
+		var auth authn.Authenticator = authn.Anonymous
+		if username != "" || password != "" {
+			auth = authn.FromConfig(authn.AuthConfig{Username: username, Password: password})
+		}
+
+		tags, err := deps.ImageService.ListImageTags(
+			imagePrefix+"/"+repository,
+			auth,
+			util.IsHTTPRegistryURL(imageRegistry.Spec.URL),
+		)
+		if err != nil {
+			// The registry refusing or not knowing the repository is an answer
+			// about the request, not a fault in the control plane: a caller
+			// offering these as suggestions has to be able to fall back to free
+			// text rather than show a server error.
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error": fmt.Sprintf("failed to list tags for %s: %v", repository, err),
+			})
+
+			return
+		}
+
+		c.JSON(http.StatusOK, ImageTagsResponse{Repository: repository, Tags: tags})
+	}
+}

--- a/internal/routes/images/image_tags_test.go
+++ b/internal/routes/images/image_tags_test.go
@@ -1,0 +1,142 @@
+package images
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	registryMocks "github.com/neutree-ai/neutree/internal/registry/mocks"
+	storageMocks "github.com/neutree-ai/neutree/pkg/storage/mocks"
+)
+
+// createTestContextWithParams drives a handler the way the router does: the
+// workspace, registry and repository come from the path, not the query.
+func createTestContextWithParams(params map[string]string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	for k, v := range params {
+		c.Params = append(c.Params, gin.Param{Key: k, Value: v})
+	}
+
+	return c, w
+}
+
+func imageTagsDeps(t *testing.T, url string) (*Dependencies, *registryMocks.MockImageService) {
+	t.Helper()
+
+	store := storageMocks.NewMockStorage(t)
+	imageService := registryMocks.NewMockImageService(t)
+	store.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{{
+		Spec: &v1.ImageRegistrySpec{URL: url, Repository: "neutree-ai"},
+	}}, nil)
+
+	return &Dependencies{Storage: store, ImageService: imageService}, imageService
+}
+
+func TestGetImageTags(t *testing.T) {
+	t.Run("asks the registry for the repository under its own prefix", func(t *testing.T) {
+		deps, imageService := imageTagsDeps(t, "https://registry.example.com")
+		imageService.
+			On("ListImageTags", "registry.example.com/neutree-ai/my-workload", mock.Anything, false).
+			Return([]string{"v1", "v2"}, nil)
+
+		ctx, recorder := createTestContextWithParams(map[string]string{
+			"workspace":  "default",
+			"registry":   "registry",
+			"repository": "my-workload",
+		})
+		getImageTags(deps)(ctx)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		var body ImageTagsResponse
+		assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+		assert.Equal(t, "my-workload", body.Repository)
+		assert.Equal(t, []string{"v1", "v2"}, body.Tags)
+		imageService.AssertExpectations(t)
+	})
+
+	t.Run("carries the registry's scheme through, as pulls do", func(t *testing.T) {
+		deps, imageService := imageTagsDeps(t, "http://registry.example.com:5000")
+		imageService.
+			On("ListImageTags", "registry.example.com:5000/neutree-ai/x", mock.Anything, true).
+			Return([]string{"v1"}, nil)
+
+		ctx, recorder := createTestContextWithParams(map[string]string{
+			"workspace": "default", "registry": "registry", "repository": "x",
+		})
+		getImageTags(deps)(ctx)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		imageService.AssertExpectations(t)
+	})
+
+	t.Run("tolerates a repository written with slashes around it", func(t *testing.T) {
+		deps, imageService := imageTagsDeps(t, "https://registry.example.com")
+		imageService.
+			On("ListImageTags", "registry.example.com/neutree-ai/team/x", mock.Anything, false).
+			Return([]string{"v1"}, nil)
+
+		ctx, recorder := createTestContextWithParams(map[string]string{
+			"workspace": "default", "registry": "registry", "repository": " /team/x/ ",
+		})
+		getImageTags(deps)(ctx)
+
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		imageService.AssertExpectations(t)
+	})
+
+	t.Run("reports a refusing registry as an upstream answer, not a server fault", func(t *testing.T) {
+		// A caller offering these as suggestions has to be able to fall back to
+		// free text, which it cannot decide on a 500.
+		deps, imageService := imageTagsDeps(t, "https://registry.example.com")
+		imageService.
+			On("ListImageTags", mock.Anything, mock.Anything, mock.Anything).
+			Return([]string(nil), errors.New("UNAUTHORIZED"))
+
+		ctx, recorder := createTestContextWithParams(map[string]string{
+			"workspace": "default", "registry": "registry", "repository": "x",
+		})
+		getImageTags(deps)(ctx)
+
+		assert.Equal(t, http.StatusBadGateway, recorder.Code)
+	})
+
+	t.Run("rejects a repository that is only separators", func(t *testing.T) {
+		// Workspace and registry come from the path, so the router will not
+		// route a request that lacks them. A repository that trims away to
+		// nothing would otherwise be asked for as the registry prefix itself.
+		for _, repository := range []string{"", " ", "/", " // "} {
+			ctx, recorder := createTestContextWithParams(map[string]string{
+				"workspace": "default", "registry": "registry", "repository": repository,
+			})
+			getImageTags(&Dependencies{})(ctx)
+
+			assert.Equalf(t, http.StatusBadRequest, recorder.Code, "repository %q", repository)
+		}
+	})
+
+	t.Run("reports an unknown registry as not found", func(t *testing.T) {
+		store := storageMocks.NewMockStorage(t)
+		store.On("ListImageRegistry", mock.Anything).Return([]v1.ImageRegistry{}, nil)
+
+		ctx, recorder := createTestContextWithParams(map[string]string{
+			"workspace": "default", "registry": "absent", "repository": "x",
+		})
+		getImageTags(&Dependencies{Storage: store})(ctx)
+
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+	})
+}

--- a/internal/routes/images/images.go
+++ b/internal/routes/images/images.go
@@ -1,0 +1,32 @@
+// Package images serves what an image registry holds, as the models package
+// serves what a model registry holds. The registry records themselves are CRUD
+// through the PostgREST proxy; these are the reads that have to talk to the
+// registry itself.
+package images
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/neutree-ai/neutree/internal/registry"
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+type Dependencies struct {
+	Storage      storage.Storage
+	ImageService registry.ImageService
+}
+
+// RegisterImageRoutes registers the image registry content routes.
+//
+// Shaped like the model registry's: workspace and registry in the path, because
+// what a registry holds is only meaningful within the workspace that can see it.
+// A repository name containing a slash is percent-encoded by the caller, which
+// the router preserves — the same thing model names rely on (see
+// routes.ConfigureEngine).
+func RegisterImageRoutes(group *gin.RouterGroup, middlewares []gin.HandlerFunc, deps *Dependencies) {
+	workspaces := group.Group("/workspaces/:workspace")
+	workspaces.Use(middlewares...)
+
+	registries := workspaces.Group("/image_registries/:registry")
+	registries.GET("/repositories/:repository/tags", getImageTags(deps))
+}


### PR DESCRIPTION
## Issue

NEU-634 — the read the console needs to offer workload image tags. UI is a separate PR.

## Summary

The workload image for a Flex endpoint is typed in by hand, so a wrong tag is only discovered when the pod cannot pull. This adds the read the console needs:

```
GET /workspaces/:workspace/image_registries/:registry/repositories/:repository/tags
```

## Tags, not repositories

Enumerating repositories needs the registry's catalog endpoint, and that is where this stops being universally answerable:

- Docker Hub does not implement `/v2/_catalog` at all;
- self-hosted registries commonly gate it behind a wider scope than pulling. Probed against `registry.smtx.io`, a pull-capable setup: `GET /v2/_catalog` answers `UNAUTHORIZED: unauthorized to list catalog`;
- a project can hold thousands of repositories, and `/v2/_catalog` offers only an `n`/`last` cursor — no search.

Tags come back with the same scope pulls use, so this answer is available wherever deploying already works. A repository picker would need the caller to hold catalog-scoped credentials, which nothing else in the product requires.

## Changes

Its own route group, shaped like the model registry's content routes: workspace and registry in the path, because what a registry holds is only meaningful within the workspace that can see it. It sits beside `routes/models` for the same reason that package exists — the registry records themselves are CRUD through the PostgREST proxy, while this is a read that has to talk to the registry. A repository name containing a slash is percent-encoded by the caller, which the router already preserves for model names.

Built on the existing `ImageService` and the same registry resolution, prefix and scheme handling the cluster version listing already uses, so a registry reachable for one is reachable for the other. The repository is taken relative to the registry's own `Repository` prefix, and surrounding whitespace and slashes are tolerated.

The route requires auth, as every route that reads a registry's stored credentials does.

A registry that refuses, or does not know the repository, is reported as `502` rather than `500`: a caller offering these as suggestions has to be able to fall back to free text, and it cannot decide that from an internal error.

## Test Plan

- [x] E2E (if affected): not affected
- [x] DB integration (`make db-test`): not affected

`go test ./...` green, `make lint` clean.

Handler tests cover the repository being asked for under the registry's prefix, the registry's scheme carried through as pulls do, a repository written with surrounding slashes, a refusing registry surfacing as `502`, a repository that trims away to nothing, and an unknown registry as `404`.

## Risk & Rollback

Additive: one new read-only route, no schema change, no change to any existing path. Rollback is reverting the commit.

The route reads the registry's stored credentials server-side, as the cluster version listing does — they are `api:"-"` masked and never leave the control plane.

## Next

The console side is deliberately not in this PR. The Flex `image` field is rendered by the generic `VariablesInput`, which is a key/value editor driven by a flat `{type, title, description}` schema and has no concept of a per-field widget — so offering a picker there is a change to a shared component rather than a form tweak, and is worth reviewing on its own.
