### PR TITLE
fix: use native image names for packages

### DIFF
--- a/.github/workflows/release-engine-package.yaml
+++ b/.github/workflows/release-engine-package.yaml
@@ -63,7 +63,6 @@ jobs:
           RAY_SHORT_VERSION: ${{ inputs.ray_short_version }}
           ENGINE_PATCH_SUFFIX: ${{ inputs.engine_patch_suffix }}
           PACKAGE_ARCH: amd64
-          IMAGE_REPO: ${{ secrets.SERVE_IMAGE_REPO }}
           IMAGE_PROJECT: ${{ secrets.RELEASE_SERVE_IMAGE_PROJECT }}
         run: |
           set -euo pipefail
@@ -90,17 +89,17 @@ jobs:
           case "$ENGINE:$ACCELERATOR" in
             vllm:nvidia)
               supported_tasks="text-generation,text-embedding,text-rerank"
-              image_ref="${IMAGE_REPO}/${IMAGE_PROJECT}/engine-vllm:${BASE_IMAGE_TAG_OVERRIDE:-$ENGINE_VERSION}${image_patch_tag}-${RAY_SHORT_VERSION}"
+              image_ref="${IMAGE_PROJECT}/engine-vllm:${BASE_IMAGE_TAG_OVERRIDE:-$ENGINE_VERSION}${image_patch_tag}-${RAY_SHORT_VERSION}"
               image_spec="nvidia_gpu:${image_ref}"
               ;;
             sglang:nvidia)
               supported_tasks="text-generation,text-embedding"
-              image_ref="${IMAGE_REPO}/${IMAGE_PROJECT}/engine-sglang:${BASE_IMAGE_TAG_OVERRIDE:-$ENGINE_VERSION}${image_patch_tag}-${RAY_SHORT_VERSION}"
+              image_ref="${IMAGE_PROJECT}/engine-sglang:${BASE_IMAGE_TAG_OVERRIDE:-$ENGINE_VERSION}${image_patch_tag}-${RAY_SHORT_VERSION}"
               image_spec="nvidia_gpu:${image_ref}"
               ;;
             llama-cpp:cpu)
               supported_tasks="text-generation,text-embedding"
-              image_ref="${IMAGE_REPO}/${IMAGE_PROJECT}/engine-llama-cpp:${ENGINE_VERSION}${image_patch_tag}-${RAY_SHORT_VERSION}"
+              image_ref="${IMAGE_PROJECT}/engine-llama-cpp:${ENGINE_VERSION}${image_patch_tag}-${RAY_SHORT_VERSION}"
               image_spec="cpu:${image_ref}"
               ;;
             *)

--- a/scripts/builder/build-engine-package.sh
+++ b/scripts/builder/build-engine-package.sh
@@ -35,16 +35,6 @@ normalize_registry() {
     echo "$registry"
 }
 
-strip_image_registry() {
-    local image="$1"
-
-    if [[ "$image" =~ ^((localhost)|([^/]*[.:][^/]*))/(.+)$ ]]; then
-        echo "${BASH_REMATCH[4]}"
-    else
-        echo "$image"
-    fi
-}
-
 parse_image_spec() {
     local spec="$1"
     local image_with_tag
@@ -211,7 +201,7 @@ Options:
     -o, --output FILE         Output package file path (default: ENGINE-VERSION-<arch>.tar.gz)
     -d, --description TEXT    Engine version description
     -p, --platform PLATFORM   Image platform used for pull and manifest (default: linux/amd64)
-    --mirror-registry URL     Mirror registry for missing images (e.g., registry.example.com)
+    --mirror-registry URL     Mirror prefix for canonical images (e.g., registry.example.com/project)
     --manifest-only           Generate only the manifest file (skip Docker image export and packaging)
     -h, --help                Show this help message
 
@@ -455,8 +445,7 @@ if [ -z "$MANIFEST_ONLY" ]; then
         FULL_IMAGE="$IMAGE_NAME:$IMAGE_TAG"
 
         if [ -n "$MIRROR_REGISTRY" ]; then
-            IMAGE_WITHOUT_REGISTRY=$(strip_image_registry "$FULL_IMAGE")
-            MIRROR_IMAGE="${MIRROR_REGISTRY}/${IMAGE_WITHOUT_REGISTRY}"
+            MIRROR_IMAGE="${MIRROR_REGISTRY}/${FULL_IMAGE}"
 
             print_info "Pulling latest $PLATFORM image from mirror: $MIRROR_IMAGE"
             if ! docker pull --platform "$PLATFORM" "$MIRROR_IMAGE"; then


### PR DESCRIPTION
## Issues

NEU-591

## Changes

- Keep Community package manifests on native `neutree/...` image names.
- Keep Community release packaging without a mirror registry; native images are pulled directly.
- Define `--mirror-registry` as an optional complete pull prefix for callers that need one.
- Preserve architecture-suffixed archives, unsuffixed manifests, and the existing upload and Slack behavior.

## Test Plan

### Unit test

- `go test ./internal/cli/packageimport`
- `bash -n scripts/builder/build-engine-package.sh`
- YAML parsing and scoped `actionlint` for the reusable package workflow.
- Manifest-only smoke check confirms `neutree/engine-*` image names and no registry prefix.
- No task-added script test is included.

### DB test

- Not required: no database, migration, or schema changes.

### E2E test

- Dispatch the existing llama.cpp AMD64 release workflow from this branch with an isolated suffix.
- Verify the uploaded standalone manifest in the configured package directory contains the native image name and no registry prefix.

## Risk & Rollback

The mirror flag now expects a complete path prefix and is only used for pulling. Revert this commit to restore the previous registry-qualified package input behavior.
