### PR TITLE
fix(db): stop a partial metadata patch from erasing creation_timestamp (NEU-717)

### DIFF
--- a/db/dbtest/metadata_creation_timestamp_test.go
+++ b/db/dbtest/metadata_creation_timestamp_test.go
@@ -1,0 +1,172 @@
+package dbtest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/neutree-ai/neutree/pkg/storage"
+)
+
+// metadata is a composite column, so PostgREST rewrites all of it from whatever
+// JSON a PATCH carries and any subfield the payload omits comes back NULL.
+// These tests go through raw HTTP rather than the typed storage client for
+// exactly that reason: the Go client always sends a whole v1.Metadata, and the
+// payload that loses a creation time is one that does not (NEU-717).
+func postgrestRequest(t *testing.T, method, path, body string) (int, string) {
+	t.Helper()
+
+	token, err := storage.CreateServiceToken(TestJWTSecret)
+	if err != nil {
+		t.Fatalf("failed to mint a service token: %v", err)
+	}
+
+	req, err := http.NewRequest(method, GetPostgRESTURL()+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to build the request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Profile", "api")
+	req.Header.Set("Content-Profile", "api")
+	req.Header.Set("Authorization", "Bearer "+*token)
+	req.Header.Set("Prefer", "return=representation")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read the response: %v", err)
+	}
+
+	return resp.StatusCode, string(raw)
+}
+
+// endpointCreationTimestamp returns the creation_timestamp of the single row a
+// representation response carries, and whether it is non-null.
+func endpointCreationTimestamp(t *testing.T, body string) (string, bool) {
+	t.Helper()
+
+	var rows []struct {
+		Metadata struct {
+			CreationTimestamp *string `json:"creation_timestamp"`
+		} `json:"metadata"`
+	}
+
+	if err := json.Unmarshal([]byte(body), &rows); err != nil {
+		t.Fatalf("failed to decode the response %q: %v", body, err)
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly one row, got %d: %s", len(rows), body)
+	}
+
+	if rows[0].Metadata.CreationTimestamp == nil {
+		return "", false
+	}
+
+	return *rows[0].Metadata.CreationTimestamp, true
+}
+
+func createTimestampTestEndpoint(t *testing.T, name string) string {
+	t.Helper()
+
+	code, body := postgrestRequest(t, http.MethodPost, "/endpoints", `{
+		"api_version": "v1",
+		"kind": "Endpoint",
+		"metadata": {"name": "`+name+`", "workspace": "default"},
+		"spec": {
+			"cluster": "c1",
+			"model": {"name": "qwen3", "version": "latest"},
+			"engine": {"engine": "vllm", "version": "v0.24.0"},
+			"replicas": {"num": 1}
+		}
+	}`)
+
+	if code != http.StatusCreated {
+		t.Fatalf("failed to create the endpoint: %d %s", code, body)
+	}
+
+	t.Cleanup(func() {
+		postgrestRequest(t, http.MethodDelete, "/endpoints?metadata->>name=eq."+name, "")
+	})
+
+	created, ok := endpointCreationTimestamp(t, body)
+	if !ok {
+		t.Fatalf("insert did not stamp a creation timestamp: %s", body)
+	}
+
+	return created
+}
+
+func TestMetadataCreationTimestampSurvivesAPartialMetadataPatch(t *testing.T) {
+	waitForPostgREST(t)
+
+	t.Run("a patch that resends metadata without the creation timestamp", func(t *testing.T) {
+		created := createTimestampTestEndpoint(t, "ts-partial")
+
+		// The shape a client produces when it echoes the fields it knows about
+		// and drops the ones it does not -- a pause, a relabel, a rename.
+		code, body := postgrestRequest(t, http.MethodPatch, "/endpoints?metadata->>name=eq.ts-partial",
+			`{"metadata": {"name": "ts-partial", "workspace": "default", "labels": {"paused": "true"}}}`)
+		if code != http.StatusOK {
+			t.Fatalf("patch failed: %d %s", code, body)
+		}
+
+		after, ok := endpointCreationTimestamp(t, body)
+		if !ok {
+			t.Fatalf("the creation timestamp was erased by the patch: %s", body)
+		}
+
+		if after != created {
+			t.Fatalf("the creation timestamp changed: created %q, after patch %q", created, after)
+		}
+	})
+
+	t.Run("a soft delete", func(t *testing.T) {
+		created := createTimestampTestEndpoint(t, "ts-soft-delete")
+
+		code, body := postgrestRequest(t, http.MethodPatch, "/endpoints?metadata->>name=eq.ts-soft-delete",
+			`{"metadata": {"name": "ts-soft-delete", "workspace": "default", "deletion_timestamp": "2026-08-25T06:29:27Z"}}`)
+		if code != http.StatusOK {
+			t.Fatalf("patch failed: %d %s", code, body)
+		}
+
+		after, ok := endpointCreationTimestamp(t, body)
+		if !ok {
+			t.Fatalf("the creation timestamp was erased by the soft delete: %s", body)
+		}
+
+		if after != created {
+			t.Fatalf("the creation timestamp changed: created %q, after patch %q", created, after)
+		}
+	})
+
+	// The insert trigger ignores a creation timestamp the payload states, so the
+	// update trigger has to ignore one too: the column belongs to the database
+	// on both paths, or it belongs to it on neither.
+	t.Run("a patch that states a creation timestamp", func(t *testing.T) {
+		created := createTimestampTestEndpoint(t, "ts-explicit")
+
+		code, body := postgrestRequest(t, http.MethodPatch, "/endpoints?metadata->>name=eq.ts-explicit",
+			`{"metadata": {"name": "ts-explicit", "workspace": "default", "creation_timestamp": "2020-01-02T03:04:05Z"}}`)
+		if code != http.StatusOK {
+			t.Fatalf("patch failed: %d %s", code, body)
+		}
+
+		after, ok := endpointCreationTimestamp(t, body)
+		if !ok {
+			t.Fatalf("the creation timestamp was erased by the patch: %s", body)
+		}
+
+		if after != created {
+			t.Fatalf("a patch rewrote the creation timestamp: created %q, after patch %q", created, after)
+		}
+	})
+}

