### PR TITLE
fix(api): reject an external endpoint name that cannot be a route path (NEU-714)

### DIFF
--- a/api/v1/model_alias_types.go
+++ b/api/v1/model_alias_types.go
@@ -12,7 +12,7 @@ import (
 // maxModelAliasLength bounds the alias in its NFKC-normalized, whitespace-
 // trimmed form -- equivalently its lowercased form, since strings.ToLower maps
 // rune to rune (simple case mapping, no special casing) and so cannot change the
-// count. It is deliberately far above maxModelNameLength: an alias is a display
+// count. It is deliberately far above maxResourceNameLength: an alias is a display
 // name, not a BentoML tag.
 const maxModelAliasLength = 128
 

--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -1,18 +1,8 @@
 package v1
 
-import (
-	"fmt"
-	"regexp"
-	"strings"
-)
-
 const (
 	LatestVersion = "latest"
-
-	maxModelNameLength = 63
 )
-
-var modelNameRegex = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$`)
 
 type ModelVersion struct {
 	Name         string `json:"name"`
@@ -42,26 +32,11 @@ type GeneralModel struct {
 
 // ValidateModelName enforces BentoML v1.4.6 tag name rules without BentoML's
 // implicit lowercasing, so API/CLI input stays consistent with stored names.
+//
+// Those rules happen to coincide with the platform-wide identity name contract,
+// so this delegates to ValidateResourceName rather than restating them. If
+// BentoML's tag rules ever diverge from what a Neutree identity may contain,
+// fork this back into its own regex instead of loosening the shared one.
 func ValidateModelName(name string) error {
-	if name != strings.TrimSpace(name) {
-		return fmt.Errorf("model name must not contain leading or trailing whitespace")
-	}
-
-	if len(name) == 0 {
-		return fmt.Errorf("model name is required")
-	}
-
-	if len(name) > maxModelNameLength {
-		return fmt.Errorf("model name must be at most %d characters", maxModelNameLength)
-	}
-
-	if strings.ToLower(name) != name {
-		return fmt.Errorf("model name must be lowercase")
-	}
-
-	if !modelNameRegex.MatchString(name) {
-		return fmt.Errorf("model name must consist of lowercase alphanumeric characters, '_', '-', or '.', and must start and end with an alphanumeric character")
-	}
-
-	return nil
+	return ValidateResourceName("model", name)
 }

--- a/api/v1/resource_name.go
+++ b/api/v1/resource_name.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 const maxResourceNameLength = 63
@@ -30,7 +31,11 @@ func ValidateResourceName(kind, name string) error {
 		return fmt.Errorf("%s name is required", kind)
 	}
 
-	if len(name) > maxResourceNameLength {
+	// Counted in runes, not bytes: a name of non-ASCII runes is rejected either
+	// way, but it is the character set that is wrong with it, and a byte count
+	// would report a length it does not have. Names that pass are ASCII, where
+	// the two counts agree.
+	if utf8.RuneCountInString(name) > maxResourceNameLength {
 		return fmt.Errorf("%s name must be at most %d characters", kind, maxResourceNameLength)
 	}
 

--- a/api/v1/resource_name.go
+++ b/api/v1/resource_name.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const maxResourceNameLength = 63
+
+// resourceNameRegex is the character set a resource name may use. It is the
+// intersection of what stays intact in a URL path, a Kong route and an ACL
+// group, a Kubernetes identity, and a filesystem path -- every place a
+// metadata.name is pasted into verbatim.
+var resourceNameRegex = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$`)
+
+// ValidateResourceName enforces the naming contract for a metadata.name that
+// becomes part of a resource's identity rather than its presentation. A
+// human-readable name belongs in metadata.display_name, which carries no such
+// restriction.
+//
+// kind names the resource in the error message ("model", "external endpoint")
+// and is expected to be lowercase, so the message reads as a sentence.
+func ValidateResourceName(kind, name string) error {
+	if name != strings.TrimSpace(name) {
+		return fmt.Errorf("%s name must not contain leading or trailing whitespace", kind)
+	}
+
+	if len(name) == 0 {
+		return fmt.Errorf("%s name is required", kind)
+	}
+
+	if len(name) > maxResourceNameLength {
+		return fmt.Errorf("%s name must be at most %d characters", kind, maxResourceNameLength)
+	}
+
+	if strings.ToLower(name) != name {
+		return fmt.Errorf("%s name must be lowercase", kind)
+	}
+
+	if !resourceNameRegex.MatchString(name) {
+		return fmt.Errorf("%s name must consist of lowercase alphanumeric characters, '_', '-', or '.', "+
+			"and must start and end with an alphanumeric character", kind)
+	}
+
+	return nil
+}

