### PR TITLE
fix: configure Kong worker processes

### DIFF
--- a/cmd/neutree-cli/app/cmd/launch/core.go
+++ b/cmd/neutree-cli/app/cmd/launch/core.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -29,6 +30,7 @@ type neutreeCoreInstallOptions struct {
 	adminPassword         string
 
 	victorialogsRetentionPeriod string
+	kongWorkerProcesses         string
 
 	// enablePublicModelRegistries provisions the built-in public model
 	// registries. Off by default so an air-gapped install does not ship a
@@ -38,10 +40,18 @@ type neutreeCoreInstallOptions struct {
 	modelScopeEndpoint          string
 }
 
-// defaultVictoriaLogsRetentionPeriod is the default VictoriaLogs log retention
-// period rendered into the neutree-core compose file. Overridable at deploy time
-// via --victorialogs-retention-period.
-const defaultVictoriaLogsRetentionPeriod = "30d"
+const (
+	// defaultVictoriaLogsRetentionPeriod is the default VictoriaLogs log retention
+	// period rendered into the neutree-core compose file. Overridable at deploy time
+	// via --victorialogs-retention-period.
+	defaultVictoriaLogsRetentionPeriod = "30d"
+
+	// defaultKongWorkerProcesses keeps Kong's PostgreSQL connection demand from
+	// scaling with host CPU count unless an operator explicitly opts in to auto.
+	defaultKongWorkerProcesses = "2"
+)
+
+var kongWorkerProcessesPattern = regexp.MustCompile(`^(auto|[1-9][0-9]*)$`)
 
 func NewNeutreeCoreInstallCmd(exector command.Executor, commonOptions *commonOptions) *cobra.Command {
 	options := neutreeCoreInstallOptions{
@@ -62,6 +72,7 @@ Configuration Options:
   --jwt-secret             JWT secret for authentication
   --metrics-remote-write-url Remote metrics storage URL
   --grafana-url            Grafana dashboard URL for system info API
+  --kong-worker-processes  Kong Nginx workers: positive integer or auto; auto follows host CPU and can increase PostgreSQL connection pressure
   --version                Component version (default: CLI release version, or v0.0.1 for non-release/local builds)
   --victorialogs-retention-period VictoriaLogs log retention period (default: 30d; e.g. 30d, 90d, 1y)
   --enable-public-model-registries Provision built-in read-only public model registries (default: false)
@@ -82,6 +93,10 @@ Examples:
 				return fmt.Errorf("--jwt-secret is required")
 			}
 
+			if _, err := normalizeKongWorkerProcesses(options.kongWorkerProcesses, false); err != nil {
+				return err
+			}
+
 			err := resolveNodeIP(cmd.OutOrStdout(), options.commonOptions, util.GetHostIP)
 			if err != nil {
 				return err
@@ -95,6 +110,8 @@ Examples:
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.dbPassword, "db-password", "pgpassword", "database password for postgres superuser")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.metricsRemoteWriteURL, "metrics-remote-write-url", "", "metrics remote write url")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.grafanaURL, "grafana-url", "", "grafana dashboard url for system info API")
+	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.kongWorkerProcesses, "kong-worker-processes", defaultKongWorkerProcesses,
+		`Kong Nginx worker processes ("auto" or a positive integer; "auto" follows host CPU and can increase PostgreSQL connection pressure)`)
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.version, "version", defaultNeutreeCoreVersion(), "neutree core version")
 	neutreeCoreInstallCmd.PersistentFlags().StringVar(&options.victorialogsRetentionPeriod, "victorialogs-retention-period",
 		defaultVictoriaLogsRetentionPeriod, "VictoriaLogs log retention period (e.g. 30d, 90d, 1y)")
@@ -179,6 +196,11 @@ func prepareNeutreeCoreDeployConfig(options neutreeCoreInstallOptions) error {
 }
 
 func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, outputWorkDir string) error {
+	kongWorkerProcesses, err := normalizeKongWorkerProcesses(options.kongWorkerProcesses, true)
+	if err != nil {
+		return err
+	}
+
 	renderedCoreWorkDir := filepath.Join(outputWorkDir, "neutree-core")
 
 	// extract neutree core deploy manifests
@@ -248,6 +270,7 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 		"JwtToken":                     *jwtToken,
 		"VectorVersion":                componentversion.Vector,
 		"KongVersion":                  componentversion.Kong,
+		"KongWorkerProcesses":          kongWorkerProcesses,
 		"KongPluginGatewayChecksum":    pluginChecksums["neutree-ai-gateway"],
 		"KongPluginStatisticsChecksum": pluginChecksums["neutree-ai-statistics"],
 		"KongPluginAccessChecksum":     pluginChecksums["neutree-ai-access"],
@@ -272,4 +295,16 @@ func prepareNeutreeCoreDeployConfigInWorkDir(options neutreeCoreInstallOptions, 
 	}
 
 	return nil
+}
+
+func normalizeKongWorkerProcesses(value string, defaultWhenEmpty bool) (string, error) {
+	if value == "" && defaultWhenEmpty {
+		value = defaultKongWorkerProcesses
+	}
+
+	if !kongWorkerProcessesPattern.MatchString(value) {
+		return "", fmt.Errorf("invalid --kong-worker-processes value %q: must be \"auto\" or a positive integer", value)
+	}
+
+	return value, nil
 }

