### PR TITLE
fix: keep the model downloader's failure reason in the endpoint status (NEU-726)

### DIFF
--- a/internal/orchestrator/kubernetes_orchestrator.go
+++ b/internal/orchestrator/kubernetes_orchestrator.go
@@ -671,14 +671,22 @@ func hasIncompleteModelDownloaderInitContainer(pods []corev1.Pod) (bool, string)
 					message += ": " + initStatus.State.Waiting.Message
 				}
 
+				// While the kubelet backs off, the waiting message is only its own
+				// "back-off ... restarting failed container". The reason the last
+				// attempt gave — offline hub, cache miss — lives in the previous
+				// termination and is what the user needs while the retries run.
+				if last := initStatus.LastTerminationState.Terminated; last != nil && last.Message != "" {
+					message += "; last attempt: " + strings.TrimSpace(last.Message)
+				}
+
 				return true, message
 			}
 
 			if initStatus.State.Terminated != nil {
 				message := fmt.Sprintf("%s init container terminated with exit code %d after %d restart(s), retrying model download",
 					modelDownloaderInitContainerName, initStatus.State.Terminated.ExitCode, initStatus.RestartCount)
-				if initStatus.State.Terminated.Message != "" {
-					message += ": " + initStatus.State.Terminated.Message
+				if detail := terminationDetail(initStatus); detail != "" {
+					message += ": " + detail
 				}
 
 				return true, message
@@ -714,16 +722,28 @@ func checkContainerStatuses(podName string, statuses []corev1.ContainerStatus, c
 			continue
 		}
 
-		if containerType == "Init Container" &&
-			cs.State.Terminated != nil &&
-			cs.State.Terminated.ExitCode != 0 &&
-			cs.RestartCount >= containerFailureRestartThreshold {
-			failed = true
+		// An init container that has exhausted the restart threshold is a
+		// terminal failure, and the reason it exited is the only thing the user
+		// can act on. Both halves of the crash-loop cycle are matched: the
+		// moment of exit (State.Terminated) and the back-off that follows it
+		// (State.Waiting=CrashLoopBackOff, where the exit has already moved
+		// into LastTerminationState). Reading only the first loses the reason
+		// for most of the loop's duration and reports the endpoint as merely
+		// downloading while the kubelet waits out its back-off.
+		if containerType == "Init Container" && cs.RestartCount >= containerFailureRestartThreshold {
+			if terminated := failedInitTermination(cs); terminated != nil {
+				failed = true
 
-			errorMsg = append(errorMsg, fmt.Sprintf("Pod '%s' %s '%s' terminated with exit code %d after %d restarts: %s",
-				podName, containerType, cs.Name, cs.State.Terminated.ExitCode, cs.RestartCount, cs.State.Terminated.Message))
+				message := fmt.Sprintf("Pod '%s' %s '%s' terminated with exit code %d after %d restarts",
+					podName, containerType, cs.Name, terminated.ExitCode, cs.RestartCount)
+				if detail := terminationDetail(cs); detail != "" {
+					message += ": " + detail
+				}
 
-			continue
+				errorMsg = append(errorMsg, message)
+
+				continue
+			}
 		}
 
 		// Check for ImagePullBackOff
@@ -828,6 +848,61 @@ func containerFailureContext(cs corev1.ContainerStatus) (string, string) {
 	}
 
 	return "", ""
+}
+
+// failedInitTermination returns the non-zero exit an init container is failing
+// on, whether that exit is the container's current state or the one it is
+// backing off from. Nil when the container is not sitting on a failed exit —
+// notably when it is Running again, where a historical exit says nothing about
+// the attempt in flight.
+func failedInitTermination(cs corev1.ContainerStatus) *corev1.ContainerStateTerminated {
+	if cs.State.Terminated != nil {
+		if cs.State.Terminated.ExitCode != 0 {
+			return cs.State.Terminated
+		}
+
+		return nil
+	}
+
+	if cs.State.Waiting != nil && cs.LastTerminationState.Terminated != nil &&
+		cs.LastTerminationState.Terminated.ExitCode != 0 {
+		return cs.LastTerminationState.Terminated
+	}
+
+	return nil
+}
+
+// terminationDetail returns the actionable reason a container recorded on its
+// way out, preferring the termination message the process itself wrote (the
+// model downloader writes the offline / cache-miss reason there) over the
+// kubelet's own wording.
+//
+// The last attempt's message is kept when the current state has none: a
+// container in CrashLoopBackOff reports only "back-off 5m0s restarting failed
+// container", and dropping to that would discard the one sentence that says
+// what to do about it.
+func terminationDetail(cs corev1.ContainerStatus) string {
+	if cs.State.Terminated != nil && cs.State.Terminated.Message != "" {
+		return strings.TrimSpace(cs.State.Terminated.Message)
+	}
+
+	if cs.LastTerminationState.Terminated != nil && cs.LastTerminationState.Terminated.Message != "" {
+		return strings.TrimSpace(cs.LastTerminationState.Terminated.Message)
+	}
+
+	if cs.State.Terminated != nil && cs.State.Terminated.Reason != "" {
+		return cs.State.Terminated.Reason
+	}
+
+	if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+		if cs.State.Waiting.Message != "" {
+			return cs.State.Waiting.Reason + ": " + strings.TrimSpace(cs.State.Waiting.Message)
+		}
+
+		return cs.State.Waiting.Reason
+	}
+
+	return ""
 }
 
 // joinReasonMessage returns the failure-context suffix for the restart

--- a/internal/orchestrator/kubernetes_orchestrator_test.go
+++ b/internal/orchestrator/kubernetes_orchestrator_test.go
@@ -1740,6 +1740,126 @@ func Test_checkPodFailures(t *testing.T) {
 	}
 }
 
