### PR TITLE
fix: align static NodeAgent startup contract

### DIFF
--- a/internal/cluster/staticcluster/metrics_components.go
+++ b/internal/cluster/staticcluster/metrics_components.go
@@ -189,13 +189,13 @@ func buildNodeAgentComponent(
 	node *v1.StaticNode,
 	profile *v1.AcceleratorProfile,
 ) (v1.NodeComponentSpec, error) {
-	volumes := nodeAgentComponentVolumes(profile)
-	args := nodeAgentComponentArgs(cluster, profile)
-	image, err := selectedNodeAgentImage(cluster.Spec.Version, profile)
-
+	selection, err := selectedNodeAgent(cluster.Spec.Version, profile)
 	if err != nil {
 		return v1.NodeComponentSpec{}, err
 	}
+
+	volumes := nodeAgentComponentVolumes(profile)
+	args := nodeAgentComponentArgs(cluster, profile, selection.Contract)
 
 	if node != nil && node.Metadata != nil {
 		args = append(args, "--node="+node.Metadata.Name)
@@ -207,7 +207,7 @@ func buildNodeAgentComponent(
 
 	return v1.NodeComponentSpec{
 		Name:             nodeAgentComponentName,
-		Image:            staticComponentImage(cluster, image),
+		Image:            staticComponentImage(cluster, selection.Image),
 		Args:             args,
 		Env:              nodeAgentComponentEnv(cluster.Spec.Version, profile),
 		DockerRunOptions: nodeAgentDockerRunOptions(profile),
@@ -222,13 +222,16 @@ func buildNodeAgentComponent(
 	}, nil
 }
 
-func nodeAgentComponentArgs(cluster *v1.StaticNodeCluster, profile *v1.AcceleratorProfile) []string {
+func nodeAgentComponentArgs(
+	cluster *v1.StaticNodeCluster,
+	profile *v1.AcceleratorProfile,
+	contract component.NodeAgentContract,
+) []string {
 	args := []string{
 		fmt.Sprintf("--listen-address=:%d", defaultNodeAgentPort),
 	}
 
-	supportsExplicitProfileContract, err := component.SupportsNodeAgentProfileContract(cluster.Spec.Version)
-	if err != nil || !supportsExplicitProfileContract || profile == nil || profile.AcceleratorType == "" {
+	if contract == component.NodeAgentContractLegacy {
 		args = append(args,
 			"--cluster-type=ray",
 			"--metrics-mode="+string(acceleratorExporterMode(cluster)),
@@ -268,27 +271,25 @@ func nodeAgentProfileTargetArgs(profile *v1.AcceleratorProfile) []string {
 	)
 }
 
-func selectedNodeAgentImage(clusterVersion string, profile *v1.AcceleratorProfile) (string, error) {
+func selectedNodeAgent(
+	clusterVersion string,
+	profile *v1.AcceleratorProfile,
+) (component.NodeAgentSelection, error) {
 	var nodeAgentProfile *v1.NodeAgentRuntimeProfile
 	if profile != nil {
 		nodeAgentProfile = profile.NodeAgentRuntime
 	}
 
-	selection, err := component.SelectNodeAgent(clusterVersion, nodeAgentProfile)
-	if err != nil {
-		return "", err
-	}
-
-	return selection.Image, nil
+	return component.SelectNodeAgent(clusterVersion, nodeAgentProfile)
 }
 
 func defaultNodeAgentImage(cluster *v1.StaticNodeCluster) string {
-	image, err := selectedNodeAgentImage(cluster.Spec.Version, nil)
-	if err != nil || image == "" {
+	selection, err := selectedNodeAgent(cluster.Spec.Version, nil)
+	if err != nil || selection.Image == "" {
 		return "neutree/neutree-node-agent:" + component.LegacyNeutreeNodeAgent
 	}
 
-	return image
+	return selection.Image
 }
 
 func nodeAgentDockerRunOptions(profile *v1.AcceleratorProfile) []string {

--- a/internal/cluster/staticcluster/planner_test.go
+++ b/internal/cluster/staticcluster/planner_test.go
@@ -406,6 +406,77 @@ func TestPlannerUsesLegacyNodeAgentContractBeforeV112(t *testing.T) {
 	}
 }
 
+func TestPlannerUsesProfileNodeAgentContractForCPUHeadWithoutProfile(t *testing.T) {
+	cluster := testStaticNodeCluster()
+	cluster.Spec.Version = "v1.2.0-alpha.3"
+	planner := &Planner{
+		AcceleratorProfileProvider: fakeAcceleratorProfileProvider{
+			profiles: map[string]*v1.AcceleratorProfile{
+				v1.AcceleratorTypeNVIDIAGPU.String(): {
+					AcceleratorType: v1.AcceleratorTypeNVIDIAGPU.String(),
+					MetricsExporter: &v1.AcceleratorExporterProfile{
+						Image: "nvcr.io/nvidia/k8s/dcgm-exporter:test",
+						Port:  19400,
+					},
+				},
+			},
+		},
+		MetricsRemoteWriteURL: "http://vm:8480/insert/0/prometheus/",
+	}
+
+	nodes := plannedStaticNodes(t, planner, cluster, []*v1.StaticNode{
+		staticNodeStatusWithAccelerator(
+			"head-0",
+			v1.StaticNodeRoleHead,
+			v1.StaticNodePhaseReady,
+			true,
+			cpuAcceleratorStatus(),
+			nil,
+		),
+		staticNodeStatusWithAccelerator(
+			"worker-0",
+			v1.StaticNodeRoleWorker,
+			v1.StaticNodePhaseReady,
+			true,
+			nvidiaAcceleratorStatus(),
+			nil,
+		),
+	})
+
+	head := findStaticNode(nodes, "head-0")
+	require.NotNil(t, head)
+	headNodeAgent := findComponent(head.Spec.Components, nodeAgentComponentName)
+	require.NotNil(t, headNodeAgent)
+	assert.Equal(t, "registry.example.com/neutree/neutree/neutree-node-agent:v1.2.0-rc.1", headNodeAgent.Image)
+	assert.Contains(t, headNodeAgent.Args, "--cluster-type="+v1.SSHClusterType)
+	assert.NotContains(t, headNodeAgent.Args, "--cluster-type=ray")
+	assert.NotContains(t, headNodeAgent.Args, "--metrics-mode=managed")
+	assert.NotContains(t, headNodeAgent.Args, "--accelerator-type=nvidia_gpu")
+	assert.NotContains(t, headNodeAgent.Args, "--accelerator-exporter-port=19400")
+	assert.NotContains(t, headNodeAgent.Args, "--accelerator-exporter-metrics-path=/metrics")
+	assert.Nil(t, findComponent(head.Spec.Components, acceleratorExporterComponentName))
+
+	worker := findStaticNode(nodes, "worker-0")
+	require.NotNil(t, worker)
+	workerNodeAgent := findComponent(worker.Spec.Components, nodeAgentComponentName)
+	require.NotNil(t, workerNodeAgent)
+	assert.Contains(t, workerNodeAgent.Args, "--cluster-type="+v1.SSHClusterType)
+	assert.Contains(t, workerNodeAgent.Args, "--accelerator-type=nvidia_gpu")
+	assert.Contains(t, workerNodeAgent.Args, "--accelerator-exporter-port=19400")
+	assert.Contains(t, workerNodeAgent.Args, "--accelerator-exporter-metrics-path=/metrics")
+	require.NotNil(t, findComponent(worker.Spec.Components, acceleratorExporterComponentName))
+
+	vmagent := findComponent(head.Spec.Components, vmagentComponentName)
+	require.NotNil(t, vmagent)
+	exporterTargets := findConfigFile(
+		vmagent.ConfigFiles,
+		"/etc/neutree/vmagent/file_sd/accelerator-exporter-nvidia-gpu.json",
+	)
+	require.NotNil(t, exporterTargets)
+	assert.Contains(t, exporterTargets.Content, "10.0.0.11:19400")
+	assert.NotContains(t, exporterTargets.Content, "10.0.0.10:19400")
+}
+
 func TestPlannerDoesNotValidateNodeAgentRuntimeProfile(t *testing.T) {
 	cluster := testStaticNodeCluster()
 	currentNodes := []*v1.StaticNode{

--- a/internal/component/node_agent_test.go
+++ b/internal/component/node_agent_test.go
@@ -21,10 +21,14 @@ func TestSelectNodeAgentUsesLegacyImageForLegacyVersions(t *testing.T) {
 }
 
 func TestSelectNodeAgentUsesDefaultProfileImageWhenProfileMissing(t *testing.T) {
-	selection, err := SelectNodeAgent("v1.1.2", nil)
-	require.NoError(t, err)
-	assert.Equal(t, NodeAgentContractProfile, selection.Contract)
-	assert.Equal(t, defaultProfileNodeAgentImage(), selection.Image)
+	for _, version := range []string{"v1.1.2", "v1.2.0-alpha.3"} {
+		t.Run(version, func(t *testing.T) {
+			selection, err := SelectNodeAgent(version, nil)
+			require.NoError(t, err)
+			assert.Equal(t, NodeAgentContractProfile, selection.Contract)
+			assert.Equal(t, defaultProfileNodeAgentImage(), selection.Image)
+		})
+	}
 }
 
 func TestSelectNodeAgentUsesProfileImageForNewerVersions(t *testing.T) {

--- a/tests/e2e/cluster_static_node_helper.go
+++ b/tests/e2e/cluster_static_node_helper.go
@@ -93,6 +93,18 @@ func eventuallyStaticNodeClusterReady(name string, desiredVersion string, desire
 	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
 }
 
+func staticNodeClusterVersion(name string) string {
+	r := RunCLI("get", "StaticNodeCluster", name, "-w", profileWorkspace(), "-o", "json")
+	ExpectWithOffset(1, r.ExitCode).To(Equal(0), r.Stderr)
+
+	var cluster v1.StaticNodeCluster
+	ExpectWithOffset(1, json.Unmarshal([]byte(r.Stdout), &cluster)).To(Succeed())
+	ExpectWithOffset(1, cluster.Status).NotTo(BeNil())
+	ExpectWithOffset(1, cluster.Status.Version).NotTo(BeEmpty())
+
+	return cluster.Status.Version
+}
+
 func assertNoStaticNodeCluster(name string) {
 	r := RunCLI("get", "StaticNodeCluster", "-w", profileWorkspace(), "-o", "json")
 	if r.ExitCode != 0 {
@@ -142,7 +154,8 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 	gpuNodeIPs := []string{}
 	nonGPUNodeIPs := []string{}
 	sshUser := profileSSHUser()
-	usesProfileContract := usesProfileNodeAgentContract(profileClusterVersion())
+	clusterVersion := staticNodeClusterVersion(clusterName)
+	usesProfileContract := usesProfileNodeAgentContract(clusterVersion)
 
 	if sshUser == "" {
 		sshUser = defaultSSHUser

--- a/tests/e2e/cluster_static_node_helper.go
+++ b/tests/e2e/cluster_static_node_helper.go
@@ -11,19 +11,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
-	"github.com/neutree-ai/neutree/internal/component"
 	"github.com/neutree-ai/neutree/internal/semver"
 )
 
 func usesStaticNodeClusterFlow(version string) bool {
 	enabled, err := semver.LessThan(v1.StaticNodeClusterFlowVersionGate, version)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "cluster version must be semver")
-
-	return enabled
-}
-
-func usesProfileNodeAgentContract(version string) bool {
-	enabled, err := component.SupportsNodeAgentProfileContract(version)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "cluster version must be semver")
 
 	return enabled
@@ -139,10 +131,7 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 	ExpectWithOffset(1, nodes).NotTo(BeEmpty())
 
 	hasGPUNode := false
-	gpuNodeIPs := []string{}
-	nonGPUNodeIPs := []string{}
 	sshUser := profileSSHUser()
-	usesProfileContract := usesProfileNodeAgentContract(profileClusterVersion())
 
 	if sshUser == "" {
 		sshUser = defaultSSHUser
@@ -167,12 +156,7 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 		nodeAgent := requireStaticNodeComponent(node, "neutree-node-agent")
 		ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--listen-address=:19101"))
 
-		if usesProfileContract {
-			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--cluster-type=" + v1.SSHClusterType))
-			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement("--cluster-type=ray"))
-			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--metrics-mode=")))
-		} else {
-			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--cluster-type=ray"))
+		if containsString(nodeAgent.Args, "--cluster-type=ray") {
 			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement(ContainSubstring("--metrics-mode=")))
 			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--accelerator-type=")))
 		}
@@ -208,11 +192,6 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 		assertStaticNodeAgentDeviceSnapshotAPI(node, sshUser, keyFile, isGPUNode)
 
 		if !isGPUNode {
-			nonGPUNodeIPs = append(nonGPUNodeIPs, node.Spec.IP)
-
-			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--accelerator-type=")))
-			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--accelerator-exporter-port=")))
-			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--accelerator-exporter-metrics-path=")))
 			ExpectWithOffset(1, findStaticNodeComponent(node.Spec.Components, "accelerator-exporter")).To(BeNil())
 			ExpectWithOffset(1, findStaticNodeComponentStatus(node.Status.Components, "accelerator-exporter")).To(BeNil())
 
@@ -220,15 +199,6 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 		}
 
 		hasGPUNode = true
-
-		gpuNodeIPs = append(gpuNodeIPs, node.Spec.IP)
-
-		if usesProfileContract {
-			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--accelerator-type=nvidia_gpu"))
-			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--accelerator-exporter-port=19400"))
-			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--accelerator-exporter-metrics-path=/metrics"))
-		}
-
 		exporter := requireStaticNodeComponent(node, "accelerator-exporter")
 		ExpectWithOffset(1, exporter.Ports).To(ContainElement(v1.NodeComponentPort{
 			Name:     "metrics",
@@ -243,20 +213,17 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 		vmagent := requireStaticNodeComponent(head, "vmagent")
 		vmagentConfig := requireStaticNodeComponentConfigFile(vmagent, "/etc/neutree/vmagent/config.yaml")
 		ExpectWithOffset(1, vmagentConfig.Content).To(ContainSubstring("job_name: accelerator-exporter-nvidia-gpu"))
+	}
+}
 
-		exporterTargets := requireStaticNodeComponentConfigFile(
-			vmagent,
-			"/etc/neutree/vmagent/file_sd/accelerator-exporter-nvidia-gpu.json",
-		)
-
-		for _, nodeIP := range gpuNodeIPs {
-			ExpectWithOffset(1, exporterTargets.Content).To(ContainSubstring(nodeIP + ":19400"))
-		}
-
-		for _, nodeIP := range nonGPUNodeIPs {
-			ExpectWithOffset(1, exporterTargets.Content).NotTo(ContainSubstring(nodeIP + ":19400"))
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
 		}
 	}
+
+	return false
 }
 
 func assertStaticNodeAgentDeviceSnapshotAPI(

--- a/tests/e2e/cluster_static_node_helper.go
+++ b/tests/e2e/cluster_static_node_helper.go
@@ -11,11 +11,19 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "github.com/neutree-ai/neutree/api/v1"
+	"github.com/neutree-ai/neutree/internal/component"
 	"github.com/neutree-ai/neutree/internal/semver"
 )
 
 func usesStaticNodeClusterFlow(version string) bool {
 	enabled, err := semver.LessThan(v1.StaticNodeClusterFlowVersionGate, version)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "cluster version must be semver")
+
+	return enabled
+}
+
+func usesProfileNodeAgentContract(version string) bool {
+	enabled, err := component.SupportsNodeAgentProfileContract(version)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "cluster version must be semver")
 
 	return enabled
@@ -131,7 +139,10 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 	ExpectWithOffset(1, nodes).NotTo(BeEmpty())
 
 	hasGPUNode := false
+	gpuNodeIPs := []string{}
+	nonGPUNodeIPs := []string{}
 	sshUser := profileSSHUser()
+	usesProfileContract := usesProfileNodeAgentContract(profileClusterVersion())
 
 	if sshUser == "" {
 		sshUser = defaultSSHUser
@@ -156,7 +167,12 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 		nodeAgent := requireStaticNodeComponent(node, "neutree-node-agent")
 		ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--listen-address=:19101"))
 
-		if containsString(nodeAgent.Args, "--cluster-type=ray") {
+		if usesProfileContract {
+			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--cluster-type=" + v1.SSHClusterType))
+			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement("--cluster-type=ray"))
+			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--metrics-mode=")))
+		} else {
+			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--cluster-type=ray"))
 			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement(ContainSubstring("--metrics-mode=")))
 			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--accelerator-type=")))
 		}
@@ -192,6 +208,11 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 		assertStaticNodeAgentDeviceSnapshotAPI(node, sshUser, keyFile, isGPUNode)
 
 		if !isGPUNode {
+			nonGPUNodeIPs = append(nonGPUNodeIPs, node.Spec.IP)
+
+			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--accelerator-type=")))
+			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--accelerator-exporter-port=")))
+			ExpectWithOffset(1, nodeAgent.Args).NotTo(ContainElement(ContainSubstring("--accelerator-exporter-metrics-path=")))
 			ExpectWithOffset(1, findStaticNodeComponent(node.Spec.Components, "accelerator-exporter")).To(BeNil())
 			ExpectWithOffset(1, findStaticNodeComponentStatus(node.Status.Components, "accelerator-exporter")).To(BeNil())
 
@@ -199,6 +220,15 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 		}
 
 		hasGPUNode = true
+
+		gpuNodeIPs = append(gpuNodeIPs, node.Spec.IP)
+
+		if usesProfileContract {
+			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--accelerator-type=nvidia_gpu"))
+			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--accelerator-exporter-port=19400"))
+			ExpectWithOffset(1, nodeAgent.Args).To(ContainElement("--accelerator-exporter-metrics-path=/metrics"))
+		}
+
 		exporter := requireStaticNodeComponent(node, "accelerator-exporter")
 		ExpectWithOffset(1, exporter.Ports).To(ContainElement(v1.NodeComponentPort{
 			Name:     "metrics",
@@ -213,17 +243,20 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 		vmagent := requireStaticNodeComponent(head, "vmagent")
 		vmagentConfig := requireStaticNodeComponentConfigFile(vmagent, "/etc/neutree/vmagent/config.yaml")
 		ExpectWithOffset(1, vmagentConfig.Content).To(ContainSubstring("job_name: accelerator-exporter-nvidia-gpu"))
-	}
-}
 
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
+		exporterTargets := requireStaticNodeComponentConfigFile(
+			vmagent,
+			"/etc/neutree/vmagent/file_sd/accelerator-exporter-nvidia-gpu.json",
+		)
+
+		for _, nodeIP := range gpuNodeIPs {
+			ExpectWithOffset(1, exporterTargets.Content).To(ContainSubstring(nodeIP + ":19400"))
+		}
+
+		for _, nodeIP := range nonGPUNodeIPs {
+			ExpectWithOffset(1, exporterTargets.Content).NotTo(ContainSubstring(nodeIP + ":19400"))
 		}
 	}
-
-	return false
 }
 
 func assertStaticNodeAgentDeviceSnapshotAPI(

--- a/tests/e2e/cluster_static_node_helper.go
+++ b/tests/e2e/cluster_static_node_helper.go
@@ -93,18 +93,6 @@ func eventuallyStaticNodeClusterReady(name string, desiredVersion string, desire
 	}, TerminalPhaseTimeout, 5*time.Second).Should(Succeed())
 }
 
-func staticNodeClusterVersion(name string) string {
-	r := RunCLI("get", "StaticNodeCluster", name, "-w", profileWorkspace(), "-o", "json")
-	ExpectWithOffset(1, r.ExitCode).To(Equal(0), r.Stderr)
-
-	var cluster v1.StaticNodeCluster
-	ExpectWithOffset(1, json.Unmarshal([]byte(r.Stdout), &cluster)).To(Succeed())
-	ExpectWithOffset(1, cluster.Status).NotTo(BeNil())
-	ExpectWithOffset(1, cluster.Status.Version).NotTo(BeEmpty())
-
-	return cluster.Status.Version
-}
-
 func assertNoStaticNodeCluster(name string) {
 	r := RunCLI("get", "StaticNodeCluster", "-w", profileWorkspace(), "-o", "json")
 	if r.ExitCode != 0 {
@@ -154,8 +142,7 @@ func assertStaticNodeMetricsComponents(clusterName string) {
 	gpuNodeIPs := []string{}
 	nonGPUNodeIPs := []string{}
 	sshUser := profileSSHUser()
-	clusterVersion := staticNodeClusterVersion(clusterName)
-	usesProfileContract := usesProfileNodeAgentContract(clusterVersion)
+	usesProfileContract := usesProfileNodeAgentContract(profileClusterVersion())
 
 	if sshUser == "" {
 		sshUser = defaultSSHUser


### PR DESCRIPTION
## Issue

n/a

## Summary

Align Static Planner NodeAgent argument generation with the version-selected NodeAgent contract. Profile-capable cluster versions now keep the Profile NodeAgent image and Profile-compatible SSH arguments even when a CPU Head has no Accelerator Profile.

## Changes

- Resolve the NodeAgent selection once and use its contract for both image and argument rendering.
- Emit legacy Ray and metrics arguments only for legacy cluster versions.
- Cover CPU Head and GPU Worker static-node contracts, including GPU-only accelerator exporter discovery, with focused planner unit tests.
- Do not modify `tests/e2e/cluster_static_node_helper.go` in this PR; its automated coverage is deferred.

## Test Plan

### Unit test

- `go test ./internal/cluster/staticcluster ./internal/component ./cmd/neutree-node-agent/app ./internal/observability/neutreemetrics/... -count=1`
- `go vet ./internal/cluster/staticcluster ./internal/component ./cmd/neutree-node-agent/app`
- `./bin/golangci-lint run ./internal/cluster/staticcluster/... ./internal/component/...`

### DB test

Not affected. No migration, schema, or persistent API change.

### E2E test

- Manual Enterprise Docker validation passed using the Alpha3 static-node flow with a CPU Head and GPU Worker.
- The CPU Head started the Profile NodeAgent without legacy metrics arguments; the GPU Worker retained exporter arguments; vmagent discovered only the GPU exporter.
- No code-backed E2E was added, compiled, or executed after the user explicitly deferred `tests/e2e/cluster_static_node_helper.go`.

## Risk and Rollback

- No schema or public API change.
- Roll back by reverting the Static Planner fix; legacy versions retain their existing contract behavior.