--- a/api/v1/resource_name_test.go
+++ b/api/v1/resource_name_test.go
@@ -1,0 +1,69 @@
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateResourceName(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		message string
+	}{
+		{name: "accepts lowercase alphanumeric", input: "endpoint1"},
+		{name: "accepts dots, hyphens and underscores", input: "ext.open_ai-1"},
+		{name: "accepts the maximum length", input: strings.Repeat("a", 63)},
+		{name: "rejects an empty name", input: "", message: "external endpoint name is required"},
+		{
+			name:    "rejects surrounding whitespace before anything else",
+			input:   " endpoint ",
+			message: "external endpoint name must not contain leading or trailing whitespace",
+		},
+		{
+			name:    "rejects a name past the maximum length",
+			input:   strings.Repeat("a", 64),
+			message: "external endpoint name must be at most 63 characters",
+		},
+		{name: "rejects uppercase", input: "Endpoint", message: "external endpoint name must be lowercase"},
+		{
+			name:    "rejects an inner space",
+			input:   "my endpoint",
+			message: "external endpoint name must consist of lowercase alphanumeric characters",
+		},
+		{
+			name:    "rejects a non-ascii rune",
+			input:   "外部端点",
+			message: "external endpoint name must consist of lowercase alphanumeric characters",
+		},
+		{
+			name:    "rejects a trailing hyphen",
+			input:   "endpoint-",
+			message: "external endpoint name must consist of lowercase alphanumeric characters",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateResourceName("external endpoint", tc.input)
+
+			if tc.message == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.message)
+		})
+	}
+}
+
+// The kind is what makes one shared rule readable in every resource's error.
+func TestValidateResourceNameNamesTheKind(t *testing.T) {
+	require.Error(t, ValidateResourceName("model", ""))
+	assert.Equal(t, "model name is required", ValidateResourceName("model", "").Error())
+	assert.Equal(t, "external endpoint name is required", ValidateResourceName("external endpoint", "").Error())
+}

