### PR TITLE
ci: add daily quick start e2e workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,18 @@
+# Self-hosted labels used by existing release and daily Quick Start E2E runners.
+self-hosted-runner:
+  labels:
+    - serve-builder
+    - X64
+    - neutree-e2e
+    - amd64-k8s
+    - arm64-k8s
+    - amd64-vm
+    - amd64-l20-k8s
+    - amd64-t4-static
+
+paths:
+  .github/workflows/daily-e2e.yaml:
+    ignore:
+      # GitHub Actions supports concurrency.queue, but actionlint v1.7.12 has
+      # not added it to the concurrency schema yet.
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/daily-e2e.yaml
+++ b/.github/workflows/daily-e2e.yaml
@@ -1,0 +1,587 @@
+name: Daily E2E
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Daily Quick Start target
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - amd64-k8s
+          - arm64-k8s
+          - amd64-vm
+          - amd64-l20-k8s
+          - amd64-t4-static
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-quick-start-e2e
+  queue: max
+
+env:
+  E2E_CLI_BINARY: ${{ github.workspace }}/bin/neutree-cli
+  E2E_GINKGO_ARGS: --ginkgo.fail-on-empty
+
+jobs:
+  amd64_k8s:
+    name: amd64 K8s
+    if: github.event_name == 'schedule' || github.event.inputs.target == 'all' || github.event.inputs.target == 'amd64-k8s'
+    runs-on:
+      - self-hosted
+      - linux
+      - neutree-e2e
+      - amd64-k8s
+    environment: e2e-amd64-k8s
+    timeout-minutes: 40
+    env:
+      E2E_DAILY_TARGET: amd64-k8s
+      E2E_PROFILE_B64: ${{ secrets.E2E_PROFILE_B64 }}
+      E2E_RUNTIME_REF: ${{ vars.E2E_RUNTIME_REF }}
+      NEUTREE_API_KEY: ${{ secrets.NEUTREE_API_KEY }}
+      NEUTREE_SERVER_URL: ${{ secrets.NEUTREE_SERVER_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate E2E profile
+        run: |
+          set -euo pipefail
+          scripts/e2e/generate-profile.sh \
+            --output "$RUNNER_TEMP/e2e-profile.yaml" \
+            --github-env "$GITHUB_ENV"
+
+      - name: Build neutree-cli
+        run: make build-neutree-cli
+
+      - name: Run daily Quick Start E2E
+        id: run
+        run: |
+          set -euo pipefail
+          run_log="$RUNNER_TEMP/daily-e2e-amd64-k8s.raw.log"
+          : "${E2E_RUNTIME_REF:?E2E_RUNTIME_REF must be set}"
+          start_epoch="$(date +%s)"
+          set +e
+          (
+            set -euo pipefail
+            printf 'target=%s\n' "$E2E_DAILY_TARGET"
+            printf 'runtime_ref=%s\n' "$E2E_RUNTIME_REF"
+            make e2e-test \
+              LABEL_FILTER='cluster && k8s && lifecycle && C2613101' \
+              E2E_TIMEOUT=20m \
+              E2E_GINKGO_ARGS="$E2E_GINKGO_ARGS"
+            make e2e-test \
+              LABEL_FILTER='external-endpoint && openai && (C2642174 || C2642175)' \
+              E2E_TIMEOUT=20m \
+              E2E_GINKGO_ARGS="$E2E_GINKGO_ARGS"
+          ) >"$run_log" 2>&1
+          exit_code=$?
+          set -e
+          duration_seconds=$(( $(date +%s) - start_epoch ))
+          {
+            printf 'raw_log=%s\n' "$run_log"
+            printf 'exit_code=%s\n' "$exit_code"
+            printf 'duration_seconds=%s\n' "$duration_seconds"
+          } >>"$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Sanitize daily E2E log
+        id: sanitize
+        if: always()
+        run: |
+          set -euo pipefail
+          raw_log="$RUNNER_TEMP/daily-e2e-amd64-k8s.raw.log"
+          sanitized_log="$RUNNER_TEMP/daily-e2e-amd64-k8s.sanitized.log"
+          if [[ -f "$raw_log" ]]; then
+            scripts/e2e/sanitize-e2e-log.sh "$raw_log" "$sanitized_log"
+            cat "$sanitized_log"
+          fi
+          printf 'path=%s\n' "$sanitized_log" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize daily E2E
+        if: always()
+        run: |
+          {
+            echo "## Daily Quick Start E2E"
+            echo "- Target: \`$E2E_DAILY_TARGET\`"
+            echo "- Checkout SHA: \`${{ github.sha }}\`"
+            echo "- Runtime ref: \`$E2E_RUNTIME_REF\`"
+            echo "- Duration: \`${{ steps.run.outputs.duration_seconds || 'not recorded' }}s\`"
+            echo "- Exit code: \`${{ steps.run.outputs.exit_code || 'not recorded' }}\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized daily E2E log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-e2e-amd64-k8s-log
+          path: ${{ steps.sanitize.outputs.path }}
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Cleanup daily E2E files
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -n "${E2E_PROFILE_PATH:-}" ]]; then
+            rm -f -- "$E2E_PROFILE_PATH"
+          fi
+          rm -f -- \
+            "$RUNNER_TEMP/daily-e2e-amd64-k8s.raw.log" \
+            "$RUNNER_TEMP/daily-e2e-amd64-k8s.sanitized.log"
+
+  arm64_k8s:
+    name: arm64 K8s
+    if: github.event_name == 'schedule' || github.event.inputs.target == 'all' || github.event.inputs.target == 'arm64-k8s'
+    runs-on:
+      - self-hosted
+      - linux
+      - neutree-e2e
+      - arm64-k8s
+    environment: e2e-arm64-k8s
+    timeout-minutes: 30
+    env:
+      E2E_DAILY_TARGET: arm64-k8s
+      E2E_PROFILE_B64: ${{ secrets.E2E_PROFILE_B64 }}
+      E2E_RUNTIME_REF: ${{ vars.E2E_RUNTIME_REF }}
+      NEUTREE_API_KEY: ${{ secrets.NEUTREE_API_KEY }}
+      NEUTREE_SERVER_URL: ${{ secrets.NEUTREE_SERVER_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate E2E profile
+        run: |
+          set -euo pipefail
+          scripts/e2e/generate-profile.sh \
+            --output "$RUNNER_TEMP/e2e-profile.yaml" \
+            --github-env "$GITHUB_ENV"
+
+      - name: Build neutree-cli
+        run: make build-neutree-cli
+
+      - name: Run daily Quick Start E2E
+        id: run
+        run: |
+          set -euo pipefail
+          run_log="$RUNNER_TEMP/daily-e2e-arm64-k8s.raw.log"
+          : "${E2E_RUNTIME_REF:?E2E_RUNTIME_REF must be set}"
+          start_epoch="$(date +%s)"
+          set +e
+          (
+            set -euo pipefail
+            printf 'target=%s\n' "$E2E_DAILY_TARGET"
+            printf 'runtime_ref=%s\n' "$E2E_RUNTIME_REF"
+            make e2e-test \
+              LABEL_FILTER='cluster && k8s && lifecycle && C2613101' \
+              E2E_TIMEOUT=20m \
+              E2E_GINKGO_ARGS="$E2E_GINKGO_ARGS"
+          ) >"$run_log" 2>&1
+          exit_code=$?
+          set -e
+          duration_seconds=$(( $(date +%s) - start_epoch ))
+          {
+            printf 'raw_log=%s\n' "$run_log"
+            printf 'exit_code=%s\n' "$exit_code"
+            printf 'duration_seconds=%s\n' "$duration_seconds"
+          } >>"$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Sanitize daily E2E log
+        id: sanitize
+        if: always()
+        run: |
+          set -euo pipefail
+          raw_log="$RUNNER_TEMP/daily-e2e-arm64-k8s.raw.log"
+          sanitized_log="$RUNNER_TEMP/daily-e2e-arm64-k8s.sanitized.log"
+          if [[ -f "$raw_log" ]]; then
+            scripts/e2e/sanitize-e2e-log.sh "$raw_log" "$sanitized_log"
+            cat "$sanitized_log"
+          fi
+          printf 'path=%s\n' "$sanitized_log" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize daily E2E
+        if: always()
+        run: |
+          {
+            echo "## Daily Quick Start E2E"
+            echo "- Target: \`$E2E_DAILY_TARGET\`"
+            echo "- Checkout SHA: \`${{ github.sha }}\`"
+            echo "- Runtime ref: \`$E2E_RUNTIME_REF\`"
+            echo "- Duration: \`${{ steps.run.outputs.duration_seconds || 'not recorded' }}s\`"
+            echo "- Exit code: \`${{ steps.run.outputs.exit_code || 'not recorded' }}\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized daily E2E log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-e2e-arm64-k8s-log
+          path: ${{ steps.sanitize.outputs.path }}
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Cleanup daily E2E files
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -n "${E2E_PROFILE_PATH:-}" ]]; then
+            rm -f -- "$E2E_PROFILE_PATH"
+          fi
+          rm -f -- \
+            "$RUNNER_TEMP/daily-e2e-arm64-k8s.raw.log" \
+            "$RUNNER_TEMP/daily-e2e-arm64-k8s.sanitized.log"
+
+  amd64_vm:
+    name: amd64 VM
+    if: github.event_name == 'schedule' || github.event.inputs.target == 'all' || github.event.inputs.target == 'amd64-vm'
+    runs-on:
+      - self-hosted
+      - linux
+      - neutree-e2e
+      - amd64-vm
+    environment: e2e-amd64-vm
+    timeout-minutes: 45
+    env:
+      E2E_DAILY_TARGET: amd64-vm
+      E2E_PROFILE_B64: ${{ secrets.E2E_PROFILE_B64 }}
+      E2E_RUNTIME_REF: ${{ vars.E2E_RUNTIME_REF }}
+      NEUTREE_API_KEY: ${{ secrets.NEUTREE_API_KEY }}
+      NEUTREE_SERVER_URL: ${{ secrets.NEUTREE_SERVER_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate E2E profile
+        run: |
+          set -euo pipefail
+          scripts/e2e/generate-profile.sh \
+            --output "$RUNNER_TEMP/e2e-profile.yaml" \
+            --github-env "$GITHUB_ENV"
+
+      - name: Build neutree-cli
+        run: make build-neutree-cli
+
+      - name: Run daily Quick Start E2E
+        id: run
+        run: |
+          set -euo pipefail
+          run_log="$RUNNER_TEMP/daily-e2e-amd64-vm.raw.log"
+          : "${E2E_RUNTIME_REF:?E2E_RUNTIME_REF must be set}"
+          start_epoch="$(date +%s)"
+          set +e
+          (
+            set -euo pipefail
+            printf 'target=%s\n' "$E2E_DAILY_TARGET"
+            printf 'runtime_ref=%s\n' "$E2E_RUNTIME_REF"
+            make e2e-test \
+              LABEL_FILTER='control-plane && deploy && online' \
+              E2E_TIMEOUT=30m \
+              E2E_GINKGO_ARGS="$E2E_GINKGO_ARGS"
+          ) >"$run_log" 2>&1
+          exit_code=$?
+          set -e
+          duration_seconds=$(( $(date +%s) - start_epoch ))
+          {
+            printf 'raw_log=%s\n' "$run_log"
+            printf 'exit_code=%s\n' "$exit_code"
+            printf 'duration_seconds=%s\n' "$duration_seconds"
+          } >>"$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Sanitize daily E2E log
+        id: sanitize
+        if: always()
+        run: |
+          set -euo pipefail
+          raw_log="$RUNNER_TEMP/daily-e2e-amd64-vm.raw.log"
+          sanitized_log="$RUNNER_TEMP/daily-e2e-amd64-vm.sanitized.log"
+          if [[ -f "$raw_log" ]]; then
+            scripts/e2e/sanitize-e2e-log.sh "$raw_log" "$sanitized_log"
+            cat "$sanitized_log"
+          fi
+          printf 'path=%s\n' "$sanitized_log" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize daily E2E
+        if: always()
+        run: |
+          {
+            echo "## Daily Quick Start E2E"
+            echo "- Target: \`$E2E_DAILY_TARGET\`"
+            echo "- Checkout SHA: \`${{ github.sha }}\`"
+            echo "- Runtime ref: \`$E2E_RUNTIME_REF\`"
+            echo "- Duration: \`${{ steps.run.outputs.duration_seconds || 'not recorded' }}s\`"
+            echo "- Exit code: \`${{ steps.run.outputs.exit_code || 'not recorded' }}\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized daily E2E log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-e2e-amd64-vm-log
+          path: ${{ steps.sanitize.outputs.path }}
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Cleanup daily E2E files
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -n "${E2E_PROFILE_PATH:-}" ]]; then
+            rm -f -- "$E2E_PROFILE_PATH"
+          fi
+          rm -f -- \
+            "$RUNNER_TEMP/daily-e2e-amd64-vm.raw.log" \
+            "$RUNNER_TEMP/daily-e2e-amd64-vm.sanitized.log"
+
+  amd64_l20_k8s:
+    name: amd64 L20 K8s
+    if: github.event_name == 'schedule' || github.event.inputs.target == 'all' || github.event.inputs.target == 'amd64-l20-k8s'
+    runs-on:
+      - self-hosted
+      - linux
+      - neutree-e2e
+      - amd64-l20-k8s
+    environment: e2e-amd64-l20-k8s
+    timeout-minutes: 45
+    env:
+      E2E_DAILY_TARGET: amd64-l20-k8s
+      E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT: ${{ vars.E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT }}
+      E2E_PROFILE_B64: ${{ secrets.E2E_PROFILE_B64 }}
+      E2E_RUNTIME_REF: ${{ vars.E2E_RUNTIME_REF }}
+      NEUTREE_API_KEY: ${{ secrets.NEUTREE_API_KEY }}
+      NEUTREE_SERVER_URL: ${{ secrets.NEUTREE_SERVER_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate E2E profile
+        run: |
+          set -euo pipefail
+          scripts/e2e/generate-profile.sh \
+            --output "$RUNNER_TEMP/e2e-profile.yaml" \
+            --github-env "$GITHUB_ENV"
+
+      - name: Build neutree-cli
+        run: make build-neutree-cli
+
+      - name: Run daily Quick Start E2E
+        id: run
+        run: |
+          set -euo pipefail
+          run_log="$RUNNER_TEMP/daily-e2e-amd64-l20-k8s.raw.log"
+          : "${E2E_RUNTIME_REF:?E2E_RUNTIME_REF must be set}"
+          : "${E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT:?E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT must be set}"
+          start_epoch="$(date +%s)"
+          set +e
+          (
+            set -euo pipefail
+            printf 'target=%s\n' "$E2E_DAILY_TARGET"
+            printf 'runtime_ref=%s\n' "$E2E_RUNTIME_REF"
+            printf 'expected_accelerator_product=%s\n' "$E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT"
+            make e2e-test \
+              LABEL_FILTER='endpoint && k8s && inference && chat && sglang && C2649559' \
+              E2E_TIMEOUT=30m \
+              E2E_GINKGO_ARGS="$E2E_GINKGO_ARGS"
+          ) >"$run_log" 2>&1
+          exit_code=$?
+          set -e
+          duration_seconds=$(( $(date +%s) - start_epoch ))
+          {
+            printf 'raw_log=%s\n' "$run_log"
+            printf 'exit_code=%s\n' "$exit_code"
+            printf 'duration_seconds=%s\n' "$duration_seconds"
+          } >>"$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Sanitize daily E2E log
+        id: sanitize
+        if: always()
+        run: |
+          set -euo pipefail
+          raw_log="$RUNNER_TEMP/daily-e2e-amd64-l20-k8s.raw.log"
+          sanitized_log="$RUNNER_TEMP/daily-e2e-amd64-l20-k8s.sanitized.log"
+          if [[ -f "$raw_log" ]]; then
+            scripts/e2e/sanitize-e2e-log.sh "$raw_log" "$sanitized_log"
+            cat "$sanitized_log"
+          fi
+          printf 'path=%s\n' "$sanitized_log" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize daily E2E
+        if: always()
+        run: |
+          {
+            echo "## Daily Quick Start E2E"
+            echo "- Target: \`$E2E_DAILY_TARGET\`"
+            echo "- Checkout SHA: \`${{ github.sha }}\`"
+            echo "- Runtime ref: \`$E2E_RUNTIME_REF\`"
+            echo "- Expected accelerator product: \`$E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT\`"
+            echo "- Duration: \`${{ steps.run.outputs.duration_seconds || 'not recorded' }}s\`"
+            echo "- Exit code: \`${{ steps.run.outputs.exit_code || 'not recorded' }}\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized daily E2E log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-e2e-amd64-l20-k8s-log
+          path: ${{ steps.sanitize.outputs.path }}
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Cleanup daily E2E files
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -n "${E2E_PROFILE_PATH:-}" ]]; then
+            rm -f -- "$E2E_PROFILE_PATH"
+          fi
+          rm -f -- \
+            "$RUNNER_TEMP/daily-e2e-amd64-l20-k8s.raw.log" \
+            "$RUNNER_TEMP/daily-e2e-amd64-l20-k8s.sanitized.log"
+
+  amd64_t4_static:
+    name: amd64 T4 static
+    needs:
+      - amd64_l20_k8s
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' || github.event.inputs.target == 'all' || github.event.inputs.target == 'amd64-t4-static') &&
+      (needs.amd64_l20_k8s.result == 'success' || needs.amd64_l20_k8s.result == 'skipped')
+    runs-on:
+      - self-hosted
+      - linux
+      - neutree-e2e
+      - amd64-t4-static
+    environment: e2e-amd64-t4-static
+    timeout-minutes: 45
+    env:
+      E2E_DAILY_TARGET: amd64-t4-static
+      E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT: ${{ vars.E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT }}
+      E2E_PROFILE_B64: ${{ secrets.E2E_PROFILE_B64 }}
+      E2E_RUNTIME_REF: ${{ vars.E2E_RUNTIME_REF }}
+      NEUTREE_API_KEY: ${{ secrets.NEUTREE_API_KEY }}
+      NEUTREE_SERVER_URL: ${{ secrets.NEUTREE_SERVER_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate E2E profile
+        run: |
+          set -euo pipefail
+          scripts/e2e/generate-profile.sh \
+            --output "$RUNNER_TEMP/e2e-profile.yaml" \
+            --github-env "$GITHUB_ENV"
+
+      - name: Build neutree-cli
+        run: make build-neutree-cli
+
+      - name: Run daily Quick Start E2E
+        id: run
+        run: |
+          set -euo pipefail
+          run_log="$RUNNER_TEMP/daily-e2e-amd64-t4-static.raw.log"
+          : "${E2E_RUNTIME_REF:?E2E_RUNTIME_REF must be set}"
+          : "${E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT:?E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT must be set}"
+          start_epoch="$(date +%s)"
+          set +e
+          (
+            set -euo pipefail
+            printf 'target=%s\n' "$E2E_DAILY_TARGET"
+            printf 'runtime_ref=%s\n' "$E2E_RUNTIME_REF"
+            printf 'expected_accelerator_product=%s\n' "$E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT"
+            make e2e-test \
+              LABEL_FILTER='endpoint && ssh && inference && chat && !sglang && !inference-error' \
+              E2E_TIMEOUT=25m \
+              E2E_GINKGO_ARGS="$E2E_GINKGO_ARGS"
+            make e2e-test \
+              LABEL_FILTER='cli && apply && C2642183' \
+              E2E_TIMEOUT=15m \
+              E2E_GINKGO_ARGS="$E2E_GINKGO_ARGS"
+          ) >"$run_log" 2>&1
+          exit_code=$?
+          set -e
+          duration_seconds=$(( $(date +%s) - start_epoch ))
+          {
+            printf 'raw_log=%s\n' "$run_log"
+            printf 'exit_code=%s\n' "$exit_code"
+            printf 'duration_seconds=%s\n' "$duration_seconds"
+          } >>"$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Sanitize daily E2E log
+        id: sanitize
+        if: always()
+        run: |
+          set -euo pipefail
+          raw_log="$RUNNER_TEMP/daily-e2e-amd64-t4-static.raw.log"
+          sanitized_log="$RUNNER_TEMP/daily-e2e-amd64-t4-static.sanitized.log"
+          if [[ -f "$raw_log" ]]; then
+            scripts/e2e/sanitize-e2e-log.sh "$raw_log" "$sanitized_log"
+            cat "$sanitized_log"
+          fi
+          printf 'path=%s\n' "$sanitized_log" >>"$GITHUB_OUTPUT"
+
+      - name: Summarize daily E2E
+        if: always()
+        run: |
+          {
+            echo "## Daily Quick Start E2E"
+            echo "- Target: \`$E2E_DAILY_TARGET\`"
+            echo "- Checkout SHA: \`${{ github.sha }}\`"
+            echo "- Runtime ref: \`$E2E_RUNTIME_REF\`"
+            echo "- Expected accelerator product: \`$E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT\`"
+            echo "- Duration: \`${{ steps.run.outputs.duration_seconds || 'not recorded' }}s\`"
+            echo "- Exit code: \`${{ steps.run.outputs.exit_code || 'not recorded' }}\`"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized daily E2E log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-e2e-amd64-t4-static-log
+          path: ${{ steps.sanitize.outputs.path }}
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Cleanup daily E2E files
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -n "${E2E_PROFILE_PATH:-}" ]]; then
+            rm -f -- "$E2E_PROFILE_PATH"
+          fi
+          rm -f -- \
+            "$RUNNER_TEMP/daily-e2e-amd64-t4-static.raw.log" \
+            "$RUNNER_TEMP/daily-e2e-amd64-t4-static.sanitized.log"

--- a/Makefile
+++ b/Makefile
@@ -210,11 +210,12 @@ test: prepare-build-cli mockgen fmt vet lint ## Run unit test
 
 LABEL_FILTER ?=
 E2E_TIMEOUT ?= 30m
+E2E_GINKGO_ARGS ?=
 
 .PHONY: e2e-test
 e2e-test: ## Run E2E tests (requires NEUTREE_SERVER_URL and NEUTREE_API_KEY)
 	$(if $(wildcard .env),set -a && source .env && set +a &&) go test -v -timeout 6h ./tests/e2e/... \
-		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips --ginkgo.timeout=$(E2E_TIMEOUT) $(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")
+		--ginkgo.v --ginkgo.no-color --ginkgo.silence-skips --ginkgo.timeout=$(E2E_TIMEOUT) $(if $(LABEL_FILTER),--ginkgo.label-filter="$(LABEL_FILTER)")$(if $(strip $(E2E_GINKGO_ARGS)), $(strip $(E2E_GINKGO_ARGS)))
 
 ##@ Gateway Lua Testing
 

--- a/scripts/e2e/generate-profile.sh
+++ b/scripts/e2e/generate-profile.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: generate-profile.sh --output <path> [--github-env <path>]
+
+Decodes E2E_PROFILE_B64 into an existing Profile-compatible YAML file. The
+result is suitable for E2E_PROFILE_PATH and does not introduce a second
+profile schema.
+EOF
+}
+
+fail() {
+  printf 'generate-profile: %s\n' "$*" >&2
+  exit 1
+}
+
+decode_base64() {
+  if base64 --decode </dev/null >/dev/null 2>&1; then
+    base64 --decode
+  else
+    base64 -D
+  fi
+}
+
+output_path=""
+github_env=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      [[ $# -ge 2 ]] || fail "--output requires a path"
+      output_path="$2"
+      shift 2
+      ;;
+    --github-env)
+      [[ $# -ge 2 ]] || fail "--github-env requires a path"
+      github_env="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$output_path" ]] || fail "--output is required"
+[[ -n "${E2E_PROFILE_B64:-}" ]] || fail "E2E_PROFILE_B64 must be set"
+
+output_dir="$(dirname "$output_path")"
+[[ -d "$output_dir" ]] || fail "output directory does not exist: $output_dir"
+if [[ -e "$output_path" && ! -f "$output_path" ]]; then
+  fail "output path is not a regular file: $output_path"
+fi
+
+umask 077
+temp_path="$(mktemp "$output_dir/.$(basename "$output_path").XXXXXX")"
+cleanup() {
+  rm -f "$temp_path"
+}
+trap cleanup EXIT
+
+if ! printf '%s' "$E2E_PROFILE_B64" | decode_base64 >"$temp_path"; then
+  fail "E2E_PROFILE_B64 is not valid base64"
+fi
+[[ -s "$temp_path" ]] || fail "decoded profile is empty"
+
+chmod 600 "$temp_path"
+mv -f "$temp_path" "$output_path"
+trap - EXIT
+
+if [[ -n "$github_env" ]]; then
+  printf 'E2E_PROFILE_PATH=%s\n' "$output_path" >>"$github_env"
+fi
+
+printf '%s\n' "$output_path"

--- a/scripts/e2e/sanitize-e2e-log.sh
+++ b/scripts/e2e/sanitize-e2e-log.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  printf 'Usage: sanitize-e2e-log.sh <input-log> <output-log|->\n' >&2
+}
+
+[[ $# -eq 2 ]] || {
+  usage
+  exit 1
+}
+
+input_path="$1"
+output_path="$2"
+[[ -f "$input_path" ]] || {
+  printf 'sanitize-e2e-log: input log does not exist: %s\n' "$input_path" >&2
+  exit 1
+}
+
+sanitize() {
+  awk '
+    {
+      line = tolower($0)
+      if (line ~ /(authorization|api[_ -]?key|password|token|secret|credential|private[ _-]?key|kubeconfig)/) {
+        print "[REDACTED SENSITIVE LOG LINE]"
+        next
+      }
+      print
+    }
+  ' "$input_path"
+}
+
+if [[ "$output_path" == "-" ]]; then
+  sanitize
+  exit 0
+fi
+
+output_dir="$(dirname "$output_path")"
+[[ -d "$output_dir" ]] || {
+  printf 'sanitize-e2e-log: output directory does not exist: %s\n' "$output_dir" >&2
+  exit 1
+}
+
+temp_path="$(mktemp "$output_dir/.$(basename "$output_path").XXXXXX")"
+cleanup() {
+  rm -f "$temp_path"
+}
+trap cleanup EXIT
+
+sanitize >"$temp_path"
+mv -f "$temp_path" "$output_path"
+trap - EXIT

--- a/tests/e2e/daily_quick_start.go
+++ b/tests/e2e/daily_quick_start.go
@@ -1,0 +1,266 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/semver"
+)
+
+const (
+	dailyTargetAMD64K8s      = "amd64-k8s"
+	dailyTargetARM64K8s      = "arm64-k8s"
+	dailyTargetAMD64VM       = "amd64-vm"
+	dailyTargetAMD64L20K8s   = "amd64-l20-k8s"
+	dailyTargetAMD64T4Static = "amd64-t4-static"
+
+	envDailyTarget                     = "E2E_DAILY_TARGET"
+	envDailyRuntimeRef                 = "E2E_RUNTIME_REF"
+	envDailyExpectedAcceleratorProduct = "E2E_DAILY_EXPECTED_ACCELERATOR_PRODUCT"
+)
+
+type dailyQuickStartConfig struct {
+	Target                     string
+	ProfilePath                string
+	ServerURL                  string
+	APIKey                     string
+	RuntimeRef                 string
+	ExpectedAcceleratorProduct string
+	TestRailRunID              string
+}
+
+func isDailyQuickStartRun() bool {
+	return strings.TrimSpace(os.Getenv(envDailyTarget)) != ""
+}
+
+func dailyQuickStartTarget() string {
+	return strings.TrimSpace(os.Getenv(envDailyTarget))
+}
+
+func validateDailyQuickStartFromEnv() error {
+	if !isDailyQuickStartRun() {
+		return nil
+	}
+
+	return validateDailyQuickStart(profile, dailyQuickStartConfig{
+		Target:                     dailyQuickStartTarget(),
+		ProfilePath:                strings.TrimSpace(os.Getenv("E2E_PROFILE_PATH")),
+		ServerURL:                  strings.TrimSpace(os.Getenv("NEUTREE_SERVER_URL")),
+		APIKey:                     strings.TrimSpace(os.Getenv("NEUTREE_API_KEY")),
+		RuntimeRef:                 strings.TrimSpace(os.Getenv(envDailyRuntimeRef)),
+		ExpectedAcceleratorProduct: strings.TrimSpace(os.Getenv(envDailyExpectedAcceleratorProduct)),
+		TestRailRunID:              strings.TrimSpace(os.Getenv("TESTRAIL_RUN_ID")),
+	})
+}
+
+func validateDailyQuickStart(profile Profile, cfg dailyQuickStartConfig) error {
+	target := strings.TrimSpace(cfg.Target)
+	if !isDailyQuickStartTarget(target) {
+		return fmt.Errorf("unsupported E2E_DAILY_TARGET %q", cfg.Target)
+	}
+
+	if cfg.ServerURL == "" {
+		return fmt.Errorf("NEUTREE_SERVER_URL must be set for daily quick start E2E")
+	}
+
+	if cfg.APIKey == "" {
+		return fmt.Errorf("NEUTREE_API_KEY must be set for daily quick start E2E")
+	}
+
+	if cfg.RuntimeRef == "" {
+		return fmt.Errorf("E2E_RUNTIME_REF must be set for daily quick start E2E")
+	}
+
+	if err := requireDailyReadableFile("E2E_PROFILE_PATH", cfg.ProfilePath); err != nil {
+		return err
+	}
+
+	if cfg.TestRailRunID != "" || configuredDailyTestRailRunID(profile) != "" {
+		return fmt.Errorf("TESTRAIL_RUN_ID and testrail.run_id must be empty for daily quick start E2E")
+	}
+
+	switch target {
+	case dailyTargetAMD64K8s:
+		if err := validateDailyK8sProfile(profile); err != nil {
+			return err
+		}
+
+		if profile.MockUpstreamHost == "" || profile.MockUpstreamHost == "host.docker.internal" {
+			return fmt.Errorf("mock_upstream_host must be explicitly routeable from the remote gateway")
+		}
+	case dailyTargetARM64K8s:
+		return validateDailyK8sProfile(profile)
+	case dailyTargetAMD64VM:
+		return validateDailyComposeProfile(profile)
+	case dailyTargetAMD64L20K8s:
+		if err := validateDailyK8sProfile(profile); err != nil {
+			return err
+		}
+
+		if err := validateDailyEndpointProfile(profile, "sglang"); err != nil {
+			return err
+		}
+	case dailyTargetAMD64T4Static:
+		if err := validateDailySSHProfile(profile); err != nil {
+			return err
+		}
+
+		if err := validateDailyEndpointProfile(profile, "vllm"); err != nil {
+			return err
+		}
+
+		staticNodeEnabled, err := semver.LessThan(v1.StaticNodeClusterFlowVersionGate, profile.Cluster.Version)
+		if err != nil || !staticNodeEnabled {
+			return fmt.Errorf("cluster.version must be a valid version greater than %s for static-node daily E2E", v1.StaticNodeClusterFlowVersionGate)
+		}
+	}
+
+	if isDailyGPUTarget(target) && cfg.ExpectedAcceleratorProduct == "" {
+		return fmt.Errorf("%s must be set for daily GPU E2E", envDailyExpectedAcceleratorProduct)
+	}
+
+	return nil
+}
+
+func isDailyQuickStartTarget(target string) bool {
+	switch target {
+	case dailyTargetAMD64K8s, dailyTargetARM64K8s, dailyTargetAMD64VM, dailyTargetAMD64L20K8s, dailyTargetAMD64T4Static:
+		return true
+	default:
+		return false
+	}
+}
+
+func isDailyGPUTarget(target string) bool {
+	return target == dailyTargetAMD64L20K8s || target == dailyTargetAMD64T4Static
+}
+
+func validateDailyK8sProfile(profile Profile) error {
+	if err := requireDailyReadableFile("kubernetes.kubeconfig", profile.Kubernetes.Kubeconfig); err != nil {
+		return err
+	}
+
+	return validateDailyImageRegistryProfile(profile)
+}
+
+func validateDailySSHProfile(profile Profile) error {
+	if len(profile.SSHNodes) == 0 || profile.SSHNodes[0].Host == "" {
+		return fmt.Errorf("ssh_nodes[0].host must be set for daily SSH E2E")
+	}
+
+	return requireDailyReadableFile("ssh_nodes[0].key_file", profile.SSHNodes[0].KeyFile)
+}
+
+func validateDailyComposeProfile(profile Profile) error {
+	if profile.ControlPlane.DeployMode != "docker-compose" {
+		return fmt.Errorf("control_plane.deploy_mode must be docker-compose for the daily VM E2E")
+	}
+
+	if profile.Auth.Password == "" {
+		return fmt.Errorf("auth.password must be set for the daily VM E2E")
+	}
+
+	if profile.ControlPlane.Version == "" {
+		return fmt.Errorf("control_plane.version must be set for the daily VM E2E")
+	}
+
+	if profile.ControlPlane.ComposeDir == "" {
+		return fmt.Errorf("control_plane.compose_dir must be set for the daily VM E2E")
+	}
+
+	if profile.ControlPlane.Host == "" || profile.ControlPlane.Host == "local" {
+		return nil
+	}
+
+	if profile.ControlPlane.SSHUser == "" {
+		return fmt.Errorf("control_plane.ssh_user must be set for remote daily VM E2E")
+	}
+
+	return requireDailyReadableFile("control_plane.ssh_key", profile.ControlPlane.SSHKey)
+}
+
+func validateDailyEndpointProfile(profile Profile, engine string) error {
+	if err := validateDailyImageRegistryProfile(profile); err != nil {
+		return err
+	}
+
+	if profile.ModelRegistry.Type == "" {
+		return fmt.Errorf("model_registry.type must be set for daily endpoint E2E")
+	}
+
+	if profile.ModelRegistry.URL == "" {
+		return fmt.Errorf("model_registry.url must be set for daily endpoint E2E")
+	}
+
+	if profile.Model.Name == "" {
+		return fmt.Errorf("model.name must be set for daily endpoint E2E")
+	}
+
+	if profile.Engines[engine].Version == "" {
+		return fmt.Errorf("engines.%s.version must be explicitly set for daily endpoint E2E", engine)
+	}
+
+	return nil
+}
+
+func validateDailyImageRegistryProfile(profile Profile) error {
+	if profile.ImageRegistry.URL == "" {
+		return fmt.Errorf("image_registry.url must be set for daily E2E")
+	}
+
+	if profile.ImageRegistry.Repository == "" {
+		return fmt.Errorf("image_registry.repository must be set for daily E2E")
+	}
+
+	return nil
+}
+
+func requireDailyReadableFile(name, path string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("%s must be set for daily E2E", name)
+	}
+
+	file, err := os.Open(expandHome(path))
+	if err != nil {
+		return fmt.Errorf("%s must reference a readable file: %w", name, err)
+	}
+
+	return file.Close()
+}
+
+func configuredDailyTestRailRunID(profile Profile) string {
+	if profile.Testrail.RunID == nil {
+		return ""
+	}
+
+	runID := strings.TrimSpace(fmt.Sprintf("%v", profile.Testrail.RunID))
+	if runID == "<nil>" {
+		return ""
+	}
+
+	return runID
+}
+
+func selectDailyExpectedAccelerator(cluster v1.Cluster, expectedProduct string) (string, string, error) {
+	expectedProduct = strings.TrimSpace(expectedProduct)
+	if expectedProduct == "" {
+		return "", "", fmt.Errorf("%s must be set for daily GPU E2E", envDailyExpectedAcceleratorProduct)
+	}
+
+	if cluster.Status == nil || cluster.Status.ResourceInfo == nil || cluster.Status.ResourceInfo.Allocatable == nil {
+		return "", "", fmt.Errorf("cluster does not report allocatable %s resources", v1.AcceleratorTypeNVIDIAGPU)
+	}
+
+	group := cluster.Status.ResourceInfo.Allocatable.AcceleratorGroups[v1.AcceleratorTypeNVIDIAGPU]
+	if group == nil {
+		return "", "", fmt.Errorf("cluster does not report allocatable %s resources", v1.AcceleratorTypeNVIDIAGPU)
+	}
+
+	if _, ok := group.ProductGroups[v1.AcceleratorProduct(expectedProduct)]; !ok {
+		return "", "", fmt.Errorf("cluster does not report expected %s product %q", v1.AcceleratorTypeNVIDIAGPU, expectedProduct)
+	}
+
+	return string(v1.AcceleratorTypeNVIDIAGPU), expectedProduct, nil
+}

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -12,6 +12,10 @@ import (
 
 func TestE2E(t *testing.T) {
 	if Cfg.ServerURL == "" || Cfg.APIKey == "" {
+		if isDailyQuickStartRun() {
+			t.Fatal("Daily Quick Start E2E requires NEUTREE_SERVER_URL and NEUTREE_API_KEY")
+		}
+
 		t.Skip("Skipping E2E tests: NEUTREE_SERVER_URL and NEUTREE_API_KEY must be set")
 	}
 	RegisterFailHandler(Fail)
@@ -22,6 +26,13 @@ var _ = BeforeSuite(func() {
 	By("Loading profile from E2E_PROFILE_PATH (if set)")
 	err := LoadProfile()
 	Expect(err).NotTo(HaveOccurred())
+
+	By("Validating daily Quick Start E2E configuration (when enabled)")
+	err = validateDailyQuickStartFromEnv()
+	Expect(err).NotTo(HaveOccurred())
+	if target := dailyQuickStartTarget(); target != "" {
+		By(fmt.Sprintf("Daily Quick Start target=%s run_id=%s resource_prefix=e2e-*-%s", target, Cfg.RunID, Cfg.RunID))
+	}
 
 	By("Building neutree-cli binary")
 	BuildCLI()

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1145,6 +1145,14 @@ func clusterAcceleratorProduct(c v1.Cluster) string {
 func getClusterAccelerator(clusterName string) (accType, accProduct string) {
 	c := getClusterFullJSON(clusterName)
 
+	if isDailyGPUTarget(dailyQuickStartTarget()) {
+		expectedProduct := strings.TrimSpace(os.Getenv(envDailyExpectedAcceleratorProduct))
+		accType, accProduct, err := selectDailyExpectedAccelerator(c, expectedProduct)
+		Expect(err).NotTo(HaveOccurred())
+
+		return accType, accProduct
+	}
+
 	accType = clusterAcceleratorType(c)
 	accProduct = clusterAcceleratorProduct(c)
 


### PR DESCRIPTION
## Issue

NEU-449

## Summary

Add a bounded daily Quick Start E2E workflow for the five pre-provisioned environments. It reuses the existing Profile YAML format, fails early for incomplete daily configuration, selects the expected NVIDIA product exactly, and keeps uploaded evidence sanitized.

## Changes

- Add daily-only profile validation, TestRail exclusion, and exact L20/T4 accelerator selection to the E2E harness.
- Add scheduled and manually dispatched workflow jobs for amd64 K8s, arm64 K8s, amd64 VM, L20 K8s, and T4 static-node runners.
- Generate a protected temporary profile from `E2E_PROFILE_B64` and upload only sanitized E2E logs.
- Add opt-in Ginkgo arguments so scheduled jobs fail when a label filter selects no specs.

## Test Plan

### Unit test

- N/A: no E2E unit test was added per task constraint.
- `go build ./tests/e2e/...`: pass.
- `go vet ./tests/e2e`: pass.

### DB test

- N/A: no database schema or data-access behavior changed.

### E2E test

- Static workflow checks passed: shellcheck, daily-workflow actionlint, profile/log script smoke checks, and Make dry-run checks for default behavior and `--ginkgo.fail-on-empty`.
- Live E2E is pending Step 5 on the configured self-hosted runners. It will manually and code-verify the selected K8s lifecycle, ExternalEndpoint, Compose deployment, L20 SGLang chat, T4 static vLLM chat, and CLI apply ordering cases.

## Risk & Rollback

The workflow depends on the documented GitHub Environment secrets, variables, local credential paths, and runner labels. Missing or mismatched configuration fails before the selected tests can silently skip. Revert `fdefb46b` to remove the scheduled workflow and daily-only harness behavior.
