### PR TITLE
fix: pin llama-cpp FastAPI version

### DIFF
--- a/cluster-image-builder/Dockerfile.engine-llama-cpp
+++ b/cluster-image-builder/Dockerfile.engine-llama-cpp
@@ -52,7 +52,7 @@ RUN --mount=type=bind,from=build_ray,src=/ray,target=/install \
 
 # Install common serve-layer dependencies
 RUN --mount=type=bind,src=requirements,target=requirements \
-    pip install --no-cache-dir -r requirements/common.txt
+    pip install --no-cache-dir -r requirements/common.txt fastapi==0.136.1
 
 # Copy Neutree serve layer code (shared + specified engine version only)
 ARG ENGINE_VERSION_DIR


### PR DESCRIPTION
## Issue

Upstream fix: https://github.com/ray-project/ray/pull/64814

## Summary

Pins the llama-cpp engine image to FastAPI 0.136.1 to avoid the Ray Serve 2.53 ASGI-app serialization failure caused by newer FastAPI releases.

## Changes

- Pin FastAPI only in the llama-cpp engine Dockerfile.
- Keep the shared engine requirements unchanged so vLLM and SGLang are unaffected.

## Test Plan

### Unit test

- Not added, as requested. This is a Dockerfile-only dependency pin.

### DB test

- Not applicable.

### E2E test

- Not applicable to this image build-time dependency pin. Manual testing is not required.

### Build verification

- `make -C cluster-image-builder --just-print docker-build-engine-llama-cpp`
- Python 3.12 pip dry-run resolves `fastapi==0.136.1` and `starlette==0.52.1` without conflicts.
- `release-engine-image-llama-cpp` [run 33833247221](https://github.com/neutree-ai/neutree/actions/runs/33833247221) passed for the same Dockerfile diff before the rebase; its build log confirms pip replaced `fastapi 0.141.1` with `0.136.1`.

## Risk & Rollback

- The pin uses the known working FastAPI version for the unpatched Ray Serve 2.53 serialization path.
- Revert this one-line pin and rebuild the llama-cpp engine image to roll back.