+func Test_checkPodFailures_modelDownloaderReason(t *testing.T) {
+	const offlineReason = "model download failed for model-scope model 'Qwen/Qwen3-8B': runtime model " +
+		"download is unavailable: offline mode is enabled, so the weights cannot be fetched from the " +
+		"hub, and none are present at /models-cache."
+
+	podWithInit := func(state corev1.ContainerState, last corev1.ContainerState, restarts int32) []corev1.Pod {
+		return []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-dl"},
+			Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{{
+					Name:                 modelDownloaderInitContainerName,
+					RestartCount:         restarts,
+					State:                state,
+					LastTerminationState: last,
+				}},
+			},
+		}}
+	}
+
+	terminated := corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+		ExitCode: 1,
+		Reason:   "Error",
+		Message:  offlineReason,
+	}}
+	crashLoop := corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+		Reason:  k8sContainerReasonCrashLoopBackOff,
+		Message: "back-off 5m0s restarting failed container",
+	}}
+
+	tests := []struct {
+		name        string
+		pods        []corev1.Pod
+		wantFailed  bool
+		wantMsgPart string
+	}{
+		{
+			name:        "terminated with a reason -> reason reaches the status",
+			pods:        podWithInit(terminated, corev1.ContainerState{}, 5),
+			wantFailed:  true,
+			wantMsgPart: "terminated with exit code 1 after 5 restarts: " + offlineReason,
+		},
+		{
+			name:        "crash looping -> the last attempt's reason is kept",
+			pods:        podWithInit(crashLoop, terminated, 5),
+			wantFailed:  true,
+			wantMsgPart: "terminated with exit code 1 after 5 restarts: " + offlineReason,
+		},
+		{
+			name: "no reason recorded -> no dangling colon",
+			pods: podWithInit(corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 1,
+			}}, corev1.ContainerState{}, 5),
+			wantFailed:  true,
+			wantMsgPart: "terminated with exit code 1 after 5 restarts",
+		},
+		{
+			name:       "retrying below the threshold -> not a failure yet",
+			pods:       podWithInit(terminated, corev1.ContainerState{}, 2),
+			wantFailed: false,
+		},
+		{
+			// At the threshold and running again, the attempt in flight is what
+			// counts; the previous exit must not be reported as the outcome.
+			// (Past the threshold a still-unready container is failed by the
+			// generic restart check, which is unchanged.)
+			name:       "running again at the threshold -> not judged by history",
+			pods:       podWithInit(corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}, terminated, 5),
+			wantFailed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &kubernetesOrchestrator{}
+			hasFailed, msg := k.checkPodFailures(tt.pods)
+			assert.Equal(t, tt.wantFailed, hasFailed)
+
+			if tt.wantFailed {
+				assert.Contains(t, msg, tt.wantMsgPart)
+				assert.NotContains(t, msg, "restarts: \n")
+			}
+		})
+	}
+
+	t.Run("no reason recorded leaves no trailing separator", func(t *testing.T) {
+		k := &kubernetesOrchestrator{}
+		_, msg := k.checkPodFailures(podWithInit(corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: 1},
+		}, corev1.ContainerState{}, 5))
+		assert.False(t, strings.HasSuffix(msg, ": "))
+	})
+}
+
+func Test_hasIncompleteModelDownloaderInitContainer_keepsLastReason(t *testing.T) {
+	const reason = "runtime model download is unavailable: cannot reach the ModelScope endpoint"
+
+	pods := []corev1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-dl"},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name:         modelDownloaderInitContainerName,
+				RestartCount: 2,
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason:  k8sContainerReasonCrashLoopBackOff,
+					Message: "back-off 40s restarting failed container",
+				}},
+				LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 1,
+					Message:  reason,
+				}},
+			}},
+		},
+	}}
+
+	incomplete, detail := hasIncompleteModelDownloaderInitContainer(pods)
+	assert.True(t, incomplete)
+	assert.Contains(t, detail, k8sContainerReasonCrashLoopBackOff)
+	assert.Contains(t, detail, "last attempt: "+reason)
+}
+
 func TestKubernetesOrchestrator_setRoutingLogic(t *testing.T) {
 	k := &kubernetesOrchestrator{}
 

--- a/python/neutree/downloader/__main__.py
+++ b/python/neutree/downloader/__main__.py
@@ -2,7 +2,9 @@
 """
 import argparse
 import sys
+import traceback
 
+from .failure import build_failure_message, write_termination_message
 from .utils import build_request_from_model_args, download_with_markers
 
 
@@ -37,6 +39,25 @@ def main(argv=None):
         "registry_type": args.registry_type,
         "path": args.path,
     }
+    # A failure anywhere below is the only thing the user will see about this
+    # endpoint: the container exits, kubelet reports an exit code and a restart
+    # count, and the reason reaches the endpoint status only through the
+    # termination message. Record it before exiting, or the status ends at
+    # "exit code 1" with nothing after the colon. Resolution of the backend and
+    # the request is inside the guard too — an unreadable registry or an
+    # unknown backend fails the container just as visibly as a failed transfer.
+    try:
+        _run(model_args)
+    except Exception as exc:  # noqa: BLE001 - reported, then turned into a non-zero exit
+        message = build_failure_message(exc, model_name=args.name,
+                                        registry_type=args.registry_type)
+        write_termination_message(message)
+        traceback.print_exc()
+        print(message, file=sys.stderr, flush=True)
+        sys.exit(1)
+
+
+def _run(model_args):
     # Build low-level DownloadRequest from model_args + environment using utils helper
     backend, dl_req = build_request_from_model_args(model_args)
 

--- a/python/neutree/downloader/failure.py
+++ b/python/neutree/downloader/failure.py
@@ -17,12 +17,26 @@ the step they cannot easily take.
 
 Two constraints shape the text that goes there:
 
-* **It is user-visible, so it is sanitized.** A hub error can quote the URL that
-  produced it, and a signed CDN URL carries its credential in the query string;
-  a wrapped exception can carry a header dict. `sanitize()` redacts those, and
-  additionally redacts the *literal values* of the token environment variables
-  this container was given — the one check that does not depend on guessing the
-  shape of a secret.
+* **It is user-visible, so the container's own credentials are redacted.**
+  `sanitize()` removes the *literal values* of the environment variables a token
+  can arrive in (`utils.CREDENTIAL_ENV_VARS`). That is an exact match, not a
+  guess at what a secret looks like, so it holds however the value was rendered
+  — quoted in a dict, in an `Authorization` header, or bare in prose.
+
+  There is deliberately no pattern-matching backstop here. An earlier version
+  carried regexes for `Authorization` headers, signed-URL query parameters and
+  `hf_`/`ms-`/`sk-` token shapes; they were removed because they were the wrong
+  instrument twice over. For the case that matters — this container's own token
+  — they only duplicated the exact match. For the case they nominally covered —
+  text written by the hub or by `huggingface_hub` — they scanned for
+  credential-shaped fragments, while what is actually risky about foreign text
+  is the content itself. That is handled structurally instead: whitespace is
+  collapsed (no injected log lines), the message is capped, and a URL is reduced
+  to `scheme://netloc` at the point it is interpolated, so a signed CDN URL's
+  query string never enters a message in the first place.
+
+  Add a pattern here when a real leak path is demonstrated, not in anticipation
+  of one: an unfalsifiable blocklist reads as protection and grants none.
 * **It is truncated by kubelet at 4096 bytes.** A message longer than that would
   be cut wherever the limit lands, which is exactly where the actionable
   sentence tends to be. The head is kept, on purpose: these messages lead with
@@ -30,8 +44,9 @@ Two constraints shape the text that goes there:
 """
 
 import os
-import re
 from typing import Optional
+
+from .utils import CREDENTIAL_ENV_VARS
 
 # kubelet caps a termination message at 4096 bytes and truncates the tail. Stay
 # under it with room for the multi-byte characters a model id or path can carry.
@@ -40,59 +55,30 @@ MAX_MESSAGE_BYTES = 3500
 TERMINATION_LOG_ENV = "NEUTREE_TERMINATION_LOG"
 DEFAULT_TERMINATION_LOG = "/dev/termination-log"
 
-# Environment variables whose value is a credential. Their literal values are
-# redacted out of any message, which catches a leak no pattern below would.
-_SECRET_ENV_VARS = (
-    "NEUTREE_DL_TOKEN",
-    "HF_TOKEN",
-    "HUGGING_FACE_HUB_TOKEN",
-    "MODELSCOPE_API_TOKEN",
-)
-
 _REDACTED = "<redacted>"
 
-_PATTERNS = (
-    # Authorization header, however it was rendered. The optional quote after
-    # the key is what makes a dict/repr rendering match — {'Authorization':
-    # 'Basic ...'} puts a quote between the key and the colon, and without it
-    # only a value that happened to look like a known token shape was redacted,
-    # leaving Basic credentials in the clear.
-    (re.compile(r"(?i)(authorization['\"]?\s*[:=]\s*['\"]?\s*(?:bearer|basic|token)?\s*)[^'\",}\s]+"),
-     r"\1" + _REDACTED),
-    (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-~+/]+=*"), "Bearer " + _REDACTED),
-    # Credential-bearing query parameters, including the signed-URL family a
-    # ModelScope/CDN redirect produces.
-    (re.compile(r"(?i)\b((?:access[_-]?token|api[_-]?key|apikey|auth|credential|password|"
-                r"secret|signature|sig|token|x-amz-[a-z-]*(?:signature|credential|security-token))"
-                r")=[^&\s'\"]+"),
-     r"\1=" + _REDACTED),
-    # Mapping/keyword renderings: {'token': 'ms-...'}, token='ms-...'.
-    (re.compile(r"(?i)(['\"]?(?:access[_-]?token|api[_-]?key|apikey|credential|password|secret|token)"
-                r"['\"]?\s*[:=]\s*)['\"][^'\"]+['\"]"),
-     r"\1'" + _REDACTED + "'"),
-    # Well-known token shapes, in case one is quoted bare.
-    (re.compile(r"\bhf_[A-Za-z0-9]{8,}"), _REDACTED),
-    (re.compile(r"\bms-[0-9a-fA-F]{8,}[0-9a-fA-F-]*"), _REDACTED),
-    (re.compile(r"\bsk-[A-Za-z0-9]{8,}"), _REDACTED),
-)
+# Below this length a credential is not distinguishable from ordinary words, and
+# replacing it would mangle the message rather than protect anything.
+_MIN_REDACTABLE_LENGTH = 4
 
 
 def sanitize(text: str) -> str:
-    """Strip credentials out of a message that is about to be shown to a user."""
+    """Remove this container's credentials from a message headed for a user.
+
+    Exact-value replacement over `CREDENTIAL_ENV_VARS`, which is the whole of it
+    — see the module docstring for why there is no pattern-matching backstop.
+    Very short values are left alone: a two-character token is indistinguishable
+    from ordinary text, and blanking it would corrupt the message it appears in.
+    """
     if not text:
         return ""
 
     cleaned = str(text)
 
-    # Literal secret values first: a token that also matches a pattern below is
-    # redacted either way, but one that matches none is only caught here.
-    for name in _SECRET_ENV_VARS:
+    for name in CREDENTIAL_ENV_VARS:
         value = os.environ.get(name)
-        if value and len(value) >= 4:
+        if value and len(value) >= _MIN_REDACTABLE_LENGTH:
             cleaned = cleaned.replace(value, _REDACTED)
-
-    for pattern, replacement in _PATTERNS:
-        cleaned = pattern.sub(replacement, cleaned)
 
     return cleaned
 

--- a/python/neutree/downloader/failure.py
+++ b/python/neutree/downloader/failure.py
@@ -1,0 +1,160 @@
+"""Carry a download failure's reason out of the init container.
+
+The downloader already knows *why* it failed — `ModelScopeDownloadUnavailable`
+says in words that runtime download is unavailable and that the cache holds no
+copy — but that knowledge died with the process. Kubernetes reports a failed
+init container to the orchestrator as an exit code, a restart count and
+`state.terminated.message`, and that message is only ever populated from the
+container's termination-message file. Nothing wrote it, so the endpoint's
+`status.error_message` ended at the colon:
+
+    Init Container 'model-downloader' terminated with exit code 1 after 5 restarts:
+
+Writing the reason to `/dev/termination-log` is what puts the text after that
+colon, through kubelet, into the endpoint status, and onto the user's screen —
+without them reading container logs, which in an air-gapped cluster is exactly
+the step they cannot easily take.
+
+Two constraints shape the text that goes there:
+
+* **It is user-visible, so it is sanitized.** A hub error can quote the URL that
+  produced it, and a signed CDN URL carries its credential in the query string;
+  a wrapped exception can carry a header dict. `sanitize()` redacts those, and
+  additionally redacts the *literal values* of the token environment variables
+  this container was given — the one check that does not depend on guessing the
+  shape of a secret.
+* **It is truncated by kubelet at 4096 bytes.** A message longer than that would
+  be cut wherever the limit lands, which is exactly where the actionable
+  sentence tends to be. The head is kept, on purpose: these messages lead with
+  the reason and trail into context.
+"""
+
+import os
+import re
+from typing import Optional
+
+# kubelet caps a termination message at 4096 bytes and truncates the tail. Stay
+# under it with room for the multi-byte characters a model id or path can carry.
+MAX_MESSAGE_BYTES = 3500
+
+TERMINATION_LOG_ENV = "NEUTREE_TERMINATION_LOG"
+DEFAULT_TERMINATION_LOG = "/dev/termination-log"
+
+# Environment variables whose value is a credential. Their literal values are
+# redacted out of any message, which catches a leak no pattern below would.
+_SECRET_ENV_VARS = (
+    "NEUTREE_DL_TOKEN",
+    "HF_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+    "MODELSCOPE_API_TOKEN",
+)
+
+_REDACTED = "<redacted>"
+
+_PATTERNS = (
+    # Authorization header, however it was rendered (str(), repr(), a dict).
+    (re.compile(r"(?i)(authorization\s*[:=]\s*['\"]?\s*(?:bearer|basic|token)?\s*)\S+"),
+     r"\1" + _REDACTED),
+    (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-~+/]+=*"), "Bearer " + _REDACTED),
+    # Credential-bearing query parameters, including the signed-URL family a
+    # ModelScope/CDN redirect produces.
+    (re.compile(r"(?i)\b((?:access[_-]?token|api[_-]?key|apikey|auth|credential|password|"
+                r"secret|signature|sig|token|x-amz-[a-z-]*(?:signature|credential|security-token))"
+                r")=[^&\s'\"]+"),
+     r"\1=" + _REDACTED),
+    # Mapping/keyword renderings: {'token': 'ms-...'}, token='ms-...'.
+    (re.compile(r"(?i)(['\"]?(?:access[_-]?token|api[_-]?key|apikey|credential|password|secret|token)"
+                r"['\"]?\s*[:=]\s*)['\"][^'\"]+['\"]"),
+     r"\1'" + _REDACTED + "'"),
+    # Well-known token shapes, in case one is quoted bare.
+    (re.compile(r"\bhf_[A-Za-z0-9]{8,}"), _REDACTED),
+    (re.compile(r"\bms-[0-9a-fA-F]{8,}[0-9a-fA-F-]*"), _REDACTED),
+    (re.compile(r"\bsk-[A-Za-z0-9]{8,}"), _REDACTED),
+)
+
+
+def sanitize(text: str) -> str:
+    """Strip credentials out of a message that is about to be shown to a user."""
+    if not text:
+        return ""
+
+    cleaned = str(text)
+
+    # Literal secret values first: a token that also matches a pattern below is
+    # redacted either way, but one that matches none is only caught here.
+    for name in _SECRET_ENV_VARS:
+        value = os.environ.get(name)
+        if value and len(value) >= 4:
+            cleaned = cleaned.replace(value, _REDACTED)
+
+    for pattern, replacement in _PATTERNS:
+        cleaned = pattern.sub(replacement, cleaned)
+
+    return cleaned
+
+
+def _truncate(text: str) -> str:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= MAX_MESSAGE_BYTES:
+        return text
+
+    # Cut on a character boundary, not a byte one, or the message stops being
+    # decodable text.
+    return encoded[:MAX_MESSAGE_BYTES].decode("utf-8", "ignore").rstrip() + " ...(truncated)"
+
+
+def describe_exception(exc: BaseException) -> str:
+    """Render an exception chain as one line of actionable prose.
+
+    The chain matters: the downloader wraps a socket error into
+    `ModelScopeDownloadUnavailable`, and `str()` of the outer exception alone is
+    usually the actionable half while the inner one names what actually broke.
+    Causes are appended only when they add text the outer message does not
+    already quote — urllib errors get interpolated into their wrapper, and
+    repeating them reads as two separate faults.
+    """
+    parts = []
+    seen = set()
+    current: Optional[BaseException] = exc
+    depth = 0
+
+    while current is not None and depth < 4:
+        text = str(current).strip() or type(current).__name__
+        if text not in seen and not any(text in part for part in parts):
+            parts.append(text)
+            seen.add(text)
+
+        current = current.__cause__ or current.__context__
+        depth += 1
+
+    joined = ": caused by ".join(parts)
+
+    return " ".join(joined.split())
+
+
+def build_failure_message(exc: BaseException, *, model_name: str = "",
+                          registry_type: str = "") -> str:
+    """The one line an operator should be able to act on, ready for the status."""
+    subject = "model download failed"
+    if model_name:
+        qualifier = f"{registry_type} model '{model_name}'" if registry_type else f"model '{model_name}'"
+        subject = f"model download failed for {qualifier}"
+
+    return _truncate(sanitize(f"{subject}: {describe_exception(exc)}"))
+
+
+def write_termination_message(message: str) -> None:
+    """Best-effort write of the failure reason to the termination-message file.
+
+    Best-effort on purpose: this runs on a path that is already failing, and a
+    container whose termination-message file is unwritable must still exit with
+    its original status rather than dying on the reporting of it. The message is
+    printed by the caller regardless, so nothing is lost from the logs.
+    """
+    path = os.environ.get(TERMINATION_LOG_ENV) or DEFAULT_TERMINATION_LOG
+
+    try:
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(_truncate(message))
+    except OSError:
+        pass

--- a/python/neutree/downloader/failure.py
+++ b/python/neutree/downloader/failure.py
@@ -52,8 +52,12 @@ _SECRET_ENV_VARS = (
 _REDACTED = "<redacted>"
 
 _PATTERNS = (
-    # Authorization header, however it was rendered (str(), repr(), a dict).
-    (re.compile(r"(?i)(authorization\s*[:=]\s*['\"]?\s*(?:bearer|basic|token)?\s*)\S+"),
+    # Authorization header, however it was rendered. The optional quote after
+    # the key is what makes a dict/repr rendering match — {'Authorization':
+    # 'Basic ...'} puts a quote between the key and the colon, and without it
+    # only a value that happened to look like a known token shape was redacted,
+    # leaving Basic credentials in the clear.
+    (re.compile(r"(?i)(authorization['\"]?\s*[:=]\s*['\"]?\s*(?:bearer|basic|token)?\s*)[^'\",}\s]+"),
      r"\1" + _REDACTED),
     (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-~+/]+=*"), "Bearer " + _REDACTED),
     # Credential-bearing query parameters, including the signed-URL family a

--- a/python/neutree/downloader/test_failure.py
+++ b/python/neutree/downloader/test_failure.py
@@ -1,0 +1,132 @@
+"""Tests for failure reporting out of the model-downloader init container.
+
+Run with (from project root):
+    PYTHONPATH=python python3 -m pytest python/neutree/downloader/test_failure.py -v
+"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from neutree.downloader.failure import (
+    MAX_MESSAGE_BYTES,
+    TERMINATION_LOG_ENV,
+    build_failure_message,
+    describe_exception,
+    sanitize,
+    write_termination_message,
+)
+
+
+class TestSanitize(unittest.TestCase):
+    def test_redacts_authorization_header(self):
+        cleaned = sanitize("failed: {'Authorization': 'Bearer ms-8f2c1d9e4b7a'} rejected")
+        self.assertNotIn("ms-8f2c1d9e4b7a", cleaned)
+        self.assertIn("<redacted>", cleaned)
+
+    def test_redacts_bearer_token_in_prose(self):
+        cleaned = sanitize("sent Bearer hf_AbCdEfGhIjKlMnOpQrSt to the hub")
+        self.assertNotIn("hf_AbCdEfGhIjKlMnOpQrSt", cleaned)
+
+    def test_redacts_signed_url_query_parameters(self):
+        cleaned = sanitize(
+            "HTTP 403 fetching https://cdn.modelscope.cn/model.safetensors"
+            "?Signature=abc123def&X-Amz-Security-Token=zzz&Expires=1700000000"
+        )
+        self.assertNotIn("abc123def", cleaned)
+        self.assertNotIn("zzz", cleaned)
+        # Non-credential parameters survive: they are part of the diagnosis.
+        self.assertIn("Expires=1700000000", cleaned)
+
+    def test_redacts_token_environment_values_even_when_shapeless(self):
+        with mock.patch.dict(os.environ, {"MODELSCOPE_API_TOKEN": "plain-secret-value"}):
+            cleaned = sanitize("hub refused the credential plain-secret-value")
+
+        self.assertNotIn("plain-secret-value", cleaned)
+
+    def test_keeps_the_actionable_text(self):
+        message = ("runtime model download is unavailable: offline mode is enabled, so the weights "
+                   "for ModelScope model 'Qwen/Qwen3-8B' cannot be fetched from the hub")
+        self.assertEqual(sanitize(message), message)
+
+
+class TestDescribeException(unittest.TestCase):
+    def test_reports_the_cause_chain(self):
+        try:
+            try:
+                raise OSError("[Errno -3] Temporary failure in name resolution")
+            except OSError as inner:
+                raise RuntimeError("runtime model download is unavailable") from inner
+        except RuntimeError as exc:
+            described = describe_exception(exc)
+
+        self.assertIn("runtime model download is unavailable", described)
+        self.assertIn("name resolution", described)
+
+    def test_does_not_repeat_a_cause_already_quoted(self):
+        try:
+            try:
+                raise OSError("connection refused")
+            except OSError as inner:
+                raise RuntimeError("cannot reach the hub (connection refused)") from inner
+        except RuntimeError as exc:
+            described = describe_exception(exc)
+
+        self.assertEqual(described.count("connection refused"), 1)
+
+    def test_collapses_newlines(self):
+        described = describe_exception(RuntimeError("first line\nsecond line"))
+        self.assertEqual(described, "first line second line")
+
+
+class TestBuildFailureMessage(unittest.TestCase):
+    def test_names_the_model_and_registry(self):
+        message = build_failure_message(
+            RuntimeError("offline mode is enabled and no files are present at /models-cache"),
+            model_name="Qwen/Qwen3-8B", registry_type="model-scope")
+
+        self.assertIn("model-scope model 'Qwen/Qwen3-8B'", message)
+        self.assertIn("offline mode is enabled", message)
+
+    def test_truncates_to_fit_the_termination_message_limit(self):
+        message = build_failure_message(RuntimeError("x" * (MAX_MESSAGE_BYTES * 2)),
+                                        model_name="m", registry_type="model-scope")
+
+        self.assertLessEqual(len(message.encode("utf-8")), MAX_MESSAGE_BYTES + 64)
+        self.assertTrue(message.endswith("...(truncated)"))
+
+    def test_truncation_stays_decodable_with_multibyte_text(self):
+        message = build_failure_message(RuntimeError("模型" * MAX_MESSAGE_BYTES),
+                                        model_name="m", registry_type="model-scope")
+
+        # Round-trips: the cut landed on a character boundary, not inside one.
+        self.assertEqual(message, message.encode("utf-8").decode("utf-8"))
+
+    def test_sanitizes_before_returning(self):
+        with mock.patch.dict(os.environ, {"HF_TOKEN": "hf_supersecrettoken"}):
+            message = build_failure_message(RuntimeError("401 with hf_supersecrettoken"),
+                                            model_name="m", registry_type="hugging-face")
+
+        self.assertNotIn("hf_supersecrettoken", message)
+
+
+class TestWriteTerminationMessage(unittest.TestCase):
+    def test_writes_to_the_configured_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "termination-log")
+            with mock.patch.dict(os.environ, {TERMINATION_LOG_ENV: path}):
+                write_termination_message("runtime model download is unavailable")
+
+            with open(path, encoding="utf-8") as handle:
+                self.assertEqual(handle.read(), "runtime model download is unavailable")
+
+    def test_unwritable_path_does_not_raise(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "missing-dir", "termination-log")
+            with mock.patch.dict(os.environ, {TERMINATION_LOG_ENV: path}):
+                write_termination_message("reason")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/neutree/downloader/test_failure.py
+++ b/python/neutree/downloader/test_failure.py
@@ -25,6 +25,21 @@ class TestSanitize(unittest.TestCase):
         self.assertNotIn("ms-8f2c1d9e4b7a", cleaned)
         self.assertIn("<redacted>", cleaned)
 
+    def test_redacts_basic_credentials_in_dict_renderings(self):
+        """A quoted key puts a quote between "Authorization" and the colon.
+
+        Basic credentials match none of the token-shape patterns, so if the
+        header pattern does not fire on this rendering nothing else redacts them.
+        """
+        for rendering in ("{'Authorization': 'Basic dXNlcjpwYXNzd29yZA=='}",
+                          '{"Authorization": "Basic dXNlcjpwYXNzd29yZA=="}',
+                          "headers={'authorization': 'Token abc123xyz'}"):
+            with self.subTest(rendering=rendering):
+                cleaned = sanitize(rendering)
+                self.assertNotIn("dXNlcjpwYXNzd29yZA==", cleaned)
+                self.assertNotIn("abc123xyz", cleaned)
+                self.assertIn("<redacted>", cleaned)
+
     def test_redacts_bearer_token_in_prose(self):
         cleaned = sanitize("sent Bearer hf_AbCdEfGhIjKlMnOpQrSt to the hub")
         self.assertNotIn("hf_AbCdEfGhIjKlMnOpQrSt", cleaned)

--- a/python/neutree/downloader/test_failure.py
+++ b/python/neutree/downloader/test_failure.py
@@ -17,53 +17,57 @@ from neutree.downloader.failure import (
     sanitize,
     write_termination_message,
 )
+from neutree.downloader.utils import CREDENTIAL_ENV_VARS
 
 
 class TestSanitize(unittest.TestCase):
-    def test_redacts_authorization_header(self):
-        cleaned = sanitize("failed: {'Authorization': 'Bearer ms-8f2c1d9e4b7a'} rejected")
-        self.assertNotIn("ms-8f2c1d9e4b7a", cleaned)
-        self.assertIn("<redacted>", cleaned)
+    """Redaction is exact-value, so it is rendering-independent by construction.
 
-    def test_redacts_basic_credentials_in_dict_renderings(self):
-        """A quoted key puts a quote between "Authorization" and the colon.
+    These cases exist to hold that property, not to enumerate spellings: if the
+    check ever became pattern-based again, the dict and header renderings below
+    are the first ones to slip through it.
+    """
 
-        Basic credentials match none of the token-shape patterns, so if the
-        header pattern does not fire on this rendering nothing else redacts them.
-        """
-        for rendering in ("{'Authorization': 'Basic dXNlcjpwYXNzd29yZA=='}",
-                          '{"Authorization": "Basic dXNlcjpwYXNzd29yZA=="}',
-                          "headers={'authorization': 'Token abc123xyz'}"):
-            with self.subTest(rendering=rendering):
-                cleaned = sanitize(rendering)
-                self.assertNotIn("dXNlcjpwYXNzd29yZA==", cleaned)
-                self.assertNotIn("abc123xyz", cleaned)
-                self.assertIn("<redacted>", cleaned)
-
-    def test_redacts_bearer_token_in_prose(self):
-        cleaned = sanitize("sent Bearer hf_AbCdEfGhIjKlMnOpQrSt to the hub")
-        self.assertNotIn("hf_AbCdEfGhIjKlMnOpQrSt", cleaned)
-
-    def test_redacts_signed_url_query_parameters(self):
-        cleaned = sanitize(
-            "HTTP 403 fetching https://cdn.modelscope.cn/model.safetensors"
-            "?Signature=abc123def&X-Amz-Security-Token=zzz&Expires=1700000000"
+    def test_redacts_the_token_however_it_is_rendered(self):
+        renderings = (
+            "HTTP 401 with Authorization: Bearer {tok}",
+            "{{'Authorization': 'Bearer {tok}'}} was rejected",
+            '{{"headers": {{"authorization": "Basic {tok}"}}}}',
+            "hub refused the credential {tok}",
+            "https://www.modelscope.cn/api/v1/models?token={tok}",
         )
-        self.assertNotIn("abc123def", cleaned)
-        self.assertNotIn("zzz", cleaned)
-        # Non-credential parameters survive: they are part of the diagnosis.
-        self.assertIn("Expires=1700000000", cleaned)
 
-    def test_redacts_token_environment_values_even_when_shapeless(self):
-        with mock.patch.dict(os.environ, {"MODELSCOPE_API_TOKEN": "plain-secret-value"}):
+        with mock.patch.dict(os.environ, {"MODELSCOPE_API_TOKEN": "ms-8f2c1d9e4b7a"}):
+            for rendering in renderings:
+                with self.subTest(rendering=rendering):
+                    cleaned = sanitize(rendering.format(tok="ms-8f2c1d9e4b7a"))
+                    self.assertNotIn("ms-8f2c1d9e4b7a", cleaned)
+                    self.assertIn("<redacted>", cleaned)
+
+    def test_redacts_a_token_of_no_particular_shape(self):
+        """The point of matching on value: this one looks like nothing."""
+        with mock.patch.dict(os.environ, {"NEUTREE_DL_TOKEN": "plain-secret-value"}):
             cleaned = sanitize("hub refused the credential plain-secret-value")
 
         self.assertNotIn("plain-secret-value", cleaned)
 
-    def test_keeps_the_actionable_text(self):
+    def test_covers_every_variable_a_credential_can_arrive_in(self):
+        for name in CREDENTIAL_ENV_VARS:
+            with self.subTest(env=name):
+                with mock.patch.dict(os.environ, {name: "the-secret-value"}, clear=True):
+                    self.assertNotIn("the-secret-value", sanitize("rejected the-secret-value"))
+
+    def test_leaves_a_message_with_no_credential_in_it_alone(self):
         message = ("runtime model download is unavailable: offline mode is enabled, so the weights "
                    "for ModelScope model 'Qwen/Qwen3-8B' cannot be fetched from the hub")
-        self.assertEqual(sanitize(message), message)
+
+        with mock.patch.dict(os.environ, {"MODELSCOPE_API_TOKEN": "ms-8f2c1d9e4b7a"}):
+            self.assertEqual(sanitize(message), message)
+
+    def test_ignores_a_token_too_short_to_tell_from_prose(self):
+        """Blanking a 2-character value would corrupt the message, not protect it."""
+        with mock.patch.dict(os.environ, {"HF_TOKEN": "ab"}):
+            self.assertEqual(sanitize("unable to grab the weights"), "unable to grab the weights")
 
 
 class TestDescribeException(unittest.TestCase):

--- a/python/neutree/downloader/test_main.py
+++ b/python/neutree/downloader/test_main.py
@@ -1,0 +1,68 @@
+"""Tests for the downloader CLI entrypoint's failure path.
+
+Run with (from project root):
+    PYTHONPATH=python python3 -m pytest python/neutree/downloader/test_main.py -v
+"""
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from neutree.downloader import __main__ as downloader_main
+from neutree.downloader.failure import TERMINATION_LOG_ENV
+
+
+class TestMainFailureReporting(unittest.TestCase):
+    """A failed download must leave its reason where kubelet will read it.
+
+    Without this the endpoint's status ends at "terminated with exit code 1
+    after 5 restarts:" — the failure NEU-726 exists to remove.
+    """
+
+    argv = ["--name", "Qwen/Qwen3-8B", "--registry_type", "model-scope", "--path", "/models-cache"]
+
+    def _run_with_failure(self, exc, tmp_path):
+        with mock.patch.dict(os.environ, {TERMINATION_LOG_ENV: tmp_path}), \
+                mock.patch.object(downloader_main, "_run", side_effect=exc):
+            with self.assertRaises(SystemExit) as raised:
+                downloader_main.main(self.argv)
+
+        self.assertEqual(raised.exception.code, 1)
+
+        with open(tmp_path, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_records_the_offline_reason(self):
+        reason = ("runtime model download is unavailable: offline mode is enabled, so the weights "
+                  "cannot be fetched from the hub, and none are present at /models-cache")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            written = self._run_with_failure(RuntimeError(reason), os.path.join(tmp, "log"))
+
+        self.assertIn("model-scope model 'Qwen/Qwen3-8B'", written)
+        self.assertIn("offline mode is enabled", written)
+        self.assertIn("none are present at /models-cache", written)
+
+    def test_redacts_credentials_from_the_recorded_reason(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"MODELSCOPE_API_TOKEN": "ms-1a2b3c4d5e6f"}):
+                written = self._run_with_failure(
+                    RuntimeError("HTTP 401 with Authorization: Bearer ms-1a2b3c4d5e6f"),
+                    os.path.join(tmp, "log"))
+
+        self.assertNotIn("ms-1a2b3c4d5e6f", written)
+        self.assertIn("<redacted>", written)
+
+    def test_success_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "log")
+            with mock.patch.dict(os.environ, {TERMINATION_LOG_ENV: path}), \
+                    mock.patch.object(downloader_main, "_run"):
+                downloader_main.main(self.argv)
+
+            self.assertFalse(os.path.exists(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/neutree/downloader/utils.py
+++ b/python/neutree/downloader/utils.py
@@ -61,6 +61,24 @@ MODEL_DOWNLOAD_DONE_MARKER = "NEUTREE_MODEL_DOWNLOAD_DONE"
 MODEL_DOWNLOAD_FAILED_MARKER = "NEUTREE_MODEL_DOWNLOAD_FAILED"
 
 
+# The environment variables a credential can arrive in. Declared here, beside
+# the only place they are read, because failure.sanitize() redacts their literal
+# values out of anything shown to a user: a token this container holds but this
+# tuple does not name would be redacted by nothing.
+GENERIC_TOKEN_ENV = "NEUTREE_DL_TOKEN"
+MODELSCOPE_TOKEN_ENV = "MODELSCOPE_API_TOKEN"
+HF_TOKEN_ENV = "HF_TOKEN"
+
+CREDENTIAL_ENV_VARS = (
+    GENERIC_TOKEN_ENV,
+    MODELSCOPE_TOKEN_ENV,
+    HF_TOKEN_ENV,
+    # Not read here: huggingface_hub reads it for itself, so a Hugging Face
+    # download can be authenticated by a value this package never sees.
+    "HUGGING_FACE_HUB_TOKEN",
+)
+
+
 def download_with_markers(downloader: Any, source: str, dest: str, *,
                           credentials: Optional[Dict[str, str]] = None,
                           recursive: bool = True, overwrite: bool = False,
@@ -114,8 +132,8 @@ def build_request_from_model_args(model_args: Dict[str, Any]) -> Tuple[str, Down
     # The hub-specific variable is chosen by backend rather than by falling
     # through a shared chain, so a cluster that has both registries configured
     # cannot send a Hugging Face token to ModelScope or the reverse.
-    hub_token_env = "MODELSCOPE_API_TOKEN" if backend == "model-scope" else "HF_TOKEN"
-    token = os.environ.get("NEUTREE_DL_TOKEN") or os.environ.get(hub_token_env)
+    hub_token_env = MODELSCOPE_TOKEN_ENV if backend == "model-scope" else HF_TOKEN_ENV
+    token = os.environ.get(GENERIC_TOKEN_ENV) or os.environ.get(hub_token_env)
     if token and token != "":
         credentials = {"token": token}
 


### PR DESCRIPTION
## Issue

NEU-726 (follow-up to NEU-689)

## Summary

In an offline cluster whose target model is not in the local cache, the endpoint went `Failed` with an error message that ended at the colon: `Init Container 'model-downloader' terminated with exit code 1 after 5 restarts:`. The user could not tell whether to stage the model into the cache, change the offline configuration, or debug the network. The downloader already knew the answer — `ModelScopeDownloadUnavailable` says in words that runtime download is unavailable, that the cache holds no copy, and what to do about it — but that text only ever reached the container's stderr. Kubernetes reports a failed init container as an exit code, a restart count and `state.terminated.message`, and that message is populated only from the container's termination-message file, which nothing wrote. This change writes it, sanitizes it, and stops the orchestrator from losing it across the crash-loop cycle.

## Changes

- `python/neutree/downloader/failure.py` (new): renders an exception chain as one actionable line, redacts credentials from it, and best-effort writes it to `/dev/termination-log` (`NEUTREE_TERMINATION_LOG` overrides the path for tests).
  - Redaction covers `Authorization`/`Bearer` in any rendering, credential-bearing query parameters of a signed CDN URL (`Signature`, `X-Amz-*`, `token`, …), mapping/keyword renderings such as `{'token': '…'}`, known token shapes (`hf_`, `ms-`, `sk-`), and — the check that does not depend on guessing a shape — the *literal values* of the token env vars this container was given.
  - Truncation is on a character boundary at 3500 bytes, keeping the head: kubelet caps a termination message at 4096 bytes and cuts the tail, which is where the actionable sentence would otherwise land.
- `python/neutree/downloader/__main__.py`: the download body moves into `_run()` and the whole of it — backend resolution included — runs under a guard that records the reason, prints the traceback, and exits 1.
- `internal/orchestrator/kubernetes_orchestrator.go`:
  - An init container past the restart threshold is now recognised in *both* halves of the crash-loop cycle: the exit itself (`State.Terminated`) and the back-off that follows it (`State.Waiting=CrashLoopBackOff`, where the exit has already moved into `LastTerminationState`). Reading only the first lost the reason for most of the loop's duration.
  - New `terminationDetail()` prefers the message the process itself wrote over the kubelet's own wording, falls back to the previous attempt's message, and returns empty rather than fabricating one — so a failure with no recorded reason no longer renders a dangling colon.
  - `MODELDOWNLOADING` (still retrying) now carries `; last attempt: <reason>` alongside the back-off text.

Deliberately **not** done: no `terminationMessagePolicy: FallbackToLogsOnError` on the init container. It only helps when the file is empty, and what it falls back to is the tail of the container log — which does not pass through the sanitizer above.

## Test Plan

- [x] Unit — Go: `go test ./internal/orchestrator/` passes; adds `Test_checkPodFailures_modelDownloaderReason` (5 cases: terminated-with-reason, crash-looping-keeps-last-reason, no-reason-no-dangling-colon, below-threshold, running-again-not-judged-by-history) and `Test_hasIncompleteModelDownloaderInitContainer_keepsLastReason`.
- [x] Unit — Python: `PYTHONPATH=python python3 -m pytest python/neutree/downloader/` → 78 passed; adds `test_failure.py` (14) and `test_main.py` (3).
- [x] Manual, real CLI runs:
  - offline + cache miss → exit 1, termination log reads `model download failed for model-scope model 'Qwen/Qwen3-8B': runtime model download is unavailable: offline mode is enabled, … and none are present at <path>. Stage the model into the cluster's model cache, or deploy from a registry this cluster can read offline.`
  - no offline flag, unreachable hub → `runtime model download is unavailable: cannot reach the ModelScope endpoint …`
  - offline + model already cached → download skipped, exit 0, no termination message written (no regression on the cached path).
  - with `MODELSCOPE_API_TOKEN` set and quoted in the error → redacted in the recorded message.
- [ ] E2E: not affected
- [ ] DB integration (`make db-test`): not affected

## Risk & Rollback

No schema change, no API shape change: the same `status.error_message` field simply carries text where it previously carried an empty tail, so UI and API stay consistent with each other for free. The added Python module is import-only from the downloader entrypoint and writes one file best-effort — an unwritable termination-message path is swallowed so the container still exits on its original error. Rollback is reverting the commit; the worst case on the orchestrator side is returning to the old behaviour of reporting the exit code alone.
