### PR TITLE
fix(api): stop the model source check from blocking a pause (NEU-715)

### DIFF
--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -222,19 +222,37 @@ func validateEndpointPatchModelSource(store storage.Storage, input *endpointVali
 		return nil
 	}
 
+	// Pausing (zero replicas) skips the model source check, exactly as it skips
+	// the resource shape check in validateEndpointResourceShape: an endpoint that
+	// runs nothing sources nothing. The UI pauses by resending the whole spec
+	// with replicas.num set to 0, so without this a pause would be rejected for
+	// a model field it is not changing and does not need -- and an endpoint
+	// whose spec.model.version is empty could never be paused at all (NEU-715).
+	//
+	// The check comes back on the way up: resuming or scaling out puts the
+	// replica count above zero, and the merged spec is validated then.
+	if endpointReplicaCount(input.New.Spec) == 0 {
+		return nil
+	}
+
 	return validateEndpointModelSource(store, input.New)
 }
 
 // endpointPatchMayAffectModelSourceValidation reports whether a PATCH can change
 // the answer. spec.engine counts alongside spec.model: the engine decides whether
 // a registry is required at all, so repointing an endpoint at another engine has
-// to be re-checked even when spec.model is untouched.
+// to be re-checked even when spec.model is untouched. The replica count counts
+// too, for the same reason it counts in endpointPatchMayAffectResourceValidation:
+// it is what decides whether the check applies, so a patch that raises the count
+// off zero has to be checked even though it names no model.
 func endpointPatchMayAffectModelSourceValidation(endpoint *v1.Endpoint) bool {
 	if endpoint == nil || endpoint.Spec == nil {
 		return false
 	}
 
-	return endpoint.Spec.Model != nil || endpoint.Spec.Engine != nil
+	return endpoint.Spec.Model != nil ||
+		endpoint.Spec.Engine != nil ||
+		endpoint.Spec.Replicas.Num != nil
 }
 
 // validateEndpointModelSource decides which parts of spec.model an endpoint has

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -2367,10 +2367,18 @@ func TestValidateEndpointModelSource(t *testing.T) {
 }
 
 func TestEndpointPatchMayAffectModelSourceValidation(t *testing.T) {
-	t.Run("skips a patch that touches neither model nor engine", func(t *testing.T) {
+	t.Run("skips a patch that touches neither model nor engine nor the replica count", func(t *testing.T) {
+		assert.False(t, endpointPatchMayAffectModelSourceValidation(&v1.Endpoint{
+			Spec: &v1.EndpointSpec{Cluster: "c2"},
+		}))
+	})
+
+	t.Run("re-checks a patch that changes the replica count", func(t *testing.T) {
+		// The count decides whether the check applies at all, so raising it off
+		// zero has to be re-checked even though the patch names no model.
 		replicas := 3
 
-		assert.False(t, endpointPatchMayAffectModelSourceValidation(&v1.Endpoint{
+		assert.True(t, endpointPatchMayAffectModelSourceValidation(&v1.Endpoint{
 			Spec: &v1.EndpointSpec{Replicas: v1.ReplicaSpec{Num: &replicas}},
 		}))
 	})
@@ -2387,5 +2395,95 @@ func TestEndpointPatchMayAffectModelSourceValidation(t *testing.T) {
 		assert.True(t, endpointPatchMayAffectModelSourceValidation(&v1.Endpoint{
 			Spec: &v1.EndpointSpec{Model: &v1.ModelSpec{Name: "other"}},
 		}))
+	})
+}
+
+// NEU-715: the UI pauses by resending the whole spec with replicas.num set to 0,
+// so the pause carries spec.model and spec.engine and used to be judged on them.
+// An endpoint whose spec.model.version is empty could then never be paused.
+func TestValidateEndpointPatchModelSourcePause(t *testing.T) {
+	zero, one := 0, 1
+
+	// A vLLM endpoint that downloads its own model but has no version recorded --
+	// the shape the issue reproduces on.
+	versionless := func(replicas *int) *v1.Endpoint {
+		endpoint := modelSourceEndpoint("ws-a",
+			&v1.ModelSpec{Registry: "hf", Name: "qwen3"}, v1.EngineNameVLLM)
+		endpoint.Spec.Replicas = v1.ReplicaSpec{Num: replicas}
+
+		return endpoint
+	}
+
+	t.Run("lets a full-spec pause through", func(t *testing.T) {
+		store := &fakeModelRegistryStorage{}
+		patch := versionless(&zero)
+
+		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
+			Operation: endpointValidationPatch,
+			Patch:     *patch,
+			New:       patch,
+		})
+
+		assert.Nil(t, err)
+		assert.Empty(t, store.options, "a pause must not even look the registry up")
+	})
+
+	t.Run("lets a replicas-only pause through", func(t *testing.T) {
+		store := &fakeModelRegistryStorage{}
+
+		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
+			Operation: endpointValidationPatch,
+			Patch:     v1.Endpoint{Spec: &v1.EndpointSpec{Replicas: v1.ReplicaSpec{Num: &zero}}},
+			New:       versionless(&zero),
+		})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("still rejects a resume that leaves the version empty", func(t *testing.T) {
+		store := &fakeModelRegistryStorage{}
+
+		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
+			Operation: endpointValidationPatch,
+			Patch:     v1.Endpoint{Spec: &v1.EndpointSpec{Replicas: v1.ReplicaSpec{Num: &one}}},
+			New:       versionless(&one),
+		})
+
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "10229", err.Code)
+			assert.Contains(t, err.Hint, "spec.model.version")
+		}
+	})
+
+	t.Run("still rejects a full-spec edit that leaves the version empty", func(t *testing.T) {
+		store := &fakeModelRegistryStorage{}
+		patch := versionless(&one)
+
+		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
+			Operation: endpointValidationPatch,
+			Patch:     *patch,
+			New:       patch,
+		})
+
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "10229", err.Code)
+		}
+	})
+
+	// An endpoint with no explicit replica count runs one replica, not zero, so
+	// it must not fall through the pause exemption.
+	t.Run("still rejects a patch that names no replica count", func(t *testing.T) {
+		store := &fakeModelRegistryStorage{}
+		patch := versionless(nil)
+
+		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
+			Operation: endpointValidationPatch,
+			Patch:     *patch,
+			New:       patch,
+		})
+
+		if assert.NotNil(t, err) {
+			assert.Equal(t, "10229", err.Code)
+		}
 	})
 }