--- a/api/v1/resource_name_test.go
+++ b/api/v1/resource_name_test.go
@@ -40,6 +40,13 @@ func TestValidateResourceName(t *testing.T) {
 			message: "external endpoint name must consist of lowercase alphanumeric characters",
 		},
 		{
+			// 30 runes, 90 bytes. What is wrong with it is the character set, and
+			// a byte-counted length check would report a length it does not have.
+			name:    "faults a long non-ascii name on its characters, not its length",
+			input:   strings.Repeat("外", 30),
+			message: "external endpoint name must consist of lowercase alphanumeric characters",
+		},
+		{
 			name:    "rejects a trailing hyphen",
 			input:   "endpoint-",
 			message: "external endpoint name must consist of lowercase alphanumeric characters",

--- a/api/v1/resource_name_test.go
+++ b/api/v1/resource_name_test.go
@@ -36,14 +36,14 @@ func TestValidateResourceName(t *testing.T) {
 		},
 		{
 			name:    "rejects a non-ascii rune",
-			input:   "外部端点",
+			input:   "ëndpoint",
 			message: "external endpoint name must consist of lowercase alphanumeric characters",
 		},
 		{
 			// 30 runes, 90 bytes. What is wrong with it is the character set, and
 			// a byte-counted length check would report a length it does not have.
 			name:    "faults a long non-ascii name on its characters, not its length",
-			input:   strings.Repeat("外", 30),
+			input:   strings.Repeat("अ", 30),
 			message: "external endpoint name must consist of lowercase alphanumeric characters",
 		},
 		{

--- a/internal/routes/proxies/external_endpoint_proxy.go
+++ b/internal/routes/proxies/external_endpoint_proxy.go
@@ -31,11 +31,12 @@ func RegisterExternalEndpointRoutes(group *gin.RouterGroup, middlewares []gin.Ha
 	proxyGroup.Use(middlewares...)
 
 	handler := CreateStructProxyHandler[v1.ExternalEndpoint](deps, storage.EXTERNAL_ENDPOINT_TABLE)
+	externalEndpointValidation := validateExternalEndpoint()
 
 	// Only register allowed methods
 	proxyGroup.GET("", handler)
-	proxyGroup.POST("", handler)
-	proxyGroup.PATCH("", handler)
+	proxyGroup.POST("", externalEndpointValidation, handler)
+	proxyGroup.PATCH("", externalEndpointValidation, handler)
 
 	// Test connectivity endpoint
 	proxyGroup.POST("/test_connectivity", handleTestConnectivity(deps))

--- a/internal/routes/proxies/external_endpoint_validation.go
+++ b/internal/routes/proxies/external_endpoint_validation.go
@@ -1,0 +1,194 @@
+package proxies
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+const (
+	externalEndpointKind = "external endpoint"
+
+	externalEndpointInvalidPayloadCode = "10231"
+	externalEndpointInvalidNameCode    = "10232"
+)
+
+// validateExternalEndpoint enforces the metadata.name contract at the API
+// boundary.
+//
+// The name is an identity, not a label: getExternalEndpointRoutePath pastes it
+// verbatim into the Kong route path, into the service URL handed back to the
+// user, and into the gateway plugin's route_prefix, and BuildNeutreeACLGroup
+// pastes it into the ACL group. A name carrying a space or a non-ASCII rune is
+// percent-encoded by the client, so it matches no Kong route: the resource is
+// created, reads back fine, advertises a URL, and answers 404 forever. UI
+// validation cannot be the only guard, because the CLI and every other caller
+// reach the same table (NEU-714).
+//
+// A human-readable name belongs in metadata.display_name, which this leaves
+// alone.
+func validateExternalEndpoint() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodPost && c.Request.Method != http.MethodPatch {
+			c.Next()
+
+			return
+		}
+
+		body, err := readAndRestoreBody(c.Request)
+		if err != nil {
+			rejectExternalEndpoint(c, invalidExternalEndpointPayloadError(err.Error()))
+
+			return
+		}
+
+		// An empty body is PostgREST's to reject, and it says so better than a
+		// name check could.
+		if len(bytes.TrimSpace(body)) == 0 {
+			c.Next()
+
+			return
+		}
+
+		payloads, err := decodeResourcePayloads(body)
+		if err != nil {
+			rejectExternalEndpoint(c, invalidExternalEndpointPayloadError(err.Error()))
+
+			return
+		}
+
+		for _, payload := range payloads {
+			if validationErr := validateExternalEndpointName(payload, c.Request.Method); validationErr != nil {
+				rejectExternalEndpoint(c, validationErr)
+
+				return
+			}
+		}
+
+		c.Next()
+	}
+}
+
+// validateExternalEndpointName checks the name a single payload carries.
+//
+// A POST must name the resource it creates. A PATCH is judged only on what it
+// actually sends: a patch that does not touch metadata.name leaves the name
+// alone, and a soft delete has to keep working even for a resource whose name
+// predates this check -- otherwise a bad name would be undeletable through the
+// API.
+func validateExternalEndpointName(payload map[string]json.RawMessage, method string) *validationError {
+	metadataRaw, hasMetadata := payload["metadata"]
+
+	var metadata map[string]json.RawMessage
+
+	if hasMetadata {
+		if err := json.Unmarshal(metadataRaw, &metadata); err != nil {
+			return invalidExternalEndpointPayloadError(err.Error())
+		}
+	}
+
+	if method == http.MethodPatch {
+		if !hasMetadata || isSoftDeleteMetadata(metadata) {
+			return nil
+		}
+
+		if _, ok := metadata["name"]; !ok {
+			return nil
+		}
+	}
+
+	var name string
+
+	if nameRaw, ok := metadata["name"]; ok {
+		if err := json.Unmarshal(nameRaw, &name); err != nil {
+			return invalidExternalEndpointPayloadError(err.Error())
+		}
+	}
+
+	if err := v1.ValidateResourceName(externalEndpointKind, name); err != nil {
+		return invalidExternalEndpointNameError(err.Error())
+	}
+
+	return nil
+}
+
+func isSoftDeleteMetadata(metadata map[string]json.RawMessage) bool {
+	raw, ok := metadata["deletion_timestamp"]
+	if !ok {
+		return false
+	}
+
+	var deletionTimestamp string
+	if err := json.Unmarshal(raw, &deletionTimestamp); err != nil {
+		return false
+	}
+
+	return deletionTimestamp != ""
+}
+
+// decodeResourcePayloads accepts both shapes PostgREST takes: a single resource
+// object and an array of them.
+func decodeResourcePayloads(body []byte) ([]map[string]json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var payloads []map[string]json.RawMessage
+		if err := json.Unmarshal(trimmed, &payloads); err != nil {
+			return nil, err
+		}
+
+		return payloads, nil
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &payload); err != nil {
+		return nil, err
+	}
+
+	return []map[string]json.RawMessage{payload}, nil
+}
+
+// readAndRestoreBody consumes the request body and puts it back, so the proxy
+// handler downstream still sees an unread body of the declared length.
+func readAndRestoreBody(r *http.Request) ([]byte, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	r.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	return body, nil
+}
+
+func rejectExternalEndpoint(c *gin.Context, validationErr *validationError) {
+	c.JSON(validationErrStatus(validationErr), validationErr)
+	c.Abort()
+}
+
+func invalidExternalEndpointPayloadError(hint string) *validationError {
+	return &validationError{
+		Code:    externalEndpointInvalidPayloadCode,
+		Message: "invalid external endpoint payload",
+		Hint:    hint,
+	}
+}
+
+func invalidExternalEndpointNameError(hint string) *validationError {
+	return &validationError{
+		Code:    externalEndpointInvalidNameCode,
+		Message: "invalid external endpoint name",
+		Hint:    hint + "; use metadata.display_name for a human-readable name",
+	}
+}

