### PR TITLE
fix: stop the orchestrators and gateway panicking on a model-free endpoint (NEU-633)

### DIFF
--- a/internal/gateway/kong.go
+++ b/internal/gateway/kong.go
@@ -753,6 +753,12 @@ func isResourceNotFoundError(err error) bool {
 }
 
 func getEndpointRouteType(ep *v1.Endpoint) string {
+	// An engine that ships its own model (e.g. Flex) may leave Spec.Model nil;
+	// there is no task to branch on, so fall through to the default route type.
+	if ep.Spec.Model == nil {
+		return v1.RouteTypeChatCompletions
+	}
+
 	switch ep.Spec.Model.Task {
 	case v1.TextGenerationModelTask:
 		return v1.RouteTypeChatCompletions

--- a/internal/gateway/kong_route_type_test.go
+++ b/internal/gateway/kong_route_type_test.go
@@ -1,0 +1,44 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+)
+
+// NEU-633: an endpoint whose engine ships its own model (e.g. Flex) may have
+// a nil Spec.Model. getEndpointRouteType must fall back to the default route
+// type instead of dereferencing it.
+func TestGetEndpointRouteType_NilModel(t *testing.T) {
+	ep := &v1.Endpoint{
+		Spec: &v1.EndpointSpec{
+			Engine: &v1.EndpointEngineSpec{Engine: "flex", Version: "1.0.0"},
+		},
+	}
+
+	assert.Equal(t, v1.RouteTypeChatCompletions, getEndpointRouteType(ep))
+}
+
+func TestGetEndpointRouteType_ByTask(t *testing.T) {
+	tests := []struct {
+		task     string
+		expected string
+	}{
+		{v1.TextGenerationModelTask, v1.RouteTypeChatCompletions},
+		{v1.TextEmbeddingModelTask, v1.RouteTypeEmbeddings},
+		{v1.TextRerankModelTask, v1.RouteTypeRerank},
+		{"", v1.RouteTypeChatCompletions},
+	}
+
+	for _, tt := range tests {
+		ep := &v1.Endpoint{
+			Spec: &v1.EndpointSpec{
+				Model: &v1.ModelSpec{Task: tt.task},
+			},
+		}
+
+		assert.Equal(t, tt.expected, getEndpointRouteType(ep))
+	}
+}

--- a/internal/orchestrator/kubernetes_orchestrator_resource.go
+++ b/internal/orchestrator/kubernetes_orchestrator_resource.go
@@ -376,8 +376,16 @@ func (k *kubernetesOrchestrator) setModelCacheVariables(data *DeploymentManifest
 	return nil
 }
 
-// setModelArgs initializes model arguments from endpoint spec
+// setModelArgs initializes model arguments from endpoint spec.
+//
+// endpoint.Spec.Model is nil for an engine that ships its own model (e.g.
+// Flex): there is nothing to place, so ModelArgs stays empty rather than
+// dereferencing a spec field the endpoint never had.
 func (k *kubernetesOrchestrator) setModelArgs(data *DeploymentManifestVariables, endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistry) {
+	if endpoint.Spec.Model == nil {
+		return
+	}
+
 	modelArgs := map[string]interface{}{
 		"name":          endpoint.Spec.Model.Name,
 		"version":       endpoint.Spec.Model.Version,

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -2496,6 +2496,20 @@ func TestKubernetesOrchestrator_setModelArgs(t *testing.T) {
 				"serve_name":    "gpt-model",
 			},
 		},
+		{
+			// NEU-633: an engine that ships its own model (e.g. Flex) is deployed
+			// with no spec.model at all. setModelArgs must not dereference it.
+			name: "nil model spec for a model-free engine",
+			endpoint: &v1.Endpoint{
+				Spec: &v1.EndpointSpec{
+					Engine: &v1.EndpointEngineSpec{
+						Engine: "flex",
+					},
+				},
+			},
+			modelRegistry:     nil,
+			expectedModelArgs: map[string]interface{}{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -324,7 +324,10 @@ func (o *RayOrchestrator) DeleteEndpoint(endpoint *v1.Endpoint) error {
 		return err
 	}
 
-	if !isNew {
+	// An endpoint that names no registry (nil Spec.Model, or Model.Registry
+	// empty for an engine that ships its own model) never had anything
+	// SSH-mounted, so there is nothing to disconnect.
+	if !isNew && endpoint.Spec.Model != nil && endpoint.Spec.Model.Registry != "" {
 		modelRegistry, mErr := getEndpointModelRegistry(o.storage, endpoint)
 
 		switch {
@@ -913,15 +916,20 @@ func EndpointToApplication(endpoint *v1.Endpoint, deployedCluster *v1.Cluster,
 		applicationEnv[k] = v
 	}
 
+	// endpoint.Spec.Model is nil for an engine that ships its own model (e.g.
+	// Flex): there is nothing to place, so modelArgs stays empty beyond
+	// registry_type rather than dereferencing a spec field the endpoint never had.
 	modelArgs := map[string]interface{}{
 		"registry_type": endpointModelRegistryType(modelRegistry),
-		"name":          endpoint.Spec.Model.Name,
-		"file":          endpoint.Spec.Model.File,
-		"version":       endpoint.Spec.Model.Version,
-		"task":          endpoint.Spec.Model.Task,
 	}
 
-	modelArgs["serve_name"] = endpointModelServeName(endpoint, modelRegistry)
+	if endpoint.Spec.Model != nil {
+		modelArgs["name"] = endpoint.Spec.Model.Name
+		modelArgs["file"] = endpoint.Spec.Model.File
+		modelArgs["version"] = endpoint.Spec.Model.Version
+		modelArgs["task"] = endpoint.Spec.Model.Task
+		modelArgs["serve_name"] = endpointModelServeName(endpoint, modelRegistry)
+	}
 
 	modelCacheRelativePath := v1.DefaultModelCacheRelativePath
 

--- a/internal/orchestrator/ray_orchestrator.go
+++ b/internal/orchestrator/ray_orchestrator.go
@@ -324,10 +324,9 @@ func (o *RayOrchestrator) DeleteEndpoint(endpoint *v1.Endpoint) error {
 		return err
 	}
 
-	// An endpoint that names no registry (nil Spec.Model, or Model.Registry
-	// empty for an engine that ships its own model) never had anything
-	// SSH-mounted, so there is nothing to disconnect.
-	if !isNew && endpoint.Spec.Model != nil && endpoint.Spec.Model.Registry != "" {
+	// An endpoint that names no registry (an engine that ships its own model,
+	// e.g. Flex) never had anything SSH-mounted, so there is nothing to disconnect.
+	if !isNew && endpointNamesModelRegistry(endpoint) {
 		modelRegistry, mErr := getEndpointModelRegistry(o.storage, endpoint)
 
 		switch {

--- a/internal/orchestrator/ray_orchestrator_test.go
+++ b/internal/orchestrator/ray_orchestrator_test.go
@@ -4144,6 +4144,32 @@ func TestEndpointToApplication_WithoutModelRegistry(t *testing.T) {
 	assert.NotContains(t, modelArgs, "registry_path")
 }
 
+// NEU-633: an Endpoint that omits spec.model entirely (not just an empty
+// ModelSpec) for an engine that ships its own model, e.g. Flex. Before the
+// fix EndpointToApplication panicked dereferencing endpoint.Spec.Model.
+func TestEndpointToApplication_WithoutModel(t *testing.T) {
+	endpoint := &v1.Endpoint{
+		Metadata: &v1.Metadata{Workspace: "production", Name: "flex-endpoint"},
+		Spec: &v1.EndpointSpec{
+			Engine:            &v1.EndpointEngineSpec{Engine: "flex", Version: "1.0.0"},
+			Resources:         &v1.ResourceSpec{Accelerator: map[string]string{}},
+			DeploymentOptions: map[string]interface{}{},
+		},
+	}
+
+	app, err := EndpointToApplication(endpoint, &v1.Cluster{}, nil, nil, nil, &acceleratormocks.MockManager{})
+
+	require.NoError(t, err)
+
+	modelArgs, ok := app.Args["model"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "", modelArgs["registry_type"])
+	assert.NotContains(t, modelArgs, "name")
+	assert.NotContains(t, modelArgs, "serve_name")
+	assert.NotContains(t, modelArgs, "registry_path")
+}
+
 // The ModelScope deploy path through the Ray (SSH cluster) orchestrator. The
 // Kubernetes orchestrator has the same test; both are here because the two
 // build their model args independently and a fix applied to one has silently

--- a/internal/orchestrator/util.go
+++ b/internal/orchestrator/util.go
@@ -36,7 +36,8 @@ func engineTPArgKey(engineName string) string {
 }
 
 // endpointModelServeName is the model id the endpoint answers to over the
-// OpenAI-compatible API.
+// OpenAI-compatible API, empty when the endpoint names no model (an engine
+// that ships its own, e.g. Flex).
 //
 // A version is appended only for registries where it names a distinct stored
 // artifact — bentoml. On a hub the "version" is a git revision, so appending it
@@ -44,6 +45,10 @@ func engineTPArgKey(engineName string) string {
 // name any client would ask for and differs from what the same model is called
 // when deployed from Hugging Face. Both hub kinds are excluded for that reason.
 func endpointModelServeName(endpoint *v1.Endpoint, modelRegistry *v1.ModelRegistry) string {
+	if endpoint.Spec.Model == nil {
+		return ""
+	}
+
 	serveName := endpoint.Spec.Model.Name
 	if endpoint.Spec.Engine != nil && endpoint.Spec.Engine.Engine == v1.EngineNameSGLang {
 		return serveName
@@ -136,13 +141,20 @@ func getUsedEngine(s storage.Storage, endpoint *v1.Endpoint) (*v1.Engine, error)
 	return &engine[0], nil
 }
 
+// endpointNamesModelRegistry reports whether the endpoint has a model
+// registry to resolve at all. False for an engine that ships its own model
+// (e.g. Flex), where Spec.Model may be nil or carry no registry.
+func endpointNamesModelRegistry(endpoint *v1.Endpoint) bool {
+	return endpoint.Spec != nil && endpoint.Spec.Model != nil && endpoint.Spec.Model.Registry != ""
+}
+
 // resolveEndpointModelRegistry returns the model registry an endpoint deploys
 // from, or nil when it names none.
 //
 // nil is a legitimate state, not a lookup failure: an engine that ships its own
 // weights has nothing to fetch. Callers must handle it.
 func resolveEndpointModelRegistry(s storage.Storage, endpoint *v1.Endpoint) (*v1.ModelRegistry, error) {
-	if endpoint.Spec == nil || endpoint.Spec.Model == nil || endpoint.Spec.Model.Registry == "" {
+	if !endpointNamesModelRegistry(endpoint) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Summary
- NEU-633 made `spec.model` optional for engines that ship their own model (e.g. Flex), but `setModelArgs` in both the Kubernetes and Ray (SSH cluster) orchestrators still dereferenced `endpoint.Spec.Model` unconditionally, panicking Neutree Core when building the deploy manifest for a model-free endpoint.
- The Ray orchestrator's `DeleteEndpoint` SSH NFS-disconnect path had the same gap, reading `endpoint.Spec.Model.Registry` without a nil check.
- `getEndpointRouteType` in the Kong gateway sync had the same gap and would have panicked next, once a model-free endpoint reached Running.
- All three now treat a nil `Spec.Model` the way the already-fixed model registry resolution does: nothing to place/branch on, so skip rather than crash.

## Test plan
- [x] `go test ./internal/orchestrator/... ./internal/gateway/...` — added regression cases for a nil `Spec.Model` in all three sites
- [x] `go build ./...`