### PR TITLE
fix: raise node agent memory limit

### DIFF
--- a/internal/cluster/component/metrics/manifests.go
+++ b/internal/cluster/component/metrics/manifests.go
@@ -606,7 +606,7 @@ func (m *MetricsComponent) buildManifestVariables() MetricsManifestVariables {
 	}
 	neutreeNodeAgentMetricsResources := map[string]string{
 		"cpu":    "500m",
-		"memory": "128Mi",
+		"memory": "256Mi",
 	}
 	nodeAgentImage := "neutree/neutree-node-agent:" + component.LegacyNeutreeNodeAgent
 

--- a/internal/cluster/component/metrics/metrics_resource_test.go
+++ b/internal/cluster/component/metrics/metrics_resource_test.go
@@ -662,6 +662,8 @@ func TestBuildMetricsResourcesIncludesNodeAgentDaemonSet(t *testing.T) {
 	assert.Equal(t, int32(19101), nodeAgent.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
 	assert.Equal(t, "500m", nodeAgent.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())
 	assert.Equal(t, "500m", nodeAgent.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String())
+	assert.Equal(t, "256Mi", nodeAgent.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())
+	assert.Equal(t, "256Mi", nodeAgent.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String())
 
 	args := strings.Join(nodeAgent.Spec.Template.Spec.Containers[0].Args, "\n")
 	assert.Assert(t, strings.Contains(args, "--listen-address=:19101"))


### PR DESCRIPTION
## Issue
n/a

## Summary
Raise the default Neutree NodeAgent memory resource from 128Mi to 256Mi. The Community manifest renderer is the source currently consumed by the Enterprise Community pin.

## Changes
- Set the NodeAgent default memory resource to 256Mi.
- Keep the existing renderer behavior: the same value is used for both `limits` and `requests`.
- Add assertions for both rendered memory fields.

## Test Plan

### Unit test
- `go test ./internal/cluster/component/metrics/... -count=1` — pass.
- `go vet ./internal/cluster/component/metrics/...` — pass.
- `gofmt -d internal/cluster/component/metrics/manifests.go internal/cluster/component/metrics/metrics_resource_test.go` — clean.
- Repository-wide `go test ./...` and `go vet ./...` remain blocked by the baseline missing embed input `cmd/neutree-cli/app/cmd/launch/manifests/neutree-core.tar`.
- Repository-required `golangci-lint` verification was unavailable because the installed tool is v1.53.3 and the host could not install v1.64.6 after running out of disk space.

### DB test
- Not affected; no database or migration changes.

### E2E test
- Not affected; this is a default resource-only manifest change and E2E is skipped under the Trivial workflow classification.

## Risk & Rollback
The NodeAgent DaemonSet reserves and permits 256Mi instead of 128Mi. Roll back by reverting this commit; no API or schema compatibility impact.