### PR DESCRIPTION
## Issue

NEU-715

## Summary

Pausing an endpoint sets its replica count to zero, and the UI does that by resending the whole spec with `replicas.num` changed. The patch therefore carries `spec.model` and `spec.engine` — which is all `validateEndpointPatchModelSource` looked at to decide whether to re-run the model source check. A vLLM, llama-cpp or SGLang endpoint with no `spec.model.version` recorded was rejected with `10229` for a field the pause neither changes nor needs, so `PauseEndpoint` never ran and the endpoint could not be paused at all.

## Changes

- `validateEndpointPatchModelSource` skips the check when the merged spec comes out at zero replicas. An endpoint that runs nothing sources nothing, and `validateEndpointResourceShape` already skips the resource shape at zero replicas for the same reason — the two exemptions now agree.
- `endpointPatchMayAffectModelSourceValidation` counts the replica count alongside `spec.model` and `spec.engine`. Without this the check would not come back on the way up: a resume can be a patch that names only `replicas.num`, and that patch has to be judged against the merged spec. This mirrors `endpointPatchMayAffectResourceValidation`, which counts the replica count for exactly the same reason.

Net effect: pausing is never blocked by the model source, and resuming or scaling out is validated exactly as before — a resume that would bring back an endpoint with no `spec.model.version` still gets `10229`.

Creation is deliberately left strict. A create states the whole endpoint, so there is no field it is "not changing", and letting a zero-replica create through would only move the rejection to the first resume.

## Test Plan

- [x] Unit: `go test ./internal/routes/proxies/` — pass. New `TestValidateEndpointPatchModelSourcePause` covers a full-spec pause, a replicas-only pause, a resume that leaves the version empty (still `10229`), a full-spec edit that leaves it empty (still `10229`), and a patch that names no replica count at all (still validated — a missing count means one replica, not zero, and must not fall through the exemption). The existing `TestEndpointPatchMayAffectModelSourceValidation` case for a replicas-only patch is updated to the new contract and a case for a patch touching nothing relevant takes its place.
- [x] E2E: not affected — no deployment or gateway change.
- [x] DB integration (`make db-test`): not affected — no schema change.

## Risk & Rollback

No schema change. Two behaviour changes, both intended:

- A patch that reaches zero replicas is no longer checked against the model source. The endpoint is not running, so nothing acts on the spec until it is resumed, and the resume is checked.
- A patch that changes only the replica count is now checked. Scaling an endpoint whose `spec.model.version` is empty up from zero — or from one to three — is refused where it previously went through. That is the intended contract per the issue, and it refuses a state that could not deploy anyway.

Rollback is reverting the commit.
