### PR TITLE
feat: add model-scoped external endpoint routing

### DIFF
--- a/api/v1/external_endpoint_types.go
+++ b/api/v1/external_endpoint_types.go
@@ -39,6 +39,10 @@ func (a *ExternalEndpointAuthSpec) AuthHeaderValue() string {
 }
 
 type ExternalEndpointUpstreamEntry struct {
+	// Name identifies this provider entry for model_routes targets. It is
+	// optional for the legacy model_mapping format.
+	Name string `json:"name,omitempty"`
+
 	// Upstream is the external API configuration (for external upstream type)
 	Upstream *ExternalEndpointUpstreamSpec `json:"upstream,omitempty"`
 
@@ -52,6 +56,24 @@ type ExternalEndpointUpstreamEntry struct {
 	// The keys are the exposed model names, values are the upstream model names
 	// e.g. {"fast": "gpt-4o-mini"} exposes "fast" and forwards as "gpt-4o-mini"
 	ModelMapping map[string]string `json:"model_mapping"`
+}
+
+// ExternalEndpointModelRouteTarget binds one virtual model to one concrete
+// upstream model. Routing policy belongs here, rather than on the provider,
+// so the same provider can be used with different policies by different
+// virtual models.
+type ExternalEndpointModelRouteTarget struct {
+	Upstream            string `json:"upstream"`
+	UpstreamModel       string `json:"upstream_model"`
+	Priority            int    `json:"priority,omitempty"`
+	Weight              int    `json:"weight,omitempty"`
+	MaxInflightRequests int    `json:"max_inflight_requests,omitempty"`
+}
+
+type ExternalEndpointModelRoute struct {
+	Model    string                             `json:"model"`
+	Strategy string                             `json:"strategy,omitempty"`
+	Targets  []ExternalEndpointModelRouteTarget `json:"targets"`
 }
 
 // Upstream entry kinds, used to describe an entry in the status without
@@ -139,6 +161,10 @@ type ExternalEndpointSpec struct {
 	// or endpoint_ref) instead of by array index, so deleting or reordering
 	// entries cannot leak one upstream's credential into another.
 	Upstreams []ExternalEndpointUpstreamEntry `json:"upstreams" mergekey:"upstream.url,endpoint_ref"`
+
+	// ModelRoutes is the model-scoped routing format. When present, the
+	// gateway uses these routes instead of the legacy upstream model_mapping.
+	ModelRoutes []ExternalEndpointModelRoute `json:"model_routes,omitempty"`
 
 	// Timeout is the request timeout in milliseconds, default 60000
 	Timeout *int `json:"timeout,omitempty"`

--- a/db/migrations/095_external_endpoint_upstream_routing.down.sql
+++ b/db/migrations/095_external_endpoint_upstream_routing.down.sql
@@ -2,5 +2,3 @@ ALTER TYPE api.external_endpoint_spec DROP ATTRIBUTE IF EXISTS model_routes;
 ALTER TYPE api.external_endpoint_upstream_entry DROP ATTRIBUTE IF EXISTS name;
 DROP TYPE IF EXISTS api.external_endpoint_model_route;
 DROP TYPE IF EXISTS api.external_endpoint_model_route_target;
-
-NOTIFY pgrst, 'reload schema';

--- a/db/migrations/095_external_endpoint_upstream_routing.down.sql
+++ b/db/migrations/095_external_endpoint_upstream_routing.down.sql
@@ -1,0 +1,6 @@
+ALTER TYPE api.external_endpoint_spec DROP ATTRIBUTE IF EXISTS model_routes;
+ALTER TYPE api.external_endpoint_upstream_entry DROP ATTRIBUTE IF EXISTS name;
+DROP TYPE IF EXISTS api.external_endpoint_model_route;
+DROP TYPE IF EXISTS api.external_endpoint_model_route_target;
+
+NOTIFY pgrst, 'reload schema';

--- a/db/migrations/095_external_endpoint_upstream_routing.up.sql
+++ b/db/migrations/095_external_endpoint_upstream_routing.up.sql
@@ -1,0 +1,18 @@
+CREATE TYPE api.external_endpoint_model_route_target AS (
+    upstream TEXT,
+    upstream_model TEXT,
+    priority INTEGER,
+    weight INTEGER,
+    max_inflight_requests INTEGER
+);
+
+CREATE TYPE api.external_endpoint_model_route AS (
+    model TEXT,
+    strategy TEXT,
+    targets api.external_endpoint_model_route_target[]
+);
+
+ALTER TYPE api.external_endpoint_upstream_entry ADD ATTRIBUTE name TEXT;
+ALTER TYPE api.external_endpoint_spec ADD ATTRIBUTE model_routes api.external_endpoint_model_route[];
+
+NOTIFY pgrst, 'reload schema';

--- a/db/migrations/095_external_endpoint_upstream_routing.up.sql
+++ b/db/migrations/095_external_endpoint_upstream_routing.up.sql
@@ -14,5 +14,3 @@ CREATE TYPE api.external_endpoint_model_route AS (
 
 ALTER TYPE api.external_endpoint_upstream_entry ADD ATTRIBUTE name TEXT;
 ALTER TYPE api.external_endpoint_spec ADD ATTRIBUTE model_routes api.external_endpoint_model_route[];
-
-NOTIFY pgrst, 'reload schema';

--- a/deploy/chart/neutree/templates/kong-install.yaml
+++ b/deploy/chart/neutree/templates/kong-install.yaml
@@ -551,6 +551,8 @@ spec:
         env:
         - name: KONG_NGINX_HTTP_CLIENT_BODY_BUFFER_SIZE
           value: "20m"
+        - name: KONG_NGINX_HTTP_LUA_SHARED_DICT
+          value: "neutree_ai_gateway_inflight 10m"
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"
         - name: KONG_ADMIN_ERROR_LOG

--- a/deploy/docker/neutree-core/docker-compose.yml
+++ b/deploy/docker/neutree-core/docker-compose.yml
@@ -378,6 +378,7 @@ services:
       neutree.ai/kong-plugin-neutree-ai-quota-checksum: "{{ .KongPluginQuotaChecksum }}"
     environment:
       KONG_NGINX_HTTP_CLIENT_BODY_BUFFER_SIZE: 20m
+      KONG_NGINX_HTTP_LUA_SHARED_DICT: "neutree_ai_gateway_inflight 10m"
       KONG_NGINX_WORKER_PROCESSES: "{{ .KongWorkerProcesses }}"
       KONG_PLUGINS: bundled,neutree-ai-gateway,neutree-ai-statistics,neutree-ai-access,neutree-ai-quota
       LUA_PATH: "/neutree-kong-plugin/?.lua;;"

--- a/gateway/kong/plugins/neutree-ai-gateway/handler.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/handler.lua
@@ -179,18 +179,169 @@ local function fail(code, msg)
     return kong.response.exit(code, msg and { error = { message = msg } } or nil)
 end
 
-local function resolve_upstream(conf, model)
-    if not conf.upstreams then
-        return nil
+local INFLIGHT_DICT_NAME = "neutree_ai_gateway_inflight"
+
+local function target_priority(entry)
+    return tonumber(entry.priority) or 0
+end
+
+local function target_weight(entry)
+    local weight = tonumber(entry.weight) or 1
+    return weight > 0 and weight or 1
+end
+
+local function target_limit(entry)
+    local limit = tonumber(entry.max_inflight_requests) or 0
+    return limit > 0 and limit or 0
+end
+
+local function inflight_dict()
+    return ngx.shared and ngx.shared[INFLIGHT_DICT_NAME] or nil
+end
+
+local function inflight_key(conf, model, index)
+    local endpoint = conf.route_prefix or conf.endpoint_name or "external-endpoint"
+    return table.concat({ "neutree-ai-gateway", endpoint, tostring(model), tostring(index) }, ":")
+end
+
+local function release_inflight()
+    local ctx = kong.ctx.plugin
+    local key = ctx.inflight_key
+    if not key then
+        return
     end
 
-    for _, entry in ipairs(conf.upstreams) do
-        if entry.model_mapping[model] then
-            return entry
+    -- Clear first so an unexpected duplicate release cannot decrement twice.
+    ctx.inflight_key = nil
+    local dict = inflight_dict()
+    if not dict then
+        kong.log.err("missing shared dictionary ", INFLIGHT_DICT_NAME, " while releasing inflight request")
+        return
+    end
+
+    local current, err = dict:incr(key, -1)
+    if not current then
+        kong.log.err("failed to release inflight request: ", err or "unknown")
+    elseif current < 0 then
+        dict:set(key, 0)
+    end
+end
+
+local function reserve_target(conf, model, candidate)
+    local limit = target_limit(candidate.entry)
+    if limit == 0 then
+        return true
+    end
+
+    local dict = inflight_dict()
+    if not dict then
+        return nil, "Kong is missing the " .. INFLIGHT_DICT_NAME .. " shared dictionary"
+    end
+
+    local key = inflight_key(conf, model, candidate.index)
+    local current, err = dict:incr(key, 1, 0)
+    if not current then
+        return nil, "failed to reserve upstream capacity: " .. (err or "unknown")
+    end
+
+    if current > limit then
+        dict:incr(key, -1)
+        return false
+    end
+
+    kong.ctx.plugin.inflight_key = key
+    return true
+end
+
+local function has_capacity(conf, model, candidate)
+    if target_limit(candidate.entry) == 0 then
+        return true
+    end
+
+    local dict = inflight_dict()
+    if not dict then
+        return nil, "Kong is missing the " .. INFLIGHT_DICT_NAME .. " shared dictionary"
+    end
+
+    return (dict:get(inflight_key(conf, model, candidate.index)) or 0) < target_limit(candidate.entry)
+end
+
+local function weighted_choice(candidates)
+    local total = 0
+    for _, candidate in ipairs(candidates) do
+        total = total + target_weight(candidate.entry)
+    end
+
+    -- Use the float form so a large, valid sum of target weights does not hit
+    -- Lua's integer argument limit for math.random.
+    local pick = math.random() * total
+    for _, candidate in ipairs(candidates) do
+        pick = pick - target_weight(candidate.entry)
+        if pick <= 0 then
+            return candidate
         end
     end
 
-    return nil
+    return candidates[#candidates]
+end
+
+local function select_upstream(conf, model)
+    if not conf.upstreams then
+        return nil, "model_not_found"
+    end
+
+    local candidates = {}
+    local priorities = {}
+    local seen_priorities = {}
+    for index, entry in ipairs(conf.upstreams) do
+        if entry.model_mapping[model] then
+            local priority = target_priority(entry)
+            candidates[#candidates + 1] = { entry = entry, index = index, priority = priority }
+            if not seen_priorities[priority] then
+                priorities[#priorities + 1] = priority
+                seen_priorities[priority] = true
+            end
+        end
+    end
+
+    if #candidates == 0 then
+        return nil, "model_not_found"
+    end
+
+    table.sort(priorities)
+    for _, priority in ipairs(priorities) do
+        while true do
+            local available = {}
+            for _, candidate in ipairs(candidates) do
+                if candidate.priority == priority then
+                    local ok, err = has_capacity(conf, model, candidate)
+                    if ok == nil then
+                        return nil, "internal_error", err
+                    end
+                    if ok then
+                        available[#available + 1] = candidate
+                    end
+                end
+            end
+
+            if #available == 0 then
+                break
+            end
+
+            local selected = weighted_choice(available)
+            local reserved, err = reserve_target(conf, model, selected)
+            if reserved then
+                return selected.entry
+            end
+            if reserved == nil then
+                return nil, "internal_error", err
+            end
+            -- Another worker filled this target after the capacity check. Loop
+            -- and select again from the remaining capacity in this priority.
+        end
+    end
+
+    return nil, "capacity_exhausted"
 end
 
 local function set_upstream_target(entry)
@@ -262,14 +413,18 @@ local function maybe_return_model_list(conf, suffix)
     if is_models_path(suffix) and kong.request.get_method() == "GET" then
         kong.ctx.plugin.skip = true
         local models = json_array()
+        local seen = {}
         for _, entry in ipairs(conf.upstreams) do
             for model_name, _ in pairs(entry.model_mapping) do
-                models[#models + 1] = {
-                    id = model_name,
-                    object = "model",
-                    created = 0,
-                    owned_by = "external-endpoint",
-                }
+                if not seen[model_name] then
+                    models[#models + 1] = {
+                        id = model_name,
+                        object = "model",
+                        created = 0,
+                        owned_by = "external-endpoint",
+                    }
+                    seen[model_name] = true
+                end
             end
         end
         kong.response.exit(200, {
@@ -282,14 +437,18 @@ local function maybe_return_model_list(conf, suffix)
     if is_anthropic_models_path(suffix) and kong.request.get_method() == "GET" then
         kong.ctx.plugin.skip = true
         local models = json_array()
+        local seen = {}
         for _, entry in ipairs(conf.upstreams) do
             for model_name, _ in pairs(entry.model_mapping) do
-                models[#models + 1] = {
-                    id = model_name,
-                    type = "model",
-                    display_name = model_name,
-                    created_at = "2025-01-01T00:00:00Z",
-                }
+                if not seen[model_name] then
+                    models[#models + 1] = {
+                        id = model_name,
+                        type = "model",
+                        display_name = model_name,
+                        created_at = "2025-01-01T00:00:00Z",
+                    }
+                    seen[model_name] = true
+                end
             end
         end
         kong.response.exit(200, {
@@ -1265,13 +1424,21 @@ function AIGatewayHandler:access(conf)
         kong.ctx.plugin.route_type = "/v1/chat/completions"
 
         if conf.upstreams then
-            local matched_entry = resolve_upstream(conf, openai_req.model)
+            local matched_entry, selection_err, selection_detail = select_upstream(conf, openai_req.model)
             if not matched_entry then
+                if selection_err == "capacity_exhausted" then
+                    return anthropic_error(503, "overloaded_error", "All upstreams are at capacity for model: " .. tostring(openai_req.model))
+                end
+                if selection_err == "internal_error" then
+                    kong.log.err(selection_detail)
+                    return anthropic_error(500, "api_error", "Unable to select an upstream")
+                end
                 return anthropic_error(400, "invalid_request_error", "No upstream configured for model: " .. tostring(openai_req.model))
             end
 
             local _, route_err = set_upstream_target(matched_entry)
             if route_err then
+                release_inflight()
                 return route_err
             end
             if matched_entry.internal then
@@ -1379,13 +1546,21 @@ function AIGatewayHandler:access(conf)
             return fail(400, "missing 'model' field in request body")
         end
 
-        local matched_entry = resolve_upstream(conf, ai_request.model)
+        local matched_entry, selection_err, selection_detail = select_upstream(conf, ai_request.model)
         if not matched_entry then
+            if selection_err == "capacity_exhausted" then
+                return fail(503, "All upstreams are at capacity for model: " .. ai_request.model)
+            end
+            if selection_err == "internal_error" then
+                kong.log.err(selection_detail)
+                return fail(500, "Unable to select an upstream")
+            end
             return fail(400, "No upstream configured for model: " .. ai_request.model)
         end
 
         local _, route_err = set_upstream_target(matched_entry)
         if route_err then
+            release_inflight()
             return route_err
         end
 
@@ -1479,6 +1654,8 @@ function AIGatewayHandler:body_filter(conf)
 end
 
 function AIGatewayHandler:log(conf)
+    release_inflight()
+
     if kong.ctx.plugin.skip then
         return
     end
@@ -1554,6 +1731,8 @@ AIGatewayHandler._TEST = {
     convert_response = convert_response,
     make_message_start = make_message_start,
     anthropic_usage_from_openai = anthropic_usage_from_openai,
+    select_upstream = select_upstream,
+    release_inflight = release_inflight,
 }
 
 return AIGatewayHandler

--- a/gateway/kong/plugins/neutree-ai-gateway/schema.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/schema.lua
@@ -50,6 +50,30 @@ local upstream_entry = {
         default = false,
       },
     },
+    {
+      priority = {
+        type = "integer",
+        required = false,
+        default = 0,
+        between = { 0, 2147483647 },
+      },
+    },
+    {
+      weight = {
+        type = "integer",
+        required = false,
+        default = 1,
+        between = { 1, 2147483647 },
+      },
+    },
+    {
+      max_inflight_requests = {
+        type = "integer",
+        required = false,
+        default = 0,
+        between = { 0, 2147483647 },
+      },
+    },
   },
 }
 

--- a/gateway/kong/plugins/neutree-ai-gateway/spec/handler_spec.lua
+++ b/gateway/kong/plugins/neutree-ai-gateway/spec/handler_spec.lua
@@ -33,8 +33,37 @@ package.loaded["kong.tools.string"] = {
     strip = function(s) return s end,
 }
 
-_G.ngx = { now = function() return 0 end }
-_G.kong = { log = { warn = function() end, err = function() end } }
+local shared_values = {}
+local inflight_dict = {
+    get = function(_, key)
+        return shared_values[key]
+    end,
+    incr = function(_, key, delta, init)
+        local current = shared_values[key]
+        if current == nil then
+            if init == nil then
+                return nil, "not found"
+            end
+            current = init
+        end
+        current = current + delta
+        shared_values[key] = current
+        return current
+    end,
+    set = function(_, key, value)
+        shared_values[key] = value
+        return true
+    end,
+}
+
+_G.ngx = {
+    now = function() return 0 end,
+    shared = { neutree_ai_gateway_inflight = inflight_dict },
+}
+_G.kong = {
+    ctx = { plugin = {} },
+    log = { warn = function() end, err = function() end },
+}
 
 -- Load the handler by file path (relative to this spec) rather than by module
 -- name, so the tests do not depend on the kong.plugins.* directory nesting
@@ -60,6 +89,64 @@ describe("json_array()", function()
         local a = T.json_array()
         a[#a + 1] = { id = "x" }
         assert.are.equal('[{"id":"x"}]', cjson.encode(a))
+    end)
+end)
+
+describe("select_upstream()", function()
+    local function entry(model, priority, weight, limit)
+        return {
+            model_mapping = { chat = model },
+            priority = priority,
+            weight = weight,
+            max_inflight_requests = limit,
+        }
+    end
+
+    before_each(function()
+        shared_values = {}
+        _G.kong.ctx.plugin = {}
+    end)
+
+    it("uses the highest-priority available group", function()
+        local high = entry("provider-a", 0, 1, 0)
+        local low = entry("provider-b", 1, 1, 0)
+        local selected, reason = T.select_upstream({
+            route_prefix = "/workspace/ws/external-endpoint/ee",
+            upstreams = { high, low },
+        }, "chat")
+
+        assert.is_nil(reason)
+        assert.are.equal(high, selected)
+    end)
+
+    it("falls through to a lower priority when the higher group is full", function()
+        local high = entry("provider-a", 0, 1, 1)
+        local low = entry("provider-b", 1, 1, 1)
+        shared_values["neutree-ai-gateway:/workspace/ws/external-endpoint/ee:chat:1"] = 1
+        local selected, reason = T.select_upstream({
+            route_prefix = "/workspace/ws/external-endpoint/ee",
+            upstreams = { high, low },
+        }, "chat")
+
+        assert.is_nil(reason)
+        assert.are.equal(low, selected)
+        assert.are.equal(1, shared_values["neutree-ai-gateway:/workspace/ws/external-endpoint/ee:chat:2"])
+        T.release_inflight()
+        assert.are.equal(0, shared_values["neutree-ai-gateway:/workspace/ws/external-endpoint/ee:chat:2"])
+    end)
+
+    it("returns capacity_exhausted when every matching target is full", function()
+        local first = entry("provider-a", 0, 1, 1)
+        local second = entry("provider-b", 0, 1, 1)
+        shared_values["neutree-ai-gateway:/workspace/ws/external-endpoint/ee:chat:1"] = 1
+        shared_values["neutree-ai-gateway:/workspace/ws/external-endpoint/ee:chat:2"] = 1
+        local selected, reason = T.select_upstream({
+            route_prefix = "/workspace/ws/external-endpoint/ee",
+            upstreams = { first, second },
+        }, "chat")
+
+        assert.is_nil(selected)
+        assert.are.equal("capacity_exhausted", reason)
     end)
 end)
 

--- a/internal/gateway/kong.go
+++ b/internal/gateway/kong.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -793,7 +794,7 @@ func (k *Kong) SyncExternalEndpoint(ee *v1.ExternalEndpoint) ([]v1.ExternalEndpo
 	}
 
 	resolved := k.resolveExternalEndpointUpstreams(ee)
-	statuses := externalEndpointUpstreamStatuses(resolved)
+	statuses := externalEndpointUpstreamStatuses(ee, resolved)
 
 	ready := make([]resolvedUpstream, 0, len(resolved))
 
@@ -806,6 +807,18 @@ func (k *Kong) SyncExternalEndpoint(ee *v1.ExternalEndpoint) ([]v1.ExternalEndpo
 	if len(ready) == 0 {
 		return statuses, errors.Errorf("external endpoint %s has no resolvable upstream: %s",
 			ee.Key(), joinUpstreamErrors(statuses))
+	}
+
+	pluginReady := ready
+	if len(ee.Spec.ModelRoutes) > 0 {
+		var err error
+		pluginReady, err = expandExternalEndpointModelRoutes(ee, ready)
+		if err != nil {
+			return statuses, err
+		}
+		if len(pluginReady) == 0 {
+			return statuses, errors.Errorf("external endpoint %s has no resolvable model route target", ee.Key())
+		}
 	}
 
 	gwService, err := k.syncExternalEndpointService(ee, ready[0])
@@ -821,7 +834,7 @@ func (k *Kong) SyncExternalEndpoint(ee *v1.ExternalEndpoint) ([]v1.ExternalEndpo
 	// sync route plugins
 	needPluginMap := make(map[string]*kong.Plugin)
 
-	aiGatewayPlugin := k.generateExternalEndpointAIGatewayPlugin(ee, route, ready)
+	aiGatewayPlugin := k.generateExternalEndpointAIGatewayPlugin(ee, route, pluginReady)
 	needPluginMap[*aiGatewayPlugin.InstanceName] = aiGatewayPlugin
 
 	aclPlugin := k.generateExternalEndpointACLPlugin(ee, route)
@@ -859,6 +872,58 @@ func (k *Kong) SyncExternalEndpoint(ee *v1.ExternalEndpoint) ([]v1.ExternalEndpo
 	}
 
 	return statuses, nil
+}
+
+// expandExternalEndpointModelRoutes compiles the model-scoped control-plane
+// format into the plugin's existing flat target list. Each route target gets
+// a one-key model_mapping, so priority and weight are evaluated per virtual
+// model target even when one provider is reused by several routes.
+func expandExternalEndpointModelRoutes(ee *v1.ExternalEndpoint, ready []resolvedUpstream) ([]resolvedUpstream, error) {
+	providers := make(map[string]resolvedUpstream, len(ready))
+	for _, r := range ready {
+		if r.entry.Name != "" {
+			providers[r.entry.Name] = r
+		}
+	}
+	configuredProviders := make(map[string]struct{}, len(ee.Spec.Upstreams))
+	for _, entry := range ee.Spec.Upstreams {
+		configuredProviders[entry.Name] = struct{}{}
+	}
+
+	expanded := make([]resolvedUpstream, 0)
+	for _, route := range ee.Spec.ModelRoutes {
+		if route.Model == "" {
+			return nil, errors.Errorf("external endpoint %s has a model route with an empty model", ee.Key())
+		}
+		for _, target := range route.Targets {
+			provider, ok := providers[target.Upstream]
+			if !ok {
+				if _, configured := configuredProviders[target.Upstream]; configured {
+					continue
+				}
+				return nil, errors.Errorf("external endpoint %s model route %q references unknown upstream %q", ee.Key(), route.Model, target.Upstream)
+			}
+			if target.UpstreamModel == "" {
+				return nil, errors.Errorf("external endpoint %s model route %q has an empty upstream_model", ee.Key(), route.Model)
+			}
+
+			entry := provider.entry
+			entry.ModelMapping = map[string]string{route.Model: target.UpstreamModel}
+			expanded = append(expanded, resolvedUpstream{
+				entry:               entry,
+				priority:            target.Priority,
+				weight:              target.Weight,
+				maxInflightRequests: target.MaxInflightRequests,
+				scheme:              provider.scheme,
+				host:                provider.host,
+				port:                provider.port,
+				path:                provider.path,
+				internal:            provider.internal,
+			})
+		}
+	}
+
+	return expanded, nil
 }
 
 // DeleteExternalEndpoint removes an external endpoint configuration from Kong
@@ -950,6 +1015,11 @@ func (k *Kong) resolveEndpointRef(workspace, endpointName string) (scheme, host 
 // out of the Kong configuration.
 type resolvedUpstream struct {
 	entry v1.ExternalEndpointUpstreamEntry
+	// Routing policy belongs to a model target, not the reusable provider
+	// entry. Legacy entries leave these at their default values.
+	priority            int
+	weight              int
+	maxInflightRequests int
 
 	scheme string
 	host   string
@@ -1001,15 +1071,32 @@ func (k *Kong) resolveExternalEndpointUpstreams(ee *v1.ExternalEndpoint) []resol
 
 // externalEndpointUpstreamStatuses projects resolution outcomes into the
 // user-visible per-upstream status list, in spec order.
-func externalEndpointUpstreamStatuses(resolved []resolvedUpstream) []v1.ExternalEndpointUpstreamStatus {
+func externalEndpointUpstreamStatuses(ee *v1.ExternalEndpoint, resolved []resolvedUpstream) []v1.ExternalEndpointUpstreamStatus {
 	statuses := make([]v1.ExternalEndpointUpstreamStatus, 0, len(resolved))
+	modelsByUpstream := make(map[string]map[string]struct{})
+	for _, route := range ee.Spec.ModelRoutes {
+		for _, target := range route.Targets {
+			if modelsByUpstream[target.Upstream] == nil {
+				modelsByUpstream[target.Upstream] = make(map[string]struct{})
+			}
+			modelsByUpstream[target.Upstream][route.Model] = struct{}{}
+		}
+	}
 
 	for i := range resolved {
 		entry := resolved[i].entry
+		models := entry.ExposedModels()
+		if routeModels := modelsByUpstream[entry.Name]; len(routeModels) > 0 {
+			models = make([]string, 0, len(routeModels))
+			for model := range routeModels {
+				models = append(models, model)
+			}
+			sort.Strings(models)
+		}
 		status := v1.ExternalEndpointUpstreamStatus{
 			Kind:   entry.Kind(),
 			Ref:    entry.Ref(),
-			Models: entry.ExposedModels(),
+			Models: models,
 			Phase:  v1.ExternalEndpointUpstreamPhaseReady,
 		}
 
@@ -1177,13 +1264,21 @@ func (k *Kong) generateExternalEndpointAIGatewayPlugin(ee *v1.ExternalEndpoint, 
 	upstreams := make([]map[string]interface{}, 0, len(ready))
 
 	for _, r := range ready {
+		weight := r.weight
+		if weight == 0 {
+			weight = 1
+		}
+
 		upstreamEntry := map[string]interface{}{
-			"model_mapping": r.entry.ModelMapping,
-			"scheme":        r.scheme,
-			"host":          r.host,
-			"port":          r.port,
-			"path":          r.path,
-			"auth_header":   nil,
+			"model_mapping":         r.entry.ModelMapping,
+			"scheme":                r.scheme,
+			"host":                  r.host,
+			"port":                  r.port,
+			"path":                  r.path,
+			"auth_header":           nil,
+			"priority":              r.priority,
+			"weight":                weight,
+			"max_inflight_requests": r.maxInflightRequests,
 			// Must explicitly set "internal" to match Kong schema default (false),
 			// otherwise the merge-patch array replacement drops it and causes a perpetual sync loop.
 			"internal": r.internal,

--- a/internal/gateway/kong.go
+++ b/internal/gateway/kong.go
@@ -810,12 +810,15 @@ func (k *Kong) SyncExternalEndpoint(ee *v1.ExternalEndpoint) ([]v1.ExternalEndpo
 	}
 
 	pluginReady := ready
+
 	if len(ee.Spec.ModelRoutes) > 0 {
 		var err error
 		pluginReady, err = expandExternalEndpointModelRoutes(ee, ready)
+
 		if err != nil {
 			return statuses, err
 		}
+
 		if len(pluginReady) == 0 {
 			return statuses, errors.Errorf("external endpoint %s has no resolvable model route target", ee.Key())
 		}
@@ -880,29 +883,36 @@ func (k *Kong) SyncExternalEndpoint(ee *v1.ExternalEndpoint) ([]v1.ExternalEndpo
 // model target even when one provider is reused by several routes.
 func expandExternalEndpointModelRoutes(ee *v1.ExternalEndpoint, ready []resolvedUpstream) ([]resolvedUpstream, error) {
 	providers := make(map[string]resolvedUpstream, len(ready))
+
 	for _, r := range ready {
 		if r.entry.Name != "" {
 			providers[r.entry.Name] = r
 		}
 	}
+
 	configuredProviders := make(map[string]struct{}, len(ee.Spec.Upstreams))
+
 	for _, entry := range ee.Spec.Upstreams {
 		configuredProviders[entry.Name] = struct{}{}
 	}
 
 	expanded := make([]resolvedUpstream, 0)
+
 	for _, route := range ee.Spec.ModelRoutes {
 		if route.Model == "" {
 			return nil, errors.Errorf("external endpoint %s has a model route with an empty model", ee.Key())
 		}
+
 		for _, target := range route.Targets {
 			provider, ok := providers[target.Upstream]
 			if !ok {
 				if _, configured := configuredProviders[target.Upstream]; configured {
 					continue
 				}
+
 				return nil, errors.Errorf("external endpoint %s model route %q references unknown upstream %q", ee.Key(), route.Model, target.Upstream)
 			}
+
 			if target.UpstreamModel == "" {
 				return nil, errors.Errorf("external endpoint %s model route %q has an empty upstream_model", ee.Key(), route.Model)
 			}
@@ -1074,11 +1084,13 @@ func (k *Kong) resolveExternalEndpointUpstreams(ee *v1.ExternalEndpoint) []resol
 func externalEndpointUpstreamStatuses(ee *v1.ExternalEndpoint, resolved []resolvedUpstream) []v1.ExternalEndpointUpstreamStatus {
 	statuses := make([]v1.ExternalEndpointUpstreamStatus, 0, len(resolved))
 	modelsByUpstream := make(map[string]map[string]struct{})
+
 	for _, route := range ee.Spec.ModelRoutes {
 		for _, target := range route.Targets {
 			if modelsByUpstream[target.Upstream] == nil {
 				modelsByUpstream[target.Upstream] = make(map[string]struct{})
 			}
+
 			modelsByUpstream[target.Upstream][route.Model] = struct{}{}
 		}
 	}
@@ -1086,13 +1098,16 @@ func externalEndpointUpstreamStatuses(ee *v1.ExternalEndpoint, resolved []resolv
 	for i := range resolved {
 		entry := resolved[i].entry
 		models := entry.ExposedModels()
+
 		if routeModels := modelsByUpstream[entry.Name]; len(routeModels) > 0 {
 			models = make([]string, 0, len(routeModels))
 			for model := range routeModels {
 				models = append(models, model)
 			}
+
 			sort.Strings(models)
 		}
+
 		status := v1.ExternalEndpointUpstreamStatus{
 			Kind:   entry.Kind(),
 			Ref:    entry.Ref(),

--- a/internal/gateway/kong_external_endpoint_test.go
+++ b/internal/gateway/kong_external_endpoint_test.go
@@ -95,7 +95,9 @@ func TestExternalEndpointUpstreamStatuses(t *testing.T) {
 		},
 	}
 
-	statuses := externalEndpointUpstreamStatuses(resolved)
+	statuses := externalEndpointUpstreamStatuses(testExternalEndpoint(
+		resolved[0].entry, resolved[1].entry,
+	), resolved)
 	require.Len(t, statuses, 2)
 
 	assert.Equal(t, v1.ExternalEndpointUpstreamKindEndpointRef, statuses[0].Kind)
@@ -111,6 +113,22 @@ func TestExternalEndpointUpstreamStatuses(t *testing.T) {
 	assert.Equal(t, v1.ExternalEndpointUpstreamPhaseFailed, statuses[1].Phase)
 	assert.Equal(t, "boom", statuses[1].ErrorMessage)
 	assert.NotContains(t, statuses[1].ErrorMessage, "sk-test")
+}
+
+func TestExternalEndpointUpstreamStatusesUsesModelRoutes(t *testing.T) {
+	entry := externalUpstream("https://api.openai.com/v1", map[string]string{"legacy": "old"})
+	entry.Name = "openai"
+	ee := testExternalEndpoint(entry)
+	ee.Spec.ModelRoutes = []v1.ExternalEndpointModelRoute{{
+		Model: "chat",
+		Targets: []v1.ExternalEndpointModelRouteTarget{{
+			Upstream: "openai", UpstreamModel: "gpt-4o",
+		}},
+	}}
+
+	statuses := externalEndpointUpstreamStatuses(ee, []resolvedUpstream{{entry: entry}})
+	require.Len(t, statuses, 1)
+	assert.Equal(t, []string{"chat"}, statuses[0].Models)
 }
 
 func TestGenerateExternalEndpointAIGatewayPluginSkipsUnresolved(t *testing.T) {
@@ -139,6 +157,69 @@ func TestGenerateExternalEndpointAIGatewayPluginSkipsUnresolved(t *testing.T) {
 	assert.Equal(t, "api.openai.com", upstreams[0]["host"])
 	assert.Equal(t, false, upstreams[0]["internal"])
 	assert.Equal(t, "Bearer sk-test", upstreams[0]["auth_header"])
+	assert.Equal(t, 0, upstreams[0]["priority"])
+	assert.Equal(t, 1, upstreams[0]["weight"])
+	assert.Equal(t, 0, upstreams[0]["max_inflight_requests"])
+}
+
+func TestExpandExternalEndpointModelRoutesScopesPolicyToTarget(t *testing.T) {
+	openai := externalUpstream("https://api.openai.com/v1", nil)
+	openai.Name = "openai"
+	qwen := externalUpstream("https://qwen.example/v1", nil)
+	qwen.Name = "qwen"
+	ee := testExternalEndpoint(openai, qwen)
+	ee.Spec.ModelRoutes = []v1.ExternalEndpointModelRoute{
+		{
+			Model: "chat",
+			Targets: []v1.ExternalEndpointModelRouteTarget{
+				{Upstream: "openai", UpstreamModel: "gpt-4o", Priority: 0, Weight: 80},
+				{Upstream: "qwen", UpstreamModel: "Qwen3-32B", Priority: 1, Weight: 20},
+			},
+		},
+		{
+			Model: "reasoning",
+			Targets: []v1.ExternalEndpointModelRouteTarget{
+				{Upstream: "qwen", UpstreamModel: "Qwen3-32B", Priority: 0, Weight: 100},
+			},
+		},
+	}
+
+	ready := []resolvedUpstream{
+		{entry: openai, scheme: "https", host: "api.openai.com", port: 443, path: "/v1"},
+		{entry: qwen, scheme: "https", host: "qwen.example", port: 443, path: "/v1"},
+	}
+	expanded, err := expandExternalEndpointModelRoutes(ee, ready)
+	require.NoError(t, err)
+	require.Len(t, expanded, 3)
+
+	assert.Equal(t, map[string]string{"chat": "gpt-4o"}, expanded[0].entry.ModelMapping)
+	assert.Equal(t, 80, expanded[0].weight)
+	assert.Equal(t, map[string]string{"chat": "Qwen3-32B"}, expanded[1].entry.ModelMapping)
+	assert.Equal(t, 20, expanded[1].weight)
+	assert.Equal(t, map[string]string{"reasoning": "Qwen3-32B"}, expanded[2].entry.ModelMapping)
+	assert.Equal(t, 100, expanded[2].weight)
+}
+
+func TestExpandExternalEndpointModelRoutesSkipsUnresolvedProvider(t *testing.T) {
+	openai := externalUpstream("https://api.openai.com/v1", nil)
+	openai.Name = "openai"
+	qwen := externalUpstream("https://qwen.example/v1", nil)
+	qwen.Name = "qwen"
+	ee := testExternalEndpoint(openai, qwen)
+	ee.Spec.ModelRoutes = []v1.ExternalEndpointModelRoute{{
+		Model: "chat",
+		Targets: []v1.ExternalEndpointModelRouteTarget{
+			{Upstream: "openai", UpstreamModel: "gpt-4o", Weight: 80},
+			{Upstream: "qwen", UpstreamModel: "Qwen3-32B", Weight: 20},
+		},
+	}}
+
+	expanded, err := expandExternalEndpointModelRoutes(ee, []resolvedUpstream{{
+		entry: openai, scheme: "https", host: "api.openai.com", port: 443, path: "/v1",
+	}})
+	require.NoError(t, err)
+	require.Len(t, expanded, 1)
+	assert.Equal(t, map[string]string{"chat": "gpt-4o"}, expanded[0].entry.ModelMapping)
 }
 
 func TestGenerateExternalEndpointAIGatewayPluginInternalEntry(t *testing.T) {

--- a/internal/routes/proxies/external_endpoint_validation.go
+++ b/internal/routes/proxies/external_endpoint_validation.go
@@ -3,6 +3,7 @@ package proxies
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -17,6 +18,7 @@ const (
 
 	externalEndpointInvalidPayloadCode = "10231"
 	externalEndpointInvalidNameCode    = "10232"
+	externalEndpointInvalidRoutingCode = "10233"
 )
 
 // validateExternalEndpoint enforces the metadata.name contract at the API
@@ -69,10 +71,141 @@ func validateExternalEndpoint() gin.HandlerFunc {
 
 				return
 			}
+
+			if validationErr := validateExternalEndpointRouting(payload); validationErr != nil {
+				rejectExternalEndpoint(c, validationErr)
+
+				return
+			}
 		}
 
 		c.Next()
 	}
+}
+
+func validateExternalEndpointRouting(payload map[string]json.RawMessage) *validationError {
+	specRaw, ok := payload["spec"]
+	if !ok || bytes.Equal(bytes.TrimSpace(specRaw), []byte("null")) {
+		return nil
+	}
+
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(specRaw, &spec); err != nil {
+		return invalidExternalEndpointPayloadError(err.Error())
+	}
+
+	upstreamsRaw, ok := spec["upstreams"]
+	if !ok || bytes.Equal(bytes.TrimSpace(upstreamsRaw), []byte("null")) {
+		return nil
+	}
+
+	var upstreams []map[string]json.RawMessage
+	if err := json.Unmarshal(upstreamsRaw, &upstreams); err != nil {
+		return invalidExternalEndpointPayloadError(err.Error())
+	}
+
+	modelRoutesRaw, ok := spec["model_routes"]
+	if !ok || bytes.Equal(bytes.TrimSpace(modelRoutesRaw), []byte("null")) {
+		return nil
+	}
+
+	var modelRoutes []struct {
+		Model    string `json:"model"`
+		Strategy string `json:"strategy"`
+		Targets  []struct {
+			Upstream      string          `json:"upstream"`
+			UpstreamModel string          `json:"upstream_model"`
+			Priority      json.RawMessage `json:"priority"`
+			Weight        json.RawMessage `json:"weight"`
+			MaxInflight   json.RawMessage `json:"max_inflight_requests"`
+		} `json:"targets"`
+	}
+	if err := json.Unmarshal(modelRoutesRaw, &modelRoutes); err != nil {
+		return invalidExternalEndpointPayloadError(err.Error())
+	}
+	providerNames := make(map[string]struct{}, len(upstreams))
+	for i, upstream := range upstreams {
+		nameRaw, hasName := upstream["name"]
+		if !hasName {
+			return invalidExternalEndpointRoutingError(i, "name is required when model_routes is configured")
+		}
+		var name string
+		if err := json.Unmarshal(nameRaw, &name); err != nil || name == "" {
+			return invalidExternalEndpointRoutingError(i, "name must be a non-empty string when model_routes is configured")
+		}
+		if _, exists := providerNames[name]; exists {
+			return invalidExternalEndpointRoutingError(i, fmt.Sprintf("duplicate upstream name %q", name))
+		}
+		providerNames[name] = struct{}{}
+	}
+	seenModels := make(map[string]struct{}, len(modelRoutes))
+	for i, route := range modelRoutes {
+		if route.Model == "" {
+			return invalidExternalEndpointRoutingError(i, "model must not be empty")
+		}
+		if len(route.Targets) == 0 {
+			return invalidExternalEndpointRoutingError(i, "targets must not be empty")
+		}
+		if route.Strategy != "" && route.Strategy != "weighted_random" {
+			return invalidExternalEndpointRoutingError(i, fmt.Sprintf("unsupported strategy %q", route.Strategy))
+		}
+		if _, exists := seenModels[route.Model]; exists {
+			return invalidExternalEndpointRoutingError(i, fmt.Sprintf("duplicate model route %q", route.Model))
+		}
+		seenModels[route.Model] = struct{}{}
+		for j, target := range route.Targets {
+			if target.Upstream == "" || target.UpstreamModel == "" {
+				return invalidExternalEndpointRoutingError(i, fmt.Sprintf("targets[%d] upstream and upstream_model are required", j))
+			}
+			if _, exists := providerNames[target.Upstream]; !exists {
+				return invalidExternalEndpointRoutingError(i, fmt.Sprintf("targets[%d] references unknown upstream %q", j, target.Upstream))
+			}
+			for field, raw := range map[string]json.RawMessage{
+				"priority":              target.Priority,
+				"weight":                target.Weight,
+				"max_inflight_requests": target.MaxInflight,
+			} {
+				if len(raw) == 0 {
+					continue
+				}
+				minimum, strict := 0, false
+				if field == "weight" {
+					strict = true
+				}
+				if err := validateOptionalRoutingInteger(map[string]json.RawMessage{field: raw}, field, minimum, strict); err != nil {
+					return invalidExternalEndpointRoutingError(i, fmt.Sprintf("targets[%d] %s", j, err.Error()))
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateOptionalRoutingInteger(target map[string]json.RawMessage, field string, minimum int,
+	strictMinimum bool) error {
+	raw, ok := target[field]
+	if !ok {
+		return nil
+	}
+
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return fmt.Errorf("%s must be an integer", field)
+	}
+
+	var value int
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return fmt.Errorf("%s must be an integer", field)
+	}
+
+	if strictMinimum && value <= minimum {
+		return fmt.Errorf("%s must be greater than %d", field, minimum)
+	}
+	if !strictMinimum && value < minimum {
+		return fmt.Errorf("%s must be greater than or equal to %d", field, minimum)
+	}
+
+	return nil
 }
 
 // validateExternalEndpointName checks the name a single payload carries.
@@ -190,5 +323,13 @@ func invalidExternalEndpointNameError(hint string) *validationError {
 		Code:    externalEndpointInvalidNameCode,
 		Message: "invalid external endpoint name",
 		Hint:    hint + "; use metadata.display_name for a human-readable name",
+	}
+}
+
+func invalidExternalEndpointRoutingError(index int, hint string) *validationError {
+	return &validationError{
+		Code:    externalEndpointInvalidRoutingCode,
+		Message: "invalid external endpoint routing policy",
+		Hint:    fmt.Sprintf("spec.upstreams[%d].%s", index, hint),
 	}
 }

--- a/internal/routes/proxies/external_endpoint_validation.go
+++ b/internal/routes/proxies/external_endpoint_validation.go
@@ -120,46 +120,61 @@ func validateExternalEndpointRouting(payload map[string]json.RawMessage) *valida
 			MaxInflight   json.RawMessage `json:"max_inflight_requests"`
 		} `json:"targets"`
 	}
+
 	if err := json.Unmarshal(modelRoutesRaw, &modelRoutes); err != nil {
 		return invalidExternalEndpointPayloadError(err.Error())
 	}
+
 	providerNames := make(map[string]struct{}, len(upstreams))
+
 	for i, upstream := range upstreams {
 		nameRaw, hasName := upstream["name"]
 		if !hasName {
 			return invalidExternalEndpointRoutingError(i, "name is required when model_routes is configured")
 		}
 		var name string
+
 		if err := json.Unmarshal(nameRaw, &name); err != nil || name == "" {
 			return invalidExternalEndpointRoutingError(i, "name must be a non-empty string when model_routes is configured")
 		}
+
 		if _, exists := providerNames[name]; exists {
 			return invalidExternalEndpointRoutingError(i, fmt.Sprintf("duplicate upstream name %q", name))
 		}
+
 		providerNames[name] = struct{}{}
 	}
+
 	seenModels := make(map[string]struct{}, len(modelRoutes))
+
 	for i, route := range modelRoutes {
 		if route.Model == "" {
 			return invalidExternalEndpointRoutingError(i, "model must not be empty")
 		}
+
 		if len(route.Targets) == 0 {
 			return invalidExternalEndpointRoutingError(i, "targets must not be empty")
 		}
+
 		if route.Strategy != "" && route.Strategy != "weighted_random" {
 			return invalidExternalEndpointRoutingError(i, fmt.Sprintf("unsupported strategy %q", route.Strategy))
 		}
+
 		if _, exists := seenModels[route.Model]; exists {
 			return invalidExternalEndpointRoutingError(i, fmt.Sprintf("duplicate model route %q", route.Model))
 		}
+
 		seenModels[route.Model] = struct{}{}
+
 		for j, target := range route.Targets {
 			if target.Upstream == "" || target.UpstreamModel == "" {
 				return invalidExternalEndpointRoutingError(i, fmt.Sprintf("targets[%d] upstream and upstream_model are required", j))
 			}
+
 			if _, exists := providerNames[target.Upstream]; !exists {
 				return invalidExternalEndpointRoutingError(i, fmt.Sprintf("targets[%d] references unknown upstream %q", j, target.Upstream))
 			}
+
 			for field, raw := range map[string]json.RawMessage{
 				"priority":              target.Priority,
 				"weight":                target.Weight,
@@ -168,10 +183,13 @@ func validateExternalEndpointRouting(payload map[string]json.RawMessage) *valida
 				if len(raw) == 0 {
 					continue
 				}
+
 				minimum, strict := 0, false
+
 				if field == "weight" {
 					strict = true
 				}
+
 				if err := validateOptionalRoutingInteger(map[string]json.RawMessage{field: raw}, field, minimum, strict); err != nil {
 					return invalidExternalEndpointRoutingError(i, fmt.Sprintf("targets[%d] %s", j, err.Error()))
 				}
@@ -201,6 +219,7 @@ func validateOptionalRoutingInteger(target map[string]json.RawMessage, field str
 	if strictMinimum && value <= minimum {
 		return fmt.Errorf("%s must be greater than %d", field, minimum)
 	}
+
 	if !strictMinimum && value < minimum {
 		return fmt.Errorf("%s must be greater than or equal to %d", field, minimum)
 	}

--- a/internal/routes/proxies/external_endpoint_validation_test.go
+++ b/internal/routes/proxies/external_endpoint_validation_test.go
@@ -74,6 +74,21 @@ func assertExternalEndpointPayloadRejected(t *testing.T, recorder *httptest.Resp
 	assert.Equal(t, "invalid external endpoint payload", payload.Message)
 }
 
+func assertExternalEndpointRoutingRejected(t *testing.T, recorder *httptest.ResponseRecorder, reached bool,
+	hint string) {
+	t.Helper()
+
+	assert.False(t, reached, "request must not reach the storage proxy")
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var payload validationError
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &payload))
+
+	assert.Equal(t, externalEndpointInvalidRoutingCode, payload.Code)
+	assert.Equal(t, "invalid external endpoint routing policy", payload.Message)
+	assert.Contains(t, payload.Hint, hint)
+}
+
 func TestValidateExternalEndpointCreateName(t *testing.T) {
 	// The matrix NEU-714 asks for: a legal ASCII name, an ASCII space, Unicode
 	// without a space, Unicode with a space, and the percent character that a
@@ -179,6 +194,82 @@ func TestValidateExternalEndpointPatch(t *testing.T) {
 	t.Run("allows a soft delete regardless of the name it carries", func(t *testing.T) {
 		_, reached, _ := runExternalEndpointValidation(t, http.MethodPatch,
 			`{"metadata":{"name":"ëndpoint spacer-2ea258e575","deletion_timestamp":"2026-08-25T06:29:27Z"}}`)
+
+		assert.True(t, reached)
+	})
+}
+
+func TestValidateExternalEndpointRouting(t *testing.T) {
+	t.Run("accepts model-scoped targets", func(t *testing.T) {
+		_, reached, _ := runExternalEndpointValidation(t, http.MethodPost, `{
+            "metadata":{"name":"model-routes"},
+            "spec":{
+              "upstreams":[
+                {"name":"openai","upstream":{"url":"https://api.openai.com/v1"}},
+                {"name":"qwen","endpoint_ref":"local-qwen"}
+              ],
+              "model_routes":[
+                {"model":"chat","strategy":"weighted_random","targets":[
+                  {"upstream":"openai","upstream_model":"gpt-4o","priority":0,"weight":80},
+                  {"upstream":"qwen","upstream_model":"Qwen3-32B","priority":1,"weight":20}
+                ]}
+              ]
+            }
+        }`)
+		assert.True(t, reached)
+	})
+
+	t.Run("rejects model route with unknown upstream", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost, `{
+            "metadata":{"name":"model-routes"},
+            "spec":{
+              "upstreams":[{"name":"openai","upstream":{"url":"https://api.openai.com/v1"}}],
+              "model_routes":[{"model":"chat","targets":[{"upstream":"missing","upstream_model":"m"}]}]
+            }
+        }`)
+		assertExternalEndpointRoutingRejected(t, recorder, reached, "unknown upstream")
+	})
+
+	t.Run("rejects unsupported strategy", func(t *testing.T) {
+		recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost, `{
+            "metadata":{"name":"model-routes"},
+            "spec":{
+              "upstreams":[{"name":"openai","upstream":{"url":"https://api.openai.com/v1"}}],
+              "model_routes":[{"model":"chat","strategy":"round_robin","targets":[
+                {"upstream":"openai","upstream_model":"gpt-4o"}
+              ]}]
+            }
+        }`)
+		assertExternalEndpointRoutingRejected(t, recorder, reached, "unsupported strategy")
+	})
+
+	cases := []struct {
+		name  string
+		field string
+		value string
+	}{
+		{name: "zero weight", field: "weight", value: "0"},
+		{name: "negative weight", field: "weight", value: "-1"},
+		{name: "fractional weight", field: "weight", value: "1.5"},
+		{name: "null weight", field: "weight", value: "null"},
+		{name: "negative priority", field: "priority", value: "-1"},
+		{name: "negative max inflight", field: "max_inflight_requests", value: "-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			body := `{"metadata":{"name":"multi-provider"},"spec":{"upstreams":[{"name":"provider-a"}],` +
+				`"model_routes":[{"model":"chat","targets":[{"upstream":"provider-a","upstream_model":"m","` +
+				tc.field + `":` + tc.value + `}]}]}}`
+			recorder, reached, _ := runExternalEndpointValidation(t, http.MethodPost, body)
+
+			assertExternalEndpointRoutingRejected(t, recorder, reached, tc.field)
+		})
+	}
+
+	t.Run("allows legacy model mapping without routing policy", func(t *testing.T) {
+		_, reached, _ := runExternalEndpointValidation(t, http.MethodPatch,
+			`{"spec":{"upstreams":[{"model_mapping":{"chat":"provider-a"}}]}}`)
 
 		assert.True(t, reached)
 	})


### PR DESCRIPTION
## Problem

An ExternalEndpoint can currently map an exposed model to only one upstream, so it cannot distribute one model across multiple providers or apply capacity-aware priority routing.

## Changes

- Add model_routes with per-target upstream model, priority, weight, and max inflight settings while preserving legacy model_mapping behavior.
- Compile model routes into the existing Kong plugin and select targets by priority, available capacity, and weighted random choice.
- Add API validation, migration, Kong schema/runtime changes, and focused Go/Lua tests.

Retry and failure-based fallback are not included. Inflight limits are shared across workers in one Kong Pod, not across Pods.

Companion PRs: neutree-ai/ui#416 and neutree-ai/neutree-enterprise#161.

## Test plan

- Go routing tests and full repository compile check
- Migration and boundary checks
- Kong Lua tests: 15 passed