--- a/cmd/neutree-cli/app/cmd/launch/core_test.go
+++ b/cmd/neutree-cli/app/cmd/launch/core_test.go
@@ -35,6 +35,7 @@ func TestNewNeutreeCoreInstallCmd(t *testing.T) {
 			},
 			expectedFields: map[string]string{
 				"jwt-secret":               "",
+				"kong-worker-processes":    defaultKongWorkerProcesses,
 				"metrics-remote-write-url": "",
 				"version":                  "v0.0.1",
 			},
@@ -51,6 +52,7 @@ func TestNewNeutreeCoreInstallCmd(t *testing.T) {
 			},
 			expectedFields: map[string]string{
 				"jwt-secret":               "",
+				"kong-worker-processes":    defaultKongWorkerProcesses,
 				"metrics-remote-write-url": "",
 				"version":                  "v0.0.1",
 			},
@@ -80,8 +82,103 @@ func TestNewNeutreeCoreInstallCmd(t *testing.T) {
 				assert.Equal(t, expectedValue, flagValue)
 			}
 
+			kongWorkerProcessesFlag := cmd.PersistentFlags().Lookup("kong-worker-processes")
+			require.NotNil(t, kongWorkerProcessesFlag)
+			assert.Contains(t, kongWorkerProcessesFlag.Usage, "PostgreSQL connection pressure")
+
 			// Verify RunE function is set
 			assert.NotNil(t, cmd.RunE)
+		})
+	}
+}
+
+func TestNewNeutreeCoreInstallCmdRejectsInvalidKongWorkerProcesses(t *testing.T) {
+	cmd := NewNeutreeCoreInstallCmd(&mocks.MockExecutor{}, &commonOptions{
+		workDir:    t.TempDir(),
+		deployType: constants.DeployTypeLocal,
+		deployMode: constants.DeployModeSingle,
+	})
+	cmd.SetArgs([]string{
+		"--jwt-secret", "test-secret",
+		"--kong-worker-processes", "0",
+	})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be \"auto\" or a positive integer")
+}
+
+func TestNormalizeKongWorkerProcesses(t *testing.T) {
+	tests := []struct {
+		name             string
+		value            string
+		defaultWhenEmpty bool
+		want             string
+		wantErr          bool
+	}{
+		{
+			name:             "defaults empty renderer option",
+			defaultWhenEmpty: true,
+			want:             defaultKongWorkerProcesses,
+		},
+		{
+			name:  "accepts positive integer",
+			value: "3",
+			want:  "3",
+		},
+		{
+			name:  "accepts auto",
+			value: "auto",
+			want:  "auto",
+		},
+		{
+			name:    "rejects empty public input",
+			wantErr: true,
+		},
+		{
+			name:    "rejects zero",
+			value:   "0",
+			wantErr: true,
+		},
+		{
+			name:    "rejects leading zero",
+			value:   "01",
+			wantErr: true,
+		},
+		{
+			name:    "rejects negative number",
+			value:   "-1",
+			wantErr: true,
+		},
+		{
+			name:    "rejects decimal",
+			value:   "1.5",
+			wantErr: true,
+		},
+		{
+			name:    "rejects upper case auto",
+			value:   "AUTO",
+			wantErr: true,
+		},
+		{
+			name:    "rejects whitespace",
+			value:   " 2",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeKongWorkerProcesses(tt.value, tt.defaultWhenEmpty)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "must be \"auto\" or a positive integer")
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -204,6 +301,82 @@ func TestPrepareNeutreeCoreDeployConfigRendersKongPluginChecksumLabels(t *testin
 		for label := range expectedLabels {
 			assert.NotContains(t, service.Labels, label, "unexpected Kong plugin checksum label on %s", service.Name)
 		}
+	}
+}
+
+func TestPrepareNeutreeCoreDeployConfigRendersKongWorkerProcesses(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		want        string
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "defaults empty option to two",
+			want: defaultKongWorkerProcesses,
+		},
+		{
+			name:  "renders custom positive integer",
+			value: "3",
+			want:  "3",
+		},
+		{
+			name:  "renders auto",
+			value: "auto",
+			want:  "auto",
+		},
+		{
+			name:        "rejects invalid value",
+			value:       "0",
+			wantErr:     true,
+			expectedErr: "must be \"auto\" or a positive integer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workDir := t.TempDir()
+			options := neutreeCoreInstallOptions{
+				commonOptions: &commonOptions{
+					workDir:    workDir,
+					nodeIP:     "192.168.1.1",
+					deployType: constants.DeployTypeLocal,
+					deployMode: constants.DeployModeSingle,
+				},
+				jwtSecret:           "test-secret",
+				version:             "v1.0.0",
+				kongWorkerProcesses: tt.value,
+			}
+
+			err := prepareNeutreeCoreDeployConfig(options)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			project, err := cli.ProjectFromOptions(&cli.ProjectOptions{
+				ConfigPaths: []string{filepath.Join(workDir, "neutree-core", "docker-compose.yml")},
+			})
+			require.NoError(t, err)
+
+			var actual *string
+			for _, service := range project.Services {
+				if service.Name != "kong" {
+					continue
+				}
+
+				actual = service.Environment["KONG_NGINX_WORKER_PROCESSES"]
+
+				break
+			}
+
+			require.NotNil(t, actual)
+			assert.Equal(t, tt.want, *actual)
+		})
 	}
 }
 