--- a/internal/routes/proxies/external_endpoint_validation_test.go
+++ b/internal/routes/proxies/external_endpoint_validation_test.go
@@ -1,0 +1,197 @@
+package proxies
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runExternalEndpointValidation sends one request through the validation
+// middleware and reports whether the handler behind it ran, plus what the
+// handler saw of the body -- the middleware reads the body, so restoring it is
+// part of the contract.
+func runExternalEndpointValidation(t *testing.T, method, body string) (*httptest.ResponseRecorder, bool, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	var (
+		reached  bool
+		seenBody string
+	)
+
+	engine := gin.New()
+	engine.Handle(method, "/api/v1/external_endpoints", validateExternalEndpoint(), func(c *gin.Context) {
+		reached = true
+
+		raw, err := io.ReadAll(c.Request.Body)
+		require.NoError(t, err)
+
+		seenBody = string(raw)
+
+		c.Status(http.StatusCreated)
+	})
+
+	req := httptest.NewRequest(method, "/api/v1/external_endpoints", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+
+	return recorder, reached, seenBody
+}
+
+func assertExternalEndpointNameRejected(t *testing.T, recorder *httptest.ResponseRecorder, reached bool) {
+	t.Helper()
+
+	assert.False(t, reached, "request must not reach the storage proxy")
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var payload validationError
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &payload))
+
+	assert.Equal(t, externalEndpointInvalidNameCode, payload.Code)
+	assert.Equal(t, "invalid external endpoint name", payload.Message)
+	assert.Contains(t, payload.Hint, "display_name")
+}
+
+func TestValidateExternalEndpointCreateName(t *testing.T) {
+	// The matrix NEU-714 asks for: a legal ASCII name, an ASCII space, Unicode
+	// without a space, Unicode with a space, and the percent character that a
+	// client would use to encode the others.
+	cases := []struct {
+		name     string
+		resource string
+		accepted bool
+	}{
+		{name: "ascii legal", resource: "external-openai-1", accepted: true},
+		{name: "ascii legal with dots and underscores", resource: "ext.open_ai-1", accepted: true},
+		{name: "ascii space", resource: "external endpoint", accepted: false},
+		{name: "leading space", resource: " external", accepted: false},
+		{name: "trailing space", resource: "external ", accepted: false},
+		{name: "unicode without space", resource: "外部端点", accepted: false},
+		{name: "unicode with space", resource: "外部 空格-2ea258e575", accepted: false},
+		{name: "percent character", resource: "external%20endpoint", accepted: false},
+		{name: "percent encoded unicode", resource: "%E5%A4%96%E9%83%A8", accepted: false},
+		{name: "uppercase", resource: "External", accepted: false},
+		{name: "slash", resource: "external/endpoint", accepted: false},
+		{name: "question mark", resource: "external?x=1", accepted: false},
+		{name: "leading hyphen", resource: "-external", accepted: false},
+		{name: "empty", resource: "", accepted: false},
+		{name: "too long", resource: strings.Repeat("a", 64), accepted: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(map[string]any{
+				"api_version": "v1",
+				"kind":        "ExternalEndpoint",
+				"metadata":    map[string]any{"workspace": "default", "name": tc.resource},
+			})
+			require.NoError(t, err)
+
+			recorder, reached, seenBody := runExternalEndpointValidation(t, http.MethodPost, string(body))
+
+			if tc.accepted {
+				assert.True(t, reached)
+				assert.JSONEq(t, string(body), seenBody, "the proxy behind the middleware must still see the body")
+
+				return
+			}
+
+			assertExternalEndpointNameRejected(t, recorder, reached)
+		})
+	}
+}
+
+func TestValidateExternalEndpointCreateRequiresName(t *testing.T) {
+	t.Run("metadata without a name", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost,
+			`{"api_version":"v1","metadata":{"workspace":"default"}}`)
+
+		assertExternalEndpointNameRejected(t, recorder, reached)
+	})
+
+	t.Run("no metadata at all", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost, `{"api_version":"v1"}`)
+
+		assertExternalEndpointNameRejected(t, recorder, reached)
+	})
+}
+
+func TestValidateExternalEndpointCreateBulk(t *testing.T) {
+	t.Run("rejects an array where any name is illegal", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost,
+			`[{"metadata":{"name":"legal-one"}},{"metadata":{"name":"外部 空格"}}]`)
+
+		assertExternalEndpointNameRejected(t, recorder, reached)
+	})
+
+	t.Run("accepts an array of legal names", func(t *testing.T) {
+		_, reached, _ := runExternalEndpointValidation(t, http.MethodPost,
+			`[{"metadata":{"name":"legal-one"}},{"metadata":{"name":"legal-two"}}]`)
+
+		assert.True(t, reached)
+	})
+}
+
+func TestValidateExternalEndpointPatch(t *testing.T) {
+	t.Run("rejects a rename to an illegal name", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPatch,
+			`{"metadata":{"name":"外部 空格-2ea258e575"}}`)
+
+		assertExternalEndpointNameRejected(t, recorder, reached)
+	})
+
+	t.Run("allows a patch that does not touch the name", func(t *testing.T) {
+		_, reached, _ := runExternalEndpointValidation(t, http.MethodPatch,
+			`{"spec":{"timeout":30},"metadata":{"display_name":"外部 端点"}}`)
+
+		assert.True(t, reached)
+	})
+
+	t.Run("allows a patch carrying no metadata", func(t *testing.T) {
+		_, reached, _ := runExternalEndpointValidation(t, http.MethodPatch, `{"spec":{"timeout":30}}`)
+
+		assert.True(t, reached)
+	})
+
+	// A resource named before this check existed still has to be deletable.
+	t.Run("allows a soft delete regardless of the name it carries", func(t *testing.T) {
+		_, reached, _ := runExternalEndpointValidation(t, http.MethodPatch,
+			`{"metadata":{"name":"外部 空格-2ea258e575","deletion_timestamp":"2026-08-25T06:29:27Z"}}`)
+
+		assert.True(t, reached)
+	})
+}
+
+func TestValidateExternalEndpointPassesThroughOtherRequests(t *testing.T) {
+	t.Run("ignores GET", func(t *testing.T) {
+		_, reached, _ := runExternalEndpointValidation(t, http.MethodGet, "")
+
+		assert.True(t, reached)
+	})
+
+	t.Run("leaves an empty body to postgrest", func(t *testing.T) {
+		_, reached, _ := runExternalEndpointValidation(t, http.MethodPost, "")
+
+		assert.True(t, reached)
+	})
+
+	t.Run("rejects a body that is not an object", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost, `"not-an-object"`)
+
+		assert.False(t, reached)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		var payload validationError
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &payload))
+		assert.Equal(t, externalEndpointInvalidPayloadCode, payload.Code)
+	})
+}

