### PR TITLE
fix: support absolute package output paths

### DIFF
--- a/scripts/builder/build-package.sh
+++ b/scripts/builder/build-package.sh
@@ -348,6 +348,7 @@ EOF
 
 # Package
 mkdir -p "$OUTPUT_DIR"
+OUTPUT_DIR=$(cd "$OUTPUT_DIR" && pwd)
 PACKAGE_FILE="${OUTPUT_DIR}/${PACKAGE_NAME}.tar.gz"
 
 log_info "Creating package: $PACKAGE_FILE"
@@ -357,9 +358,9 @@ CURRENT_DIR=$(pwd)
 cd "$TEMP_DIR" || exit 1
 
 if command -v pigz &> /dev/null; then
-    tar -I "pigz -p 16" -cf "${CURRENT_DIR}/${PACKAGE_FILE}" *
+    tar -I "pigz -p 16" -cf "$PACKAGE_FILE" ./*
 else
-    tar -czf "${CURRENT_DIR}/${PACKAGE_FILE}" *
+    tar -czf "$PACKAGE_FILE" ./*
 fi
 
 cd "$CURRENT_DIR" || exit 1


### PR DESCRIPTION
## Issue

n/a

## Summary

Make the shared cluster package builder work with absolute output directories used by the enterprise release pipeline.

## Changes

- Normalize the package archive destination before changing into the temporary package directory.
- Keep the community repository free of a duplicate cluster package workflow; release orchestration is centralized in the enterprise repository.

## Test Plan

### Unit test

- Modern Bash fake-Docker package path check passed.
- GitHub Actions workflow and shell syntax validation passed.

### DB test

Not required: no database change.

### E2E test

Not required: builder path behavior only. Live image packaging is validated by the enterprise dispatch workflow.

## Risk & Rollback

Relative output directories retain their existing location semantics. Revert this commit to restore the previous archive path handling.