--- a/db/migrations/093_preserve_creation_timestamp.down.sql
+++ b/db/migrations/093_preserve_creation_timestamp.down.sql
@@ -1,0 +1,17 @@
+-- Body restored from 019, the definition this migration replaced.
+CREATE OR REPLACE FUNCTION update_metadata_update_timestamp_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.metadata := ROW(
+        (NEW.metadata).name,
+        (NEW.metadata).display_name,
+        (NEW.metadata).workspace,
+        (NEW.metadata).deletion_timestamp,
+        (NEW.metadata).creation_timestamp,
+        CURRENT_TIMESTAMP,
+        (NEW.metadata).labels,
+        (NEW.metadata).annotations
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/db/migrations/093_preserve_creation_timestamp.up.sql
+++ b/db/migrations/093_preserve_creation_timestamp.up.sql
@@ -1,0 +1,35 @@
+-- A resource's creation_timestamp was losable by accident.
+--
+-- Both timestamps are the database's to maintain, and the insert trigger
+-- treats them that way: set_default_metadata_timestamp_column writes
+-- CURRENT_TIMESTAMP into both positions and ignores whatever the payload said.
+-- The update trigger held that line for update_timestamp but not for
+-- creation_timestamp, which it read back out of NEW -- that is, out of the
+-- caller's payload.
+--
+-- metadata is a composite column, so PostgREST rewrites the whole of it from
+-- whatever JSON a PATCH carries: any subfield the payload leaves out comes back
+-- NULL. A client that resends metadata to change one field -- a label, a
+-- display name, a deletion timestamp -- and does not echo creation_timestamp
+-- therefore erased it, and the trigger preserved that NULL faithfully. The UI
+-- renders the result as "-" and the creation time is gone for good (NEU-717).
+--
+-- Take the value from OLD instead, unconditionally. Creation time is now the
+-- database's alone on both paths: an insert stamps it, an update cannot touch
+-- it, and neither one can be talked out of it by a payload.
+CREATE OR REPLACE FUNCTION update_metadata_update_timestamp_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.metadata := ROW(
+        (NEW.metadata).name,
+        (NEW.metadata).display_name,
+        (NEW.metadata).workspace,
+        (NEW.metadata).deletion_timestamp,
+        (OLD.metadata).creation_timestamp,
+        CURRENT_TIMESTAMP,
+        (NEW.metadata).labels,
+        (NEW.metadata).annotations
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Issue

NEU-717

## Summary

An endpoint in the list showed `-` where its creation time should be. `Timestamp` renders `-` only when the value is null, so the row genuinely had no `metadata.creation_timestamp` — and the insert trigger always stamps one, so something erased it after the fact.

The root cause is in the database's own timestamp contract, not in a caller. Both timestamps are the database's to maintain, and `set_default_metadata_timestamp_column` treats them that way on insert: it writes `CURRENT_TIMESTAMP` into both positions and ignores whatever the payload said. `update_metadata_update_timestamp_column` held that line for `update_timestamp` but not for `creation_timestamp`, which it read back out of `NEW` — that is, out of the caller's payload.

`metadata` is a composite column, so PostgREST rewrites all of it from whatever JSON a PATCH carries and any subfield the payload omits comes back NULL. A client that resends `metadata` to change one field — a label, a display name, a deletion timestamp — and does not echo `creation_timestamp` therefore erased it, and the trigger preserved that NULL faithfully.

Reproduced against a real Postgres + PostgREST before writing the fix:

```
POST   /endpoints  -> creation_timestamp = 2026-08-25T16:59:20.829366+00:00
PATCH  /endpoints  -> creation_timestamp = null      # payload carried metadata, minus that field
```

## Changes

- `db/migrations/093_preserve_creation_timestamp.{up,down}.sql` — the update trigger takes `creation_timestamp` from `OLD`, unconditionally. Creation time becomes the database's alone on both paths: an insert stamps it, an update cannot touch it, and neither one can be talked out of it by a payload. The function is shared by every resource, so this closes the whole class, not just the endpoint case it was reported on.
- `db/dbtest/metadata_creation_timestamp_test.go` — covers a patch that resends `metadata` without the field, a soft delete, and a patch that states a creation timestamp explicitly (now ignored, matching insert). These go through raw HTTP rather than the typed storage client on purpose: the Go client always sends a whole `v1.Metadata`, and the payload that loses a creation time is one that does not.

An earlier revision of this branch used `COALESCE(NEW, OLD)` to let an explicitly stated value still win. That was the wrong call: an insert already refuses to take a creation timestamp from the payload, so no "state the creation time" path exists to preserve, and honouring one on update would have left the two triggers disagreeing about who owns the column.

## Test Plan

- [x] DB integration (`make db-test`): pass — full suite green with the migration applied.
- [x] Each case checked in both directions, so none of them is vacuous. With migration 093 reverted to the 019 body, the partial-metadata patch and the soft delete both fail with `creation_timestamp: null`. With the intermediate `COALESCE` body, the explicit-value case fails — the patch rewrites the creation timestamp to `2020-01-02`. All three pass on the committed body.
- [x] E2E: not affected.

## Risk & Rollback

Schema change is a function body only — no table, type or column is touched, and the migration is idempotent (`CREATE OR REPLACE`).

The behavioural change beyond the fix itself: an update that states a `creation_timestamp` is now ignored rather than honoured. Nothing in the repo writes that field — Go only ever reads it through `GetCreationTimestamp()`, and the endpoint controller's update carries no metadata at all — so this takes away a capability no caller uses, and aligns update with insert.

**Not covered:** rows whose creation timestamp is already NULL stay NULL. The true value is not recoverable and backfilling from `update_timestamp` would fabricate data, so those rows keep rendering `-` until they are recreated. Restoring one now needs direct SQL rather than a PATCH — a deliberate consequence of putting the column fully under the database's control.

I have also not identified which client sent the partial payload in the reported environment — the current UI's pause and delete paths both echo the whole `metadata`. The fix removes the mechanism regardless of which caller triggers it, but if the erasure recurs after this ships, the remaining caller is worth finding.

Rollback is the down migration, which restores the 019 body verbatim.