--- a/internal/routes/proxies/external_endpoint_validation_test.go
+++ b/internal/routes/proxies/external_endpoint_validation_test.go
@@ -61,6 +61,19 @@ func assertExternalEndpointNameRejected(t *testing.T, recorder *httptest.Respons
 	assert.Contains(t, payload.Hint, "display_name")
 }
 
+func assertExternalEndpointPayloadRejected(t *testing.T, recorder *httptest.ResponseRecorder, reached bool) {
+	t.Helper()
+
+	assert.False(t, reached, "request must not reach the storage proxy")
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var payload validationError
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &payload))
+
+	assert.Equal(t, externalEndpointInvalidPayloadCode, payload.Code)
+	assert.Equal(t, "invalid external endpoint payload", payload.Message)
+}
+
 func TestValidateExternalEndpointCreateName(t *testing.T) {
 	// The matrix NEU-714 asks for: a legal ASCII name, an ASCII space, Unicode
 	// without a space, Unicode with a space, and the percent character that a
@@ -184,14 +197,27 @@ func TestValidateExternalEndpointPassesThroughOtherRequests(t *testing.T) {
 		assert.True(t, reached)
 	})
 
+	t.Run("rejects metadata that is not an object", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPatch, `{"metadata": 5}`)
+
+		assertExternalEndpointPayloadRejected(t, recorder, reached)
+	})
+
+	t.Run("rejects a name that is not a string", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost, `{"metadata":{"name": 5}}`)
+
+		assertExternalEndpointPayloadRejected(t, recorder, reached)
+	})
+
+	t.Run("rejects an array that is not an array of objects", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost, `["legal-one"]`)
+
+		assertExternalEndpointPayloadRejected(t, recorder, reached)
+	})
+
 	t.Run("rejects a body that is not an object", func(t *testing.T) {
 		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost, `"not-an-object"`)
 
-		assert.False(t, reached)
-		assert.Equal(t, http.StatusBadRequest, recorder.Code)
-
-		var payload validationError
-		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &payload))
-		assert.Equal(t, externalEndpointInvalidPayloadCode, payload.Code)
+		assertExternalEndpointPayloadRejected(t, recorder, reached)
 	})
 }

