### PR TITLE
fix(api): stop demanding a model version an endpoint never needed (NEU-633)

### DIFF
--- a/internal/routes/proxies/endpoint_validation.go
+++ b/internal/routes/proxies/endpoint_validation.go
@@ -258,12 +258,21 @@ func endpointPatchMayAffectModelSourceValidation(endpoint *v1.Endpoint) bool {
 // validateEndpointModelSource decides which parts of spec.model an endpoint has
 // to fill in, and checks that the registry it names is real.
 //
-// Registry, model name and version are required exactly when Neutree downloads
-// the model itself, which v1.IsBuiltInModelDownloaderEngine answers and the
-// orchestrator keys its download step off as well -- keep the two on the same
-// predicate, or validation and deployment will disagree about which endpoints
-// need a model at all. An engine that brings its own model has none of these to
-// give, and the database no longer demands them.
+// Registry and model name are required exactly when Neutree downloads the model
+// itself, which v1.IsBuiltInModelDownloaderEngine answers and the orchestrator
+// keys its download step off as well -- keep the two on the same predicate, or
+// validation and deployment will disagree about which endpoints need a model at
+// all. An engine that brings its own model has neither to give, and the database
+// no longer demands them.
+//
+// spec.model.version is deliberately *not* in that list. An empty version is a
+// supported value meaning "whatever the registry calls its default", and every
+// registry type resolves it: getDeployedModelRealVersion passes "" through to
+// Hugging Face and ModelScope so the hub picks the repository's default branch,
+// and looks the latest version up for BentoML. Migration 045 dropped the
+// presence trigger for exactly this reason, so endpoints without a version have
+// been legal -- and deployable -- ever since; demanding one here would strand
+// them on any spec change, including the resume that follows a pause.
 //
 // A registry that *is* named is resolved against the endpoint's own workspace
 // whichever engine is in play: deps.Storage runs as the service role and does
@@ -284,7 +293,6 @@ func validateEndpointModelSource(store storage.Storage, endpoint *v1.Endpoint) *
 		}{
 			{"spec.model.registry", model.Registry},
 			{"spec.model.name", model.Name},
-			{"spec.model.version", model.Version},
 		} {
 			if required.value == "" {
 				return endpointModelSourceError(fmt.Sprintf(

--- a/internal/routes/proxies/endpoint_validation_test.go
+++ b/internal/routes/proxies/endpoint_validation_test.go
@@ -2305,14 +2305,13 @@ func TestValidateEndpointModelSource(t *testing.T) {
 		}
 	})
 
-	t.Run("requires registry, name and version for an engine Neutree downloads for", func(t *testing.T) {
+	t.Run("requires registry and name for an engine Neutree downloads for", func(t *testing.T) {
 		for _, tc := range []struct {
 			missing string
 			model   *v1.ModelSpec
 		}{
 			{"spec.model.registry", &v1.ModelSpec{Name: "qwen3", Version: "latest"}},
 			{"spec.model.name", &v1.ModelSpec{Registry: "hf", Version: "latest"}},
-			{"spec.model.version", &v1.ModelSpec{Registry: "hf", Name: "qwen3"}},
 		} {
 			for _, engine := range []string{v1.EngineNameVLLM, v1.EngineNameLlamaCpp, v1.EngineNameSGLang} {
 				store := &fakeModelRegistryStorage{registries: visible}
@@ -2324,6 +2323,22 @@ func TestValidateEndpointModelSource(t *testing.T) {
 					assert.Contains(t, err.Hint, tc.missing+" is required")
 				}
 			}
+		}
+	})
+
+	t.Run("accepts an empty version from an engine Neutree downloads for", func(t *testing.T) {
+		// An empty version is not a missing field, it is the way to say "the
+		// registry's default": Hugging Face and ModelScope resolve it to the
+		// repository's default branch and BentoML to its latest version. Migration
+		// 045 dropped the presence trigger for this reason, so versionless
+		// endpoints exist in the wild and have always deployed.
+		for _, engine := range []string{v1.EngineNameVLLM, v1.EngineNameLlamaCpp, v1.EngineNameSGLang} {
+			store := &fakeModelRegistryStorage{registries: visible}
+
+			err := validateEndpointModelSource(store, modelSourceEndpoint("ws-a",
+				&v1.ModelSpec{Registry: "hf", Name: "qwen3"}, engine))
+
+			assert.Nilf(t, err, "engine %s", engine)
 		}
 	})
 
@@ -2399,16 +2414,18 @@ func TestEndpointPatchMayAffectModelSourceValidation(t *testing.T) {
 }
 
 // NEU-715: the UI pauses by resending the whole spec with replicas.num set to 0,
-// so the pause carries spec.model and spec.engine and used to be judged on them.
-// An endpoint whose spec.model.version is empty could then never be paused.
+// so the pause carries spec.model and spec.engine and is judged on them. The
+// replica-count exemption keeps a pause from being blocked by a model source the
+// endpoint cannot fix while it is on its way down.
 func TestValidateEndpointPatchModelSourcePause(t *testing.T) {
 	zero, one := 0, 1
 
-	// A vLLM endpoint that downloads its own model but has no version recorded --
-	// the shape the issue reproduces on.
-	versionless := func(replicas *int) *v1.Endpoint {
+	// A vLLM endpoint that downloads its own model but names no registry -- a
+	// spec the check genuinely rejects, so it shows the exemption at work rather
+	// than the absence of anything to exempt.
+	registryless := func(replicas *int) *v1.Endpoint {
 		endpoint := modelSourceEndpoint("ws-a",
-			&v1.ModelSpec{Registry: "hf", Name: "qwen3"}, v1.EngineNameVLLM)
+			&v1.ModelSpec{Name: "qwen3", Version: "latest"}, v1.EngineNameVLLM)
 		endpoint.Spec.Replicas = v1.ReplicaSpec{Num: replicas}
 
 		return endpoint
@@ -2416,7 +2433,7 @@ func TestValidateEndpointPatchModelSourcePause(t *testing.T) {
 
 	t.Run("lets a full-spec pause through", func(t *testing.T) {
 		store := &fakeModelRegistryStorage{}
-		patch := versionless(&zero)
+		patch := registryless(&zero)
 
 		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
 			Operation: endpointValidationPatch,
@@ -2434,30 +2451,30 @@ func TestValidateEndpointPatchModelSourcePause(t *testing.T) {
 		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
 			Operation: endpointValidationPatch,
 			Patch:     v1.Endpoint{Spec: &v1.EndpointSpec{Replicas: v1.ReplicaSpec{Num: &zero}}},
-			New:       versionless(&zero),
+			New:       registryless(&zero),
 		})
 
 		assert.Nil(t, err)
 	})
 
-	t.Run("still rejects a resume that leaves the version empty", func(t *testing.T) {
+	t.Run("still rejects a resume that leaves the registry empty", func(t *testing.T) {
 		store := &fakeModelRegistryStorage{}
 
 		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
 			Operation: endpointValidationPatch,
 			Patch:     v1.Endpoint{Spec: &v1.EndpointSpec{Replicas: v1.ReplicaSpec{Num: &one}}},
-			New:       versionless(&one),
+			New:       registryless(&one),
 		})
 
 		if assert.NotNil(t, err) {
 			assert.Equal(t, "10229", err.Code)
-			assert.Contains(t, err.Hint, "spec.model.version")
+			assert.Contains(t, err.Hint, "spec.model.registry")
 		}
 	})
 
-	t.Run("still rejects a full-spec edit that leaves the version empty", func(t *testing.T) {
+	t.Run("still rejects a full-spec edit that leaves the registry empty", func(t *testing.T) {
 		store := &fakeModelRegistryStorage{}
-		patch := versionless(&one)
+		patch := registryless(&one)
 
 		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
 			Operation: endpointValidationPatch,
@@ -2474,7 +2491,7 @@ func TestValidateEndpointPatchModelSourcePause(t *testing.T) {
 	// it must not fall through the pause exemption.
 	t.Run("still rejects a patch that names no replica count", func(t *testing.T) {
 		store := &fakeModelRegistryStorage{}
-		patch := versionless(nil)
+		patch := registryless(nil)
 
 		err := validateEndpointPatchModelSource(store, &endpointValidationInput{
 			Operation: endpointValidationPatch,
@@ -2486,4 +2503,44 @@ func TestValidateEndpointPatchModelSourcePause(t *testing.T) {
 			assert.Equal(t, "10229", err.Code)
 		}
 	})
+}
+
+// The reported bug: a vLLM endpoint recorded without a model version --
+// legal since migration 045, and the shape endpoints created between then and
+// the NEU-633 validation move carry -- was refused on the way back up from a
+// pause. Nothing about it is invalid, so every direction has to pass.
+func TestValidateEndpointPatchModelSourceEmptyVersion(t *testing.T) {
+	zero, one := 0, 1
+
+	versionless := func(replicas *int) *v1.Endpoint {
+		endpoint := modelSourceEndpoint("ws-a",
+			&v1.ModelSpec{Registry: "hf", Name: "qwen3"}, v1.EngineNameVLLM)
+		endpoint.Spec.Replicas = v1.ReplicaSpec{Num: replicas}
+
+		return endpoint
+	}
+
+	visible := []v1.ModelRegistry{{Metadata: &v1.Metadata{Name: "hf", Workspace: "ws-a"}}}
+
+	for _, tc := range []struct {
+		name     string
+		replicas *int
+	}{
+		{"resumes", &one},
+		{"pauses", &zero},
+		{"edits with no replica count", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeModelRegistryStorage{registries: visible}
+			patch := versionless(tc.replicas)
+
+			err := validateEndpointPatchModelSource(store, &endpointValidationInput{
+				Operation: endpointValidationPatch,
+				Patch:     *patch,
+				New:       patch,
+			})
+
+			assert.Nil(t, err)
+		})
+	}
 }


### PR DESCRIPTION
## Issue

NEU-633

## Summary

An endpoint whose `spec.model.version` is empty could not be resumed after a pause: the API rejected it with `invalid endpoint model source: spec.model.version is required for engine vllm, which downloads its own model`. Nothing about that endpoint is invalid. Migration 045 dropped the version presence trigger back in December precisely so an empty version could mean "whatever the registry calls its default", and `getDeployedModelRealVersion` implements that for every registry type — it passes `""` through to Hugging Face and ModelScope so the hub resolves the repository's default branch, and looks the latest version up for BentoML. Versionless endpoints have been legal, and deployable, ever since.

The check came back by accident in #592. Migration 091 moved the model name and version rules out of the database into the endpoint proxy; the name check was a faithful move, but the version check was no longer in the live schema to move. It was reconstructed from 045's own **down**-migration — the rollback body — and so reappeared as a Go check eight months after the database stopped asking for it.

The blast radius was wider than new endpoints. Any spec change re-validates the merged spec, so every versionless endpoint already running in a cluster was frozen: resume, scale, and engine changes all failed. #601 (NEU-715) exempted `replicas.num == 0` and unblocked the pause, which only widened the gap between an endpoint that could be stopped and one that could be started again.

## Changes

- `validateEndpointModelSource` no longer requires `spec.model.version`. Registry and name stay required for an engine Neutree downloads for — those the database really did enforce before 090/091 moved them.
- The doc comment now records why version is deliberately absent from that list, pointing at migration 045 and the three registry paths in `getDeployedModelRealVersion`, so it does not get "restored" a third time.
- Tests: the required-fields table drops the version row and gains a case asserting an empty version is accepted for vLLM / llama.cpp / SGLang. `TestValidateEndpointPatchModelSourcePause` kept asserting the resume rejection, which was the bug written down as a contract — it now exercises the replica-count exemption with a spec that is genuinely invalid (no registry), and a new `TestValidateEndpointPatchModelSourceEmptyVersion` covers resume / pause / no-replica-count on a versionless endpoint.

## Test Plan

- [x] E2E (if affected): not affected — no deployment path changes; `getDeployedModelRealVersion` and both orchestrators already handled an empty version and are untouched.
- [x] DB integration (`make db-test`): not affected — no migration or schema change. `db/dbtest/validation_test.go` already asserts the database accepts an endpoint with no model name or version (migration 091 coverage); this PR brings the API layer back in line with it.

`go build ./...`, `go vet ./internal/routes/proxies/` and `go test ./internal/routes/proxies/ -count=1` pass.

Note: the pre-commit lint gate fails on `internal/observability/neutreemetrics/adapter/nvidia/nvidia_hardware_labels.go:57` (`nvidiaFormatCUDADriverVersion` unused), which is pre-existing on `main` from #596 and unrelated to these two files.

## Risk & Rollback

No schema change, no new API surface — the change only removes a rejection, so it cannot break a request that succeeds today. Backward-compatible with running clients: specs that carry a version behave exactly as before. Endpoints stranded by the old check start working again with no migration or manual edit. Rollback is a plain revert.