### PR TITLE
fix: normalize vLLM KV cache size arguments

### DIFF
--- a/internal/engine/schema_test.go
+++ b/internal/engine/schema_test.go
@@ -12,6 +12,7 @@ func TestGetVLLMV0_17_1EngineSchema(t *testing.T) {
 	if schema == nil {
 		t.Fatal("expected schema to be non-nil")
 	}
+	assertHumanReadableKVCacheMemorySchema(t, schema)
 }
 
 func TestGetVLLMV0_24_0EngineSchema(t *testing.T) {
@@ -22,6 +23,7 @@ func TestGetVLLMV0_24_0EngineSchema(t *testing.T) {
 	if schema == nil {
 		t.Fatal("expected schema to be non-nil")
 	}
+	assertHumanReadableKVCacheMemorySchema(t, schema)
 
 	props, ok := schema["properties"].(map[string]interface{})
 	if !ok {
@@ -50,6 +52,26 @@ func TestGetVLLMV0_24_0EngineSchema(t *testing.T) {
 
 	if _, err := GetEngineSchema("vllm-v0.24.0"); err != nil {
 		t.Fatalf("EngineSchemas lookup for vLLM v0.24.0 failed: %v", err)
+	}
+}
+
+func assertHumanReadableKVCacheMemorySchema(t *testing.T, schema map[string]interface{}) {
+	t.Helper()
+
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("schema.properties missing or wrong type")
+	}
+	kvCache, ok := props["kv_cache_memory_bytes"].(map[string]interface{})
+	if !ok {
+		t.Fatal("kv_cache_memory_bytes schema missing or wrong type")
+	}
+	types, ok := kvCache["type"].([]interface{})
+	if !ok || len(types) != 2 || types[0] != "integer" || types[1] != "string" {
+		t.Fatalf("kv_cache_memory_bytes type = %#v, want [integer string]", kvCache["type"])
+	}
+	if _, ok := kvCache["pattern"].(string); !ok {
+		t.Fatal("kv_cache_memory_bytes string pattern is missing")
 	}
 }
 

--- a/internal/engine/vllm/v0.17.1/schema.json
+++ b/internal/engine/vllm/v0.17.1/schema.json
@@ -371,8 +371,9 @@
       "description": "The fraction of GPU memory to be used"
     },
     "kv_cache_memory_bytes": {
-      "type": "integer",
-      "description": "Size of KV Cache per GPU in bytes"
+      "type": ["integer", "string"],
+      "pattern": "^(?:\\d+|\\d+(?:\\.\\d+)?[kmgt]|\\d+[KMGT])$",
+      "description": "Size of KV Cache per GPU in bytes. Supports integer bytes or human-readable values such as 8G"
     },
     "max_num_batched_tokens": {
       "type": "integer",

--- a/internal/engine/vllm/v0.24.0/schema.json
+++ b/internal/engine/vllm/v0.24.0/schema.json
@@ -513,8 +513,9 @@
       "type": "number"
     },
     "kv_cache_memory_bytes": {
-      "description": "Size of KV Cache per GPU in bytes",
-      "type": "integer"
+      "description": "Size of KV Cache per GPU in bytes. Supports integer bytes or human-readable values such as 8G",
+      "type": ["integer", "string"],
+      "pattern": "^(?:\\d+|\\d+(?:\\.\\d+)?[kmgt]|\\d+[KMGT])$"
     },
     "max_num_batched_tokens": {
       "description": "Maximum number of batched tokens per iteration",

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -177,7 +177,7 @@ func setEngineTensorParallelDefault(data *DeploymentManifestVariables, endpoint 
 }
 
 // setEngineArgs sets engine arguments from endpoint variables
-func (k *kubernetesOrchestrator) setEngineArgs(data *DeploymentManifestVariables, endpoint *v1.Endpoint, engine *v1.Engine) {
+func (k *kubernetesOrchestrator) setEngineArgs(data *DeploymentManifestVariables, endpoint *v1.Endpoint, engine *v1.Engine) error {
 	// Set engine-specific default arguments first
 	k.setEngineDefaultArgs(data, engine)
 
@@ -195,9 +195,17 @@ func (k *kubernetesOrchestrator) setEngineArgs(data *DeploymentManifestVariables
 	// that expose a TP arg (vLLM / SGLang).
 	setEngineTensorParallelDefault(data, endpoint, engine)
 
+	if engine.Metadata.Name == v1.EngineNameVLLM {
+		if err := normalizeVLLMEngineArgs(data.EngineArgs); err != nil {
+			return err
+		}
+	}
+
 	// Prepare engine arg values for YAML double-quoted template rendering.
 	// Handles native maps, unescaped JSON strings, and pre-escaped strings.
 	prepareEngineArgsForTemplate(data.EngineArgs, engine.Metadata.Name)
+
+	return nil
 }
 
 func prepareEngineArgsForTemplate(args map[string]interface{}, engineName string) {
@@ -228,6 +236,14 @@ func prepareEngineArgsForTemplate(args map[string]interface{}, engineName string
 
 func prepareEngineArgValueForDoubleQuote(v interface{}) interface{} {
 	switch val := v.(type) {
+	case float64:
+		// Numbers decoded into map[string]interface{} become float64. Preserve
+		// integer-valued engine arguments as decimal strings because Go's default
+		// template formatting can emit large floats in scientific notation, which
+		// vLLM's integer parsers reject.
+		if !math.IsNaN(val) && !math.IsInf(val, 0) && math.Trunc(val) == val {
+			return strconv.FormatFloat(val, 'f', -1, 64)
+		}
 	case map[string]interface{}, []interface{}:
 		b, err := json.Marshal(v)
 		if err == nil {
@@ -515,7 +531,9 @@ func (k *kubernetesOrchestrator) buildManifestVariables(endpoint *v1.Endpoint, d
 	k.setRoutingLogic(&data, endpoint)
 
 	// Set engine args
-	k.setEngineArgs(&data, endpoint, engine)
+	if err := k.setEngineArgs(&data, endpoint, engine); err != nil {
+		return DeploymentManifestVariables{}, err
+	}
 
 	// Set resource variables
 	if err := k.setResourceVariables(&data, endpoint, deployedCluster); err != nil {

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -2179,10 +2179,26 @@ func TestKubernetesOrchestrator_setEngineArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			data := newDeploymentManifestVariables()
-			k.setEngineArgs(&data, tt.endpoint, tt.engine)
+			require.NoError(t, k.setEngineArgs(&data, tt.endpoint, tt.engine))
 			assert.Equal(t, tt.expectedArgs, data.EngineArgs)
 		})
 	}
+}
+
+func TestKubernetesOrchestrator_NormalizesKVCacheWithoutMutatingEndpoint(t *testing.T) {
+	k := &kubernetesOrchestrator{}
+	originalArgs := map[string]interface{}{"kv_cache_memory_bytes": "8G"}
+	endpoint := &v1.Endpoint{Spec: &v1.EndpointSpec{
+		Variables: map[string]interface{}{"engine_args": originalArgs},
+	}}
+	engine := &v1.Engine{Metadata: &v1.Metadata{Name: v1.EngineNameVLLM}}
+	data := newDeploymentManifestVariables()
+
+	require.NoError(t, k.setEngineArgs(&data, endpoint, engine))
+
+	assert.Equal(t, int64(8589934592), data.EngineArgs["kv_cache_memory_bytes"])
+	assert.Equal(t, "8G", originalArgs["kv_cache_memory_bytes"])
+	assert.Equal(t, "8G", endpoint.Spec.Variables["engine_args"].(map[string]interface{})["kv_cache_memory_bytes"])
 }
 
 func TestEscapeEngineArgsForTemplate(t *testing.T) {
@@ -2277,6 +2293,7 @@ func TestPrepareEngineArgsForTemplate_VLLMListSemantics(t *testing.T) {
 		"allowed_media_domains":      []string{"a.example.com", "b.example.com"},
 		"override_generation_config": map[string]interface{}{"temperature": 0.8},
 		"gpu_memory_utilization":     "0.85",
+		"kv_cache_memory_bytes":      float64(8589934592),
 		"enable_prefix_caching":      "false",
 	}
 
@@ -2287,7 +2304,55 @@ func TestPrepareEngineArgsForTemplate_VLLMListSemantics(t *testing.T) {
 	assert.Equal(t, []interface{}{"a.example.com", "b.example.com"}, args["allowed_media_domains"])
 	assert.Equal(t, `{\"temperature\":0.8}`, args["override_generation_config"])
 	assert.Equal(t, "0.85", args["gpu_memory_utilization"])
+	assert.Equal(t, "8589934592", args["kv_cache_memory_bytes"])
 	assert.Equal(t, "false", args["enable_prefix_caching"])
+}
+
+func TestBuildDeployment_VLLMLargeIntegerUsesDecimalNotation(t *testing.T) {
+	cases := []string{"vllm-v0.17.1", "vllm-v0.24.0"}
+
+	for _, templateKey := range cases {
+		t.Run(templateKey, func(t *testing.T) {
+			data := DeploymentManifestVariables{
+				NeutreeVersion:  "v0.1.0",
+				ClusterName:     "test-cluster",
+				Workspace:       "test-workspace",
+				Namespace:       "default",
+				ImagePrefix:     "registry.example.com",
+				ImageRepo:       "myrepo",
+				ImageTag:        "v1.0.0",
+				ImagePullSecret: "my-secret",
+				EngineName:      v1.EngineNameVLLM,
+				EngineVersion:   "v1.0.0",
+				EndpointName:    "test-endpoint",
+				ModelArgs: map[string]interface{}{
+					"name":          "gpt-4",
+					"task":          "text-generation",
+					"path":          "/mnt/models/gpt-4",
+					"registry_type": "bentoml",
+					"registry_path": "/mnt/registry/gpt-4-model",
+					"serve_name":    "gpt-4-serve",
+				},
+				EngineArgs: map[string]interface{}{
+					"kv_cache_memory_bytes": float64(8589934592),
+				},
+				Resources: map[string]string{
+					"cpu":    "500m",
+					"memory": "1Gi",
+				},
+				RoutingLogic: "roundrobin",
+				Replicas:     1,
+			}
+
+			prepareEngineArgsForTemplate(data.EngineArgs, v1.EngineNameVLLM)
+			objs, err := buildDeploymentObjects(realEmbeddedTemplate(t, templateKey), data)
+			require.NoError(t, err)
+
+			tokens := extractEngineCLITokens(t, objs)
+			assertFlagWithValue(t, tokens, "--kv_cache_memory_bytes", "8589934592")
+			assert.NotContains(t, tokens, "8.589934592e+09")
+		})
+	}
 }
 
 func TestPrepareEngineArgsForTemplate_NonVLLMListCompatibility(t *testing.T) {

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -988,6 +988,17 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 
 	maps.Copy(app.Args, endpoint.Spec.Variables)
 
+	if engineArgs, ok := app.Args["engine_args"].(map[string]interface{}); ok {
+		engineArgs = maps.Clone(engineArgs)
+		if endpoint.Spec.Engine.Engine == v1.EngineNameVLLM {
+			if err := normalizeVLLMEngineArgs(engineArgs); err != nil {
+				return dashboard.RayServeApplication{}, err
+			}
+		}
+
+		app.Args["engine_args"] = engineArgs
+	}
+
 	setDefaultSGLangEnableMetricsForApplication(endpoint, &app)
 
 	setDefaultTensorParallelSize(endpoint, &app, endpoint.Spec.Resources.GetGPUCount())

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -2250,6 +2250,40 @@ func TestEndpointToApplication_TensorParallelSize(t *testing.T) {
 	}
 }
 
+func TestEndpointToApplication_NormalizesKVCacheWithoutMutatingEndpoint(t *testing.T) {
+	originalArgs := map[string]interface{}{"kv_cache_memory_bytes": "8G"}
+	endpoint := &v1.Endpoint{
+		Metadata: &v1.Metadata{Workspace: "test", Name: "test-endpoint"},
+		Spec: &v1.EndpointSpec{
+			Engine: &v1.EndpointEngineSpec{Engine: v1.EngineNameVLLM, Version: "v0.24.0"},
+			Resources: &v1.ResourceSpec{
+				Accelerator: map[string]string{},
+			},
+			Replicas:  v1.ReplicaSpec{Num: pointy.Int(1)},
+			Variables: map[string]interface{}{"engine_args": originalArgs},
+			Model:     &v1.ModelSpec{Name: "test-model"},
+		},
+	}
+	modelRegistry := &v1.ModelRegistry{Spec: &v1.ModelRegistrySpec{
+		Type: v1.HuggingFaceModelRegistryType,
+	}}
+
+	app, err := EndpointToApplication(
+		endpoint,
+		&v1.Cluster{},
+		modelRegistry,
+		nil,
+		nil,
+		&acceleratormocks.MockManager{},
+	)
+	require.NoError(t, err)
+
+	runtimeArgs := app.Args["engine_args"].(map[string]interface{})
+	assert.Equal(t, int64(8589934592), runtimeArgs["kv_cache_memory_bytes"])
+	assert.Equal(t, "8G", originalArgs["kv_cache_memory_bytes"])
+	assert.Equal(t, "8G", endpoint.Spec.Variables["engine_args"].(map[string]interface{})["kv_cache_memory_bytes"])
+}
+
 func TestEndpointToApplication_TensorParallelSizeUsesRequestedGPUCount(t *testing.T) {
 	const customAcceleratorType = "custom_accelerator"
 

--- a/internal/orchestrator/util.go
+++ b/internal/orchestrator/util.go
@@ -3,7 +3,10 @@ package orchestrator
 import (
 	"fmt"
 	"maps"
+	"math"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -17,6 +20,87 @@ import (
 )
 
 const acceleratorTypeCPU = "cpu"
+
+var vllmHumanReadableIntPattern = regexp.MustCompile(`^(\d+(?:\.\d+)?)([kKmMgGtT])$`)
+
+// normalizeVLLMEngineArgs converts vLLM's human-readable KV-cache size to the
+// native integer expected by its Python API. Callers must pass a runtime copy,
+// not the map stored on the Endpoint, so the user's readable value is retained.
+func normalizeVLLMEngineArgs(args map[string]interface{}) error {
+	const key = "kv_cache_memory_bytes"
+
+	value, ok := args[key]
+	if !ok {
+		return nil
+	}
+
+	parsed, err := parseVLLMHumanReadableInt(value)
+	if err != nil {
+		return errors.Wrapf(err, "invalid vLLM engine argument %s", key)
+	}
+
+	args[key] = parsed
+
+	return nil
+}
+
+func parseVLLMHumanReadableInt(value interface{}) (int64, error) {
+	switch value := value.(type) {
+	case int:
+		if value < 0 {
+			return 0, errors.Errorf("expected a non-negative integer, got %d", value)
+		}
+
+		return int64(value), nil
+	case int64:
+		if value < 0 {
+			return 0, errors.Errorf("expected a non-negative integer, got %d", value)
+		}
+
+		return value, nil
+	case float64:
+		if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || math.Trunc(value) != value || value > math.MaxInt64 {
+			return 0, errors.Errorf("expected a non-negative integer, got %v", value)
+		}
+
+		return int64(value), nil
+	case string:
+		value = strings.TrimSpace(value)
+		if plain, err := strconv.ParseInt(value, 10, 64); err == nil && plain >= 0 {
+			return plain, nil
+		}
+
+		matches := vllmHumanReadableIntPattern.FindStringSubmatch(value)
+		if matches == nil {
+			return 0, errors.Errorf("expected integer bytes or a k/K/m/M/g/G/t/T suffix, got %q", value)
+		}
+
+		number, suffix := matches[1], matches[2]
+		multipliers := map[string]int64{
+			"k": 1_000, "m": 1_000_000, "g": 1_000_000_000, "t": 1_000_000_000_000,
+			"K": 1 << 10, "M": 1 << 20, "G": 1 << 30, "T": 1 << 40,
+		}
+		multiplier := multipliers[suffix]
+
+		if suffix == strings.ToUpper(suffix) {
+			integer, err := strconv.ParseInt(number, 10, 64)
+			if err != nil || integer > math.MaxInt64/multiplier {
+				return 0, errors.Errorf("value %q is not a representable binary size", value)
+			}
+
+			return integer * multiplier, nil
+		}
+
+		decimal, err := strconv.ParseFloat(number, 64)
+		if err != nil || decimal*float64(multiplier) > math.MaxInt64 {
+			return 0, errors.Errorf("value %q is not a representable decimal size", value)
+		}
+
+		return int64(decimal * float64(multiplier)), nil
+	default:
+		return 0, errors.Errorf("expected integer or string, got %T", value)
+	}
+}
 
 // engineTPArgKey returns the underscore-form engine_args key the engine
 // uses for tensor parallel size. vLLM uses `tensor_parallel_size`; SGLang's

--- a/internal/orchestrator/util_test.go
+++ b/internal/orchestrator/util_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"fmt"
 	"testing"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
@@ -257,6 +258,37 @@ func TestCPUOnly_OnlyMemory(t *testing.T) {
 	assert.NotNil(t, k8s)
 	assert.Equal(t, "16Gi", k8s.Requests["memory"])
 	assert.Empty(t, k8s.Requests["cpu"])
+}
+
+func TestParseVLLMHumanReadableInt(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  int64
+	}{
+		{name: "plain integer string", value: "8589934592", want: 8589934592},
+		{name: "binary gigabytes", value: "8G", want: 8 * (1 << 30)},
+		{name: "decimal gigabytes", value: "8g", want: 8_000_000_000},
+		{name: "fractional decimal gigabytes", value: "1.5g", want: 1_500_000_000},
+		{name: "native JSON number", value: float64(8589934592), want: 8589934592},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVLLMHumanReadableInt(tt.value)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseVLLMHumanReadableIntRejectsInvalidValues(t *testing.T) {
+	for _, value := range []interface{}{"8GB", "1.5G", "abc", -1, 1.5} {
+		t.Run(fmt.Sprint(value), func(t *testing.T) {
+			_, err := parseVLLMHumanReadableInt(value)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestGPUZero_NoAcceleratorType(t *testing.T) {

--- a/internal/routes/logs/trace_store_test.go
+++ b/internal/routes/logs/trace_store_test.go
@@ -237,11 +237,11 @@ func TestAssembleBody(t *testing.T) {
 	b64 := func(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
 
 	cases := []struct {
-		name   string
-		parts  []traceChunk
-		want   int
-		body   string
-		ok     bool
+		name  string
+		parts []traceChunk
+		want  int
+		body  string
+		ok    bool
 	}{
 		{"empty complete", nil, 0, "", true},
 		{"single", []traceChunk{{seq: 0, data: b64("abc")}}, 1, "abc", true},


### PR DESCRIPTION
## Summary

- `kv_cache_memory_bytes` was treated as integer-only, although vLLM accepts human-readable values such as `8G`; large numeric values could also be rendered in scientific notation and fail vLLM startup.
- Allow integer or vLLM-style string values in the built-in schemas, normalize them for Kubernetes and Ray runtime configs without changing the stored Endpoint value, and render large integers in decimal notation.
- Companion UI change: neutree-ai/ui#401.

## Test plan

- [x] `GOCACHE=/tmp/neutree-go-cache go test ./internal/orchestrator ./internal/engine`