--- a/internal/routes/proxies/external_endpoint_validation_test.go
+++ b/internal/routes/proxies/external_endpoint_validation_test.go
@@ -88,10 +88,10 @@ func TestValidateExternalEndpointCreateName(t *testing.T) {
 		{name: "ascii space", resource: "external endpoint", accepted: false},
 		{name: "leading space", resource: " external", accepted: false},
 		{name: "trailing space", resource: "external ", accepted: false},
-		{name: "unicode without space", resource: "外部端点", accepted: false},
-		{name: "unicode with space", resource: "外部 空格-2ea258e575", accepted: false},
+		{name: "unicode without space", resource: "ëndpoint", accepted: false},
+		{name: "unicode with space", resource: "ëndpoint spacer-2ea258e575", accepted: false},
 		{name: "percent character", resource: "external%20endpoint", accepted: false},
-		{name: "percent encoded unicode", resource: "%E5%A4%96%E9%83%A8", accepted: false},
+		{name: "percent encoded unicode", resource: "%C3%ABndpoint", accepted: false},
 		{name: "uppercase", resource: "External", accepted: false},
 		{name: "slash", resource: "external/endpoint", accepted: false},
 		{name: "question mark", resource: "external?x=1", accepted: false},
@@ -141,7 +141,7 @@ func TestValidateExternalEndpointCreateRequiresName(t *testing.T) {
 func TestValidateExternalEndpointCreateBulk(t *testing.T) {
 	t.Run("rejects an array where any name is illegal", func(t *testing.T) {
 		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost,
-			`[{"metadata":{"name":"legal-one"}},{"metadata":{"name":"外部 空格"}}]`)
+			`[{"metadata":{"name":"legal-one"}},{"metadata":{"name":"ëndpoint spacer"}}]`)
 
 		assertExternalEndpointNameRejected(t, recorder, reached)
 	})
@@ -157,14 +157,14 @@ func TestValidateExternalEndpointCreateBulk(t *testing.T) {
 func TestValidateExternalEndpointPatch(t *testing.T) {
 	t.Run("rejects a rename to an illegal name", func(t *testing.T) {
 		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPatch,
-			`{"metadata":{"name":"外部 空格-2ea258e575"}}`)
+			`{"metadata":{"name":"ëndpoint spacer-2ea258e575"}}`)
 
 		assertExternalEndpointNameRejected(t, recorder, reached)
 	})
 
 	t.Run("allows a patch that does not touch the name", func(t *testing.T) {
 		_, reached, _ := runExternalEndpointValidation(t, http.MethodPatch,
-			`{"spec":{"timeout":30},"metadata":{"display_name":"外部 端点"}}`)
+			`{"spec":{"timeout":30},"metadata":{"display_name":"Ëndpoint Rëname"}}`)
 
 		assert.True(t, reached)
 	})