--- a/deploy/chart/neutree/templates/_helpers.tpl
+++ b/deploy/chart/neutree/templates/_helpers.tpl
@@ -96,6 +96,17 @@ Get the JWT secret with validation.
 {{- end -}}
 
 {{/*
+Validate the Kong Nginx worker process value shared by every Kong workload.
+*/}}
+{{- define "neutree.kong.workerProcesses" -}}
+{{- $value := toString .Values.kong.workerProcesses -}}
+{{- if not (regexMatch "^(auto|[1-9][0-9]*)$" $value) -}}
+{{- fail (printf "kong.workerProcesses must be \"auto\" or a positive integer (got %q)" $value) -}}
+{{- end -}}
+{{- $value -}}
+{{- end -}}
+
+{{/*
 Resolve the AI inference trace store (VictoriaLogs) base URL.
 Returns the in-cluster VictoriaLogs service when victorialogs.enabled is true,
 otherwise the externally configured system.aiTraceStoreUrl. Empty when neither

--- a/deploy/chart/neutree/templates/kong-install.yaml
+++ b/deploy/chart/neutree/templates/kong-install.yaml
@@ -76,7 +76,7 @@ spec:
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;/opt/?/init.lua;;"
         - name: KONG_NGINX_WORKER_PROCESSES
-          value: "2"
+          value: {{ include "neutree.kong.workerProcesses" . | quote }}
         - name: KONG_PG_DATABASE
           value: "neutree"
         - name: KONG_PG_HOST
@@ -212,7 +212,7 @@ spec:
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;/opt/?/init.lua;;"
         - name: KONG_NGINX_WORKER_PROCESSES
-          value: "2"
+          value: {{ include "neutree.kong.workerProcesses" . | quote }}
         - name: KONG_PG_DATABASE
           value: "neutree"
         - name: KONG_PG_HOST
@@ -394,7 +394,7 @@ spec:
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;/opt/?/init.lua;;"
         - name: KONG_NGINX_WORKER_PROCESSES
-          value: "2"
+          value: {{ include "neutree.kong.workerProcesses" . | quote }}
         - name: KONG_PG_DATABASE
           value: "neutree"
         - name: KONG_PG_HOST
@@ -472,7 +472,7 @@ spec:
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;/opt/?/init.lua;;"
         - name: KONG_NGINX_WORKER_PROCESSES
-          value: "2"
+          value: {{ include "neutree.kong.workerProcesses" . | quote }}
         - name: KONG_PG_DATABASE
           value: "neutree"
         - name: KONG_PG_HOST
@@ -568,7 +568,7 @@ spec:
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;/opt/?/init.lua;;"
         - name: KONG_NGINX_WORKER_PROCESSES
-          value: "2"
+          value: {{ include "neutree.kong.workerProcesses" . | quote }}
         - name: KONG_PG_DATABASE
           value: "neutree"
         - name: KONG_PG_HOST
@@ -767,7 +767,7 @@ spec:
         - name: KONG_LUA_PACKAGE_PATH
           value: "/opt/?.lua;/opt/?/init.lua;;"
         - name: KONG_NGINX_WORKER_PROCESSES
-          value: "2"
+          value: {{ include "neutree.kong.workerProcesses" . | quote }}
         - name: KONG_PG_DATABASE
           value: "neutree"
         - name: KONG_PG_HOST

--- a/deploy/chart/neutree/values.yaml
+++ b/deploy/chart/neutree/values.yaml
@@ -237,6 +237,9 @@ vmagent:
       - ReadWriteOnce
 
 kong:
+  # Use "auto" only after confirming that host CPU count and PostgreSQL
+  # connection capacity can support the resulting Kong worker count.
+  workerProcesses: "2"
   image:
     registry: ""
     repository: kong/kong

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -378,6 +378,7 @@ services:
       neutree.ai/kong-plugin-neutree-ai-quota-checksum: "{{ .KongPluginQuotaChecksum }}"
     environment:
       KONG_NGINX_HTTP_CLIENT_BODY_BUFFER_SIZE: 20m
+      KONG_NGINX_WORKER_PROCESSES: "2"
       KONG_PLUGINS: bundled,neutree-ai-gateway,neutree-ai-statistics,neutree-ai-access,neutree-ai-quota
       LUA_PATH: "/neutree-kong-plugin/?.lua;;"
       KONG_DATABASE: "postgres"

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -378,7 +378,7 @@ services:
       neutree.ai/kong-plugin-neutree-ai-quota-checksum: "{{ .KongPluginQuotaChecksum }}"
     environment:
       KONG_NGINX_HTTP_CLIENT_BODY_BUFFER_SIZE: 20m
-      KONG_NGINX_WORKER_PROCESSES: "2"
+      KONG_NGINX_WORKER_PROCESSES: "{{ .KongWorkerProcesses }}"
       KONG_PLUGINS: bundled,neutree-ai-gateway,neutree-ai-statistics,neutree-ai-access,neutree-ai-quota
       LUA_PATH: "/neutree-kong-plugin/?.lua;;"
       KONG_DATABASE: "postgres"

--- a/tests/e2e/cp_deploy_test.go
+++ b/tests/e2e/cp_deploy_test.go
@@ -78,6 +78,10 @@ var _ = Describe("Control Plane Deploy", Ordered, Label("control-plane", "deploy
 		It("should have all obs-stack containers healthy", Label("C2610697"), func() {
 			cph.VerifyDeployed(cph.ParseCompose("obs-stack"))
 		})
+
+		It("should render the default Kong worker process count", Label("kong-worker-processes"), func() {
+			expectComposeKongWorkerProcesses(cph, "2")
+		})
 	})
 
 	// --- Mirror registry deploy: custom registry + custom DB (multiple checks) ---
@@ -102,6 +106,7 @@ var _ = Describe("Control Plane Deploy", Ordered, Label("control-plane", "deploy
 				"--version", profileCPVersion(),
 				"--admin-password", profile.Auth.Password,
 				"--db-password", customPwd,
+				"--kong-worker-processes", "3",
 				"--metrics-remote-write-url", cph.MetricsRemoteWriteURL(),
 			}, mirrorRegistryArgs()...)
 			r = cph.RunCLI(args...)
@@ -142,6 +147,10 @@ var _ = Describe("Control Plane Deploy", Ordered, Label("control-plane", "deploy
 			Expect(err).NotTo(HaveOccurred())
 			Expect(jwt).NotTo(BeEmpty(),
 				"admin login should succeed, proving all components connect with custom db-password")
+		})
+
+		It("should render the custom Kong worker process count", Label("kong-worker-processes"), func() {
+			expectComposeKongWorkerProcesses(cph, "3")
 		})
 	})
 
@@ -194,3 +203,19 @@ var _ = Describe("Control Plane Deploy", Ordered, Label("control-plane", "deploy
 		})
 	})
 })
+
+func expectComposeKongWorkerProcesses(cph *CPHelper, expected string) {
+	var actual *string
+	for _, service := range cph.ParseCompose("neutree-core").Services {
+		if service.Name != "kong" {
+			continue
+		}
+
+		actual = service.Environment["KONG_NGINX_WORKER_PROCESSES"]
+
+		break
+	}
+
+	Expect(actual).NotTo(BeNil())
+	Expect(*actual).To(Equal(expected))
+}

--- a/tests/e2e/cp_k8s_deploy_test.go
+++ b/tests/e2e/cp_k8s_deploy_test.go
@@ -55,6 +55,10 @@ var _ = Describe("K8s Control Plane Deploy", Ordered, Label("control-plane", "k8
 			}, 15*time.Minute, 10*time.Second).Should(Succeed(),
 				"all resources should be healthy")
 		})
+
+		It("should render the default Kong worker process count in every Kong workload", Label("kong-worker-processes"), func() {
+			expectRenderedKongWorkerProcesses(h.HelmTemplate(baseValues...), "2")
+		})
 	})
 
 	// --- Custom install: LB + private registry + custom DB in one deploy ---
@@ -81,6 +85,7 @@ var _ = Describe("K8s Control Plane Deploy", Ordered, Label("control-plane", "k8
 				"api.service.type=LoadBalancer",
 				"global.imagePullSecrets[0].name=" + secretName,
 				"db.password=" + customPwd,
+				"kong.workerProcesses=3",
 			}, helmMirrorRegistrySetValues()...)
 			setValues = append(baseValues, customValues...)
 
@@ -242,5 +247,54 @@ var _ = Describe("K8s Control Plane Deploy", Ordered, Label("control-plane", "k8
 			}, 1*time.Minute, 3*time.Second).Should(Succeed(),
 				"API should be accessible with custom db.password")
 		})
+
+		It("should render the custom Kong worker process count in every Kong workload", Label("kong-worker-processes"), func() {
+			expectRenderedKongWorkerProcesses(resources, "3")
+		})
 	})
 })
+
+func expectRenderedKongWorkerProcesses(resources []unstructured.Unstructured, expected string) {
+	var actual []string
+
+	for _, resource := range resources {
+		containers, found, err := unstructured.NestedSlice(resource.Object, "spec", "template", "spec", "containers")
+		Expect(err).NotTo(HaveOccurred())
+		if !found {
+			continue
+		}
+
+		for _, container := range containers {
+			containerMap, ok := container.(map[string]interface{})
+			Expect(ok).To(BeTrue(), "rendered container should be an object")
+			if !ok {
+				continue
+			}
+
+			env, found, err := unstructured.NestedSlice(containerMap, "env")
+			Expect(err).NotTo(HaveOccurred())
+			if !found {
+				continue
+			}
+
+			for _, entry := range env {
+				entryMap, ok := entry.(map[string]interface{})
+				Expect(ok).To(BeTrue(), "rendered environment entry should be an object")
+				if !ok {
+					continue
+				}
+
+				if entryMap["name"] == "KONG_NGINX_WORKER_PROCESSES" {
+					value, ok := entryMap["value"].(string)
+					Expect(ok).To(BeTrue(), "Kong worker process value should be a string")
+					actual = append(actual, value)
+				}
+			}
+		}
+	}
+
+	Expect(actual).To(HaveLen(6), "all six Kong workloads should set worker processes")
+	for _, value := range actual {
+		Expect(value).To(Equal(expected))
+	}
+}


### PR DESCRIPTION
## Issue

NEU-716

## Summary

Adds an explicit Kong Nginx worker-process configuration so deployments default to 2 workers instead of scaling with host CPU count. Operators can intentionally select auto, with a warning about possible PostgreSQL connection pressure.

## Changes

- Adds --kong-worker-processes to neutree-cli launch neutree-core with a default of 2 and strict auto-or-positive-integer validation.
- Renders the value into Docker Compose and exposes kong.workerProcesses for Helm, consistently applied to all six Kong workloads.
- Rejects invalid inputs at the CLI and chart-render boundaries; does not add an unsupported Kong max-worker setting.
- Adds focused unit/render coverage and Docker/Kubernetes deployment E2E assertions for default and custom values.

## Test Plan

### Unit test

- Passed: go test ./cmd/neutree-cli/app/cmd/launch -count=1
- Passed: go vet ./cmd/neutree-cli/app/cmd/launch and go vet ./tests/e2e
- Passed: Helm lint and render matrix for 2, 3, auto, and invalid inputs.

### DB test

- Not affected: no schema, migration, query, or persistent-data change.

### E2E test

- Docker manual runtime passed for the default 2, custom 3, and safety-gated auto values; each run reached API health and verified the rendered and running Kong setting.
- Code-backed Docker and Kubernetes deployment assertions were added; the E2E package compiled successfully and PR CI passed.
- Kubernetes runtime deployment is blocked by an existing Grafana dashboard ConfigMap exceeding Kubernetes 1 MiB ConfigMap limit; this PR does not change Grafana paths.
- In this runner, live Code E2E execution is constrained by local temporary disk capacity and a macOS-to-Linux CLI build mismatch. The documented Docker manual runtime results above are the environment-specific fallback.

## Risk & Rollback

- No database schema change. The default caps Kong workers at 2; explicit auto can increase PostgreSQL connection demand and is documented as an operator opt-in.
- Revert this change to restore the previous Kong worker-process behavior.