@@ -178,7 +178,7 @@ func TestValidateExternalEndpointPatch(t *testing.T) {
 	// A resource named before this check existed still has to be deletable.
 	t.Run("allows a soft delete regardless of the name it carries", func(t *testing.T) {
 		_, reached, _ := runExternalEndpointValidation(t, http.MethodPatch,
-			`{"metadata":{"name":"外部 空格-2ea258e575","deletion_timestamp":"2026-08-25T06:29:27Z"}}`)
+			`{"metadata":{"name":"ëndpoint spacer-2ea258e575","deletion_timestamp":"2026-08-25T06:29:27Z"}}`)
 
 		assert.True(t, reached)
 	})


### PR DESCRIPTION
## Issue

NEU-714

## Summary

An external endpoint's `metadata.name` is an identity, not a label. `getExternalEndpointRoutePath` pastes it verbatim into the Kong route path, into the `status.service_url` handed back to the user, and into the gateway plugin's `route_prefix`; `BuildNeutreeACLGroup` pastes it into the ACL group. Nothing checked what went in. A name carrying a space or a non-ASCII rune is percent-encoded by the client, so it matches no Kong route: the endpoint is created, reads back fine, advertises a URL, and answers `404 no Route matched with those values` forever. The UI only marks the field `required`, and UI validation cannot hold the contract anyway — the CLI and every other caller reach the same table.

This validates the name at the API boundary. A human-readable name belongs in `metadata.display_name`, which is left alone.

## Changes

- `api/v1/resource_name.go` (new) — `ValidateResourceName(kind, name)`: lowercase alphanumerics plus `.`, `-`, `_`, first and last rune alphanumeric, at most 63 characters. The `kind` argument names the resource in the message so one rule reads correctly everywhere.
- `api/v1/model_types.go` — `ValidateModelName` now delegates to it and its regex is gone. Every message is byte-identical to before. The doc comment records that the two rule sets coincide today and that model validation should fork back out if BentoML's tag rules ever diverge, rather than the shared rule being loosened.
- `internal/routes/proxies/external_endpoint_validation.go` (new) — `validateExternalEndpoint()` middleware on `POST`/`PATCH /api/v1/external_endpoints`. An illegal name gets a 400 before anything is persisted or synced to Kong. Codes `10231` (payload) and `10232` (name); the hint points at `display_name`.

Three judgment calls worth a reviewer's attention:

- **A PATCH is judged only on what it sends.** Key presence in the raw JSON decides, so an explicit `"name": ""` is still rejected, but a patch that never mentions the name leaves it alone.
- **A soft delete is always let through.** A resource named before this check has to stay deletable through the API; the failing test run created exactly one such resource.
- **Array payloads are validated element by element.** PostgREST accepts a bulk insert and this route had no middleware at all, so rejecting arrays outright would have been a regression rather than a fix.

Internal endpoints have the same hole, with a wider blast radius (ACL group, Ray Serve route prefix, Ray Serve application name, NFS mount path), and so does `workspace`. Both are deliberately out of scope here and tracked for the next cycle.

## Test Plan

- [x] Unit: `go test ./api/v1/... ./internal/routes/...` — pass. New coverage is the matrix the issue asked for: legal ASCII, ASCII space (including leading and trailing), Unicode without a space, Unicode with a space, `%` and the percent-encoded forms, plus uppercase, `/`, `?`, empty and over-length. Bulk array payloads and each PATCH branch are covered too, and the tests assert the proxy behind the middleware still receives an intact body.
- [x] E2E: not affected — no deployment or gateway change; the fix is a rejection at the API boundary.
- [x] DB integration (`make db-test`): not affected — no schema change.

## Risk & Rollback

No schema change; no migration. The behavioural change is that a create or rename carrying an illegal name now gets a 400 where it used to get a 201 and an unusable resource. Existing resources are untouched: reads, unrelated patches and deletes all still work regardless of the name they carry, so no running client loses access to anything it can use today.

A DB `CHECK` constraint would be the stronger guard but is deliberately not part of this change — environments already hold resources with illegal names, so the constraint would fail on migration until a cleanup path exists.

Rollback is reverting the commit; nothing persists.
